### PR TITLE
Vietnamese added

### DIFF
--- a/source/v2000 - initial glyphs migration/LibreBodoni Italics.glyphs
+++ b/source/v2000 - initial glyphs migration/LibreBodoni Italics.glyphs
@@ -184,110 +184,137 @@ xHeight = 450;
 glyphs = (
 {
 glyphname = A;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:42:24 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{241, 0}";
+},
+{
+name = ogonek;
+position = "{474, 10}";
+},
+{
+name = top;
+position = "{508, 754}";
+}
+);
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
 paths = (
 {
 closed = 1;
 nodes = (
-"336 10 LINE",
+"21 20 LINE",
+"384 551 LINE",
+"493 764 LINE",
+"-18 20 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"123 0 LINE",
+"123 25 LINE",
+"-91 25 LINE",
+"-91 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"538 0 LINE",
+"538 25 LINE",
+"269 25 LINE",
+"269 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"434 247 LINE",
+"434 275 LINE",
+"165 275 LINE",
+"165 247 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "459 10 LINE",
 "514 764 LINE",
 "493 764 LINE",
 "381 547 LINE",
-"385 547 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"538 25 LINE",
-"269 25 LINE",
-"269 0 LINE",
-"538 0 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"123 25 LINE",
-"-91 25 LINE",
-"-91 0 LINE",
-"123 0 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"384 551 LINE",
-"493 764 LINE",
-"-18 20 LINE",
-"21 20 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"165 247 LINE",
-"434 247 LINE",
-"434 275 LINE",
-"165 275 LINE"
+"385 547 LINE",
+"336 10 LINE"
 );
 }
 );
 width = 585;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{259, 0}";
+},
+{
+name = ogonek;
+position = "{507, 10}";
+},
+{
+name = top;
+position = "{516, 754}";
+}
+);
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
 paths = (
 {
 closed = 1;
 nodes = (
-"337 10 LINE",
+"22 20 LINE",
+"385 551 LINE",
+"502 768 LINE",
+"-20 20 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"124 0 LINE",
+"124 30 LINE",
+"-66 30 LINE",
+"-66 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"569 0 LINE",
+"569 30 LINE",
+"250 30 LINE",
+"250 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"415 212 LINE",
+"415 245 LINE",
+"146 245 LINE",
+"146 212 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "490 10 LINE",
 "545 768 LINE",
 "494 768 LINE",
 "382 547 LINE",
-"386 547 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"569 30 LINE",
-"250 30 LINE",
-"250 0 LINE",
-"569 0 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"124 30 LINE",
-"-66 30 LINE",
-"-66 0 LINE",
-"124 0 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"385 551 LINE",
-"502 768 LINE",
-"487 768 LINE",
-"-20 20 LINE",
-"22 20 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"146 212 LINE",
-"415 212 LINE",
-"415 245 LINE",
-"146 245 LINE"
+"386 547 LINE",
+"337 10 LINE"
 );
 }
 );
@@ -300,7 +327,7 @@ unicode = 0041;
 },
 {
 glyphname = Aacute;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:05:38 +0000";
 layers = (
 {
 components = (
@@ -308,8 +335,8 @@ components = (
 name = A;
 },
 {
-name = acute.cap;
-transform = "{1, 0, 0, 1, 219, 0}";
+name = acutecomb;
+transform = "{1, 0, 0, 1, 149, 304}";
 }
 );
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -321,8 +348,8 @@ components = (
 name = A;
 },
 {
-name = acute.cap;
-transform = "{1, 0, 0, 1, 215, 0}";
+name = acutecomb;
+transform = "{1, 0, 0, 1, 111, 304}";
 }
 );
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
@@ -335,7 +362,7 @@ unicode = 00C1;
 },
 {
 glyphname = Abreve;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:16:36 +0000";
 layers = (
 {
 components = (
@@ -343,8 +370,8 @@ components = (
 name = A;
 },
 {
-name = breve.cap;
-transform = "{1, 0, 0, 1, 190, 0}";
+name = brevecomb;
+transform = "{1, 0, 0, 1, 134, 304}";
 }
 );
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -356,8 +383,8 @@ components = (
 name = A;
 },
 {
-name = breve.cap;
-transform = "{1, 0, 0, 1, 192, 0}";
+name = brevecomb;
+transform = "{1, 0, 0, 1, 135, 304}";
 }
 );
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
@@ -369,8 +396,8 @@ rightKerningGroup = A;
 unicode = 0102;
 },
 {
-glyphname = Acircumflex;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = Abreveacute;
+lastChange = "2016-08-22 14:16:36 +0000";
 layers = (
 {
 components = (
@@ -378,8 +405,8 @@ components = (
 name = A;
 },
 {
-name = circumflex.cap;
-transform = "{1, 0, 0, 1, 187, 0}";
+name = brevecomb_acutecomb;
+transform = "{1, 0, 0, 1, 149, 304}";
 }
 );
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -391,8 +418,190 @@ components = (
 name = A;
 },
 {
-name = circumflex.cap;
-transform = "{1, 0, 0, 1, 207, 0}";
+name = brevecomb_acutecomb;
+transform = "{1, 0, 0, 1, 159, 304}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 621;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 1EAE;
+},
+{
+glyphname = Abrevedotbelow;
+lastChange = "2016-08-22 14:16:36 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = dotbelowcomb;
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, 134, 304}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 585;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 9, 0}";
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, 135, 304}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 621;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 1EB6;
+},
+{
+glyphname = Abrevegrave;
+lastChange = "2016-08-22 14:16:36 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = brevecomb_gravecomb;
+transform = "{1, 0, 0, 1, 135, 304}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 585;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = brevecomb_gravecomb;
+transform = "{1, 0, 0, 1, 146, 304}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 621;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 1EB0;
+},
+{
+glyphname = Abrevehookabove;
+lastChange = "2016-08-22 14:16:36 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = brevecomb_hookabovecomb;
+transform = "{1, 0, 0, 1, 131, 304}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 585;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = brevecomb_hookabovecomb;
+transform = "{1, 0, 0, 1, 166, 304}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 621;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 1EB2;
+},
+{
+glyphname = Abrevetilde;
+lastChange = "2016-08-22 14:16:36 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = brevecomb_tildecomb;
+transform = "{1, 0, 0, 1, 134, 304}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 585;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = brevecomb_tildecomb;
+transform = "{1, 0, 0, 1, 136, 304}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 621;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 1EB4;
+},
+{
+glyphname = Acircumflex;
+lastChange = "2016-08-22 14:16:36 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 136, 304}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 585;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 171, 304}";
 }
 );
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
@@ -404,8 +613,8 @@ rightKerningGroup = A;
 unicode = 00C2;
 },
 {
-glyphname = Adblgrave;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = Acircumflexacute;
+lastChange = "2016-08-22 14:16:36 +0000";
 layers = (
 {
 components = (
@@ -413,7 +622,189 @@ components = (
 name = A;
 },
 {
-name = uni030F.cap;
+name = circumflexcomb_acutecomb;
+transform = "{1, 0, 0, 1, 140, 304}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 585;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = circumflexcomb_acutecomb;
+transform = "{1, 0, 0, 1, 149, 304}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 621;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 1EA4;
+},
+{
+glyphname = Acircumflexdotbelow;
+lastChange = "2016-08-22 14:16:36 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = dotbelowcomb;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 136, 304}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 585;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 9, 0}";
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 171, 304}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 621;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 1EAC;
+},
+{
+glyphname = Acircumflexgrave;
+lastChange = "2016-08-22 14:16:36 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = circumflexcomb_gravecomb;
+transform = "{1, 0, 0, 1, 144, 304}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 585;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = circumflexcomb_gravecomb;
+transform = "{1, 0, 0, 1, 153, 304}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 621;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 1EA6;
+},
+{
+glyphname = Acircumflexhookabove;
+lastChange = "2016-08-22 14:16:36 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = circumflexcomb_hookabovecomb;
+transform = "{1, 0, 0, 1, 138, 304}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 585;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = circumflexcomb_hookabovecomb;
+transform = "{1, 0, 0, 1, 150, 304}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 621;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 1EA8;
+},
+{
+glyphname = Acircumflextilde;
+lastChange = "2016-08-22 14:16:36 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = circumflexcomb_tildecomb;
+transform = "{1, 0, 0, 1, 140, 304}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 585;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = circumflexcomb_tildecomb;
+transform = "{1, 0, 0, 1, 147, 304}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 621;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 1EAA;
+},
+{
+glyphname = Adblgrave;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = dblgravecomb.cap;
 transform = "{1, 0, 0, 1, 36, 0}";
 }
 );
@@ -426,7 +817,7 @@ components = (
 name = A;
 },
 {
-name = uni030F.cap;
+name = dblgravecomb.cap;
 transform = "{1, 0, 0, 1, 77, 0}";
 }
 );
@@ -440,7 +831,7 @@ unicode = 0200;
 },
 {
 glyphname = Adieresis;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:15 +0000";
 layers = (
 {
 components = (
@@ -448,7 +839,7 @@ components = (
 name = A;
 },
 {
-name = dieresis.cap;
+name = dieresis.case;
 transform = "{1, 0, 0, 1, 204, 0}";
 }
 );
@@ -461,7 +852,7 @@ components = (
 name = A;
 },
 {
-name = dieresis.cap;
+name = dieresis.case;
 transform = "{1, 0, 0, 1, 210, 0}";
 }
 );
@@ -474,8 +865,8 @@ rightKerningGroup = A;
 unicode = 00C4;
 },
 {
-glyphname = Agrave;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = Adotbelow;
+lastChange = "2016-08-22 14:16:42 +0000";
 layers = (
 {
 components = (
@@ -483,8 +874,7 @@ components = (
 name = A;
 },
 {
-name = grave.cap;
-transform = "{1, 0, 0, 1, 162, 0}";
+name = dotbelowcomb;
 }
 );
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -496,8 +886,43 @@ components = (
 name = A;
 },
 {
-name = grave.cap;
-transform = "{1, 0, 0, 1, 205, 0}";
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 9, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 621;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 1EA0;
+},
+{
+glyphname = Agrave;
+lastChange = "2016-08-22 14:16:42 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 160, 304}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 585;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 200, 304}";
 }
 );
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
@@ -509,8 +934,8 @@ rightKerningGroup = A;
 unicode = 00C0;
 },
 {
-glyphname = Ainvertedbreve;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = Ahookabove;
+lastChange = "2016-08-22 14:16:42 +0000";
 layers = (
 {
 components = (
@@ -518,7 +943,42 @@ components = (
 name = A;
 },
 {
-name = uni0311.cap;
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 185, 304}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 585;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 184, 304}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 621;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 1EA2;
+},
+{
+glyphname = Ainvertedbreve;
+lastChange = "2016-08-22 14:16:42 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = breveinvertedcomb.cap;
 transform = "{1, 0, 0, 1, 197, 0}";
 }
 );
@@ -531,7 +991,7 @@ components = (
 name = A;
 },
 {
-name = uni0311.cap;
+name = breveinvertedcomb.cap;
 transform = "{1, 0, 0, 1, 193, 0}";
 }
 );
@@ -545,7 +1005,7 @@ unicode = 0202;
 },
 {
 glyphname = Amacron;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:16:42 +0000";
 layers = (
 {
 components = (
@@ -553,7 +1013,7 @@ components = (
 name = A;
 },
 {
-name = macron.cap;
+name = macron.case;
 transform = "{1, 0, 0, 1, 170, 0}";
 }
 );
@@ -566,7 +1026,7 @@ components = (
 name = A;
 },
 {
-name = macron.cap;
+name = macron.case;
 transform = "{1, 0, 0, 1, 181, 0}";
 }
 );
@@ -580,7 +1040,7 @@ unicode = 0100;
 },
 {
 glyphname = Aogonek;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:16:42 +0000";
 layers = (
 {
 components = (
@@ -615,7 +1075,7 @@ unicode = 0104;
 },
 {
 glyphname = Aring;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:16:42 +0000";
 layers = (
 {
 components = (
@@ -623,7 +1083,7 @@ components = (
 name = A;
 },
 {
-name = ring.cap;
+name = ring.case;
 transform = "{1, 0, 0, 1, 258, 0}";
 }
 );
@@ -636,7 +1096,7 @@ components = (
 name = A;
 },
 {
-name = ring.cap;
+name = ring.case;
 transform = "{1, 0, 0, 1, 266, 0}";
 }
 );
@@ -650,174 +1110,40 @@ unicode = 00C5;
 },
 {
 glyphname = Aringacute;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:16:42 +0000";
 layers = (
 {
-layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
-paths = (
+components = (
 {
-closed = 1;
-nodes = (
-"642 843 LINE SMOOTH",
-"681 852 OFFCURVE",
-"697 870 OFFCURVE",
-"697 893 CURVE SMOOTH",
-"697 913 OFFCURVE",
-"685 924 OFFCURVE",
-"667 924 CURVE SMOOTH",
-"651 924 OFFCURVE",
-"633 916 OFFCURVE",
-"599 895 CURVE SMOOTH",
-"519 846 LINE",
-"511 849 OFFCURVE",
-"503 851 OFFCURVE",
-"494 851 CURVE SMOOTH",
-"454 851 OFFCURVE",
-"420 819 OFFCURVE",
-"420 779 CURVE SMOOTH",
-"420 751 OFFCURVE",
-"435 727 OFFCURVE",
-"458 714 CURVE",
-"-14 25 LINE",
-"-91 25 LINE",
-"-91 0 LINE",
-"123 0 LINE",
-"123 25 LINE",
-"24 25 LINE",
-"176 247 LINE",
-"357 247 LINE",
-"337 25 LINE",
-"269 25 LINE",
-"269 0 LINE",
-"538 0 LINE",
-"538 25 LINE",
-"460 25 LINE",
-"509 705 LINE",
-"543 713 OFFCURVE",
-"567 743 OFFCURVE",
-"567 779 CURVE SMOOTH",
-"567 796 OFFCURVE",
-"561 811 OFFCURVE",
-"552 823 CURVE"
-);
+name = A;
 },
 {
-closed = 1;
-nodes = (
-"385 547 LINE",
-"360 275 LINE",
-"195 275 LINE",
-"381 547 LINE"
-);
+name = ring.case;
+transform = "{1, 0, 0, 1, 261, -48}";
 },
 {
-closed = 1;
-nodes = (
-"494 818 LINE SMOOTH",
-"515 818 OFFCURVE",
-"534 800 OFFCURVE",
-"534 779 CURVE SMOOTH",
-"534 757 OFFCURVE",
-"516 737 OFFCURVE",
-"494 737 CURVE SMOOTH",
-"472 737 OFFCURVE",
-"453 757 OFFCURVE",
-"453 779 CURVE SMOOTH",
-"453 800 OFFCURVE",
-"473 818 OFFCURVE",
-"494 818 CURVE SMOOTH"
-);
+name = acute.case;
+transform = "{1, 0, 0, 1, 370, 55}";
 }
 );
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
 width = 585;
 },
 {
-layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
-paths = (
+components = (
 {
-closed = 1;
-nodes = (
-"464 734 LINE",
-"-13 30 LINE",
-"-66 30 LINE",
-"-66 0 LINE",
-"124 0 LINE",
-"124 30 LINE",
-"29 30 LINE",
-"153 212 LINE",
-"355 212 LINE",
-"339 30 LINE",
-"250 30 LINE",
-"250 0 LINE",
-"569 0 LINE",
-"569 30 LINE",
-"491 30 LINE",
-"543 734 LINE"
-);
+name = A;
 },
 {
-closed = 1;
-nodes = (
-"386 547 LINE",
-"358 245 LINE",
-"176 245 LINE",
-"382 547 LINE"
-);
+name = ring.case;
+transform = "{1, 0, 0, 1, 259, -46}";
 },
 {
-closed = 1;
-nodes = (
-"511 700 LINE SMOOTH",
-"560 700 OFFCURVE",
-"590 730 OFFCURVE",
-"590 779 CURVE SMOOTH",
-"590 828 OFFCURVE",
-"560 857 OFFCURVE",
-"511 857 CURVE SMOOTH",
-"462 857 OFFCURVE",
-"432 828 OFFCURVE",
-"432 779 CURVE SMOOTH",
-"432 730 OFFCURVE",
-"462 700 OFFCURVE",
-"511 700 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"511 821 LINE SMOOTH",
-"535 821 OFFCURVE",
-"547 806 OFFCURVE",
-"547 782 CURVE SMOOTH",
-"547 758 OFFCURVE",
-"535 741 OFFCURVE",
-"511 741 CURVE SMOOTH",
-"487 741 OFFCURVE",
-"475 758 OFFCURVE",
-"475 782 CURVE SMOOTH",
-"475 806 OFFCURVE",
-"487 821 OFFCURVE",
-"511 821 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"553 806 LINE",
-"704 834 LINE SMOOTH",
-"736 840 OFFCURVE",
-"751 862 OFFCURVE",
-"751 881 CURVE SMOOTH",
-"751 903 OFFCURVE",
-"732 924 OFFCURVE",
-"699 924 CURVE SMOOTH",
-"674 924 OFFCURVE",
-"657 918 OFFCURVE",
-"622 897 CURVE SMOOTH",
-"524 836 LINE"
-);
+name = acute.case;
+transform = "{1, 0, 0, 1, 392, 40}";
 }
 );
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
 width = 621;
 }
 );
@@ -827,7 +1153,7 @@ unicode = 01FA;
 },
 {
 glyphname = Atilde;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:05:38 +0000";
 layers = (
 {
 components = (
@@ -835,8 +1161,8 @@ components = (
 name = A;
 },
 {
-name = tilde.cap;
-transform = "{1, 0, 0, 1, 172, 0}";
+name = tildecomb;
+transform = "{1, 0, 0, 1, 149, 304}";
 }
 );
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -848,8 +1174,8 @@ components = (
 name = A;
 },
 {
-name = tilde.cap;
-transform = "{1, 0, 0, 1, 190, 0}";
+name = tildecomb;
+transform = "{1, 0, 0, 1, 151, 304}";
 }
 );
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
@@ -862,7 +1188,7 @@ unicode = 00C3;
 },
 {
 glyphname = AE;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -870,80 +1196,80 @@ paths = (
 {
 closed = 1;
 nodes = (
-"101 25 LINE",
-"-113 25 LINE",
-"-113 0 LINE",
-"101 0 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"-1 20 LINE",
 "486 734 LINE",
 "455 741 LINE",
-"-40 20 LINE",
-"-1 20 LINE"
+"-40 20 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"143 247 LINE",
+"101 0 LINE",
+"101 25 LINE",
+"-113 25 LINE",
+"-113 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "412 247 LINE",
 "412 275 LINE",
-"143 275 LINE"
+"143 275 LINE",
+"143 247 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"624 754 LINE",
-"507 754 LINE",
-"343 0 LINE",
-"456 0 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"338 729 LINE",
-"728 729 LINE SMOOTH",
-"870 729 OFFCURVE",
-"899 692 OFFCURVE",
-"899 553 CURVE",
-"929 553 LINE",
-"957 754 LINE",
-"338 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"491 378 LINE",
-"578 378 LINE SMOOTH",
-"661 378 OFFCURVE",
-"676 351 OFFCURVE",
-"676 226 CURVE",
-"706 226 LINE",
-"765 534 LINE",
-"740 534 LINE",
-"709 430 OFFCURVE",
-"674 403 OFFCURVE",
-"594 403 CURVE SMOOTH",
-"491 403 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"247 0 LINE",
 "837 0 LINE",
 "897 232 LINE",
 "867 232 LINE",
 "791 64 OFFCURVE",
 "729 25 OFFCURVE",
 "640 25 CURVE SMOOTH",
-"247 25 LINE"
+"247 25 LINE",
+"247 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"456 0 LINE",
+"624 754 LINE",
+"507 754 LINE",
+"343 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"706 226 LINE",
+"765 534 LINE",
+"740 534 LINE",
+"709 430 OFFCURVE",
+"674 403 OFFCURVE",
+"594 403 CURVE SMOOTH",
+"491 403 LINE",
+"491 378 LINE",
+"578 378 LINE SMOOTH",
+"661 378 OFFCURVE",
+"676 351 OFFCURVE",
+"676 226 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"929 553 LINE",
+"957 754 LINE",
+"338 754 LINE",
+"338 729 LINE",
+"728 729 LINE SMOOTH",
+"870 729 OFFCURVE",
+"899 692 OFFCURVE",
+"899 553 CURVE"
 );
 }
 );
@@ -955,80 +1281,80 @@ paths = (
 {
 closed = 1;
 nodes = (
-"702 754 LINE",
-"551 754 LINE",
-"387 0 LINE",
-"534 0 LINE"
+"-14 20 LINE",
+"542 734 LINE",
+"505 741 LINE",
+"-56 20 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"396 724 LINE",
-"796 724 LINE SMOOTH",
-"920 724 OFFCURVE",
-"957 687 OFFCURVE",
-"957 548 CURVE",
-"997 548 LINE",
-"1033 754 LINE",
-"396 754 LINE"
+"88 0 LINE",
+"88 30 LINE",
+"-102 30 LINE",
+"-102 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"295 0 LINE",
+"439 212 LINE",
+"439 245 LINE",
+"130 245 LINE",
+"130 212 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "905 0 LINE",
 "965 232 LINE",
 "925 232 LINE",
 "849 68 OFFCURVE",
 "787 30 OFFCURVE",
 "698 30 CURVE SMOOTH",
-"295 30 LINE"
+"295 30 LINE",
+"295 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"567 374 LINE",
-"654 374 LINE SMOOTH",
-"714 374 OFFCURVE",
-"752 348 OFFCURVE",
-"752 227 CURVE",
+"534 0 LINE",
+"702 754 LINE",
+"551 754 LINE",
+"387 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "786 227 LINE",
 "851 535 LINE",
 "816 535 LINE",
 "786 441 OFFCURVE",
 "737 404 OFFCURVE",
 "670 404 CURVE SMOOTH",
-"567 404 LINE"
+"567 404 LINE",
+"567 374 LINE",
+"654 374 LINE SMOOTH",
+"714 374 OFFCURVE",
+"752 348 OFFCURVE",
+"752 227 CURVE"
 );
 },
 {
 closed = 1;
 nodes = (
-"88 30 LINE",
-"-102 30 LINE",
-"-102 0 LINE",
-"88 0 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"542 734 LINE",
-"505 741 LINE",
-"-56 20 LINE",
-"-14 20 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"130 212 LINE",
-"439 212 LINE",
-"439 245 LINE",
-"130 245 LINE"
+"997 548 LINE",
+"1033 754 LINE",
+"396 754 LINE",
+"396 724 LINE",
+"796 724 LINE SMOOTH",
+"920 724 OFFCURVE",
+"957 687 OFFCURVE",
+"957 548 CURVE"
 );
 }
 );
@@ -1041,7 +1367,7 @@ unicode = 00C6;
 },
 {
 glyphname = AEacute;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:15 +0000";
 layers = (
 {
 components = (
@@ -1049,7 +1375,7 @@ components = (
 name = AE;
 },
 {
-name = acute.cap;
+name = acute.case;
 transform = "{1, 0, 0, 1, 374, 0}";
 }
 );
@@ -1062,7 +1388,7 @@ components = (
 name = AE;
 },
 {
-name = acute.cap;
+name = acute.case;
 transform = "{1, 0, 0, 1, 451, 0}";
 }
 );
@@ -1076,43 +1402,21 @@ unicode = 01FC;
 },
 {
 glyphname = B;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:59 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{285, 0}";
+},
+{
+name = top;
+position = "{459, 754}";
+}
+);
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
 paths = (
-{
-closed = 1;
-nodes = (
-"360 754 LINE",
-"243 754 LINE",
-"79 0 LINE",
-"192 0 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"144 754 LINE",
-"144 729 LINE",
-"423 729 LINE SMOOTH",
-"526 729 OFFCURVE",
-"553 690 OFFCURVE",
-"553 609 CURVE SMOOTH",
-"553 490 OFFCURVE",
-"494 403 OFFCURVE",
-"399 403 CURVE SMOOTH",
-"201 403 LINE",
-"201 378 LINE",
-"343 378 LINE SMOOTH",
-"546 378 OFFCURVE",
-"680 464 OFFCURVE",
-"680 586 CURVE SMOOTH",
-"680 684 OFFCURVE",
-"593 754 OFFCURVE",
-"423 754 CURVE SMOOTH"
-);
-},
 {
 closed = 1;
 nodes = (
@@ -1121,10 +1425,13 @@ nodes = (
 "632 85 OFFCURVE",
 "632 198 CURVE SMOOTH",
 "632 285 OFFCURVE",
-"576 348 OFFCURVE",
-"465 386 CURVE",
-"465 390 LINE",
-"343 378 LINE",
+"565 373 OFFCURVE",
+"454 391 CURVE",
+"425 398 OFFCURVE",
+"379 404 OFFCURVE",
+"363 404 CURVE SMOOTH",
+"231 404 LINE",
+"231 378 LINE",
 "378 378 LINE",
 "458 378 OFFCURVE",
 "503 337 OFFCURVE",
@@ -1135,25 +1442,100 @@ nodes = (
 "-7 25 LINE",
 "-7 0 LINE"
 );
+},
+{
+closed = 1;
+nodes = (
+"192 0 LINE",
+"360 754 LINE",
+"243 754 LINE",
+"79 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"343 378 LINE SMOOTH",
+"546 378 OFFCURVE",
+"680 464 OFFCURVE",
+"680 586 CURVE SMOOTH",
+"680 684 OFFCURVE",
+"593 754 OFFCURVE",
+"423 754 CURVE SMOOTH",
+"144 754 LINE",
+"144 729 LINE",
+"423 729 LINE SMOOTH",
+"526 729 OFFCURVE",
+"553 690 OFFCURVE",
+"553 609 CURVE SMOOTH",
+"553 490 OFFCURVE",
+"494 403 OFFCURVE",
+"399 403 CURVE SMOOTH",
+"201 403 LINE",
+"201 378 LINE"
+);
 }
 );
 width = 674;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{295, 0}";
+},
+{
+name = top;
+position = "{469, 754}";
+}
+);
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
 paths = (
 {
 closed = 1;
 nodes = (
-"366 754 LINE",
-"215 754 LINE",
-"51 0 LINE",
-"198 0 LINE"
+"370 0 LINE SMOOTH",
+"519 0 OFFCURVE",
+"644 82 OFFCURVE",
+"644 224 CURVE SMOOTH",
+"644 310 OFFCURVE",
+"598 363 OFFCURVE",
+"485 389 CURVE",
+"447 401 OFFCURVE",
+"423 409 OFFCURVE",
+"391 409 CURVE SMOOTH",
+"198 409 LINE",
+"198 379 LINE",
+"379 379 LINE SMOOTH",
+"453 379 OFFCURVE",
+"471 331 OFFCURVE",
+"471 256 CURVE SMOOTH",
+"471 104 OFFCURVE",
+"398 31 OFFCURVE",
+"291 31 CURVE SMOOTH",
+"-28 31 LINE",
+"-28 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
+"198 0 LINE",
+"366 754 LINE",
+"215 754 LINE",
+"51 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"331 379 LINE SMOOTH",
+"558 379 OFFCURVE",
+"684 455 OFFCURVE",
+"684 584 CURVE SMOOTH",
+"684 684 OFFCURVE",
+"607 754 OFFCURVE",
+"431 754 CURVE SMOOTH",
 "110 754 LINE",
 "110 724 LINE",
 "419 724 LINE SMOOTH",
@@ -1164,41 +1546,7 @@ nodes = (
 "461 409 OFFCURVE",
 "359 409 CURVE SMOOTH",
 "167 409 LINE",
-"167 379 LINE",
-"331 379 LINE SMOOTH",
-"558 379 OFFCURVE",
-"684 455 OFFCURVE",
-"684 584 CURVE SMOOTH",
-"684 684 OFFCURVE",
-"607 754 OFFCURVE",
-"431 754 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"170 409 LINE",
-"170 379 LINE",
-"379 379 LINE SMOOTH",
-"453 379 OFFCURVE",
-"471 331 OFFCURVE",
-"471 256 CURVE SMOOTH",
-"471 104 OFFCURVE",
-"398 31 OFFCURVE",
-"291 31 CURVE SMOOTH",
-"-28 31 LINE",
-"-28 0 LINE",
-"370 0 LINE SMOOTH",
-"519 0 OFFCURVE",
-"644 82 OFFCURVE",
-"644 224 CURVE SMOOTH",
-"644 310 OFFCURVE",
-"598 363 OFFCURVE",
-"485 389 CURVE",
-"485 393 LINE",
-"460 398 OFFCURVE",
-"422 409 OFFCURVE",
-"391 409 CURVE SMOOTH"
+"167 379 LINE"
 );
 }
 );
@@ -1209,15 +1557,34 @@ unicode = 0042;
 },
 {
 glyphname = C;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:47:47 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{295, 0}";
+},
+{
+name = top;
+position = "{469, 754}";
+}
+);
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
 paths = (
 {
 closed = 1;
 nodes = (
-"355 19 LINE SMOOTH",
+"420 -13 OFFCURVE",
+"484 12 OFFCURVE",
+"539 49 CURVE",
+"569 0 LINE",
+"594 0 LINE",
+"647 206 LINE",
+"622 206 LINE",
+"532 56 OFFCURVE",
+"435 19 OFFCURVE",
+"355 19 CURVE SMOOTH",
 "266 19 OFFCURVE",
 "217 64 OFFCURVE",
 "217 207 CURVE SMOOTH",
@@ -1239,29 +1606,38 @@ nodes = (
 "79 288 CURVE SMOOTH",
 "79 127 OFFCURVE",
 "177 -13 OFFCURVE",
-"348 -13 CURVE SMOOTH",
-"420 -13 OFFCURVE",
-"484 12 OFFCURVE",
-"539 49 CURVE",
-"569 0 LINE",
-"594 0 LINE",
-"647 206 LINE",
-"622 206 LINE",
-"532 56 OFFCURVE",
-"435 19 OFFCURVE",
-"355 19 CURVE SMOOTH"
+"348 -13 CURVE SMOOTH"
 );
 }
 );
 width = 693;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{289, 0}";
+},
+{
+name = top;
+position = "{463, 754}";
+}
+);
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
 paths = (
 {
 closed = 1;
 nodes = (
-"357 24 LINE SMOOTH",
+"414 -13 OFFCURVE",
+"474 8 OFFCURVE",
+"529 34 CURVE",
+"559 0 LINE",
+"589 0 LINE",
+"642 206 LINE",
+"612 206 LINE",
+"523 59 OFFCURVE",
+"424 24 OFFCURVE",
+"357 24 CURVE SMOOTH",
 "282 24 OFFCURVE",
 "241 68 OFFCURVE",
 "241 200 CURVE SMOOTH",
@@ -1283,17 +1659,7 @@ nodes = (
 "64 283 CURVE SMOOTH",
 "64 128 OFFCURVE",
 "162 -13 OFFCURVE",
-"344 -13 CURVE SMOOTH",
-"414 -13 OFFCURVE",
-"474 8 OFFCURVE",
-"529 34 CURVE",
-"559 0 LINE",
-"589 0 LINE",
-"642 206 LINE",
-"612 206 LINE",
-"523 59 OFFCURVE",
-"424 24 OFFCURVE",
-"357 24 CURVE SMOOTH"
+"344 -13 CURVE SMOOTH"
 );
 }
 );
@@ -1306,7 +1672,7 @@ unicode = 0043;
 },
 {
 glyphname = Cacute;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:15 +0000";
 layers = (
 {
 components = (
@@ -1314,7 +1680,7 @@ components = (
 name = C;
 },
 {
-name = acute.cap;
+name = acute.case;
 transform = "{1, 0, 0, 1, 326, 0}";
 }
 );
@@ -1327,7 +1693,7 @@ components = (
 name = C;
 },
 {
-name = acute.cap;
+name = acute.case;
 transform = "{1, 0, 0, 1, 318, 0}";
 }
 );
@@ -1341,7 +1707,7 @@ unicode = 0106;
 },
 {
 glyphname = Ccaron;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:15 +0000";
 layers = (
 {
 components = (
@@ -1349,7 +1715,7 @@ components = (
 name = C;
 },
 {
-name = caron.cap;
+name = caron.case;
 transform = "{1, 0, 0, 1, 187, 0}";
 }
 );
@@ -1362,7 +1728,7 @@ components = (
 name = C;
 },
 {
-name = caron.cap;
+name = caron.case;
 transform = "{1, 0, 0, 1, 201, 0}";
 }
 );
@@ -1411,7 +1777,7 @@ unicode = 00C7;
 },
 {
 glyphname = Ccircumflex;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:15 +0000";
 layers = (
 {
 components = (
@@ -1419,7 +1785,7 @@ components = (
 name = C;
 },
 {
-name = circumflex.cap;
+name = circumflex.case;
 transform = "{1, 0, 0, 1, 189, 0}";
 }
 );
@@ -1432,7 +1798,7 @@ components = (
 name = C;
 },
 {
-name = circumflex.cap;
+name = circumflex.case;
 transform = "{1, 0, 0, 1, 200, 0}";
 }
 );
@@ -1446,7 +1812,7 @@ unicode = 0108;
 },
 {
 glyphname = Cdotaccent;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:15 +0000";
 layers = (
 {
 components = (
@@ -1454,7 +1820,7 @@ components = (
 name = C;
 },
 {
-name = dotaccent.cap;
+name = dotaccent.case;
 transform = "{1, 0, 0, 1, 306, 0}";
 }
 );
@@ -1467,7 +1833,7 @@ components = (
 name = C;
 },
 {
-name = dotaccent.cap;
+name = dotaccent.case;
 transform = "{1, 0, 0, 1, 278, 0}";
 }
 );
@@ -1481,24 +1847,32 @@ unicode = 010A;
 },
 {
 glyphname = D;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:48:01 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{330, 0}";
+},
+{
+name = center;
+position = "{417, 377}";
+},
+{
+name = top;
+position = "{504, 754}";
+}
+);
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
 paths = (
 {
 closed = 1;
 nodes = (
-"353 754 LINE",
-"236 754 LINE",
-"72 0 LINE",
-"185 0 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"745 438 LINE SMOOTH",
+"312 0 LINE SMOOTH",
+"564 0 OFFCURVE",
+"745 189 OFFCURVE",
+"745 438 CURVE SMOOTH",
 "745 634 OFFCURVE",
 "623 754 OFFCURVE",
 "416 754 CURVE SMOOTH",
@@ -1512,32 +1886,45 @@ nodes = (
 "485 27 OFFCURVE",
 "300 27 CURVE SMOOTH",
 "-14 27 LINE",
-"-14 0 LINE",
-"312 0 LINE SMOOTH",
-"564 0 OFFCURVE",
-"745 189 OFFCURVE",
-"745 438 CURVE SMOOTH"
+"-14 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"185 0 LINE",
+"353 754 LINE",
+"236 754 LINE",
+"72 0 LINE"
 );
 }
 );
 width = 764;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{333, 0}";
+},
+{
+name = center;
+position = "{420, 377}";
+},
+{
+name = top;
+position = "{507, 754}";
+}
+);
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
 paths = (
 {
 closed = 1;
 nodes = (
-"363 754 LINE",
-"212 754 LINE",
-"48 0 LINE",
-"195 0 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"748 438 LINE SMOOTH",
+"325 0 LINE SMOOTH",
+"571 0 OFFCURVE",
+"748 209 OFFCURVE",
+"748 438 CURVE SMOOTH",
 "748 634 OFFCURVE",
 "643 754 OFFCURVE",
 "436 754 CURVE SMOOTH",
@@ -1551,11 +1938,16 @@ nodes = (
 "474 32 OFFCURVE",
 "296 32 CURVE SMOOTH",
 "-41 32 LINE",
-"-41 0 LINE",
-"325 0 LINE SMOOTH",
-"571 0 OFFCURVE",
-"748 209 OFFCURVE",
-"748 438 CURVE SMOOTH"
+"-41 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"195 0 LINE",
+"363 754 LINE",
+"212 754 LINE",
+"48 0 LINE"
 );
 }
 );
@@ -1567,8 +1959,86 @@ rightKerningGroup = D;
 unicode = 0044;
 },
 {
+glyphname = DZ;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+components = (
+{
+name = D;
+},
+{
+name = Z;
+transform = "{1, 0, 0, 1, 764, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 1413;
+},
+{
+components = (
+{
+name = D;
+},
+{
+name = Z;
+transform = "{1, 0, 0, 1, 770, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 1439;
+}
+);
+leftKerningGroup = D;
+rightKerningGroup = Z;
+unicode = 01F1;
+},
+{
+glyphname = DZcaron;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+components = (
+{
+name = D;
+},
+{
+name = Z;
+transform = "{1, 0, 0, 1, 764, 0}";
+},
+{
+name = caron.case;
+transform = "{1, 0, 0, 1, 919, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 1413;
+},
+{
+components = (
+{
+name = D;
+},
+{
+name = Z;
+transform = "{1, 0, 0, 1, 770, 0}";
+},
+{
+name = caron.case;
+transform = "{1, 0, 0, 1, 944, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 1439;
+}
+);
+leftKerningGroup = D;
+rightKerningGroup = Z;
+unicode = 01C4;
+},
+{
 glyphname = Eth;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 components = (
@@ -1581,10 +2051,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"16 367 LINE",
 "381 367 LINE",
 "381 402 LINE",
-"16 402 LINE"
+"16 402 LINE",
+"16 367 LINE"
 );
 }
 );
@@ -1601,10 +2071,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"39 362 LINE",
 "404 362 LINE",
 "404 402 LINE",
-"39 402 LINE"
+"39 402 LINE",
+"39 362 LINE"
 );
 }
 );
@@ -1616,7 +2086,7 @@ unicode = 00D0;
 },
 {
 glyphname = Dcaron;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:15 +0000";
 layers = (
 {
 components = (
@@ -1624,7 +2094,7 @@ components = (
 name = D;
 },
 {
-name = caron.cap;
+name = caron.case;
 transform = "{1, 0, 0, 1, 143, 0}";
 }
 );
@@ -1637,7 +2107,7 @@ components = (
 name = D;
 },
 {
-name = caron.cap;
+name = caron.case;
 transform = "{1, 0, 0, 1, 170, 0}";
 }
 );
@@ -1651,46 +2121,24 @@ unicode = 010E;
 },
 {
 glyphname = Dcroat;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:05:38 +0000";
 layers = (
 {
 components = (
 {
-name = D;
+name = Eth;
 }
 );
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
-paths = (
-{
-closed = 1;
-nodes = (
-"16 367 LINE",
-"381 367 LINE",
-"381 402 LINE",
-"16 402 LINE"
-);
-}
-);
 width = 764;
 },
 {
 components = (
 {
-name = D;
+name = Eth;
 }
 );
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
-paths = (
-{
-closed = 1;
-nodes = (
-"39 362 LINE",
-"404 362 LINE",
-"404 402 LINE",
-"39 402 LINE"
-);
-}
-);
 width = 770;
 }
 );
@@ -1733,120 +2181,234 @@ rightKerningGroup = D;
 unicode = 1E0C;
 },
 {
-glyphname = E;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = Dz;
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
+components = (
+{
+name = D;
+},
+{
+name = z;
+transform = "{1, 0, 0, 1, 764, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 1238;
+},
+{
+components = (
+{
+name = D;
+},
+{
+name = z;
+transform = "{1, 0, 0, 1, 770, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 1264;
+}
+);
+leftKerningGroup = D;
+rightKerningGroup = z;
+unicode = 01F2;
+},
+{
+glyphname = Dzcaron;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+components = (
+{
+name = D;
+},
+{
+name = z;
+transform = "{1, 0, 0, 1, 764, 0}";
+},
+{
+name = caron;
+transform = "{1, 0, 0, 1, 831, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 1238;
+},
+{
+components = (
+{
+name = D;
+},
+{
+name = z;
+transform = "{1, 0, 0, 1, 770, 0}";
+},
+{
+name = caron;
+transform = "{1, 0, 0, 1, 805, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 1264;
+}
+);
+leftKerningGroup = D;
+rightKerningGroup = z;
+unicode = 01C5;
+},
+{
+glyphname = E;
+lastChange = "2016-08-22 13:41:59 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{279, 0}";
+},
+{
+name = ogonek;
+position = "{544, 10}";
+},
+{
+name = top;
+position = "{453, 754}";
+},
+{
+name = topleft;
+position = "{142, 754}";
+}
+);
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
 paths = (
 {
 closed = 1;
 nodes = (
+"172 0 LINE",
 "340 754 LINE",
 "223 754 LINE",
-"59 0 LINE",
-"172 0 LINE"
+"59 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"114 729 LINE",
-"444 729 LINE SMOOTH",
-"586 729 OFFCURVE",
-"615 692 OFFCURVE",
-"615 553 CURVE",
-"645 553 LINE",
-"673 754 LINE",
-"114 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"207 378 LINE",
-"294 378 LINE SMOOTH",
-"377 378 OFFCURVE",
-"392 351 OFFCURVE",
-"392 226 CURVE",
-"422 226 LINE",
-"481 534 LINE",
-"456 534 LINE",
-"425 430 OFFCURVE",
-"390 403 OFFCURVE",
-"310 403 CURVE SMOOTH",
-"207 403 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"-37 0 LINE",
 "553 0 LINE",
 "613 232 LINE",
 "583 232 LINE",
 "507 64 OFFCURVE",
 "445 25 OFFCURVE",
 "356 25 CURVE SMOOTH",
-"-37 25 LINE"
+"-37 25 LINE",
+"-37 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"422 226 LINE",
+"481 534 LINE",
+"456 534 LINE",
+"425 430 OFFCURVE",
+"390 403 OFFCURVE",
+"310 403 CURVE SMOOTH",
+"207 403 LINE",
+"207 378 LINE",
+"294 378 LINE SMOOTH",
+"377 378 OFFCURVE",
+"392 351 OFFCURVE",
+"392 226 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"645 553 LINE",
+"673 754 LINE",
+"114 754 LINE",
+"114 729 LINE",
+"444 729 LINE SMOOTH",
+"586 729 OFFCURVE",
+"615 692 OFFCURVE",
+"615 553 CURVE"
 );
 }
 );
 width = 662;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{293, 0}";
+},
+{
+name = ogonek;
+position = "{569, 10}";
+},
+{
+name = top;
+position = "{467, 754}";
+},
+{
+name = topleft;
+position = "{142, 754}";
+}
+);
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
 paths = (
 {
 closed = 1;
 nodes = (
+"226 0 LINE",
 "394 754 LINE",
 "243 754 LINE",
-"79 0 LINE",
-"226 0 LINE"
+"79 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"128 724 LINE",
-"488 724 LINE SMOOTH",
-"612 724 OFFCURVE",
-"649 687 OFFCURVE",
-"649 548 CURVE",
-"689 548 LINE",
-"725 754 LINE",
-"128 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"-13 0 LINE",
 "597 0 LINE",
 "657 232 LINE",
 "617 232 LINE",
 "541 68 OFFCURVE",
 "479 30 OFFCURVE",
 "390 30 CURVE SMOOTH",
-"-13 30 LINE"
+"-13 30 LINE",
+"-13 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"259 374 LINE",
-"346 374 LINE SMOOTH",
-"406 374 OFFCURVE",
-"444 348 OFFCURVE",
-"444 227 CURVE",
 "478 227 LINE",
 "543 535 LINE",
 "508 535 LINE",
 "478 441 OFFCURVE",
 "429 404 OFFCURVE",
 "362 404 CURVE SMOOTH",
-"259 404 LINE"
+"259 404 LINE",
+"259 374 LINE",
+"346 374 LINE SMOOTH",
+"406 374 OFFCURVE",
+"444 348 OFFCURVE",
+"444 227 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"689 548 LINE",
+"725 754 LINE",
+"128 754 LINE",
+"128 724 LINE",
+"488 724 LINE SMOOTH",
+"612 724 OFFCURVE",
+"649 687 OFFCURVE",
+"649 548 CURVE"
 );
 }
 );
@@ -1859,7 +2421,7 @@ unicode = 0045;
 },
 {
 glyphname = Eacute;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:05:38 +0000";
 layers = (
 {
 components = (
@@ -1867,8 +2429,8 @@ components = (
 name = E;
 },
 {
-name = acute.cap;
-transform = "{1, 0, 0, 1, 160, 0}";
+name = acutecomb;
+transform = "{1, 0, 0, 1, 94, 304}";
 }
 );
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -1880,8 +2442,8 @@ components = (
 name = E;
 },
 {
-name = acute.cap;
-transform = "{1, 0, 0, 1, 194, 0}";
+name = acutecomb;
+transform = "{1, 0, 0, 1, 62, 304}";
 }
 );
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
@@ -1894,7 +2456,7 @@ unicode = 00C9;
 },
 {
 glyphname = Ebreve;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:15 +0000";
 layers = (
 {
 components = (
@@ -1902,7 +2464,7 @@ components = (
 name = E;
 },
 {
-name = breve.cap;
+name = breve.case;
 transform = "{1, 0, 0, 1, 104, 0}";
 }
 );
@@ -1915,7 +2477,7 @@ components = (
 name = E;
 },
 {
-name = breve.cap;
+name = breve.case;
 transform = "{1, 0, 0, 1, 145, 0}";
 }
 );
@@ -1929,7 +2491,7 @@ unicode = 0114;
 },
 {
 glyphname = Ecaron;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:15 +0000";
 layers = (
 {
 components = (
@@ -1937,7 +2499,7 @@ components = (
 name = E;
 },
 {
-name = caron.cap;
+name = caron.case;
 transform = "{1, 0, 0, 1, 111, 0}";
 }
 );
@@ -1950,7 +2512,7 @@ components = (
 name = E;
 },
 {
-name = caron.cap;
+name = caron.case;
 transform = "{1, 0, 0, 1, 125, 0}";
 }
 );
@@ -1964,7 +2526,7 @@ unicode = 011A;
 },
 {
 glyphname = Ecircumflex;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:05:38 +0000";
 layers = (
 {
 components = (
@@ -1972,8 +2534,8 @@ components = (
 name = E;
 },
 {
-name = circumflex.cap;
-transform = "{1, 0, 0, 1, 106, 0}";
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 81, 304}";
 }
 );
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -1985,8 +2547,8 @@ components = (
 name = E;
 },
 {
-name = circumflex.cap;
-transform = "{1, 0, 0, 1, 152, 0}";
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 122, 304}";
 }
 );
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
@@ -1998,8 +2560,8 @@ rightKerningGroup = E;
 unicode = 00CA;
 },
 {
-glyphname = Edblgrave;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = Ecircumflexacute;
+lastChange = "2016-08-22 14:16:53 +0000";
 layers = (
 {
 components = (
@@ -2007,7 +2569,190 @@ components = (
 name = E;
 },
 {
-name = uni030F.cap;
+name = circumflexcomb_acutecomb;
+transform = "{1, 0, 0, 1, 85, 304}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 662;
+},
+{
+components = (
+{
+name = E;
+},
+{
+name = circumflexcomb_acutecomb;
+transform = "{1, 0, 0, 1, 100, 304}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 690;
+}
+);
+leftKerningGroup = E;
+rightKerningGroup = E;
+unicode = 1EBE;
+},
+{
+glyphname = Ecircumflexdotbelow;
+lastChange = "2016-08-22 14:16:53 +0000";
+layers = (
+{
+components = (
+{
+name = E;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 38, 0}";
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 81, 304}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 662;
+},
+{
+components = (
+{
+name = E;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 43, 0}";
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 122, 304}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 690;
+}
+);
+leftKerningGroup = E;
+rightKerningGroup = E;
+unicode = 1EC6;
+},
+{
+glyphname = Ecircumflexgrave;
+lastChange = "2016-08-22 14:16:53 +0000";
+layers = (
+{
+components = (
+{
+name = E;
+},
+{
+name = circumflexcomb_gravecomb;
+transform = "{1, 0, 0, 1, 89, 304}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 662;
+},
+{
+components = (
+{
+name = E;
+},
+{
+name = circumflexcomb_gravecomb;
+transform = "{1, 0, 0, 1, 104, 304}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 690;
+}
+);
+leftKerningGroup = E;
+rightKerningGroup = E;
+unicode = 1EC0;
+},
+{
+glyphname = Ecircumflexhookabove;
+lastChange = "2016-08-22 14:16:53 +0000";
+layers = (
+{
+components = (
+{
+name = E;
+},
+{
+name = circumflexcomb_hookabovecomb;
+transform = "{1, 0, 0, 1, 83, 304}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 662;
+},
+{
+components = (
+{
+name = E;
+},
+{
+name = circumflexcomb_hookabovecomb;
+transform = "{1, 0, 0, 1, 101, 304}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 690;
+}
+);
+leftKerningGroup = E;
+rightKerningGroup = E;
+unicode = 1EC2;
+},
+{
+glyphname = Ecircumflextilde;
+lastChange = "2016-08-22 14:16:53 +0000";
+layers = (
+{
+components = (
+{
+name = E;
+},
+{
+name = circumflexcomb_tildecomb;
+transform = "{1, 0, 0, 1, 85, 304}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 662;
+},
+{
+components = (
+{
+name = E;
+},
+{
+name = circumflexcomb_tildecomb;
+transform = "{1, 0, 0, 1, 98, 304}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 690;
+}
+);
+leftKerningGroup = E;
+rightKerningGroup = E;
+unicode = 1EC4;
+},
+{
+glyphname = Edblgrave;
+lastChange = "2016-08-22 14:16:53 +0000";
+layers = (
+{
+components = (
+{
+name = E;
+},
+{
+name = dblgravecomb.cap;
 transform = "{1, 0, 0, 1, -1, 0}";
 }
 );
@@ -2020,7 +2765,7 @@ components = (
 name = E;
 },
 {
-name = uni030F.cap;
+name = dblgravecomb.cap;
 transform = "{1, 0, 0, 1, 24, 0}";
 }
 );
@@ -2034,7 +2779,7 @@ unicode = 0204;
 },
 {
 glyphname = Edieresis;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:16:53 +0000";
 layers = (
 {
 components = (
@@ -2042,7 +2787,7 @@ components = (
 name = E;
 },
 {
-name = dieresis.cap;
+name = dieresis.case;
 transform = "{1, 0, 0, 1, 119, 0}";
 }
 );
@@ -2055,7 +2800,7 @@ components = (
 name = E;
 },
 {
-name = dieresis.cap;
+name = dieresis.case;
 transform = "{1, 0, 0, 1, 158, 0}";
 }
 );
@@ -2069,7 +2814,7 @@ unicode = 00CB;
 },
 {
 glyphname = Edotaccent;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:16:53 +0000";
 layers = (
 {
 components = (
@@ -2077,7 +2822,7 @@ components = (
 name = E;
 },
 {
-name = dotaccent.cap;
+name = dotaccent.case;
 transform = "{1, 0, 0, 1, 226, 0}";
 }
 );
@@ -2090,7 +2835,7 @@ components = (
 name = E;
 },
 {
-name = dotaccent.cap;
+name = dotaccent.case;
 transform = "{1, 0, 0, 1, 215, 0}";
 }
 );
@@ -2104,7 +2849,7 @@ unicode = 0116;
 },
 {
 glyphname = Edotbelow;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:16:53 +0000";
 layers = (
 {
 components = (
@@ -2112,8 +2857,8 @@ components = (
 name = E;
 },
 {
-name = dotbelow;
-transform = "{1, 0, 0, 1, 266, 0}";
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 38, 0}";
 }
 );
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -2125,8 +2870,8 @@ components = (
 name = E;
 },
 {
-name = dotbelow;
-transform = "{1, 0, 0, 1, 297, 0}";
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 43, 0}";
 }
 );
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
@@ -2139,7 +2884,7 @@ unicode = 1EB8;
 },
 {
 glyphname = Egrave;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:16:53 +0000";
 layers = (
 {
 components = (
@@ -2147,8 +2892,8 @@ components = (
 name = E;
 },
 {
-name = grave.cap;
-transform = "{1, 0, 0, 1, 145, 0}";
+name = gravecomb;
+transform = "{1, 0, 0, 1, 105, 304}";
 }
 );
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -2160,8 +2905,8 @@ components = (
 name = E;
 },
 {
-name = grave.cap;
-transform = "{1, 0, 0, 1, 151, 0}";
+name = gravecomb;
+transform = "{1, 0, 0, 1, 151, 304}";
 }
 );
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
@@ -2173,8 +2918,8 @@ rightKerningGroup = E;
 unicode = 00C8;
 },
 {
-glyphname = Einvertedbreve;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = Ehookabove;
+lastChange = "2016-08-22 14:16:53 +0000";
 layers = (
 {
 components = (
@@ -2182,7 +2927,42 @@ components = (
 name = E;
 },
 {
-name = uni0311.cap;
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 130, 304}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 662;
+},
+{
+components = (
+{
+name = E;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 135, 304}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 690;
+}
+);
+leftKerningGroup = E;
+rightKerningGroup = E;
+unicode = 1EBA;
+},
+{
+glyphname = Einvertedbreve;
+lastChange = "2016-08-22 14:16:53 +0000";
+layers = (
+{
+components = (
+{
+name = E;
+},
+{
+name = breveinvertedcomb.cap;
 transform = "{1, 0, 0, 1, 119, 0}";
 }
 );
@@ -2195,7 +2975,7 @@ components = (
 name = E;
 },
 {
-name = uni0311.cap;
+name = breveinvertedcomb.cap;
 transform = "{1, 0, 0, 1, 145, 0}";
 }
 );
@@ -2209,7 +2989,7 @@ unicode = 0206;
 },
 {
 glyphname = Emacron;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:16:53 +0000";
 layers = (
 {
 components = (
@@ -2217,7 +2997,7 @@ components = (
 name = E;
 },
 {
-name = macron.cap;
+name = macron.case;
 transform = "{1, 0, 0, 1, 111, 0}";
 }
 );
@@ -2230,7 +3010,7 @@ components = (
 name = E;
 },
 {
-name = macron.cap;
+name = macron.case;
 transform = "{1, 0, 0, 1, 142, 0}";
 }
 );
@@ -2244,7 +3024,7 @@ unicode = 0112;
 },
 {
 glyphname = Eogonek;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:16:53 +0000";
 layers = (
 {
 components = (
@@ -2279,7 +3059,7 @@ unicode = 0118;
 },
 {
 glyphname = Etilde;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:16:53 +0000";
 layers = (
 {
 components = (
@@ -2287,8 +3067,8 @@ components = (
 name = E;
 },
 {
-name = tilde.cap;
-transform = "{1, 0, 0, 1, 87, 0}";
+name = tildecomb;
+transform = "{1, 0, 0, 1, 94, 304}";
 }
 );
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -2300,8 +3080,8 @@ components = (
 name = E;
 },
 {
-name = tilde.cap;
-transform = "{1, 0, 0, 1, 147, 0}";
+name = tildecomb;
+transform = "{1, 0, 0, 1, 102, 304}";
 }
 );
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
@@ -2314,111 +3094,131 @@ unicode = 1EBC;
 },
 {
 glyphname = F;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:59 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{266, 0}";
+},
+{
+name = top;
+position = "{440, 754}";
+}
+);
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
 paths = (
 {
 closed = 1;
 nodes = (
+"211 0 LINE",
 "379 754 LINE",
 "262 754 LINE",
-"98 0 LINE",
-"211 0 LINE"
+"98 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"153 729 LINE",
-"483 729 LINE SMOOTH",
-"622 729 OFFCURVE",
-"651 692 OFFCURVE",
-"651 529 CURVE",
-"681 529 LINE",
-"712 754 LINE",
-"153 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"2 0 LINE",
 "321 0 LINE",
 "321 25 LINE",
-"2 25 LINE"
+"2 25 LINE",
+"2 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"235 376 LINE",
-"322 376 LINE SMOOTH",
-"405 376 OFFCURVE",
-"420 349 OFFCURVE",
-"420 224 CURVE",
 "450 224 LINE",
 "506 528 LINE",
 "481 528 LINE",
 "450 428 OFFCURVE",
 "415 401 OFFCURVE",
 "338 401 CURVE SMOOTH",
-"235 401 LINE"
+"235 401 LINE",
+"235 376 LINE",
+"322 376 LINE SMOOTH",
+"405 376 OFFCURVE",
+"420 349 OFFCURVE",
+"420 224 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"681 529 LINE",
+"712 754 LINE",
+"153 754 LINE",
+"153 729 LINE",
+"483 729 LINE SMOOTH",
+"622 729 OFFCURVE",
+"651 692 OFFCURVE",
+"651 529 CURVE"
 );
 }
 );
 width = 635;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{278, 0}";
+},
+{
+name = top;
+position = "{452, 754}";
+}
+);
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
 paths = (
 {
 closed = 1;
 nodes = (
+"214 0 LINE",
 "382 754 LINE",
 "231 754 LINE",
-"67 0 LINE",
-"214 0 LINE"
+"67 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"116 724 LINE",
-"476 724 LINE SMOOTH",
-"600 724 OFFCURVE",
-"637 687 OFFCURVE",
-"637 548 CURVE",
-"677 548 LINE",
-"713 754 LINE",
-"116 754 LINE"
+"349 0 LINE",
+"349 31 LINE",
+"-20 31 LINE",
+"-20 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"247 374 LINE",
-"334 374 LINE SMOOTH",
-"394 374 OFFCURVE",
-"432 348 OFFCURVE",
-"432 227 CURVE",
 "466 227 LINE",
 "531 535 LINE",
 "496 535 LINE",
 "466 441 OFFCURVE",
 "417 404 OFFCURVE",
 "350 404 CURVE SMOOTH",
-"247 404 LINE"
+"247 404 LINE",
+"247 374 LINE",
+"334 374 LINE SMOOTH",
+"394 374 OFFCURVE",
+"432 348 OFFCURVE",
+"432 227 CURVE"
 );
 },
 {
 closed = 1;
 nodes = (
-"-20 0 LINE",
-"349 0 LINE",
-"349 31 LINE",
-"-20 31 LINE"
+"677 548 LINE",
+"713 754 LINE",
+"116 754 LINE",
+"116 724 LINE",
+"476 724 LINE SMOOTH",
+"600 724 OFFCURVE",
+"637 687 OFFCURVE",
+"637 548 CURVE"
 );
 }
 );
@@ -2429,15 +3229,31 @@ unicode = 0046;
 },
 {
 glyphname = G;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:59 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{323, 0}";
+},
+{
+name = top;
+position = "{497, 754}";
+}
+);
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
 paths = (
 {
 closed = 1;
 nodes = (
-"363 19 LINE SMOOTH",
+"519 -13 OFFCURVE",
+"652 69 OFFCURVE",
+"702 256 CURVE",
+"547 256 LINE",
+"515 76 OFFCURVE",
+"469 19 OFFCURVE",
+"363 19 CURVE SMOOTH",
 "271 19 OFFCURVE",
 "222 62 OFFCURVE",
 "222 205 CURVE SMOOTH",
@@ -2459,35 +3275,44 @@ nodes = (
 "84 314 CURVE SMOOTH",
 "84 188 OFFCURVE",
 "149 -13 OFFCURVE",
-"375 -13 CURVE SMOOTH",
-"519 -13 OFFCURVE",
-"652 69 OFFCURVE",
-"702 256 CURVE",
-"547 256 LINE",
-"515 76 OFFCURVE",
-"469 19 OFFCURVE",
-"363 19 CURVE SMOOTH"
+"375 -13 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"441 253 LINE",
 "778 253 LINE",
 "778 278 LINE",
-"441 278 LINE"
+"441 278 LINE",
+"441 253 LINE"
 );
 }
 );
 width = 749;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{329, 0}";
+},
+{
+name = top;
+position = "{503, 754}";
+}
+);
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
 paths = (
 {
 closed = 1;
 nodes = (
-"363 24 LINE SMOOTH",
+"559 -13 OFFCURVE",
+"644 73 OFFCURVE",
+"698 243 CURVE",
+"522 243 LINE",
+"494 65 OFFCURVE",
+"430 24 OFFCURVE",
+"363 24 CURVE SMOOTH",
 "290 24 OFFCURVE",
 "248 73 OFFCURVE",
 "248 207 CURVE SMOOTH",
@@ -2509,24 +3334,16 @@ nodes = (
 "72 287 CURVE SMOOTH",
 "72 134 OFFCURVE",
 "165 -13 OFFCURVE",
-"364 -13 CURVE SMOOTH",
-"473 -13 OFFCURVE",
-"561 31 OFFCURVE",
-"671 130 CURVE",
-"698 243 LINE",
-"522 243 LINE",
-"494 65 OFFCURVE",
-"430 24 OFFCURVE",
-"363 24 CURVE SMOOTH"
+"364 -13 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"423 237 LINE",
 "773 237 LINE",
 "773 267 LINE",
-"423 267 LINE"
+"423 267 LINE",
+"423 237 LINE"
 );
 }
 );
@@ -2539,7 +3356,7 @@ unicode = 0047;
 },
 {
 glyphname = Gacute;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:15 +0000";
 layers = (
 {
 components = (
@@ -2547,7 +3364,7 @@ components = (
 name = G;
 },
 {
-name = acute.cap;
+name = acute.case;
 transform = "{1, 0, 0, 1, 236, 0}";
 }
 );
@@ -2560,7 +3377,7 @@ components = (
 name = G;
 },
 {
-name = acute.cap;
+name = acute.case;
 transform = "{1, 0, 0, 1, 240, 0}";
 }
 );
@@ -2574,7 +3391,7 @@ unicode = 01F4;
 },
 {
 glyphname = Gbreve;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:15 +0000";
 layers = (
 {
 components = (
@@ -2582,7 +3399,7 @@ components = (
 name = G;
 },
 {
-name = breve.cap;
+name = breve.case;
 transform = "{1, 0, 0, 1, 207, 0}";
 }
 );
@@ -2595,7 +3412,7 @@ components = (
 name = G;
 },
 {
-name = breve.cap;
+name = breve.case;
 transform = "{1, 0, 0, 1, 172, 0}";
 }
 );
@@ -2609,7 +3426,7 @@ unicode = 011E;
 },
 {
 glyphname = Gcircumflex;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:15 +0000";
 layers = (
 {
 components = (
@@ -2617,7 +3434,7 @@ components = (
 name = G;
 },
 {
-name = circumflex.cap;
+name = circumflex.case;
 transform = "{1, 0, 0, 1, 214, 0}";
 }
 );
@@ -2630,7 +3447,7 @@ components = (
 name = G;
 },
 {
-name = circumflex.cap;
+name = circumflex.case;
 transform = "{1, 0, 0, 1, 183, 1}";
 }
 );
@@ -2644,7 +3461,7 @@ unicode = 011C;
 },
 {
 glyphname = Gcommaaccent;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 components = (
@@ -2652,7 +3469,7 @@ components = (
 name = G;
 },
 {
-name = commaaccent;
+name = commaaccentcomb;
 transform = "{1, 0, 0, 1, 330, 0}";
 }
 );
@@ -2665,7 +3482,7 @@ components = (
 name = G;
 },
 {
-name = commaaccent;
+name = commaaccentcomb;
 transform = "{1, 0, 0, 1, 316, 0}";
 }
 );
@@ -2679,7 +3496,7 @@ unicode = 0122;
 },
 {
 glyphname = Gdotaccent;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:15 +0000";
 layers = (
 {
 components = (
@@ -2687,7 +3504,7 @@ components = (
 name = G;
 },
 {
-name = dotaccent.cap;
+name = dotaccent.case;
 transform = "{1, 0, 0, 1, 312, 0}";
 }
 );
@@ -2700,7 +3517,7 @@ components = (
 name = G;
 },
 {
-name = dotaccent.cap;
+name = dotaccent.case;
 transform = "{1, 0, 0, 1, 266, 0}";
 }
 );
@@ -2714,141 +3531,177 @@ unicode = 0120;
 },
 {
 glyphname = H;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:59 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{342, 0}";
+},
+{
+name = center;
+position = "{429, 377}";
+},
+{
+name = top;
+position = "{516, 754}";
+},
+{
+name = topleft;
+position = "{142, 754}";
+}
+);
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
 paths = (
 {
 closed = 1;
 nodes = (
-"152 729 LINE",
-"441 729 LINE",
-"441 754 LINE",
-"152 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"580 729 LINE",
-"876 729 LINE",
-"876 754 LINE",
-"580 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"192 377 LINE",
-"631 377 LINE",
-"631 405 LINE",
-"192 405 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"-1 0 LINE",
-"288 0 LINE",
-"288 25 LINE",
-"-1 25 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"431 0 LINE",
-"727 0 LINE",
-"727 25 LINE",
-"431 25 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"356 754 LINE",
-"239 754 LINE",
-"75 0 LINE",
-"188 0 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"625 0 LINE",
 "793 754 LINE",
 "676 754 LINE",
-"512 0 LINE",
-"625 0 LINE"
+"512 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"288 0 LINE",
+"288 25 LINE",
+"-1 25 LINE",
+"-1 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"727 0 LINE",
+"727 25 LINE",
+"431 25 LINE",
+"431 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"188 0 LINE",
+"356 754 LINE",
+"239 754 LINE",
+"75 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"631 377 LINE",
+"631 405 LINE",
+"192 405 LINE",
+"192 377 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"441 729 LINE",
+"441 754 LINE",
+"152 754 LINE",
+"152 729 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"876 729 LINE",
+"876 754 LINE",
+"580 754 LINE",
+"580 729 LINE"
 );
 }
 );
 width = 787;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{352, 0}";
+},
+{
+name = center;
+position = "{439, 377}";
+},
+{
+name = top;
+position = "{526, 754}";
+},
+{
+name = topleft;
+position = "{142, 754}";
+}
+);
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
 paths = (
 {
 closed = 1;
 nodes = (
-"389 754 LINE",
-"238 754 LINE",
-"74 0 LINE",
-"221 0 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"138 724 LINE",
-"477 724 LINE",
-"477 754 LINE",
-"138 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"-13 0 LINE",
-"336 0 LINE",
-"336 31 LINE",
-"-13 31 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"630 0 LINE",
 "798 754 LINE",
 "647 754 LINE",
-"483 0 LINE",
-"630 0 LINE"
+"483 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"547 724 LINE",
-"886 724 LINE",
-"886 754 LINE",
-"547 754 LINE"
+"336 0 LINE",
+"336 31 LINE",
+"-13 31 LINE",
+"-13 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"396 0 LINE",
 "745 0 LINE",
 "745 31 LINE",
-"396 31 LINE"
+"396 31 LINE",
+"396 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"269 365 LINE",
+"221 0 LINE",
+"389 754 LINE",
+"238 754 LINE",
+"74 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "608 365 LINE",
 "608 395 LINE",
-"269 395 LINE"
+"269 395 LINE",
+"269 365 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"477 724 LINE",
+"477 754 LINE",
+"138 754 LINE",
+"138 724 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"886 724 LINE",
+"886 754 LINE",
+"547 754 LINE",
+"547 724 LINE"
 );
 }
 );
@@ -2861,7 +3714,7 @@ unicode = 0048;
 },
 {
 glyphname = Hbar;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 components = (
@@ -2874,10 +3727,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"88 548 LINE",
 "857 548 LINE",
 "857 578 LINE",
-"88 578 LINE"
+"88 578 LINE",
+"88 548 LINE"
 );
 }
 );
@@ -2894,10 +3747,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"100 538 LINE",
 "869 538 LINE",
 "869 578 LINE",
-"100 578 LINE"
+"100 578 LINE",
+"100 538 LINE"
 );
 }
 );
@@ -2908,7 +3761,7 @@ unicode = 0126;
 },
 {
 glyphname = Hcircumflex;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:15 +0000";
 layers = (
 {
 components = (
@@ -2916,7 +3769,7 @@ components = (
 name = H;
 },
 {
-name = circumflex.cap;
+name = circumflex.case;
 transform = "{1, 0, 0, 1, 221, 0}";
 }
 );
@@ -2929,7 +3782,7 @@ components = (
 name = H;
 },
 {
-name = circumflex.cap;
+name = circumflex.case;
 transform = "{1, 0, 0, 1, 230, 0}";
 }
 );
@@ -2978,69 +3831,105 @@ unicode = 1E24;
 },
 {
 glyphname = I;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:59 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{128, 0}";
+},
+{
+name = ogonek;
+position = "{272, 10}";
+},
+{
+name = top;
+position = "{302, 754}";
+},
+{
+name = topleft;
+position = "{142, 754}";
+}
+);
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
 paths = (
 {
 closed = 1;
 nodes = (
+"193 0 LINE",
 "361 754 LINE",
 "244 754 LINE",
-"80 0 LINE",
-"193 0 LINE"
+"80 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"145 729 LINE",
-"444 729 LINE",
-"444 754 LINE",
-"145 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"-6 0 LINE",
 "303 0 LINE",
 "303 25 LINE",
-"-6 25 LINE"
+"-6 25 LINE",
+"-6 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"444 729 LINE",
+"444 754 LINE",
+"145 754 LINE",
+"145 729 LINE"
 );
 }
 );
 width = 360;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{143, 0}";
+},
+{
+name = ogonek;
+position = "{299, 10}";
+},
+{
+name = top;
+position = "{317, 754}";
+},
+{
+name = topleft;
+position = "{142, 754}";
+}
+);
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
 paths = (
 {
 closed = 1;
 nodes = (
+"207 0 LINE",
 "375 754 LINE",
 "224 754 LINE",
-"60 0 LINE",
-"207 0 LINE"
+"60 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"144 724 LINE",
-"443 724 LINE",
-"443 754 LINE",
-"144 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"-7 0 LINE",
 "302 0 LINE",
 "302 31 LINE",
-"-7 31 LINE"
+"-7 31 LINE",
+"-7 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"443 724 LINE",
+"443 754 LINE",
+"144 754 LINE",
+"144 724 LINE"
 );
 }
 );
@@ -3088,7 +3977,7 @@ unicode = 0132;
 },
 {
 glyphname = Iacute;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:05:38 +0000";
 layers = (
 {
 components = (
@@ -3096,8 +3985,8 @@ components = (
 name = I;
 },
 {
-name = acute.cap;
-transform = "{1, 0, 0, 1, 19, 0}";
+name = acutecomb;
+transform = "{1, 0, 0, 1, -57, 304}";
 }
 );
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -3109,8 +3998,8 @@ components = (
 name = I;
 },
 {
-name = acute.cap;
-transform = "{1, 0, 0, 1, 20, 0}";
+name = acutecomb;
+transform = "{1, 0, 0, 1, -88, 304}";
 }
 );
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
@@ -3123,7 +4012,7 @@ unicode = 00CD;
 },
 {
 glyphname = Ibreve;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:15 +0000";
 layers = (
 {
 components = (
@@ -3131,7 +4020,7 @@ components = (
 name = I;
 },
 {
-name = breve.cap;
+name = breve.case;
 transform = "{1, 0, 0, 1, 8, 0}";
 }
 );
@@ -3144,7 +4033,7 @@ components = (
 name = I;
 },
 {
-name = breve.cap;
+name = breve.case;
 transform = "{1, 0, 0, 1, -6, 0}";
 }
 );
@@ -3158,7 +4047,7 @@ unicode = 012C;
 },
 {
 glyphname = Icircumflex;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:15 +0000";
 layers = (
 {
 components = (
@@ -3166,7 +4055,7 @@ components = (
 name = I;
 },
 {
-name = circumflex.cap;
+name = circumflex.case;
 transform = "{1, 0, 0, 1, 9, 0}";
 }
 );
@@ -3179,7 +4068,7 @@ components = (
 name = I;
 },
 {
-name = circumflex.cap;
+name = circumflex.case;
 transform = "{1, 0, 0, 1, 8, 0}";
 }
 );
@@ -3193,7 +4082,7 @@ unicode = 00CE;
 },
 {
 glyphname = Idblgrave;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 components = (
@@ -3201,7 +4090,7 @@ components = (
 name = I;
 },
 {
-name = uni030F.cap;
+name = dblgravecomb.cap;
 transform = "{1, 0, 0, 1, -108, 0}";
 }
 );
@@ -3214,7 +4103,7 @@ components = (
 name = I;
 },
 {
-name = uni030F.cap;
+name = dblgravecomb.cap;
 transform = "{1, 0, 0, 1, -119, 0}";
 }
 );
@@ -3228,7 +4117,7 @@ unicode = 0208;
 },
 {
 glyphname = Idieresis;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:15 +0000";
 layers = (
 {
 components = (
@@ -3236,7 +4125,7 @@ components = (
 name = I;
 },
 {
-name = dieresis.cap;
+name = dieresis.case;
 transform = "{1, 0, 0, 1, 12, 0}";
 }
 );
@@ -3249,7 +4138,7 @@ components = (
 name = I;
 },
 {
-name = dieresis.cap;
+name = dieresis.case;
 transform = "{1, 0, 0, 1, 14, 0}";
 }
 );
@@ -3263,7 +4152,7 @@ unicode = 00CF;
 },
 {
 glyphname = Idotaccent;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:15 +0000";
 layers = (
 {
 components = (
@@ -3271,7 +4160,7 @@ components = (
 name = I;
 },
 {
-name = dotaccent.cap;
+name = dotaccent.case;
 transform = "{1, 0, 0, 1, 88, 0}";
 }
 );
@@ -3284,7 +4173,7 @@ components = (
 name = I;
 },
 {
-name = dotaccent.cap;
+name = dotaccent.case;
 transform = "{1, 0, 0, 1, 70, 0}";
 }
 );
@@ -3298,7 +4187,7 @@ unicode = 0130;
 },
 {
 glyphname = Idotbelow;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:06:03 +0000";
 layers = (
 {
 components = (
@@ -3306,8 +4195,8 @@ components = (
 name = I;
 },
 {
-name = dotbelow;
-transform = "{1, 0, 0, 1, 99, 0}";
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -113, 0}";
 }
 );
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -3319,8 +4208,8 @@ components = (
 name = I;
 },
 {
-name = dotbelow;
-transform = "{1, 0, 0, 1, 109, 0}";
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -107, 0}";
 }
 );
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
@@ -3333,7 +4222,7 @@ unicode = 1ECA;
 },
 {
 glyphname = Igrave;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:05:38 +0000";
 layers = (
 {
 components = (
@@ -3341,8 +4230,8 @@ components = (
 name = I;
 },
 {
-name = grave.cap;
-transform = "{1, 0, 0, 1, 20, 0}";
+name = gravecomb;
+transform = "{1, 0, 0, 1, -46, 304}";
 }
 );
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -3354,8 +4243,8 @@ components = (
 name = I;
 },
 {
-name = grave.cap;
-transform = "{1, 0, 0, 1, 21, 0}";
+name = gravecomb;
+transform = "{1, 0, 0, 1, 1, 304}";
 }
 );
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
@@ -3367,8 +4256,8 @@ rightKerningGroup = I;
 unicode = 00CC;
 },
 {
-glyphname = Iinvertedbreve;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = Ihookabove;
+lastChange = "2016-08-22 14:17:04 +0000";
 layers = (
 {
 components = (
@@ -3376,7 +4265,42 @@ components = (
 name = I;
 },
 {
-name = uni0311.cap;
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, -21, 304}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 360;
+},
+{
+components = (
+{
+name = I;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, -15, 304}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 390;
+}
+);
+leftKerningGroup = I;
+rightKerningGroup = I;
+unicode = 1EC8;
+},
+{
+glyphname = Iinvertedbreve;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+components = (
+{
+name = I;
+},
+{
+name = breveinvertedcomb.cap;
 transform = "{1, 0, 0, 1, 12, 0}";
 }
 );
@@ -3389,7 +4313,7 @@ components = (
 name = I;
 },
 {
-name = uni0311.cap;
+name = breveinvertedcomb.cap;
 transform = "{1, 0, 0, 1, -9, 0}";
 }
 );
@@ -3403,7 +4327,7 @@ unicode = 020A;
 },
 {
 glyphname = Imacron;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:15 +0000";
 layers = (
 {
 components = (
@@ -3411,7 +4335,7 @@ components = (
 name = I;
 },
 {
-name = macron.cap;
+name = macron.case;
 transform = "{1, 0, 0, 1, 4, 0}";
 }
 );
@@ -3424,7 +4348,7 @@ components = (
 name = I;
 },
 {
-name = macron.cap;
+name = macron.case;
 transform = "{1, 0, 0, 1, 4, 0}";
 }
 );
@@ -3473,7 +4397,7 @@ unicode = 012E;
 },
 {
 glyphname = Itilde;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:05:38 +0000";
 layers = (
 {
 components = (
@@ -3481,8 +4405,8 @@ components = (
 name = I;
 },
 {
-name = tilde.cap;
-transform = "{1, 0, 0, 1, -12, 0}";
+name = tildecomb;
+transform = "{1, 0, 0, 1, -57, 304}";
 }
 );
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -3494,8 +4418,8 @@ components = (
 name = I;
 },
 {
-name = tilde.cap;
-transform = "{1, 0, 0, 1, -11, 0}";
+name = tildecomb;
+transform = "{1, 0, 0, 1, -48, 304}";
 }
 );
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
@@ -3508,14 +4432,27 @@ unicode = 0128;
 },
 {
 glyphname = J;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:59 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{132, 0}";
+},
+{
+name = top;
+position = "{306, 754}";
+}
+);
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
 paths = (
 {
 closed = 1;
 nodes = (
+"131 -101 OFFCURVE",
+"211 -36 OFFCURVE",
+"253 152 CURVE SMOOTH",
 "387 754 LINE",
 "270 754 LINE",
 "121 71 LINE SMOOTH",
@@ -3536,30 +4473,40 @@ nodes = (
 "-92 -8 CURVE SMOOTH",
 "-92 -60 OFFCURVE",
 "-50 -101 OFFCURVE",
-"30 -101 CURVE SMOOTH",
-"131 -101 OFFCURVE",
-"211 -36 OFFCURVE",
-"253 152 CURVE SMOOTH"
+"30 -101 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"181 729 LINE",
 "470 729 LINE",
 "470 754 LINE",
-"181 754 LINE"
+"181 754 LINE",
+"181 729 LINE"
 );
 }
 );
 width = 368;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{168, 0}";
+},
+{
+name = top;
+position = "{342, 754}";
+}
+);
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
 paths = (
 {
 closed = 1;
 nodes = (
+"141 -119 OFFCURVE",
+"257 -46 OFFCURVE",
+"296 142 CURVE SMOOTH",
 "423 754 LINE",
 "272 754 LINE",
 "114 34 LINE SMOOTH",
@@ -3580,19 +4527,16 @@ nodes = (
 "-101 -3 CURVE SMOOTH",
 "-101 -61 OFFCURVE",
 "-49 -119 OFFCURVE",
-"41 -119 CURVE SMOOTH",
-"141 -119 OFFCURVE",
-"257 -46 OFFCURVE",
-"296 142 CURVE SMOOTH"
+"41 -119 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"162 724 LINE",
 "491 724 LINE",
 "491 754 LINE",
-"162 754 LINE"
+"162 754 LINE",
+"162 724 LINE"
 );
 }
 );
@@ -3605,7 +4549,7 @@ unicode = 004A;
 },
 {
 glyphname = Jcircumflex;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:15 +0000";
 layers = (
 {
 components = (
@@ -3613,7 +4557,7 @@ components = (
 name = J;
 },
 {
-name = circumflex.cap;
+name = circumflex.case;
 transform = "{1, 0, 0, 1, 26, 0}";
 }
 );
@@ -3626,7 +4570,7 @@ components = (
 name = J;
 },
 {
-name = circumflex.cap;
+name = circumflex.case;
 transform = "{1, 0, 0, 1, 22, 0}";
 }
 );
@@ -3640,141 +4584,161 @@ unicode = 0134;
 },
 {
 glyphname = K;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:59 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{311, 0}";
+},
+{
+name = top;
+position = "{485, 754}";
+}
+);
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
 paths = (
 {
 closed = 1;
 nodes = (
+"214 0 LINE",
 "382 754 LINE",
 "265 754 LINE",
-"101 0 LINE",
-"214 0 LINE"
+"101 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"156 729 LINE",
-"475 729 LINE",
-"475 754 LINE",
-"156 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"15 0 LINE",
 "324 0 LINE",
 "324 25 LINE",
-"15 25 LINE"
+"15 25 LINE",
+"15 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"418 0 LINE",
 "764 0 LINE",
 "764 25 LINE",
-"418 25 LINE"
+"418 25 LINE",
+"418 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
+"673 9 LINE",
 "421 461 LINE",
 "322 395 LINE",
-"541 9 LINE",
-"673 9 LINE"
+"541 9 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"322 395 LINE",
+"475 729 LINE",
+"475 754 LINE",
+"156 754 LINE",
+"156 729 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "365 395 LINE",
 "730 734 LINE",
-"687 734 LINE"
+"687 734 LINE",
+"322 395 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"568 729 LINE",
 "833 729 LINE",
 "833 754 LINE",
-"568 754 LINE"
+"568 754 LINE",
+"568 729 LINE"
 );
 }
 );
 width = 726;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{317, 0}";
+},
+{
+name = top;
+position = "{491, 754}";
+}
+);
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
 paths = (
 {
 closed = 1;
 nodes = (
+"221 0 LINE",
 "389 754 LINE",
 "238 754 LINE",
-"74 0 LINE",
-"221 0 LINE"
+"74 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"158 724 LINE",
-"457 724 LINE",
-"457 754 LINE",
-"158 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"7 0 LINE",
 "316 0 LINE",
 "316 31 LINE",
-"7 31 LINE"
+"7 31 LINE",
+"7 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"394 0 LINE",
 "750 0 LINE",
 "750 30 LINE",
-"394 30 LINE"
+"394 30 LINE",
+"394 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
+"674 9 LINE",
 "457 472 LINE",
 "328 395 LINE",
-"497 9 LINE",
-"674 9 LINE"
+"497 9 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"328 395 LINE",
+"457 724 LINE",
+"457 754 LINE",
+"158 754 LINE",
+"158 724 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "380 395 LINE",
 "765 734 LINE",
-"713 734 LINE"
+"713 734 LINE",
+"328 395 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"551 724 LINE",
 "816 724 LINE",
 "816 754 LINE",
-"551 754 LINE"
+"551 754 LINE",
+"551 724 LINE"
 );
 }
 );
@@ -3787,7 +4751,7 @@ unicode = 004B;
 },
 {
 glyphname = Kcommaaccent;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 components = (
@@ -3795,7 +4759,7 @@ components = (
 name = K;
 },
 {
-name = commaaccent;
+name = commaaccentcomb;
 transform = "{1, 0, 0, 1, 315, 0}";
 }
 );
@@ -3808,7 +4772,7 @@ components = (
 name = K;
 },
 {
-name = commaaccent;
+name = commaaccentcomb;
 transform = "{1, 0, 0, 1, 297, 0}";
 }
 );
@@ -3822,77 +4786,113 @@ unicode = 0136;
 },
 {
 glyphname = L;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:59 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{247, 0}";
+},
+{
+name = center;
+position = "{334, 377}";
+},
+{
+name = top;
+position = "{421, 754}";
+},
+{
+name = topright;
+position = "{700, 754}";
+}
+);
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
 paths = (
 {
 closed = 1;
 nodes = (
+"167 0 LINE",
 "335 754 LINE",
 "218 754 LINE",
-"54 0 LINE",
-"167 0 LINE"
+"54 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"129 729 LINE",
-"418 729 LINE",
-"418 754 LINE",
-"129 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"-22 0 LINE",
 "536 0 LINE",
 "596 232 LINE",
 "566 232 LINE",
 "490 64 OFFCURVE",
 "428 25 OFFCURVE",
 "339 25 CURVE SMOOTH",
-"-22 25 LINE"
+"-22 25 LINE",
+"-22 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"418 729 LINE",
+"418 754 LINE",
+"129 754 LINE",
+"129 729 LINE"
 );
 }
 );
 width = 598;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{261, 0}";
+},
+{
+name = center;
+position = "{348, 377}";
+},
+{
+name = top;
+position = "{435, 754}";
+},
+{
+name = topright;
+position = "{728, 754}";
+}
+);
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
 paths = (
 {
 closed = 1;
 nodes = (
+"210 0 LINE",
 "378 754 LINE",
 "227 754 LINE",
-"63 0 LINE",
-"210 0 LINE"
+"63 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"-29 0 LINE",
 "561 0 LINE",
 "621 232 LINE",
 "581 232 LINE",
 "505 78 OFFCURVE",
 "423 30 OFFCURVE",
 "344 30 CURVE SMOOTH",
-"-29 30 LINE"
+"-29 30 LINE",
+"-29 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"107 724 LINE",
 "486 724 LINE",
 "486 754 LINE",
-"107 754 LINE"
+"107 754 LINE",
+"107 724 LINE"
 );
 }
 );
@@ -3904,8 +4904,8 @@ rightKerningGroup = L;
 unicode = 004C;
 },
 {
-glyphname = Lacute;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = LJ;
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 components = (
@@ -3913,7 +4913,42 @@ components = (
 name = L;
 },
 {
-name = acute.cap;
+name = J;
+transform = "{1, 0, 0, 1, 598, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 966;
+},
+{
+components = (
+{
+name = L;
+},
+{
+name = J;
+transform = "{1, 0, 0, 1, 626, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 1066;
+}
+);
+leftKerningGroup = L;
+rightKerningGroup = J;
+unicode = 01C7;
+},
+{
+glyphname = Lacute;
+lastChange = "2016-08-22 13:41:15 +0000";
+layers = (
+{
+components = (
+{
+name = L;
+},
+{
+name = acute.case;
 transform = "{1, 0, 0, 1, 110, 0}";
 }
 );
@@ -3926,7 +4961,7 @@ components = (
 name = L;
 },
 {
-name = acute.cap;
+name = acute.case;
 transform = "{1, 0, 0, 1, 122, 0}";
 }
 );
@@ -3974,7 +5009,7 @@ unicode = 013D;
 },
 {
 glyphname = Lcommaaccent;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 components = (
@@ -3982,7 +5017,7 @@ components = (
 name = L;
 },
 {
-name = commaaccent;
+name = commaaccentcomb;
 transform = "{1, 0, 0, 1, 209, 0}";
 }
 );
@@ -3995,7 +5030,7 @@ components = (
 name = L;
 },
 {
-name = commaaccent;
+name = commaaccentcomb;
 transform = "{1, 0, 0, 1, 255, 0}";
 }
 );
@@ -4042,8 +5077,43 @@ leftKerningGroup = L;
 unicode = 013F;
 },
 {
+glyphname = Lj;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+components = (
+{
+name = L;
+},
+{
+name = j;
+transform = "{1, 0, 0, 1, 598, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 889;
+},
+{
+components = (
+{
+name = L;
+},
+{
+name = j;
+transform = "{1, 0, 0, 1, 626, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 913;
+}
+);
+leftKerningGroup = L;
+rightKerningGroup = j;
+unicode = 01C8;
+},
+{
 glyphname = Lslash;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 components = (
@@ -4056,10 +5126,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"12 237 LINE",
 "399 463 LINE",
 "399 503 LINE",
-"12 277 LINE"
+"12 277 LINE",
+"12 237 LINE"
 );
 }
 );
@@ -4076,10 +5146,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"18 227 LINE",
 "452 453 LINE",
 "463 503 LINE",
-"29 277 LINE"
+"29 277 LINE",
+"18 227 LINE"
 );
 }
 );
@@ -4090,169 +5160,187 @@ unicode = 0141;
 },
 {
 glyphname = M;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:59 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{388, 0}";
+},
+{
+name = top;
+position = "{562, 754}";
+}
+);
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
 paths = (
 {
 closed = 1;
 nodes = (
-"876 754 LINE",
+"798 754 LINE",
 "759 754 LINE",
-"595 0 LINE",
-"708 0 LINE"
+"458 227 LINE",
+"368 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"166 729 LINE",
-"408 729 LINE",
-"408 754 LINE",
-"166 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"509 0 LINE",
-"825 0 LINE",
-"825 25 LINE",
-"509 25 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"14 0 LINE",
 "236 0 LINE",
 "236 25 LINE",
-"14 25 LINE"
+"14 25 LINE",
+"14 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
+"131 0 LINE",
 "295 754 LINE",
 "265 754 LINE",
-"101 0 LINE",
-"131 0 LINE"
+"101 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
+"825 0 LINE",
+"825 25 LINE",
+"509 25 LINE",
+"509 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"368 0 LINE",
+"458 227 LINE",
+"454 227 LINE",
 "408 754 LINE",
 "284 754 LINE",
 "284 705 LINE",
 "288 705 LINE",
-"347 0 LINE",
-"368 0 LINE",
-"458 227 LINE",
-"454 227 LINE"
+"347 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"458 227 LINE",
-"368 0 LINE",
-"798 754 LINE",
-"759 754 LINE"
+"408 729 LINE",
+"408 754 LINE",
+"166 754 LINE",
+"166 729 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"759 729 LINE",
+"708 0 LINE",
+"876 754 LINE",
+"759 754 LINE",
+"595 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "975 729 LINE",
 "975 754 LINE",
-"759 754 LINE"
+"759 754 LINE",
+"759 729 LINE"
 );
 }
 );
 width = 879;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{402, 0}";
+},
+{
+name = top;
+position = "{576, 754}";
+}
+);
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
 paths = (
 {
 closed = 1;
 nodes = (
-"907 754 LINE",
-"756 754 LINE",
-"592 0 LINE",
-"739 0 LINE"
+"796 754 LINE",
+"747 754 LINE",
+"480 272 LINE",
+"366 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"786 724 LINE",
-"995 724 LINE",
-"995 754 LINE",
-"786 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"505 0 LINE",
-"854 0 LINE",
-"854 31 LINE",
-"505 31 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"164 724 LINE",
-"420 724 LINE",
-"420 754 LINE",
-"164 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"12 0 LINE",
 "234 0 LINE",
 "234 30 LINE",
-"12 30 LINE"
+"12 30 LINE",
+"12 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
+"129 0 LINE",
 "293 754 LINE",
 "253 754 LINE",
-"89 0 LINE",
-"129 0 LINE"
+"89 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
+"854 0 LINE",
+"854 31 LINE",
+"505 31 LINE",
+"505 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"366 0 LINE",
+"480 272 LINE",
+"476 272 LINE",
 "420 754 LINE",
 "282 754 LINE",
 "265 626 LINE",
 "269 626 LINE",
-"345 0 LINE",
-"366 0 LINE",
-"480 272 LINE",
-"476 272 LINE"
+"345 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"480 272 LINE",
-"366 0 LINE",
-"723 626 LINE",
-"729 626 LINE",
-"796 754 LINE",
-"747 754 LINE"
+"420 724 LINE",
+"420 754 LINE",
+"164 754 LINE",
+"164 724 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"739 0 LINE",
+"907 754 LINE",
+"756 754 LINE",
+"592 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"995 724 LINE",
+"995 754 LINE",
+"786 754 LINE",
+"786 724 LINE"
 );
 }
 );
@@ -4263,132 +5351,151 @@ unicode = 004D;
 },
 {
 glyphname = N;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:59 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{333, 0}";
+},
+{
+name = top;
+position = "{507, 754}";
+}
+);
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
 paths = (
 {
 closed = 1;
 nodes = (
-"147 729 LINE",
-"399 729 LINE",
-"399 754 LINE",
-"147 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"-5 0 LINE",
-"237 0 LINE",
-"237 25 LINE",
-"-5 25 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"286 754 LINE",
-"256 754 LINE",
-"92 0 LINE",
-"122 0 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"580 -13 LINE",
+"613 228 LINE",
+"609 228 LINE",
 "399 754 LINE",
 "275 754 LINE",
 "275 705 LINE",
 "279 705 LINE",
-"560 -13 LINE",
-"580 -13 LINE",
-"613 228 LINE",
-"609 228 LINE"
+"560 -13 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"854 754 LINE",
-"612 754 LINE",
-"612 729 LINE",
-"854 729 LINE"
+"237 0 LINE",
+"237 25 LINE",
+"-5 25 LINE",
+"-5 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"560 -13 LINE",
+"122 0 LINE",
+"286 754 LINE",
+"256 754 LINE",
+"92 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"399 729 LINE",
+"399 754 LINE",
+"147 754 LINE",
+"147 729 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "590 -13 LINE",
 "757 754 LINE",
-"727 754 LINE"
+"727 754 LINE",
+"560 -13 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"854 729 LINE",
+"854 754 LINE",
+"612 754 LINE",
+"612 729 LINE"
 );
 }
 );
 width = 769;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{323, 0}";
+},
+{
+name = top;
+position = "{497, 754}";
+}
+);
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
 paths = (
 {
 closed = 1;
 nodes = (
-"127 724 LINE",
-"384 724 LINE",
-"384 754 LINE",
-"127 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"-15 0 LINE",
-"222 0 LINE",
-"222 30 LINE",
-"-15 30 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"276 754 LINE",
-"236 754 LINE",
-"72 0 LINE",
-"112 0 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"612 724 LINE",
-"830 724 LINE",
-"830 754 LINE",
-"612 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"753 754 LINE",
-"713 754 LINE",
-"549 0 LINE",
-"564 -13 LINE",
-"586 -13 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"575 -13 LINE",
+"619 267 LINE",
+"615 267 LINE",
 "384 754 LINE",
 "270 754 LINE",
 "251 637 LINE",
 "255 637 LINE",
-"555 -13 LINE",
-"575 -13 LINE",
-"611 285 LINE",
-"607 285 LINE"
+"555 -13 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"222 0 LINE",
+"222 30 LINE",
+"-15 30 LINE",
+"-15 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"112 0 LINE",
+"276 754 LINE",
+"236 754 LINE",
+"72 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"384 724 LINE",
+"384 754 LINE",
+"127 754 LINE",
+"127 724 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"586 -13 LINE",
+"753 754 LINE",
+"713 754 LINE",
+"564 -13 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"830 724 LINE",
+"830 754 LINE",
+"612 754 LINE",
+"612 724 LINE"
 );
 }
 );
@@ -4400,8 +5507,8 @@ rightKerningGroup = N;
 unicode = 004E;
 },
 {
-glyphname = Nacute;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = NJ;
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 components = (
@@ -4409,7 +5516,42 @@ components = (
 name = N;
 },
 {
-name = acute.cap;
+name = J;
+transform = "{1, 0, 0, 1, 769, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 1137;
+},
+{
+components = (
+{
+name = N;
+},
+{
+name = J;
+transform = "{1, 0, 0, 1, 749, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 1189;
+}
+);
+leftKerningGroup = N;
+rightKerningGroup = J;
+unicode = 01CA;
+},
+{
+glyphname = Nacute;
+lastChange = "2016-08-22 13:41:15 +0000";
+layers = (
+{
+components = (
+{
+name = N;
+},
+{
+name = acute.case;
 transform = "{1, 0, 0, 1, 238, 0}";
 }
 );
@@ -4422,7 +5564,7 @@ components = (
 name = N;
 },
 {
-name = acute.cap;
+name = acute.case;
 transform = "{1, 0, 0, 1, 207, 0}";
 }
 );
@@ -4436,7 +5578,7 @@ unicode = 0143;
 },
 {
 glyphname = Ncaron;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:15 +0000";
 layers = (
 {
 components = (
@@ -4444,7 +5586,7 @@ components = (
 name = N;
 },
 {
-name = caron.cap;
+name = caron.case;
 transform = "{1, 0, 0, 1, 193, 0}";
 }
 );
@@ -4457,7 +5599,7 @@ components = (
 name = N;
 },
 {
-name = caron.cap;
+name = caron.case;
 transform = "{1, 0, 0, 1, 195, 0}";
 }
 );
@@ -4471,7 +5613,7 @@ unicode = 0147;
 },
 {
 glyphname = Ncommaaccent;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 components = (
@@ -4479,7 +5621,7 @@ components = (
 name = N;
 },
 {
-name = commaaccent;
+name = commaaccentcomb;
 transform = "{1, 0, 0, 1, 312, 0}";
 }
 );
@@ -4492,7 +5634,7 @@ components = (
 name = N;
 },
 {
-name = commaaccent;
+name = commaaccentcomb;
 transform = "{1, 0, 0, 1, 299, 0}";
 }
 );
@@ -4506,7 +5648,7 @@ unicode = 0145;
 },
 {
 glyphname = Ndotaccent;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:15 +0000";
 layers = (
 {
 components = (
@@ -4514,7 +5656,7 @@ components = (
 name = N;
 },
 {
-name = dotaccent.cap;
+name = dotaccent.case;
 transform = "{1, 0, 0, 1, 294, 0}";
 }
 );
@@ -4527,7 +5669,7 @@ components = (
 name = N;
 },
 {
-name = dotaccent.cap;
+name = dotaccent.case;
 transform = "{1, 0, 0, 1, 271, 0}";
 }
 );
@@ -4541,7 +5683,7 @@ unicode = 1E44;
 },
 {
 glyphname = Eng;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -4549,6 +5691,9 @@ paths = (
 {
 closed = 1;
 nodes = (
+"537 -158 OFFCURVE",
+"572 -81 OFFCURVE",
+"598 35 CURVE SMOOTH",
 "753 737 LINE",
 "723 737 LINE",
 "567 19 LINE SMOOTH",
@@ -4569,59 +5714,56 @@ nodes = (
 "352 -64 CURVE SMOOTH",
 "352 -118 OFFCURVE",
 "397 -158 OFFCURVE",
-"456 -158 CURVE SMOOTH",
-"537 -158 OFFCURVE",
-"572 -81 OFFCURVE",
-"598 35 CURVE SMOOTH"
+"456 -158 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"147 729 LINE",
-"399 729 LINE",
-"399 754 LINE",
-"147 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"-5 0 LINE",
 "237 0 LINE",
 "237 25 LINE",
-"-5 25 LINE"
+"-5 25 LINE",
+"-5 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
+"122 0 LINE",
 "286 754 LINE",
 "256 754 LINE",
-"92 0 LINE",
-"122 0 LINE"
+"92 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
+"593 47 LINE",
+"625 286 LINE",
+"621 286 LINE",
 "399 754 LINE",
 "275 754 LINE",
 "275 705 LINE",
 "279 705 LINE",
-"573 47 LINE",
-"593 47 LINE",
-"625 286 LINE",
-"621 286 LINE"
+"573 47 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
+"399 729 LINE",
+"399 754 LINE",
+"147 754 LINE",
+"147 729 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"854 729 LINE",
 "854 754 LINE",
 "612 754 LINE",
-"612 729 LINE",
-"854 729 LINE"
+"612 729 LINE"
 );
 }
 );
@@ -4633,55 +5775,9 @@ paths = (
 {
 closed = 1;
 nodes = (
-"127 724 LINE",
-"384 724 LINE",
-"384 754 LINE",
-"127 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"-15 0 LINE",
-"222 0 LINE",
-"222 30 LINE",
-"-15 30 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"276 754 LINE",
-"236 754 LINE",
-"72 0 LINE",
-"112 0 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"612 724 LINE",
-"830 724 LINE",
-"830 754 LINE",
-"612 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"384 754 LINE",
-"270 754 LINE",
-"251 637 LINE",
-"255 637 LINE",
-"567 39 LINE",
-"587 39 LINE",
-"623 337 LINE",
-"619 337 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"532 -157 OFFCURVE",
+"573 -81 OFFCURVE",
+"594 16 CURVE SMOOTH",
 "751 737 LINE",
 "711 737 LINE",
 "548 -4 LINE SMOOTH",
@@ -4702,10 +5798,56 @@ nodes = (
 "333 -41 CURVE SMOOTH",
 "333 -95 OFFCURVE",
 "378 -157 OFFCURVE",
-"451 -157 CURVE SMOOTH",
-"532 -157 OFFCURVE",
-"573 -81 OFFCURVE",
-"594 16 CURVE SMOOTH"
+"451 -157 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"222 0 LINE",
+"222 30 LINE",
+"-15 30 LINE",
+"-15 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"112 0 LINE",
+"276 754 LINE",
+"236 754 LINE",
+"72 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"587 39 LINE",
+"623 337 LINE",
+"619 337 LINE",
+"384 754 LINE",
+"270 754 LINE",
+"251 637 LINE",
+"255 637 LINE",
+"567 39 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"384 724 LINE",
+"384 754 LINE",
+"127 754 LINE",
+"127 724 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"830 724 LINE",
+"830 754 LINE",
+"612 754 LINE",
+"612 724 LINE"
 );
 }
 );
@@ -4716,8 +5858,8 @@ leftKerningGroup = N;
 unicode = 014A;
 },
 {
-glyphname = Ntilde;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = Nj;
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 components = (
@@ -4725,7 +5867,42 @@ components = (
 name = N;
 },
 {
-name = tilde.cap;
+name = j;
+transform = "{1, 0, 0, 1, 769, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 1060;
+},
+{
+components = (
+{
+name = N;
+},
+{
+name = j;
+transform = "{1, 0, 0, 1, 749, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 1036;
+}
+);
+leftKerningGroup = N;
+rightKerningGroup = j;
+unicode = 01CB;
+},
+{
+glyphname = Ntilde;
+lastChange = "2016-08-22 13:41:15 +0000";
+layers = (
+{
+components = (
+{
+name = N;
+},
+{
+name = tilde.case;
 transform = "{1, 0, 0, 1, 172, 0}";
 }
 );
@@ -4738,7 +5915,7 @@ components = (
 name = N;
 },
 {
-name = tilde.cap;
+name = tilde.case;
 transform = "{1, 0, 0, 1, 182, 0}";
 }
 );
@@ -4752,15 +5929,40 @@ unicode = 00D1;
 },
 {
 glyphname = O;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:09:58 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{333, 0}";
+},
+{
+name = center;
+position = "{420, 377}";
+},
+{
+name = ogonek;
+position = "{640, 10}";
+},
+{
+name = top;
+position = "{533, 754}";
+},
+{
+name = topleft;
+position = "{142, 754}";
+},
+{
+name = topright;
+position = "{666, 703}";
+}
+);
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
 paths = (
 {
 closed = 1;
 nodes = (
-"343 -11 LINE SMOOTH",
 "599 -11 OFFCURVE",
 "781 278 OFFCURVE",
 "781 475 CURVE SMOOTH",
@@ -4778,52 +5980,55 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"520 736 LINE SMOOTH",
-"588 736 OFFCURVE",
-"651 704 OFFCURVE",
-"651 547 CURVE SMOOTH",
-"651 377 OFFCURVE",
-"578 19 OFFCURVE",
-"349 19 CURVE SMOOTH",
 "248 19 OFFCURVE",
 "210 89 OFFCURVE",
 "210 208 CURVE SMOOTH",
 "210 390 OFFCURVE",
 "298 736 OFFCURVE",
-"520 736 CURVE SMOOTH"
+"520 736 CURVE SMOOTH",
+"588 736 OFFCURVE",
+"651 704 OFFCURVE",
+"651 547 CURVE SMOOTH",
+"651 377 OFFCURVE",
+"578 19 OFFCURVE",
+"349 19 CURVE SMOOTH"
 );
 }
 );
 width = 769;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{343, 0}";
+},
+{
+name = center;
+position = "{430, 377}";
+},
+{
+name = ogonek;
+position = "{658, 10}";
+},
+{
+name = top;
+position = "{517, 754}";
+},
+{
+name = topleft;
+position = "{142, 754}";
+},
+{
+name = topright;
+position = "{658, 701}";
+}
+);
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
 paths = (
 {
 closed = 1;
 nodes = (
-"357 21 LINE SMOOTH",
-"278 21 OFFCURVE",
-"246 72 OFFCURVE",
-"239 170 CURVE SMOOTH",
-"238 181 OFFCURVE",
-"238 192 OFFCURVE",
-"238 194 CURVE SMOOTH",
-"238 384 OFFCURVE",
-"298 731 OFFCURVE",
-"503 731 CURVE SMOOTH",
-"613 731 OFFCURVE",
-"624 630 OFFCURVE",
-"624 551 CURVE SMOOTH",
-"624 369 OFFCURVE",
-"565 21 OFFCURVE",
-"357 21 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"363 -11 LINE SMOOTH",
 "589 -11 OFFCURVE",
 "798 227 OFFCURVE",
 "798 454 CURVE SMOOTH",
@@ -4837,6 +6042,23 @@ nodes = (
 "190 -11 OFFCURVE",
 "363 -11 CURVE SMOOTH"
 );
+},
+{
+closed = 1;
+nodes = (
+"270 21 OFFCURVE",
+"238 89 OFFCURVE",
+"238 194 CURVE SMOOTH",
+"238 384 OFFCURVE",
+"298 731 OFFCURVE",
+"503 731 CURVE SMOOTH",
+"613 731 OFFCURVE",
+"624 630 OFFCURVE",
+"624 551 CURVE SMOOTH",
+"624 369 OFFCURVE",
+"565 21 OFFCURVE",
+"357 21 CURVE SMOOTH"
+);
 }
 );
 width = 789;
@@ -4848,7 +6070,7 @@ unicode = 004F;
 },
 {
 glyphname = Oacute;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:10:02 +0000";
 layers = (
 {
 components = (
@@ -4856,8 +6078,8 @@ components = (
 name = O;
 },
 {
-name = acute.cap;
-transform = "{1, 0, 0, 1, 217, 0}";
+name = acutecomb;
+transform = "{1, 0, 0, 1, 174, 304}";
 }
 );
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -4869,8 +6091,8 @@ components = (
 name = O;
 },
 {
-name = acute.cap;
-transform = "{1, 0, 0, 1, 238, 0}";
+name = acutecomb;
+transform = "{1, 0, 0, 1, 112, 304}";
 }
 );
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
@@ -4883,7 +6105,7 @@ unicode = 00D3;
 },
 {
 glyphname = Obreve;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:15 +0000";
 layers = (
 {
 components = (
@@ -4891,7 +6113,7 @@ components = (
 name = O;
 },
 {
-name = breve.cap;
+name = breve.case;
 transform = "{1, 0, 0, 1, 208, 0}";
 }
 );
@@ -4904,7 +6126,7 @@ components = (
 name = O;
 },
 {
-name = breve.cap;
+name = breve.case;
 transform = "{1, 0, 0, 1, 191, 0}";
 }
 );
@@ -4918,7 +6140,7 @@ unicode = 014E;
 },
 {
 glyphname = Ocircumflex;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:10:02 +0000";
 layers = (
 {
 components = (
@@ -4926,8 +6148,8 @@ components = (
 name = O;
 },
 {
-name = circumflex.cap;
-transform = "{1, 0, 0, 1, 218, 0}";
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 161, 304}";
 }
 );
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -4939,8 +6161,8 @@ components = (
 name = O;
 },
 {
-name = circumflex.cap;
-transform = "{1, 0, 0, 1, 202, 0}";
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 172, 304}";
 }
 );
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
@@ -4952,8 +6174,8 @@ rightKerningGroup = O;
 unicode = 00D4;
 },
 {
-glyphname = Odblgrave;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = Ocircumflexacute;
+lastChange = "2016-08-22 14:17:18 +0000";
 layers = (
 {
 components = (
@@ -4961,7 +6183,190 @@ components = (
 name = O;
 },
 {
-name = uni030F.cap;
+name = circumflexcomb_acutecomb;
+transform = "{1, 0, 0, 1, 165, 304}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 769;
+},
+{
+components = (
+{
+name = O;
+},
+{
+name = circumflexcomb_acutecomb;
+transform = "{1, 0, 0, 1, 150, 304}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 789;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 1ED0;
+},
+{
+glyphname = Ocircumflexdotbelow;
+lastChange = "2016-08-22 14:17:18 +0000";
+layers = (
+{
+components = (
+{
+name = O;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 92, 0}";
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 161, 304}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 769;
+},
+{
+components = (
+{
+name = O;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 93, 0}";
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 172, 304}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 789;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 1ED8;
+},
+{
+glyphname = Ocircumflexgrave;
+lastChange = "2016-08-22 14:17:18 +0000";
+layers = (
+{
+components = (
+{
+name = O;
+},
+{
+name = circumflexcomb_gravecomb;
+transform = "{1, 0, 0, 1, 169, 304}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 769;
+},
+{
+components = (
+{
+name = O;
+},
+{
+name = circumflexcomb_gravecomb;
+transform = "{1, 0, 0, 1, 154, 304}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 789;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 1ED2;
+},
+{
+glyphname = Ocircumflexhookabove;
+lastChange = "2016-08-22 14:17:18 +0000";
+layers = (
+{
+components = (
+{
+name = O;
+},
+{
+name = circumflexcomb_hookabovecomb;
+transform = "{1, 0, 0, 1, 163, 304}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 769;
+},
+{
+components = (
+{
+name = O;
+},
+{
+name = circumflexcomb_hookabovecomb;
+transform = "{1, 0, 0, 1, 151, 304}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 789;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 1ED4;
+},
+{
+glyphname = Ocircumflextilde;
+lastChange = "2016-08-22 14:17:18 +0000";
+layers = (
+{
+components = (
+{
+name = O;
+},
+{
+name = circumflexcomb_tildecomb;
+transform = "{1, 0, 0, 1, 165, 304}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 769;
+},
+{
+components = (
+{
+name = O;
+},
+{
+name = circumflexcomb_tildecomb;
+transform = "{1, 0, 0, 1, 148, 304}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 789;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 1ED6;
+},
+{
+glyphname = Odblgrave;
+lastChange = "2016-08-22 14:17:18 +0000";
+layers = (
+{
+components = (
+{
+name = O;
+},
+{
+name = dblgravecomb.cap;
 transform = "{1, 0, 0, 1, 155, 0}";
 }
 );
@@ -4974,7 +6379,7 @@ components = (
 name = O;
 },
 {
-name = uni030F.cap;
+name = dblgravecomb.cap;
 transform = "{1, 0, 0, 1, 107, 0}";
 }
 );
@@ -4988,7 +6393,7 @@ unicode = 020C;
 },
 {
 glyphname = Odieresis;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:17:18 +0000";
 layers = (
 {
 components = (
@@ -4996,7 +6401,7 @@ components = (
 name = O;
 },
 {
-name = dieresis.cap;
+name = dieresis.case;
 transform = "{1, 0, 0, 1, 225, 0}";
 }
 );
@@ -5009,7 +6414,7 @@ components = (
 name = O;
 },
 {
-name = dieresis.cap;
+name = dieresis.case;
 transform = "{1, 0, 0, 1, 224, 0}";
 }
 );
@@ -5023,7 +6428,7 @@ unicode = 00D6;
 },
 {
 glyphname = Odotbelow;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:17:18 +0000";
 layers = (
 {
 components = (
@@ -5031,8 +6436,8 @@ components = (
 name = O;
 },
 {
-name = dotbelow;
-transform = "{1, 0, 0, 1, 300, 0}";
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 92, 0}";
 }
 );
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -5044,8 +6449,8 @@ components = (
 name = O;
 },
 {
-name = dotbelow;
-transform = "{1, 0, 0, 1, 310, 0}";
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 93, 0}";
 }
 );
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
@@ -5058,7 +6463,7 @@ unicode = 1ECC;
 },
 {
 glyphname = Ograve;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:17:18 +0000";
 layers = (
 {
 components = (
@@ -5066,8 +6471,8 @@ components = (
 name = O;
 },
 {
-name = grave.cap;
-transform = "{1, 0, 0, 1, 222, 0}";
+name = gravecomb;
+transform = "{1, 0, 0, 1, 185, 304}";
 }
 );
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -5079,8 +6484,8 @@ components = (
 name = O;
 },
 {
-name = grave.cap;
-transform = "{1, 0, 0, 1, 196, 0}";
+name = gravecomb;
+transform = "{1, 0, 0, 1, 201, 304}";
 }
 );
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
@@ -5092,8 +6497,8 @@ rightKerningGroup = O;
 unicode = 00D2;
 },
 {
-glyphname = Ohungarumlaut;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = Ohookabove;
+lastChange = "2016-08-22 14:17:18 +0000";
 layers = (
 {
 components = (
@@ -5101,7 +6506,252 @@ components = (
 name = O;
 },
 {
-name = hungarumlaut.cap;
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 210, 304}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 769;
+},
+{
+components = (
+{
+name = O;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 185, 304}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 789;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 1ECE;
+},
+{
+glyphname = Ohorn;
+lastChange = "2016-08-22 14:17:18 +0000";
+layers = (
+{
+components = (
+{
+name = O;
+},
+{
+name = horncomb;
+transform = "{1, 0, 0, 1, 361, 253}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 769;
+},
+{
+components = (
+{
+name = O;
+},
+{
+name = horncomb;
+transform = "{1, 0, 0, 1, 345, 251}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 789;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 01A0;
+},
+{
+glyphname = Ohornacute;
+lastChange = "2016-08-22 14:17:18 +0000";
+layers = (
+{
+components = (
+{
+name = Ohorn;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 174, 304}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 769;
+},
+{
+components = (
+{
+name = Ohorn;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 112, 304}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 789;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 1EDA;
+},
+{
+glyphname = Ohorndotbelow;
+lastChange = "2016-08-22 14:17:18 +0000";
+layers = (
+{
+components = (
+{
+name = Ohorn;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 92, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 769;
+},
+{
+components = (
+{
+name = Ohorn;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 93, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 789;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 1EE2;
+},
+{
+glyphname = Ohorngrave;
+lastChange = "2016-08-22 14:17:18 +0000";
+layers = (
+{
+components = (
+{
+name = Ohorn;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 185, 304}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 769;
+},
+{
+components = (
+{
+name = Ohorn;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 201, 304}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 789;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 1EDC;
+},
+{
+glyphname = Ohornhookabove;
+lastChange = "2016-08-22 14:17:18 +0000";
+layers = (
+{
+components = (
+{
+name = Ohorn;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 210, 304}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 769;
+},
+{
+components = (
+{
+name = Ohorn;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 185, 304}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 789;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 1EDE;
+},
+{
+glyphname = Ohorntilde;
+lastChange = "2016-08-22 14:17:18 +0000";
+layers = (
+{
+components = (
+{
+name = Ohorn;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, 174, 304}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 769;
+},
+{
+components = (
+{
+name = Ohorn;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, 152, 304}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 789;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 1EE0;
+},
+{
+glyphname = Ohungarumlaut;
+lastChange = "2016-08-22 14:17:18 +0000";
+layers = (
+{
+components = (
+{
+name = O;
+},
+{
+name = hungarumlaut.case;
 transform = "{1, 0, 0, 1, 181, 0}";
 }
 );
@@ -5114,7 +6764,7 @@ components = (
 name = O;
 },
 {
-name = hungarumlaut.cap;
+name = hungarumlaut.case;
 transform = "{1, 0, 0, 1, 128, 0}";
 }
 );
@@ -5128,7 +6778,7 @@ unicode = 0150;
 },
 {
 glyphname = Oinvertedbreve;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:17:18 +0000";
 layers = (
 {
 components = (
@@ -5136,7 +6786,7 @@ components = (
 name = O;
 },
 {
-name = uni0311.cap;
+name = breveinvertedcomb.cap;
 transform = "{1, 0, 0, 1, 233, 0}";
 }
 );
@@ -5149,7 +6799,7 @@ components = (
 name = O;
 },
 {
-name = uni0311.cap;
+name = breveinvertedcomb.cap;
 transform = "{1, 0, 0, 1, 198, 0}";
 }
 );
@@ -5163,7 +6813,7 @@ unicode = 020E;
 },
 {
 glyphname = Omacron;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:17:18 +0000";
 layers = (
 {
 components = (
@@ -5171,7 +6821,7 @@ components = (
 name = O;
 },
 {
-name = macron.cap;
+name = macron.case;
 transform = "{1, 0, 0, 1, 201, 0}";
 }
 );
@@ -5184,7 +6834,7 @@ components = (
 name = O;
 },
 {
-name = macron.cap;
+name = macron.case;
 transform = "{1, 0, 0, 1, 189, 0}";
 }
 );
@@ -5198,7 +6848,7 @@ unicode = 014C;
 },
 {
 glyphname = Oogonek;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:17:18 +0000";
 layers = (
 {
 components = (
@@ -5233,7 +6883,7 @@ unicode = 01EA;
 },
 {
 glyphname = Oslash;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:17:28 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -5270,33 +6920,28 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"520 736 LINE SMOOTH",
-"571 736 OFFCURVE",
-"620 717 OFFCURVE",
-"640 640 CURVE",
-"214 145 LINE",
-"211 164 OFFCURVE",
-"210 185 OFFCURVE",
-"210 208 CURVE SMOOTH",
-"210 390 OFFCURVE",
-"298 736 OFFCURVE",
-"520 736 CURVE SMOOTH"
+"279 19 OFFCURVE",
+"240 52 OFFCURVE",
+"222 111 CURVE",
+"647 605 LINE",
+"689 367 OFFCURVE",
+"547 19 OFFCURVE",
+"349 19 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"651 547 LINE SMOOTH",
-"651 377 OFFCURVE",
-"578 19 OFFCURVE",
-"349 19 CURVE SMOOTH",
-"279 19 OFFCURVE",
-"240 52 OFFCURVE",
-"222 111 CURVE",
-"647 605 LINE",
-"650 588 OFFCURVE",
-"651 568 OFFCURVE",
-"651 547 CURVE SMOOTH"
+"211 164 OFFCURVE",
+"210 185 OFFCURVE",
+"210 208 CURVE SMOOTH",
+"210 390 OFFCURVE",
+"298 736 OFFCURVE",
+"520 736 CURVE SMOOTH",
+"571 736 OFFCURVE",
+"620 717 OFFCURVE",
+"640 640 CURVE",
+"214 145 LINE"
 );
 }
 );
@@ -5337,9 +6982,20 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"239 170 LINE SMOOTH",
-"238 181 OFFCURVE",
-"238 192 OFFCURVE",
+"297 21 OFFCURVE",
+"264 50 OFFCURVE",
+"249 106 CURVE",
+"624 541 LINE",
+"622 357 OFFCURVE",
+"561 21 OFFCURVE",
+"357 21 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"239 168 OFFCURVE",
+"238 191 OFFCURVE",
 "238 194 CURVE SMOOTH",
 "238 384 OFFCURVE",
 "298 731 OFFCURVE",
@@ -5348,19 +7004,6 @@ nodes = (
 "614 670 OFFCURVE",
 "621 606 CURVE",
 "239 162 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"357 21 LINE SMOOTH",
-"297 21 OFFCURVE",
-"264 50 OFFCURVE",
-"249 106 CURVE",
-"624 541 LINE",
-"622 357 OFFCURVE",
-"561 21 OFFCURVE",
-"357 21 CURVE SMOOTH"
 );
 }
 );
@@ -5371,7 +7014,7 @@ unicode = 00D8;
 },
 {
 glyphname = Oslashacute;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:17:28 +0000";
 layers = (
 {
 components = (
@@ -5379,7 +7022,7 @@ components = (
 name = Oslash;
 },
 {
-name = acute.cap;
+name = acute.case;
 transform = "{1, 0, 0, 1, 301, 0}";
 }
 );
@@ -5392,7 +7035,7 @@ components = (
 name = Oslash;
 },
 {
-name = acute.cap;
+name = acute.case;
 transform = "{1, 0, 0, 1, 236, 0}";
 }
 );
@@ -5404,7 +7047,7 @@ unicode = 01FE;
 },
 {
 glyphname = Otilde;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:10:02 +0000";
 layers = (
 {
 components = (
@@ -5412,8 +7055,8 @@ components = (
 name = O;
 },
 {
-name = tilde.cap;
-transform = "{1, 0, 0, 1, 201, 0}";
+name = tildecomb;
+transform = "{1, 0, 0, 1, 174, 304}";
 }
 );
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -5425,8 +7068,8 @@ components = (
 name = O;
 },
 {
-name = tilde.cap;
-transform = "{1, 0, 0, 1, 187, 0}";
+name = tildecomb;
+transform = "{1, 0, 0, 1, 152, 304}";
 }
 );
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
@@ -5439,7 +7082,7 @@ unicode = 00D5;
 },
 {
 glyphname = OE;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 11:02:24 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -5447,65 +7090,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"811 754 LINE",
-"694 754 LINE",
-"530 0 LINE",
-"643 0 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"503 729 LINE",
-"573 723 LINE",
-"672 631 LINE",
-"729 729 LINE",
-"915 729 LINE SMOOTH",
-"1057 729 OFFCURVE",
-"1086 692 OFFCURVE",
-"1086 553 CURVE",
-"1116 553 LINE",
-"1144 754 LINE",
-"503 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"678 378 LINE",
-"765 378 LINE SMOOTH",
-"848 378 OFFCURVE",
-"863 351 OFFCURVE",
-"863 226 CURVE",
-"893 226 LINE",
-"952 534 LINE",
-"927 534 LINE",
-"896 430 OFFCURVE",
-"861 403 OFFCURVE",
-"781 403 CURVE SMOOTH",
-"678 403 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"344 0 LINE",
-"1024 0 LINE",
-"1084 232 LINE",
-"1054 232 LINE",
-"978 64 OFFCURVE",
-"916 25 OFFCURVE",
-"827 25 CURVE SMOOTH",
-"572 25 LINE",
-"571 124 LINE",
-"471 49 LINE",
-"344 25 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"343 0 LINE SMOOTH",
 "575 0 OFFCURVE",
 "735 279 OFFCURVE",
 "735 472 CURVE SMOOTH",
@@ -5523,19 +7107,74 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"508 727 LINE SMOOTH",
-"572 727 OFFCURVE",
-"631 695 OFFCURVE",
-"631 551 CURVE SMOOTH",
-"631 373 OFFCURVE",
-"551 30 OFFCURVE",
-"336 30 CURVE SMOOTH",
 "259 30 OFFCURVE",
 "210 75 OFFCURVE",
 "210 204 CURVE SMOOTH",
 "210 389 OFFCURVE",
 "295 727 OFFCURVE",
-"508 727 CURVE SMOOTH"
+"508 727 CURVE SMOOTH",
+"572 727 OFFCURVE",
+"631 695 OFFCURVE",
+"631 551 CURVE SMOOTH",
+"631 373 OFFCURVE",
+"551 30 OFFCURVE",
+"336 30 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"1024 0 LINE",
+"1084 232 LINE",
+"1054 232 LINE",
+"978 64 OFFCURVE",
+"916 25 OFFCURVE",
+"827 25 CURVE SMOOTH",
+"572 25 LINE",
+"571 124 LINE",
+"471 49 LINE",
+"352 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"643 0 LINE",
+"811 754 LINE",
+"694 754 LINE",
+"530 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"893 226 LINE",
+"952 534 LINE",
+"927 534 LINE",
+"896 430 OFFCURVE",
+"861 403 OFFCURVE",
+"781 403 CURVE SMOOTH",
+"678 403 LINE",
+"678 378 LINE",
+"765 378 LINE SMOOTH",
+"848 378 OFFCURVE",
+"863 351 OFFCURVE",
+"863 226 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"1116 553 LINE",
+"1144 754 LINE",
+"503 754 LINE",
+"573 723 LINE",
+"672 631 LINE",
+"729 729 LINE",
+"915 729 LINE SMOOTH",
+"1057 729 OFFCURVE",
+"1086 692 OFFCURVE",
+"1086 553 CURVE"
 );
 }
 );
@@ -5547,65 +7186,23 @@ paths = (
 {
 closed = 1;
 nodes = (
-"818 754 LINE",
-"667 754 LINE",
-"503 0 LINE",
-"650 0 LINE"
+"540 0 OFFCURVE",
+"742 241 OFFCURVE",
+"742 466 CURVE SMOOTH",
+"742 619 OFFCURVE",
+"651 754 OFFCURVE",
+"507 754 CURVE SMOOTH",
+"285 754 OFFCURVE",
+"65 511 OFFCURVE",
+"65 286 CURVE SMOOTH",
+"65 135 OFFCURVE",
+"170 0 OFFCURVE",
+"337 0 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"552 724 LINE",
-"602 724 LINE",
-"656 643 LINE",
-"705 724 LINE",
-"912 724 LINE SMOOTH",
-"1036 724 OFFCURVE",
-"1073 687 OFFCURVE",
-"1073 548 CURVE",
-"1113 548 LINE",
-"1149 754 LINE",
-"512 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"335 0 LINE",
-"1021 0 LINE",
-"1081 232 LINE",
-"1041 232 LINE",
-"965 68 OFFCURVE",
-"903 30 OFFCURVE",
-"814 30 CURVE SMOOTH",
-"572 30 LINE",
-"515 100 LINE",
-"436 30 LINE",
-"411 30 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"683 374 LINE",
-"770 374 LINE SMOOTH",
-"830 374 OFFCURVE",
-"868 348 OFFCURVE",
-"868 227 CURVE",
-"902 227 LINE",
-"967 535 LINE",
-"932 535 LINE",
-"902 441 OFFCURVE",
-"853 404 OFFCURVE",
-"786 404 CURVE SMOOTH",
-"683 404 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"331 32 LINE SMOOTH",
 "270 32 OFFCURVE",
 "233 66 OFFCURVE",
 "233 170 CURVE SMOOTH",
@@ -5623,19 +7220,57 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"335 0 LINE SMOOTH",
-"538 0 OFFCURVE",
-"742 241 OFFCURVE",
-"742 466 CURVE SMOOTH",
-"742 619 OFFCURVE",
-"651 754 OFFCURVE",
-"507 754 CURVE SMOOTH",
-"285 754 OFFCURVE",
-"65 511 OFFCURVE",
-"65 286 CURVE SMOOTH",
-"65 135 OFFCURVE",
-"168 0 OFFCURVE",
-"335 0 CURVE SMOOTH"
+"1021 0 LINE",
+"1081 232 LINE",
+"1041 232 LINE",
+"965 68 OFFCURVE",
+"903 30 OFFCURVE",
+"814 30 CURVE SMOOTH",
+"572 30 LINE",
+"515 100 LINE",
+"436 30 LINE",
+"351 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"650 0 LINE",
+"818 754 LINE",
+"667 754 LINE",
+"503 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"902 227 LINE",
+"967 535 LINE",
+"932 535 LINE",
+"902 441 OFFCURVE",
+"853 404 OFFCURVE",
+"786 404 CURVE SMOOTH",
+"683 404 LINE",
+"683 374 LINE",
+"770 374 LINE SMOOTH",
+"830 374 OFFCURVE",
+"868 348 OFFCURVE",
+"868 227 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"1113 548 LINE",
+"1149 754 LINE",
+"512 754 LINE",
+"602 724 LINE",
+"656 643 LINE",
+"705 724 LINE",
+"912 724 LINE SMOOTH",
+"1036 724 OFFCURVE",
+"1073 687 OFFCURVE",
+"1073 548 CURVE"
 );
 }
 );
@@ -5648,23 +7283,31 @@ unicode = 0152;
 },
 {
 glyphname = P;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:59 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{270, 0}";
+},
+{
+name = top;
+position = "{444, 754}";
+}
+);
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
 paths = (
 {
 closed = 1;
 nodes = (
-"342 754 LINE",
-"225 754 LINE",
-"61 0 LINE",
-"174 0 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"347 348 LINE SMOOTH",
+"538 348 OFFCURVE",
+"676 437 OFFCURVE",
+"676 569 CURVE SMOOTH",
+"676 675 OFFCURVE",
+"586 754 OFFCURVE",
+"417 754 CURVE SMOOTH",
 "126 754 LINE",
 "126 729 LINE",
 "405 729 LINE SMOOTH",
@@ -5675,14 +7318,7 @@ nodes = (
 "478 373 OFFCURVE",
 "342 373 CURVE SMOOTH",
 "183 373 LINE",
-"183 348 LINE",
-"347 348 LINE SMOOTH",
-"538 348 OFFCURVE",
-"676 437 OFFCURVE",
-"676 569 CURVE SMOOTH",
-"676 675 OFFCURVE",
-"586 754 OFFCURVE",
-"417 754 CURVE SMOOTH"
+"183 348 LINE"
 );
 },
 {
@@ -5693,34 +7329,42 @@ nodes = (
 "-25 25 LINE",
 "-25 0 LINE"
 );
+},
+{
+closed = 1;
+nodes = (
+"174 0 LINE",
+"342 754 LINE",
+"225 754 LINE",
+"61 0 LINE"
+);
 }
 );
 width = 643;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{290, 0}";
+},
+{
+name = top;
+position = "{464, 754}";
+}
+);
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
 paths = (
 {
 closed = 1;
 nodes = (
-"377 754 LINE",
-"226 754 LINE",
-"62 0 LINE",
-"209 0 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"-5 0 LINE",
-"304 0 LINE",
-"304 31 LINE",
-"-5 31 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"342 348 LINE SMOOTH",
+"581 348 OFFCURVE",
+"715 436 OFFCURVE",
+"715 571 CURVE SMOOTH",
+"715 684 OFFCURVE",
+"622 754 OFFCURVE",
+"442 754 CURVE SMOOTH",
 "121 754 LINE",
 "121 724 LINE",
 "430 724 LINE SMOOTH",
@@ -5731,14 +7375,25 @@ nodes = (
 "484 373 OFFCURVE",
 "370 373 CURVE SMOOTH",
 "178 373 LINE",
-"178 348 LINE",
-"342 348 LINE SMOOTH",
-"581 348 OFFCURVE",
-"715 436 OFFCURVE",
-"715 571 CURVE SMOOTH",
-"715 684 OFFCURVE",
-"622 754 OFFCURVE",
-"442 754 CURVE SMOOTH"
+"178 348 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"304 0 LINE",
+"304 31 LINE",
+"-5 31 LINE",
+"-5 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"209 0 LINE",
+"377 754 LINE",
+"226 754 LINE",
+"62 0 LINE"
 );
 }
 );
@@ -5750,7 +7405,7 @@ unicode = 0050;
 },
 {
 glyphname = Thorn;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -5758,33 +7413,10 @@ paths = (
 {
 closed = 1;
 nodes = (
+"171 0 LINE",
 "339 754 LINE",
 "222 754 LINE",
-"58 0 LINE",
-"171 0 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"213 584 LINE",
-"213 559 LINE",
-"362 559 LINE SMOOTH",
-"474 559 OFFCURVE",
-"497 524 OFFCURVE",
-"497 431 CURVE SMOOTH",
-"497 279 OFFCURVE",
-"435 203 OFFCURVE",
-"299 203 CURVE SMOOTH",
-"140 203 LINE",
-"140 178 LINE",
-"304 178 LINE SMOOTH",
-"495 178 OFFCURVE",
-"633 267 OFFCURVE",
-"633 399 CURVE SMOOTH",
-"633 505 OFFCURVE",
-"543 584 OFFCURVE",
-"374 584 CURVE SMOOTH"
+"58 0 LINE"
 );
 },
 {
@@ -5799,10 +7431,33 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"116 754 LINE",
-"116 729 LINE",
+"304 178 LINE SMOOTH",
+"495 178 OFFCURVE",
+"633 267 OFFCURVE",
+"633 399 CURVE SMOOTH",
+"633 505 OFFCURVE",
+"543 584 OFFCURVE",
+"374 584 CURVE SMOOTH",
+"213 584 LINE",
+"213 559 LINE",
+"362 559 LINE SMOOTH",
+"474 559 OFFCURVE",
+"497 524 OFFCURVE",
+"497 431 CURVE SMOOTH",
+"497 279 OFFCURVE",
+"435 203 OFFCURVE",
+"299 203 CURVE SMOOTH",
+"140 203 LINE",
+"140 178 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "445 729 LINE",
-"445 754 LINE"
+"445 754 LINE",
+"116 754 LINE",
+"116 729 LINE"
 );
 }
 );
@@ -5814,24 +7469,31 @@ paths = (
 {
 closed = 1;
 nodes = (
+"204 0 LINE",
 "372 754 LINE",
 "221 754 LINE",
-"57 0 LINE",
-"204 0 LINE"
+"57 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"-10 0 LINE",
 "299 0 LINE",
 "299 31 LINE",
-"-10 31 LINE"
+"-10 31 LINE",
+"-10 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
+"303 175 LINE SMOOTH",
+"542 175 OFFCURVE",
+"676 263 OFFCURVE",
+"676 398 CURVE SMOOTH",
+"676 511 OFFCURVE",
+"583 581 OFFCURVE",
+"403 581 CURVE SMOOTH",
 "222 581 LINE",
 "222 551 LINE",
 "391 551 LINE SMOOTH",
@@ -5842,23 +7504,16 @@ nodes = (
 "445 200 OFFCURVE",
 "331 200 CURVE SMOOTH",
 "139 200 LINE",
-"139 175 LINE",
-"303 175 LINE SMOOTH",
-"542 175 OFFCURVE",
-"676 263 OFFCURVE",
-"676 398 CURVE SMOOTH",
-"676 511 OFFCURVE",
-"583 581 OFFCURVE",
-"403 581 CURVE SMOOTH"
+"139 175 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"144 723 LINE",
 "453 723 LINE",
 "453 754 LINE",
-"144 754 LINE"
+"144 754 LINE",
+"144 723 LINE"
 );
 }
 );
@@ -5869,15 +7524,24 @@ unicode = 00DE;
 },
 {
 glyphname = Q;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:59 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{333, 0}";
+},
+{
+name = top;
+position = "{507, 754}";
+}
+);
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
 paths = (
 {
 closed = 1;
 nodes = (
-"343 -11 LINE SMOOTH",
 "599 -11 OFFCURVE",
 "781 278 OFFCURVE",
 "781 475 CURVE SMOOTH",
@@ -5895,31 +7559,6 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"520 736 LINE SMOOTH",
-"588 736 OFFCURVE",
-"651 704 OFFCURVE",
-"651 547 CURVE SMOOTH",
-"651 377 OFFCURVE",
-"578 19 OFFCURVE",
-"349 19 CURVE SMOOTH",
-"248 19 OFFCURVE",
-"210 89 OFFCURVE",
-"210 208 CURVE SMOOTH",
-"210 390 OFFCURVE",
-"298 736 OFFCURVE",
-"520 736 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"265 6 LINE",
-"263 -10 OFFCURVE",
-"262 -26 OFFCURVE",
-"262 -40 CURVE SMOOTH",
-"262 -173 OFFCURVE",
-"350 -242 OFFCURVE",
-"506 -242 CURVE SMOOTH",
 "539 -242 OFFCURVE",
 "577 -239 OFFCURVE",
 "618 -232 CURVE",
@@ -5932,37 +7571,52 @@ nodes = (
 "404 -85 CURVE SMOOTH",
 "404 -48 OFFCURVE",
 "413 -18 OFFCURVE",
-"431 12 CURVE"
+"431 12 CURVE",
+"265 6 LINE",
+"263 -10 OFFCURVE",
+"262 -26 OFFCURVE",
+"262 -40 CURVE SMOOTH",
+"262 -173 OFFCURVE",
+"350 -242 OFFCURVE",
+"506 -242 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"248 19 OFFCURVE",
+"210 89 OFFCURVE",
+"210 208 CURVE SMOOTH",
+"210 390 OFFCURVE",
+"298 736 OFFCURVE",
+"520 736 CURVE SMOOTH",
+"588 736 OFFCURVE",
+"651 704 OFFCURVE",
+"651 547 CURVE SMOOTH",
+"651 377 OFFCURVE",
+"578 19 OFFCURVE",
+"349 19 CURVE SMOOTH"
 );
 }
 );
 width = 769;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{343, 0}";
+},
+{
+name = top;
+position = "{517, 754}";
+}
+);
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
 paths = (
 {
 closed = 1;
 nodes = (
-"349 21 LINE SMOOTH",
-"279 21 OFFCURVE",
-"236 57 OFFCURVE",
-"236 170 CURVE SMOOTH",
-"236 326 OFFCURVE",
-"310 731 OFFCURVE",
-"529 731 CURVE SMOOTH",
-"624 731 OFFCURVE",
-"642 666 OFFCURVE",
-"642 591 CURVE SMOOTH",
-"642 427 OFFCURVE",
-"567 21 OFFCURVE",
-"349 21 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"353 -11 LINE SMOOTH",
 "583 -11 OFFCURVE",
 "810 236 OFFCURVE",
 "810 466 CURVE SMOOTH",
@@ -5980,13 +7634,6 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"251 15 LINE",
-"249 -1 OFFCURVE",
-"247 -26 OFFCURVE",
-"247 -40 CURVE SMOOTH",
-"247 -173 OFFCURVE",
-"335 -242 OFFCURVE",
-"491 -242 CURVE SMOOTH",
 "524 -242 OFFCURVE",
 "562 -239 OFFCURVE",
 "603 -232 CURVE",
@@ -5999,7 +7646,31 @@ nodes = (
 "409 -85 CURVE SMOOTH",
 "409 -48 OFFCURVE",
 "411 -18 OFFCURVE",
-"416 12 CURVE"
+"416 12 CURVE",
+"251 15 LINE",
+"249 -1 OFFCURVE",
+"247 -26 OFFCURVE",
+"247 -40 CURVE SMOOTH",
+"247 -173 OFFCURVE",
+"335 -242 OFFCURVE",
+"491 -242 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"279 21 OFFCURVE",
+"236 57 OFFCURVE",
+"236 170 CURVE SMOOTH",
+"236 326 OFFCURVE",
+"310 731 OFFCURVE",
+"529 731 CURVE SMOOTH",
+"624 731 OFFCURVE",
+"642 666 OFFCURVE",
+"642 591 CURVE SMOOTH",
+"642 427 OFFCURVE",
+"567 21 OFFCURVE",
+"349 21 CURVE SMOOTH"
 );
 }
 );
@@ -6011,41 +7682,28 @@ unicode = 0051;
 },
 {
 glyphname = R;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:59 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{300, 0}";
+},
+{
+name = top;
+position = "{474, 754}";
+}
+);
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
 paths = (
 {
 closed = 1;
 nodes = (
+"198 0 LINE",
 "366 754 LINE",
 "249 754 LINE",
-"85 0 LINE",
-"198 0 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"150 754 LINE",
-"150 729 LINE",
-"429 729 LINE SMOOTH",
-"542 729 OFFCURVE",
-"564 700 OFFCURVE",
-"564 620 CURVE SMOOTH",
-"564 487 OFFCURVE",
-"502 416 OFFCURVE",
-"392 416 CURVE SMOOTH",
-"207 416 LINE",
-"207 391 LINE",
-"371 391 LINE SMOOTH",
-"580 391 OFFCURVE",
-"700 469 OFFCURVE",
-"700 585 CURVE SMOOTH",
-"700 685 OFFCURVE",
-"610 754 OFFCURVE",
-"441 754 CURVE SMOOTH"
+"85 0 LINE"
 );
 },
 {
@@ -6060,13 +7718,6 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"315 390 LINE",
-"398 390 OFFCURVE",
-"451 345 OFFCURVE",
-"458 233 CURVE SMOOTH",
-"463 154 OFFCURVE",
-"446 -10 OFFCURVE",
-"633 -10 CURVE SMOOTH",
 "688 -10 OFFCURVE",
 "708 4 OFFCURVE",
 "727 25 CURVE",
@@ -6080,66 +7731,76 @@ nodes = (
 "594 283 OFFCURVE",
 "576 335 OFFCURVE",
 "438 389 CURVE",
-"438 393 LINE"
+"438 393 LINE",
+"315 390 LINE",
+"398 390 OFFCURVE",
+"451 345 OFFCURVE",
+"458 233 CURVE SMOOTH",
+"463 154 OFFCURVE",
+"446 -10 OFFCURVE",
+"633 -10 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"371 391 LINE SMOOTH",
+"580 391 OFFCURVE",
+"700 469 OFFCURVE",
+"700 585 CURVE SMOOTH",
+"700 685 OFFCURVE",
+"610 754 OFFCURVE",
+"441 754 CURVE SMOOTH",
+"150 754 LINE",
+"150 729 LINE",
+"429 729 LINE SMOOTH",
+"542 729 OFFCURVE",
+"564 700 OFFCURVE",
+"564 620 CURVE SMOOTH",
+"564 487 OFFCURVE",
+"502 416 OFFCURVE",
+"392 416 CURVE SMOOTH",
+"207 416 LINE",
+"207 391 LINE"
 );
 }
 );
 width = 703;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{310, 0}";
+},
+{
+name = top;
+position = "{484, 754}";
+}
+);
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
 paths = (
 {
 closed = 1;
 nodes = (
+"213 0 LINE",
 "381 754 LINE",
 "230 754 LINE",
-"66 0 LINE",
-"213 0 LINE"
+"66 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"-1 0 LINE",
 "308 0 LINE",
 "308 31 LINE",
-"-1 31 LINE"
+"-1 31 LINE",
+"-1 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"125 754 LINE",
-"125 724 LINE",
-"434 724 LINE SMOOTH",
-"529 724 OFFCURVE",
-"553 690 OFFCURVE",
-"553 614 CURVE SMOOTH",
-"553 491 OFFCURVE",
-"488 415 OFFCURVE",
-"374 415 CURVE SMOOTH",
-"182 415 LINE",
-"182 385 LINE",
-"346 385 LINE SMOOTH",
-"586 385 OFFCURVE",
-"719 454 OFFCURVE",
-"719 578 CURVE SMOOTH",
-"719 681 OFFCURVE",
-"626 754 OFFCURVE",
-"446 754 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"334 385 LINE",
-"436 385 OFFCURVE",
-"440 310 OFFCURVE",
-"443 233 CURVE SMOOTH",
-"448 110 OFFCURVE",
-"453 -11 OFFCURVE",
-"612 -11 CURVE SMOOTH",
 "668 -11 OFFCURVE",
 "708 4 OFFCURVE",
 "732 25 CURVE",
@@ -6153,7 +7814,37 @@ nodes = (
 "607 287 OFFCURVE",
 "576 352 OFFCURVE",
 "457 387 CURVE",
-"457 391 LINE"
+"457 391 LINE",
+"334 385 LINE",
+"436 385 OFFCURVE",
+"440 310 OFFCURVE",
+"443 233 CURVE SMOOTH",
+"448 110 OFFCURVE",
+"453 -11 OFFCURVE",
+"612 -11 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"346 385 LINE SMOOTH",
+"586 385 OFFCURVE",
+"719 454 OFFCURVE",
+"719 578 CURVE SMOOTH",
+"719 681 OFFCURVE",
+"626 754 OFFCURVE",
+"446 754 CURVE SMOOTH",
+"125 754 LINE",
+"125 724 LINE",
+"434 724 LINE SMOOTH",
+"529 724 OFFCURVE",
+"553 690 OFFCURVE",
+"553 614 CURVE SMOOTH",
+"553 491 OFFCURVE",
+"488 415 OFFCURVE",
+"374 415 CURVE SMOOTH",
+"182 415 LINE",
+"182 385 LINE"
 );
 }
 );
@@ -6166,7 +7857,7 @@ unicode = 0052;
 },
 {
 glyphname = Racute;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:15 +0000";
 layers = (
 {
 components = (
@@ -6174,7 +7865,7 @@ components = (
 name = R;
 },
 {
-name = acute.cap;
+name = acute.case;
 transform = "{1, 0, 0, 1, 181, 0}";
 }
 );
@@ -6187,7 +7878,7 @@ components = (
 name = R;
 },
 {
-name = acute.cap;
+name = acute.case;
 transform = "{1, 0, 0, 1, 194, 0}";
 }
 );
@@ -6201,7 +7892,7 @@ unicode = 0154;
 },
 {
 glyphname = Rcaron;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:15 +0000";
 layers = (
 {
 components = (
@@ -6209,7 +7900,7 @@ components = (
 name = R;
 },
 {
-name = caron.cap;
+name = caron.case;
 transform = "{1, 0, 0, 1, 125, 0}";
 }
 );
@@ -6222,7 +7913,7 @@ components = (
 name = R;
 },
 {
-name = caron.cap;
+name = caron.case;
 transform = "{1, 0, 0, 1, 139, 0}";
 }
 );
@@ -6236,7 +7927,7 @@ unicode = 0158;
 },
 {
 glyphname = Rcommaaccent;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 components = (
@@ -6244,7 +7935,7 @@ components = (
 name = R;
 },
 {
-name = commaaccent;
+name = commaaccentcomb;
 transform = "{1, 0, 0, 1, 318, 0}";
 }
 );
@@ -6257,7 +7948,7 @@ components = (
 name = R;
 },
 {
-name = commaaccent;
+name = commaaccentcomb;
 transform = "{1, 0, 0, 1, 294, 0}";
 }
 );
@@ -6271,7 +7962,7 @@ unicode = 0156;
 },
 {
 glyphname = Rdblgrave;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 components = (
@@ -6279,7 +7970,7 @@ components = (
 name = R;
 },
 {
-name = uni030F.cap;
+name = dblgravecomb.cap;
 transform = "{1, 0, 0, 1, 14, 0}";
 }
 );
@@ -6292,7 +7983,7 @@ components = (
 name = R;
 },
 {
-name = uni030F.cap;
+name = dblgravecomb.cap;
 transform = "{1, 0, 0, 1, 57, 0}";
 }
 );
@@ -6341,7 +8032,7 @@ unicode = 1E5A;
 },
 {
 glyphname = Rinvertedbreve;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 components = (
@@ -6349,7 +8040,7 @@ components = (
 name = R;
 },
 {
-name = uni0311.cap;
+name = breveinvertedcomb.cap;
 transform = "{1, 0, 0, 1, 142, 0}";
 }
 );
@@ -6362,7 +8053,7 @@ components = (
 name = R;
 },
 {
-name = uni0311.cap;
+name = breveinvertedcomb.cap;
 transform = "{1, 0, 0, 1, 129, 0}";
 }
 );
@@ -6376,14 +8067,39 @@ unicode = 0212;
 },
 {
 glyphname = S;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:59 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{237, 0}";
+},
+{
+name = top;
+position = "{411, 754}";
+}
+);
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
 paths = (
 {
 closed = 1;
 nodes = (
+"419 -13 OFFCURVE",
+"535 93 OFFCURVE",
+"535 247 CURVE SMOOTH",
+"535 492 OFFCURVE",
+"212 464 OFFCURVE",
+"212 617 CURVE SMOOTH",
+"212 695 OFFCURVE",
+"301 738 OFFCURVE",
+"374 738 CURVE SMOOTH",
+"473 738 OFFCURVE",
+"530 664 OFFCURVE",
+"530 555 CURVE",
+"555 555 LINE",
+"595 754 LINE",
+"570 754 LINE",
 "528 708 LINE",
 "497 740 OFFCURVE",
 "449 763 OFFCURVE",
@@ -6406,33 +8122,43 @@ nodes = (
 "99 54 LINE",
 "137 14 OFFCURVE",
 "192 -13 OFFCURVE",
-"268 -13 CURVE SMOOTH",
-"419 -13 OFFCURVE",
-"535 93 OFFCURVE",
-"535 247 CURVE SMOOTH",
-"535 492 OFFCURVE",
-"212 464 OFFCURVE",
-"212 617 CURVE SMOOTH",
-"212 695 OFFCURVE",
-"301 738 OFFCURVE",
-"374 738 CURVE SMOOTH",
-"473 738 OFFCURVE",
-"530 664 OFFCURVE",
-"530 555 CURVE",
-"555 555 LINE",
-"595 754 LINE",
-"570 754 LINE"
+"268 -13 CURVE SMOOTH"
 );
 }
 );
 width = 577;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{239, 0}";
+},
+{
+name = top;
+position = "{413, 754}";
+}
+);
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
 paths = (
 {
 closed = 1;
 nodes = (
+"430 -13 OFFCURVE",
+"545 97 OFFCURVE",
+"545 253 CURVE SMOOTH",
+"545 514 OFFCURVE",
+"221 467 OFFCURVE",
+"221 618 CURVE SMOOTH",
+"221 677 OFFCURVE",
+"270 728 OFFCURVE",
+"355 728 CURVE SMOOTH",
+"447 728 OFFCURVE",
+"523 669 OFFCURVE",
+"523 555 CURVE",
+"553 555 LINE",
+"587 754 LINE",
+"562 754 LINE",
 "522 708 LINE",
 "488 740 OFFCURVE",
 "431 763 OFFCURVE",
@@ -6455,22 +8181,7 @@ nodes = (
 "100 49 LINE",
 "141 12 OFFCURVE",
 "199 -13 OFFCURVE",
-"274 -13 CURVE SMOOTH",
-"430 -13 OFFCURVE",
-"545 97 OFFCURVE",
-"545 253 CURVE SMOOTH",
-"545 514 OFFCURVE",
-"221 467 OFFCURVE",
-"221 618 CURVE SMOOTH",
-"221 677 OFFCURVE",
-"270 728 OFFCURVE",
-"355 728 CURVE SMOOTH",
-"447 728 OFFCURVE",
-"523 669 OFFCURVE",
-"523 555 CURVE",
-"553 555 LINE",
-"587 754 LINE",
-"562 754 LINE"
+"274 -13 CURVE SMOOTH"
 );
 }
 );
@@ -6483,7 +8194,7 @@ unicode = 0053;
 },
 {
 glyphname = Sacute;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:15 +0000";
 layers = (
 {
 components = (
@@ -6491,7 +8202,7 @@ components = (
 name = S;
 },
 {
-name = acute.cap;
+name = acute.case;
 transform = "{1, 0, 0, 1, 126, 0}";
 }
 );
@@ -6504,7 +8215,7 @@ components = (
 name = S;
 },
 {
-name = acute.cap;
+name = acute.case;
 transform = "{1, 0, 0, 1, 140, 0}";
 }
 );
@@ -6518,7 +8229,7 @@ unicode = 015A;
 },
 {
 glyphname = Scaron;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:15 +0000";
 layers = (
 {
 components = (
@@ -6526,7 +8237,7 @@ components = (
 name = S;
 },
 {
-name = caron.cap;
+name = caron.case;
 transform = "{1, 0, 0, 1, 86, 0}";
 }
 );
@@ -6539,7 +8250,7 @@ components = (
 name = S;
 },
 {
-name = caron.cap;
+name = caron.case;
 transform = "{1, 0, 0, 1, 60, 0}";
 }
 );
@@ -6552,8 +8263,8 @@ rightKerningGroup = S;
 unicode = 0160;
 },
 {
-glyphname = Scircumflex;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = Scedilla;
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 components = (
@@ -6561,7 +8272,42 @@ components = (
 name = S;
 },
 {
-name = circumflex.cap;
+name = cedilla;
+transform = "{1, 0, 0, 1, 171, -8}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 577;
+},
+{
+components = (
+{
+name = S;
+},
+{
+name = cedilla;
+transform = "{1, 0, 0, 1, 209, -9}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 581;
+}
+);
+leftKerningGroup = S;
+rightKerningGroup = S;
+unicode = 015E;
+},
+{
+glyphname = Scircumflex;
+lastChange = "2016-08-22 13:41:15 +0000";
+layers = (
+{
+components = (
+{
+name = S;
+},
+{
+name = circumflex.case;
 transform = "{1, 0, 0, 1, 89, 0}";
 }
 );
@@ -6574,7 +8320,7 @@ components = (
 name = S;
 },
 {
-name = circumflex.cap;
+name = circumflex.case;
 transform = "{1, 0, 0, 1, 84, 0}";
 }
 );
@@ -6585,6 +8331,41 @@ width = 581;
 leftKerningGroup = S;
 rightKerningGroup = S;
 unicode = 015C;
+},
+{
+glyphname = Scommaaccent;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+components = (
+{
+name = S;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 203, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 577;
+},
+{
+components = (
+{
+name = S;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 235, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 581;
+}
+);
+leftKerningGroup = S;
+rightKerningGroup = S;
+unicode = 0218;
 },
 {
 glyphname = Sdotbelow;
@@ -6623,7 +8404,7 @@ unicode = 1E62;
 },
 {
 glyphname = Schwa;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:49:19 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -6631,7 +8412,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"303 -13 LINE SMOOTH",
 "529 -13 OFFCURVE",
 "731 225 OFFCURVE",
 "731 462 CURVE SMOOTH",
@@ -6681,7 +8461,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"290 -11 LINE SMOOTH",
 "533 -11 OFFCURVE",
 "745 223 OFFCURVE",
 "745 453 CURVE SMOOTH",
@@ -6730,24 +8509,46 @@ unicode = 018F;
 },
 {
 glyphname = T;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:59 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{289, 0}";
+},
+{
+name = center;
+position = "{376, 377}";
+},
+{
+name = top;
+position = "{463, 754}";
+}
+);
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
 paths = (
 {
 closed = 1;
 nodes = (
+"353 0 LINE",
 "521 754 LINE",
 "404 754 LINE",
-"240 0 LINE",
-"353 0 LINE"
+"240 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"88 513 LINE",
+"473 0 LINE",
+"473 25 LINE",
+"134 25 LINE",
+"134 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "118 513 LINE",
 "177 661 OFFCURVE",
 "266 729 OFFCURVE",
@@ -6758,46 +8559,51 @@ nodes = (
 "701 513 CURVE",
 "731 513 LINE",
 "764 754 LINE",
-"160 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"134 0 LINE",
-"473 0 LINE",
-"473 25 LINE",
-"134 25 LINE"
+"160 754 LINE",
+"88 513 LINE"
 );
 }
 );
 width = 681;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{299, 0}";
+},
+{
+name = center;
+position = "{386, 377}";
+},
+{
+name = top;
+position = "{473, 754}";
+}
+);
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
 paths = (
 {
 closed = 1;
 nodes = (
+"377 0 LINE",
 "545 754 LINE",
 "394 754 LINE",
-"230 0 LINE",
-"377 0 LINE"
+"230 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"133 0 LINE",
 "512 0 LINE",
 "512 31 LINE",
-"133 31 LINE"
+"133 31 LINE",
+"133 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"88 513 LINE",
 "123 513 LINE",
 "180 658 OFFCURVE",
 "267 724 OFFCURVE",
@@ -6808,7 +8614,8 @@ nodes = (
 "706 513 CURVE",
 "741 513 LINE",
 "774 754 LINE",
-"160 754 LINE"
+"160 754 LINE",
+"88 513 LINE"
 );
 }
 );
@@ -6821,7 +8628,7 @@ unicode = 0054;
 },
 {
 glyphname = Tbar;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 components = (
@@ -6834,10 +8641,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"190 416 LINE",
 "605 416 LINE",
 "605 451 LINE",
-"190 451 LINE"
+"190 451 LINE",
+"190 416 LINE"
 );
 }
 );
@@ -6854,10 +8661,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"188 406 LINE",
 "603 406 LINE",
 "603 451 LINE",
-"188 451 LINE"
+"188 451 LINE",
+"188 406 LINE"
 );
 }
 );
@@ -6868,7 +8675,7 @@ unicode = 0166;
 },
 {
 glyphname = Tcaron;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:15 +0000";
 layers = (
 {
 components = (
@@ -6876,7 +8683,7 @@ components = (
 name = T;
 },
 {
-name = caron.cap;
+name = caron.case;
 transform = "{1, 0, 0, 1, 138, 0}";
 }
 );
@@ -6889,7 +8696,7 @@ components = (
 name = T;
 },
 {
-name = caron.cap;
+name = caron.case;
 transform = "{1, 0, 0, 1, 173, 1}";
 }
 );
@@ -6900,6 +8707,76 @@ width = 701;
 leftKerningGroup = T;
 rightKerningGroup = T;
 unicode = 0164;
+},
+{
+glyphname = Tcedilla;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+components = (
+{
+name = T;
+},
+{
+name = cedilla;
+transform = "{1, 0, 0, 1, 212, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 681;
+},
+{
+components = (
+{
+name = T;
+},
+{
+name = cedilla;
+transform = "{1, 0, 0, 1, 232, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 701;
+}
+);
+leftKerningGroup = T;
+rightKerningGroup = T;
+unicode = 0162;
+},
+{
+glyphname = Tcommaaccent;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+components = (
+{
+name = T;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 260, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 681;
+},
+{
+components = (
+{
+name = T;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 274, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 701;
+}
+);
+leftKerningGroup = T;
+rightKerningGroup = T;
+unicode = 021A;
 },
 {
 glyphname = Tdotbelow;
@@ -6938,41 +8815,32 @@ unicode = 1E6C;
 },
 {
 glyphname = U;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:07:27 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{314, 0}";
+},
+{
+name = ogonek;
+position = "{607, 10}";
+},
+{
+name = top;
+position = "{488, 754}";
+},
+{
+name = topright;
+position = "{806, 701}";
+}
+);
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
 paths = (
 {
 closed = 1;
 nodes = (
-"125 729 LINE",
-"448 729 LINE",
-"448 754 LINE",
-"125 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"842 754 LINE",
-"600 754 LINE",
-"600 729 LINE",
-"842 729 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"361 754 LINE",
-"244 754 LINE",
-"137 266 LINE SMOOTH",
-"130 233 OFFCURVE",
-"126 203 OFFCURVE",
-"126 176 CURVE SMOOTH",
-"126 51 OFFCURVE",
-"214 -13 OFFCURVE",
-"357 -13 CURVE SMOOTH",
 "540 -13 OFFCURVE",
 "603 92 OFFCURVE",
 "633 231 CURVE SMOOTH",
@@ -6987,27 +8855,63 @@ nodes = (
 "237 167 CURVE SMOOTH",
 "237 192 OFFCURVE",
 "241 227 OFFCURVE",
-"250 266 CURVE SMOOTH"
+"250 266 CURVE SMOOTH",
+"361 754 LINE",
+"244 754 LINE",
+"137 266 LINE SMOOTH",
+"130 233 OFFCURVE",
+"126 203 OFFCURVE",
+"126 176 CURVE SMOOTH",
+"126 51 OFFCURVE",
+"214 -13 OFFCURVE",
+"357 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"448 729 LINE",
+"448 754 LINE",
+"125 754 LINE",
+"125 729 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"842 729 LINE",
+"842 754 LINE",
+"600 754 LINE",
+"600 729 LINE"
 );
 }
 );
 width = 732;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{324, 0}";
+},
+{
+name = ogonek;
+position = "{625, 10}";
+},
+{
+name = top;
+position = "{498, 754}";
+},
+{
+name = topright;
+position = "{820, 701}";
+}
+);
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
 paths = (
 {
 closed = 1;
 nodes = (
-"385 754 LINE",
-"234 754 LINE",
-"120 226 LINE SMOOTH",
-"116 206 OFFCURVE",
-"114 187 OFFCURVE",
-"114 170 CURVE SMOOTH",
-"114 64 OFFCURVE",
-"196 -11 OFFCURVE",
-"365 -11 CURVE SMOOTH",
 "539 -11 OFFCURVE",
 "610 69 OFFCURVE",
 "644 226 CURVE SMOOTH",
@@ -7022,25 +8926,34 @@ nodes = (
 "260 168 CURVE SMOOTH",
 "260 185 OFFCURVE",
 "262 206 OFFCURVE",
-"267 226 CURVE SMOOTH"
+"267 226 CURVE SMOOTH",
+"385 754 LINE",
+"234 754 LINE",
+"120 226 LINE SMOOTH",
+"116 206 OFFCURVE",
+"114 187 OFFCURVE",
+"114 170 CURVE SMOOTH",
+"114 64 OFFCURVE",
+"196 -11 OFFCURVE",
+"365 -11 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"114 724 LINE",
 "473 724 LINE",
 "473 754 LINE",
-"114 754 LINE"
+"114 754 LINE",
+"114 724 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"611 724 LINE",
 "838 724 LINE",
 "838 754 LINE",
-"611 754 LINE"
+"611 754 LINE",
+"611 724 LINE"
 );
 }
 );
@@ -7053,7 +8966,7 @@ unicode = 0055;
 },
 {
 glyphname = Uacute;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:05:38 +0000";
 layers = (
 {
 components = (
@@ -7061,8 +8974,8 @@ components = (
 name = U;
 },
 {
-name = acute.cap;
-transform = "{1, 0, 0, 1, 244, 0}";
+name = acutecomb;
+transform = "{1, 0, 0, 1, 129, 304}";
 }
 );
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -7074,8 +8987,8 @@ components = (
 name = U;
 },
 {
-name = acute.cap;
-transform = "{1, 0, 0, 1, 260, 0}";
+name = acutecomb;
+transform = "{1, 0, 0, 1, 93, 304}";
 }
 );
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
@@ -7088,7 +9001,7 @@ unicode = 00DA;
 },
 {
 glyphname = Ubreve;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:15 +0000";
 layers = (
 {
 components = (
@@ -7096,7 +9009,7 @@ components = (
 name = U;
 },
 {
-name = breve.cap;
+name = breve.case;
 transform = "{1, 0, 0, 1, 201, 0}";
 }
 );
@@ -7109,7 +9022,7 @@ components = (
 name = U;
 },
 {
-name = breve.cap;
+name = breve.case;
 transform = "{1, 0, 0, 1, 221, 0}";
 }
 );
@@ -7123,7 +9036,7 @@ unicode = 016C;
 },
 {
 glyphname = Ucircumflex;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:15 +0000";
 layers = (
 {
 components = (
@@ -7131,7 +9044,7 @@ components = (
 name = U;
 },
 {
-name = circumflex.cap;
+name = circumflex.case;
 transform = "{1, 0, 0, 1, 205, 0}";
 }
 );
@@ -7144,7 +9057,7 @@ components = (
 name = U;
 },
 {
-name = circumflex.cap;
+name = circumflex.case;
 transform = "{1, 0, 0, 1, 207, 0}";
 }
 );
@@ -7158,7 +9071,7 @@ unicode = 00DB;
 },
 {
 glyphname = Udblgrave;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 components = (
@@ -7166,7 +9079,7 @@ components = (
 name = U;
 },
 {
-name = uni030F.cap;
+name = dblgravecomb.cap;
 transform = "{1, 0, 0, 1, 79, 0}";
 }
 );
@@ -7179,7 +9092,7 @@ components = (
 name = U;
 },
 {
-name = uni030F.cap;
+name = dblgravecomb.cap;
 transform = "{1, 0, 0, 1, 148, 0}";
 }
 );
@@ -7193,7 +9106,7 @@ unicode = 0214;
 },
 {
 glyphname = Udieresis;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:15 +0000";
 layers = (
 {
 components = (
@@ -7201,7 +9114,7 @@ components = (
 name = U;
 },
 {
-name = dieresis.cap;
+name = dieresis.case;
 transform = "{1, 0, 0, 1, 206, 0}";
 }
 );
@@ -7214,7 +9127,7 @@ components = (
 name = U;
 },
 {
-name = dieresis.cap;
+name = dieresis.case;
 transform = "{1, 0, 0, 1, 245, 0}";
 }
 );
@@ -7228,7 +9141,7 @@ unicode = 00DC;
 },
 {
 glyphname = Udotbelow;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:05:38 +0000";
 layers = (
 {
 components = (
@@ -7236,8 +9149,8 @@ components = (
 name = U;
 },
 {
-name = dotbelow;
-transform = "{1, 0, 0, 1, 334, 0}";
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 73, 0}";
 }
 );
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -7249,8 +9162,8 @@ components = (
 name = U;
 },
 {
-name = dotbelow;
-transform = "{1, 0, 0, 1, 354, 0}";
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 74, 0}";
 }
 );
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
@@ -7263,7 +9176,7 @@ unicode = 1EE4;
 },
 {
 glyphname = Ugrave;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:05:38 +0000";
 layers = (
 {
 components = (
@@ -7271,8 +9184,8 @@ components = (
 name = U;
 },
 {
-name = grave.cap;
-transform = "{1, 0, 0, 1, 201, 0}";
+name = gravecomb;
+transform = "{1, 0, 0, 1, 140, 304}";
 }
 );
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -7284,8 +9197,8 @@ components = (
 name = U;
 },
 {
-name = grave.cap;
-transform = "{1, 0, 0, 1, 218, 0}";
+name = gravecomb;
+transform = "{1, 0, 0, 1, 182, 304}";
 }
 );
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
@@ -7297,8 +9210,8 @@ rightKerningGroup = U;
 unicode = 00D9;
 },
 {
-glyphname = Uhungarumlaut;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = Uhookabove;
+lastChange = "2016-08-22 14:17:42 +0000";
 layers = (
 {
 components = (
@@ -7306,7 +9219,380 @@ components = (
 name = U;
 },
 {
-name = hungarumlaut.cap;
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 165, 304}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 732;
+},
+{
+components = (
+{
+name = U;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 166, 304}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 752;
+}
+);
+leftKerningGroup = U;
+rightKerningGroup = U;
+unicode = 1EE6;
+},
+{
+glyphname = Uhorn;
+lastChange = "2016-08-22 14:17:42 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{314, 0}";
+},
+{
+name = ogonek;
+position = "{607, 10}";
+},
+{
+name = top;
+position = "{488, 754}";
+},
+{
+name = topright;
+position = "{806, 701}";
+}
+);
+components = (
+{
+name = horncomb;
+transform = "{1, 0, 0, 1, 501, 251}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+paths = (
+{
+closed = 1;
+nodes = (
+"540 -13 OFFCURVE",
+"603 92 OFFCURVE",
+"633 231 CURVE SMOOTH",
+"745 754 LINE",
+"715 754 LINE",
+"598 205 LINE SMOOTH",
+"573 86 OFFCURVE",
+"493 17 OFFCURVE",
+"387 17 CURVE SMOOTH",
+"294 17 OFFCURVE",
+"237 70 OFFCURVE",
+"237 167 CURVE SMOOTH",
+"237 192 OFFCURVE",
+"241 227 OFFCURVE",
+"250 266 CURVE SMOOTH",
+"361 754 LINE",
+"244 754 LINE",
+"137 266 LINE SMOOTH",
+"130 233 OFFCURVE",
+"126 203 OFFCURVE",
+"126 176 CURVE SMOOTH",
+"126 51 OFFCURVE",
+"214 -13 OFFCURVE",
+"357 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"448 729 LINE",
+"448 754 LINE",
+"125 754 LINE",
+"125 729 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"733 729 LINE",
+"733 754 LINE",
+"600 754 LINE",
+"600 729 LINE"
+);
+}
+);
+width = 732;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{324, 0}";
+},
+{
+name = ogonek;
+position = "{625, 10}";
+},
+{
+name = top;
+position = "{498, 754}";
+},
+{
+name = topright;
+position = "{820, 701}";
+}
+);
+components = (
+{
+name = horncomb;
+transform = "{1, 0, 0, 1, 507, 251}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+paths = (
+{
+closed = 1;
+nodes = (
+"539 -11 OFFCURVE",
+"610 69 OFFCURVE",
+"644 226 CURVE SMOOTH",
+"758 754 LINE",
+"718 754 LINE",
+"604 226 LINE SMOOTH",
+"575 90 OFFCURVE",
+"491 31 OFFCURVE",
+"398 31 CURVE SMOOTH",
+"315 31 OFFCURVE",
+"260 79 OFFCURVE",
+"260 168 CURVE SMOOTH",
+"260 185 OFFCURVE",
+"262 206 OFFCURVE",
+"267 226 CURVE SMOOTH",
+"385 754 LINE",
+"234 754 LINE",
+"120 226 LINE SMOOTH",
+"116 206 OFFCURVE",
+"114 187 OFFCURVE",
+"114 170 CURVE SMOOTH",
+"114 64 OFFCURVE",
+"196 -11 OFFCURVE",
+"365 -11 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"473 724 LINE",
+"473 754 LINE",
+"114 754 LINE",
+"114 724 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"744 724 LINE",
+"744 754 LINE",
+"611 754 LINE",
+"611 724 LINE"
+);
+}
+);
+width = 752;
+}
+);
+leftKerningGroup = U;
+rightKerningGroup = U;
+unicode = 01AF;
+},
+{
+glyphname = Uhornacute;
+lastChange = "2016-08-22 14:17:42 +0000";
+layers = (
+{
+components = (
+{
+name = Uhorn;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 129, 304}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 732;
+},
+{
+components = (
+{
+name = Uhorn;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 93, 304}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 752;
+}
+);
+leftKerningGroup = U;
+rightKerningGroup = U;
+unicode = 1EE8;
+},
+{
+glyphname = Uhorndotbelow;
+lastChange = "2016-08-22 14:17:42 +0000";
+layers = (
+{
+components = (
+{
+name = Uhorn;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 73, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 732;
+},
+{
+components = (
+{
+name = Uhorn;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 74, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 752;
+}
+);
+leftKerningGroup = U;
+rightKerningGroup = U;
+unicode = 1EF0;
+},
+{
+glyphname = Uhorngrave;
+lastChange = "2016-08-22 14:17:42 +0000";
+layers = (
+{
+components = (
+{
+name = Uhorn;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 140, 304}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 732;
+},
+{
+components = (
+{
+name = Uhorn;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 182, 304}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 752;
+}
+);
+leftKerningGroup = U;
+rightKerningGroup = U;
+unicode = 1EEA;
+},
+{
+glyphname = Uhornhookabove;
+lastChange = "2016-08-22 14:17:42 +0000";
+layers = (
+{
+components = (
+{
+name = Uhorn;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 165, 304}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 732;
+},
+{
+components = (
+{
+name = Uhorn;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 166, 304}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 752;
+}
+);
+leftKerningGroup = U;
+rightKerningGroup = U;
+unicode = 1EEC;
+},
+{
+glyphname = Uhorntilde;
+lastChange = "2016-08-22 14:17:42 +0000";
+layers = (
+{
+components = (
+{
+name = Uhorn;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, 129, 304}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 732;
+},
+{
+components = (
+{
+name = Uhorn;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, 133, 304}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 752;
+}
+);
+leftKerningGroup = U;
+rightKerningGroup = U;
+unicode = 1EEE;
+},
+{
+glyphname = Uhungarumlaut;
+lastChange = "2016-08-22 13:41:15 +0000";
+layers = (
+{
+components = (
+{
+name = U;
+},
+{
+name = hungarumlaut.case;
 transform = "{1, 0, 0, 1, 181, 0}";
 }
 );
@@ -7319,7 +9605,7 @@ components = (
 name = U;
 },
 {
-name = hungarumlaut.cap;
+name = hungarumlaut.case;
 transform = "{1, 0, 0, 1, 151, 0}";
 }
 );
@@ -7333,7 +9619,7 @@ unicode = 0170;
 },
 {
 glyphname = Uinvertedbreve;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 components = (
@@ -7341,7 +9627,7 @@ components = (
 name = U;
 },
 {
-name = uni0311.cap;
+name = breveinvertedcomb.cap;
 transform = "{1, 0, 0, 1, 232, 0}";
 }
 );
@@ -7354,7 +9640,7 @@ components = (
 name = U;
 },
 {
-name = uni0311.cap;
+name = breveinvertedcomb.cap;
 transform = "{1, 0, 0, 1, 228, 0}";
 }
 );
@@ -7368,7 +9654,7 @@ unicode = 0216;
 },
 {
 glyphname = Umacron;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:15 +0000";
 layers = (
 {
 components = (
@@ -7376,7 +9662,7 @@ components = (
 name = U;
 },
 {
-name = macron.cap;
+name = macron.case;
 transform = "{1, 0, 0, 1, 192, 0}";
 }
 );
@@ -7389,7 +9675,7 @@ components = (
 name = U;
 },
 {
-name = macron.cap;
+name = macron.case;
 transform = "{1, 0, 0, 1, 219, 0}";
 }
 );
@@ -7438,7 +9724,7 @@ unicode = 0172;
 },
 {
 glyphname = Uring;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:15 +0000";
 layers = (
 {
 components = (
@@ -7446,7 +9732,7 @@ components = (
 name = U;
 },
 {
-name = ring.cap;
+name = ring.case;
 transform = "{1, 0, 0, 1, 262, 0}";
 }
 );
@@ -7459,7 +9745,7 @@ components = (
 name = U;
 },
 {
-name = ring.cap;
+name = ring.case;
 transform = "{1, 0, 0, 1, 299, 0}";
 }
 );
@@ -7473,7 +9759,7 @@ unicode = 016E;
 },
 {
 glyphname = Utilde;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:05:38 +0000";
 layers = (
 {
 components = (
@@ -7481,8 +9767,8 @@ components = (
 name = U;
 },
 {
-name = tilde.cap;
-transform = "{1, 0, 0, 1, 201, 0}";
+name = tildecomb;
+transform = "{1, 0, 0, 1, 129, 304}";
 }
 );
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -7494,8 +9780,8 @@ components = (
 name = U;
 },
 {
-name = tilde.cap;
-transform = "{1, 0, 0, 1, 212, 0}";
+name = tildecomb;
+transform = "{1, 0, 0, 1, 133, 304}";
 }
 );
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
@@ -7508,92 +9794,113 @@ unicode = 0168;
 },
 {
 glyphname = V;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:59 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{230, 0}";
+},
+{
+name = top;
+position = "{404, 754}";
+}
+);
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
 paths = (
 {
 closed = 1;
 nodes = (
-"313 744 LINE",
-"190 744 LINE",
-"135 -10 LINE",
+"158 -10 LINE",
+"667 734 LINE",
+"628 734 LINE",
+"265 203 LINE",
+"153 -10 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "156 -10 LINE",
 "268 207 LINE",
-"264 207 LINE"
+"264 207 LINE",
+"313 744 LINE",
+"190 744 LINE",
+"135 -10 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"111 729 LINE",
 "380 729 LINE",
 "380 754 LINE",
-"111 754 LINE"
+"111 754 LINE",
+"111 729 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"526 729 LINE",
 "740 729 LINE",
 "740 754 LINE",
-"526 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"265 203 LINE",
-"156 -10 LINE",
-"667 734 LINE",
-"628 734 LINE"
+"526 754 LINE",
+"526 729 LINE"
 );
 }
 );
 width = 564;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{256, 0}";
+},
+{
+name = top;
+position = "{430, 754}";
+}
+);
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
 paths = (
 {
 closed = 1;
 nodes = (
-"339 744 LINE",
-"176 744 LINE",
-"141 -13 LINE",
-"172 -13 LINE",
-"308 224 LINE",
-"304 224 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"97 724 LINE",
-"416 724 LINE",
-"416 754 LINE",
-"97 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"582 724 LINE",
-"802 724 LINE",
-"802 754 LINE",
-"582 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"305 220 LINE",
-"164 -13 LINE",
 "174 -13 LINE",
 "731 734 LINE",
-"694 734 LINE"
+"694 734 LINE",
+"305 220 LINE",
+"164 -13 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"172 -13 LINE",
+"308 224 LINE",
+"304 224 LINE",
+"339 744 LINE",
+"176 744 LINE",
+"141 -13 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"416 724 LINE",
+"416 754 LINE",
+"97 754 LINE",
+"97 724 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"802 724 LINE",
+"802 754 LINE",
+"582 754 LINE",
+"582 724 LINE"
 );
 }
 );
@@ -7604,112 +9911,155 @@ unicode = 0056;
 },
 {
 glyphname = W;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:59 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{383, 0}";
+},
+{
+name = top;
+position = "{557, 754}";
+}
+);
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
 paths = (
 {
 closed = 1;
 nodes = (
-"307 744 LINE",
-"184 744 LINE",
-"129 -10 LINE",
-"150 -10 LINE",
-"267 202 LINE",
-"263 202 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"105 729 LINE",
-"796 729 LINE",
-"796 754 LINE",
-"105 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"264 198 LINE",
-"150 -10 LINE",
-"500 458 LINE",
-"467 458 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"585 744 LINE",
-"462 744 LINE",
-"407 -10 LINE",
-"428 -10 LINE",
-"541 200 LINE",
-"537 200 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"838 729 LINE",
-"1052 729 LINE",
-"1052 754 LINE",
-"838 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"538 196 LINE",
 "428 -10 LINE",
 "979 734 LINE",
-"946 734 LINE"
+"946 734 LINE",
+"538 196 LINE",
+"423 -10 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"497 478 LINE",
-"531 467 LINE",
+"150 -10 LINE",
+"500 458 LINE",
+"467 458 LINE",
+"264 198 LINE",
+"146 -10 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"150 -10 LINE",
+"267 202 LINE",
+"263 202 LINE",
+"307 744 LINE",
+"184 744 LINE",
+"129 -10 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"428 -10 LINE",
+"541 200 LINE",
+"537 200 LINE",
+"585 744 LINE",
+"462 744 LINE",
+"407 -10 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"796 729 LINE",
+"796 754 LINE",
+"105 754 LINE",
+"105 729 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "733 738 LINE",
-"700 738 LINE"
+"700 738 LINE",
+"497 478 LINE",
+"531 467 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"1052 729 LINE",
+"1052 754 LINE",
+"838 754 LINE",
+"838 729 LINE"
 );
 }
 );
 width = 870;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{409, 0}";
+},
+{
+name = top;
+position = "{583, 754}";
+}
+);
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
 paths = (
 {
 closed = 1;
 nodes = (
-"315 744 LINE",
-"152 744 LINE",
-"117 -13 LINE",
-"148 -13 LINE",
-"284 210 LINE",
-"280 210 LINE"
+"452 -13 LINE",
+"1029 734 LINE",
+"990 734 LINE",
+"580 210 LINE",
+"442 -13 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"68 724 LINE",
-"826 724 LINE",
-"826 754 LINE",
-"68 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"150 -13 LINE",
+"478 388 LINE",
 "465 424 LINE",
 "281 206 LINE",
-"140 -13 LINE",
-"150 -13 LINE",
-"478 388 LINE"
+"140 -13 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"148 -13 LINE",
+"284 210 LINE",
+"280 210 LINE",
+"315 744 LINE",
+"152 744 LINE",
+"117 -13 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"444 -13 LINE",
+"580 210 LINE",
+"576 210 LINE",
+"611 744 LINE",
+"448 744 LINE",
+"413 -13 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"826 724 LINE",
+"826 754 LINE",
+"68 754 LINE",
+"68 724 LINE"
 );
 },
 {
@@ -7724,31 +10074,10 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"863 724 LINE",
 "1083 724 LINE",
 "1083 754 LINE",
-"863 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"580 210 LINE",
-"442 -13 LINE",
-"452 -13 LINE",
-"1029 734 LINE",
-"990 734 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"611 744 LINE",
-"448 744 LINE",
-"413 -13 LINE",
-"444 -13 LINE",
-"580 210 LINE",
-"576 210 LINE"
+"863 754 LINE",
+"863 724 LINE"
 );
 }
 );
@@ -7761,7 +10090,7 @@ unicode = 0057;
 },
 {
 glyphname = Wacute;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:15 +0000";
 layers = (
 {
 components = (
@@ -7769,7 +10098,7 @@ components = (
 name = W;
 },
 {
-name = acute.cap;
+name = acute.case;
 transform = "{1, 0, 0, 1, 344, 0}";
 }
 );
@@ -7782,7 +10111,7 @@ components = (
 name = W;
 },
 {
-name = acute.cap;
+name = acute.case;
 transform = "{1, 0, 0, 1, 348, 0}";
 }
 );
@@ -7796,7 +10125,7 @@ unicode = 1E82;
 },
 {
 glyphname = Wcircumflex;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:15 +0000";
 layers = (
 {
 components = (
@@ -7804,7 +10133,7 @@ components = (
 name = W;
 },
 {
-name = circumflex.cap;
+name = circumflex.case;
 transform = "{1, 0, 0, 1, 305, 0}";
 }
 );
@@ -7817,7 +10146,7 @@ components = (
 name = W;
 },
 {
-name = circumflex.cap;
+name = circumflex.case;
 transform = "{1, 0, 0, 1, 322, 0}";
 }
 );
@@ -7831,7 +10160,7 @@ unicode = 0174;
 },
 {
 glyphname = Wdieresis;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:15 +0000";
 layers = (
 {
 components = (
@@ -7839,7 +10168,7 @@ components = (
 name = W;
 },
 {
-name = dieresis.cap;
+name = dieresis.case;
 transform = "{1, 0, 0, 1, 319, 0}";
 }
 );
@@ -7852,7 +10181,7 @@ components = (
 name = W;
 },
 {
-name = dieresis.cap;
+name = dieresis.case;
 transform = "{1, 0, 0, 1, 353, 0}";
 }
 );
@@ -7866,7 +10195,7 @@ unicode = 1E84;
 },
 {
 glyphname = Wgrave;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:15 +0000";
 layers = (
 {
 components = (
@@ -7874,7 +10203,7 @@ components = (
 name = W;
 },
 {
-name = grave.cap;
+name = grave.case;
 transform = "{1, 0, 0, 1, 277, 0}";
 }
 );
@@ -7887,7 +10216,7 @@ components = (
 name = W;
 },
 {
-name = grave.cap;
+name = grave.case;
 transform = "{1, 0, 0, 1, 308, 0}";
 }
 );
@@ -7901,149 +10230,169 @@ unicode = 1E80;
 },
 {
 glyphname = X;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:59 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{250, 0}";
+},
+{
+name = top;
+position = "{424, 754}";
+}
+);
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
 paths = (
 {
 closed = 1;
 nodes = (
+"556 0 LINE",
 "274 754 LINE",
 "149 754 LINE",
-"435 0 LINE",
-"556 0 LINE"
+"435 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"62 729 LINE",
-"381 729 LINE",
-"381 754 LINE",
-"62 754 LINE"
+"202 0 LINE",
+"202 25 LINE",
+"-55 25 LINE",
+"-55 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"321 0 LINE",
-"650 0 LINE",
-"650 25 LINE",
-"321 25 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"387 462 LINE",
-"383 462 LINE",
-"334 395 LINE",
-"369 395 LINE",
-"641 734 LINE",
-"606 734 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"487 729 LINE",
-"732 729 LINE",
-"732 754 LINE",
-"487 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"73 20 LINE",
 "309 323 LINE",
 "313 323 LINE",
 "362 389 LINE",
 "327 389 LINE",
-"38 20 LINE",
-"73 20 LINE"
+"38 20 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"202 25 LINE",
-"-55 25 LINE",
-"-55 0 LINE",
-"202 0 LINE"
+"650 0 LINE",
+"650 25 LINE",
+"321 25 LINE",
+"321 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"381 729 LINE",
+"381 754 LINE",
+"62 754 LINE",
+"62 729 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"369 395 LINE",
+"641 734 LINE",
+"606 734 LINE",
+"387 462 LINE",
+"383 462 LINE",
+"334 395 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"732 729 LINE",
+"732 754 LINE",
+"487 754 LINE",
+"487 729 LINE"
 );
 }
 );
 width = 603;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{266, 0}";
+},
+{
+name = top;
+position = "{440, 754}";
+}
+);
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
 paths = (
 {
 closed = 1;
 nodes = (
+"577 0 LINE",
 "295 754 LINE",
 "130 754 LINE",
-"416 0 LINE",
-"577 0 LINE"
+"416 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"63 724 LINE",
-"382 724 LINE",
-"382 754 LINE",
-"63 754 LINE"
+"203 0 LINE",
+"203 30 LINE",
+"-54 30 LINE",
+"-54 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"322 0 LINE",
-"651 0 LINE",
-"651 30 LINE",
-"322 30 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"401 479 LINE",
-"397 479 LINE",
-"345 408 LINE",
-"383 408 LINE",
-"642 734 LINE",
-"607 734 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"488 724 LINE",
-"733 724 LINE",
-"733 754 LINE",
-"488 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"74 20 LINE",
 "297 306 LINE",
 "301 306 LINE",
 "363 389 LINE",
 "320 389 LINE",
-"34 20 LINE",
-"74 20 LINE"
+"34 20 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"203 30 LINE",
-"-54 30 LINE",
-"-54 0 LINE",
-"203 0 LINE"
+"651 0 LINE",
+"651 30 LINE",
+"322 30 LINE",
+"322 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"382 724 LINE",
+"382 754 LINE",
+"63 754 LINE",
+"63 724 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"383 408 LINE",
+"642 734 LINE",
+"607 734 LINE",
+"401 479 LINE",
+"397 479 LINE",
+"345 408 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"733 724 LINE",
+"733 754 LINE",
+"488 754 LINE",
+"488 724 LINE"
 );
 }
 );
@@ -8054,127 +10403,155 @@ unicode = 0058;
 },
 {
 glyphname = Y;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:59 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{240, 0}";
+},
+{
+name = top;
+position = "{414, 754}";
+},
+{
+name = topleft;
+position = "{142, 754}";
+}
+);
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
 paths = (
 {
 closed = 1;
 nodes = (
-"401 376 LINE",
-"284 376 LINE",
-"204 0 LINE",
-"317 0 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"95 0 LINE",
-"447 0 LINE",
-"447 25 LINE",
-"95 25 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"393 365 LINE",
 "249 754 LINE",
 "124 754 LINE",
-"284 334 LINE",
-"393 365 LINE"
+"284 334 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"42 729 LINE",
-"376 729 LINE",
-"376 754 LINE",
-"42 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"388 390 LINE",
-"384 390 LINE",
-"337 317 LINE",
 "372 317 LINE",
 "664 734 LINE",
-"629 734 LINE"
+"629 734 LINE",
+"388 390 LINE",
+"384 390 LINE",
+"337 317 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"510 729 LINE",
+"317 0 LINE",
+"401 376 LINE",
+"284 376 LINE",
+"204 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"447 0 LINE",
+"447 25 LINE",
+"95 25 LINE",
+"95 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"376 729 LINE",
+"376 754 LINE",
+"42 754 LINE",
+"42 729 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "755 729 LINE",
 "755 754 LINE",
-"510 754 LINE"
+"510 754 LINE",
+"510 729 LINE"
 );
 }
 );
 width = 583;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{272, 0}";
+},
+{
+name = top;
+position = "{446, 754}";
+},
+{
+name = topleft;
+position = "{142, 754}";
+}
+);
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
 paths = (
 {
 closed = 1;
 nodes = (
-"445 347 LINE",
-"294 347 LINE",
-"219 0 LINE",
-"366 0 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"112 0 LINE",
-"491 0 LINE",
-"491 31 LINE",
-"112 31 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"445 348 LINE",
 "294 754 LINE",
 "139 754 LINE",
-"299 294 LINE",
-"445 348 LINE"
+"299 294 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"67 724 LINE",
-"421 724 LINE",
-"421 754 LINE",
-"67 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"439 374 LINE",
-"435 374 LINE",
-"384 300 LINE",
 "430 300 LINE",
 "701 734 LINE",
-"666 734 LINE"
+"666 734 LINE",
+"439 374 LINE",
+"435 374 LINE",
+"384 300 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"547 724 LINE",
+"366 0 LINE",
+"445 347 LINE",
+"294 347 LINE",
+"219 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"491 0 LINE",
+"491 31 LINE",
+"112 31 LINE",
+"112 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"421 724 LINE",
+"421 754 LINE",
+"67 754 LINE",
+"67 724 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "772 724 LINE",
 "772 754 LINE",
-"547 754 LINE"
+"547 754 LINE",
+"547 724 LINE"
 );
 }
 );
@@ -8187,7 +10564,7 @@ unicode = 0059;
 },
 {
 glyphname = Yacute;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:05:38 +0000";
 layers = (
 {
 components = (
@@ -8195,8 +10572,8 @@ components = (
 name = Y;
 },
 {
-name = acute.cap;
-transform = "{1, 0, 0, 1, 179, 0}";
+name = acutecomb;
+transform = "{1, 0, 0, 1, 55, 304}";
 }
 );
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -8208,8 +10585,8 @@ components = (
 name = Y;
 },
 {
-name = acute.cap;
-transform = "{1, 0, 0, 1, 240, 0}";
+name = acutecomb;
+transform = "{1, 0, 0, 1, 41, 304}";
 }
 );
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
@@ -8222,7 +10599,7 @@ unicode = 00DD;
 },
 {
 glyphname = Ycircumflex;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:15 +0000";
 layers = (
 {
 components = (
@@ -8230,7 +10607,7 @@ components = (
 name = Y;
 },
 {
-name = circumflex.cap;
+name = circumflex.case;
 transform = "{1, 0, 0, 1, 124, 0}";
 }
 );
@@ -8243,7 +10620,7 @@ components = (
 name = Y;
 },
 {
-name = circumflex.cap;
+name = circumflex.case;
 transform = "{1, 0, 0, 1, 171, 0}";
 }
 );
@@ -8257,7 +10634,7 @@ unicode = 0176;
 },
 {
 glyphname = Ydieresis;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:15 +0000";
 layers = (
 {
 components = (
@@ -8265,7 +10642,7 @@ components = (
 name = Y;
 },
 {
-name = dieresis.cap;
+name = dieresis.case;
 transform = "{1, 0, 0, 1, 127, 0}";
 }
 );
@@ -8278,7 +10655,7 @@ components = (
 name = Y;
 },
 {
-name = dieresis.cap;
+name = dieresis.case;
 transform = "{1, 0, 0, 1, 196, 0}";
 }
 );
@@ -8291,8 +10668,8 @@ rightKerningGroup = Y;
 unicode = 0178;
 },
 {
-glyphname = Ygrave;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = Ydotbelow;
+lastChange = "2016-08-22 14:17:47 +0000";
 layers = (
 {
 components = (
@@ -8300,8 +10677,8 @@ components = (
 name = Y;
 },
 {
-name = grave.cap;
-transform = "{1, 0, 0, 1, 110, 0}";
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -1, 0}";
 }
 );
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -8313,8 +10690,43 @@ components = (
 name = Y;
 },
 {
-name = grave.cap;
-transform = "{1, 0, 0, 1, 164, 0}";
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 22, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 647;
+}
+);
+leftKerningGroup = Y;
+rightKerningGroup = Y;
+unicode = 1EF4;
+},
+{
+glyphname = Ygrave;
+lastChange = "2016-08-22 14:17:47 +0000";
+layers = (
+{
+components = (
+{
+name = Y;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 66, 304}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 583;
+},
+{
+components = (
+{
+name = Y;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 130, 304}";
 }
 );
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
@@ -8326,8 +10738,8 @@ rightKerningGroup = Y;
 unicode = 1EF2;
 },
 {
-glyphname = Ytilde;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = Yhookabove;
+lastChange = "2016-08-22 14:17:47 +0000";
 layers = (
 {
 components = (
@@ -8335,8 +10747,8 @@ components = (
 name = Y;
 },
 {
-name = tilde.cap;
-transform = "{1, 0, 0, 1, 96, 0}";
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 91, 304}";
 }
 );
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -8348,8 +10760,43 @@ components = (
 name = Y;
 },
 {
-name = tilde.cap;
-transform = "{1, 0, 0, 1, 156, 0}";
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 114, 304}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 647;
+}
+);
+leftKerningGroup = Y;
+rightKerningGroup = Y;
+unicode = 1EF6;
+},
+{
+glyphname = Ytilde;
+lastChange = "2016-08-22 14:05:38 +0000";
+layers = (
+{
+components = (
+{
+name = Y;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, 55, 304}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 583;
+},
+{
+components = (
+{
+name = Y;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, 81, 304}";
 }
 );
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
@@ -8362,90 +10809,109 @@ unicode = 1EF8;
 },
 {
 glyphname = Z;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:59 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{273, 0}";
+},
+{
+name = top;
+position = "{447, 754}";
+}
+);
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
 paths = (
 {
 closed = 1;
 nodes = (
+"149 25 LINE",
+"149 29 LINE",
 "702 729 LINE",
-"559 734 LINE",
 "556 729 LINE",
 "556 725 LINE",
-"9 25 LINE",
-"149 20 LINE",
-"149 29 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"9 0 LINE",
-"550 0 LINE",
-"610 232 LINE",
-"580 232 LINE",
-"504 64 OFFCURVE",
-"442 25 OFFCURVE",
-"353 25 CURVE SMOOTH",
 "9 25 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"702 754 LINE",
-"210 754 LINE",
-"150 542 LINE",
+"550 0 LINE",
+"610 232 LINE",
+"580 232 LINE",
+"504 64 OFFCURVE",
+"442 25 OFFCURVE",
+"353 25 CURVE SMOOTH",
+"9 25 LINE",
+"9 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "180 542 LINE",
 "256 694 OFFCURVE",
 "318 729 OFFCURVE",
 "407 729 CURVE SMOOTH",
-"702 729 LINE"
+"702 729 LINE",
+"702 754 LINE",
+"210 754 LINE",
+"150 542 LINE"
 );
 }
 );
 width = 649;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{283, 0}";
+},
+{
+name = top;
+position = "{457, 754}";
+}
+);
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
 paths = (
 {
 closed = 1;
 nodes = (
-"146 533 LINE",
-"181 533 LINE",
-"235 664 OFFCURVE",
-"318 724 OFFCURVE",
-"392 724 CURVE SMOOTH",
+"190 30 LINE",
+"190 35 LINE",
 "720 724 LINE",
-"720 754 LINE",
-"208 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"-1 0 LINE",
-"556 0 LINE",
-"616 232 LINE",
-"576 232 LINE",
-"500 68 OFFCURVE",
-"438 30 OFFCURVE",
-"349 30 CURVE SMOOTH",
+"543 724 LINE",
+"543 720 LINE",
 "-1 30 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"720 724 LINE",
-"543 724 LINE",
-"543 720 LINE",
+"556 0 LINE",
+"616 232 LINE",
+"576 232 LINE",
+"500 68 OFFCURVE",
+"438 30 OFFCURVE",
+"349 30 CURVE SMOOTH",
 "-1 30 LINE",
-"190 30 LINE",
-"190 35 LINE"
+"-1 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"181 533 LINE",
+"235 664 OFFCURVE",
+"318 724 OFFCURVE",
+"392 724 CURVE SMOOTH",
+"720 724 LINE",
+"720 754 LINE",
+"208 754 LINE",
+"146 533 LINE"
 );
 }
 );
@@ -8458,7 +10924,7 @@ unicode = 005A;
 },
 {
 glyphname = Zacute;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:15 +0000";
 layers = (
 {
 components = (
@@ -8466,7 +10932,7 @@ components = (
 name = Z;
 },
 {
-name = acute.cap;
+name = acute.case;
 transform = "{1, 0, 0, 1, 198, 0}";
 }
 );
@@ -8479,7 +10945,7 @@ components = (
 name = Z;
 },
 {
-name = acute.cap;
+name = acute.case;
 transform = "{1, 0, 0, 1, 219, 0}";
 }
 );
@@ -8493,7 +10959,7 @@ unicode = 0179;
 },
 {
 glyphname = Zcaron;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:15 +0000";
 layers = (
 {
 components = (
@@ -8501,7 +10967,7 @@ components = (
 name = Z;
 },
 {
-name = caron.cap;
+name = caron.case;
 transform = "{1, 0, 0, 1, 155, 0}";
 }
 );
@@ -8514,7 +10980,7 @@ components = (
 name = Z;
 },
 {
-name = caron.cap;
+name = caron.case;
 transform = "{1, 0, 0, 1, 174, 0}";
 }
 );
@@ -8528,7 +10994,7 @@ unicode = 017D;
 },
 {
 glyphname = Zdotaccent;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:15 +0000";
 layers = (
 {
 components = (
@@ -8536,7 +11002,7 @@ components = (
 name = Z;
 },
 {
-name = dotaccent.cap;
+name = dotaccent.case;
 transform = "{1, 0, 0, 1, 264, 0}";
 }
 );
@@ -8549,7 +11015,7 @@ components = (
 name = Z;
 },
 {
-name = dotaccent.cap;
+name = dotaccent.case;
 transform = "{1, 0, 0, 1, 237, 0}";
 }
 );
@@ -8597,488 +11063,29 @@ rightKerningGroup = Z;
 unicode = 1E92;
 },
 {
-glyphname = uni015E;
-lastChange = "2016-08-16 11:12:44 +0000";
-layers = (
-{
-components = (
-{
-name = S;
-},
-{
-name = cedilla;
-transform = "{1, 0, 0, 1, 171, -8}";
-}
-);
-layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
-width = 577;
-},
-{
-components = (
-{
-name = S;
-},
-{
-name = cedilla;
-transform = "{1, 0, 0, 1, 209, -9}";
-}
-);
-layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
-width = 581;
-}
-);
-leftKerningGroup = S;
-rightKerningGroup = S;
-unicode = 015E;
-},
-{
-glyphname = uni0162;
-lastChange = "2016-08-16 11:12:44 +0000";
-layers = (
-{
-components = (
-{
-name = T;
-},
-{
-name = cedilla;
-transform = "{1, 0, 0, 1, 212, 0}";
-}
-);
-layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
-width = 681;
-},
-{
-components = (
-{
-name = T;
-},
-{
-name = cedilla;
-transform = "{1, 0, 0, 1, 232, 0}";
-}
-);
-layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
-width = 701;
-}
-);
-leftKerningGroup = T;
-rightKerningGroup = T;
-unicode = 0162;
-},
-{
-glyphname = uni01C4;
-lastChange = "2016-08-16 11:12:44 +0000";
-layers = (
-{
-components = (
-{
-name = D;
-},
-{
-name = Z;
-transform = "{1, 0, 0, 1, 764, 0}";
-},
-{
-name = caron.cap;
-transform = "{1, 0, 0, 1, 919, 0}";
-}
-);
-layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
-width = 1413;
-},
-{
-components = (
-{
-name = D;
-},
-{
-name = Z;
-transform = "{1, 0, 0, 1, 770, 0}";
-},
-{
-name = caron.cap;
-transform = "{1, 0, 0, 1, 944, 0}";
-}
-);
-layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
-width = 1439;
-}
-);
-leftKerningGroup = D;
-rightKerningGroup = Z;
-unicode = 01C4;
-},
-{
-glyphname = uni01C5;
-lastChange = "2016-08-16 11:12:44 +0000";
-layers = (
-{
-components = (
-{
-name = D;
-},
-{
-name = z;
-transform = "{1, 0, 0, 1, 764, 0}";
-},
-{
-name = caron;
-transform = "{1, 0, 0, 1, 831, 0}";
-}
-);
-layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
-width = 1238;
-},
-{
-components = (
-{
-name = D;
-},
-{
-name = z;
-transform = "{1, 0, 0, 1, 770, 0}";
-},
-{
-name = caron;
-transform = "{1, 0, 0, 1, 805, 0}";
-}
-);
-layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
-width = 1264;
-}
-);
-leftKerningGroup = D;
-rightKerningGroup = z;
-unicode = 01C5;
-},
-{
-glyphname = uni01C7;
-lastChange = "2016-08-16 11:12:44 +0000";
-layers = (
-{
-components = (
-{
-name = L;
-},
-{
-name = J;
-transform = "{1, 0, 0, 1, 598, 0}";
-}
-);
-layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
-width = 966;
-},
-{
-components = (
-{
-name = L;
-},
-{
-name = J;
-transform = "{1, 0, 0, 1, 626, 0}";
-}
-);
-layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
-width = 1066;
-}
-);
-leftKerningGroup = L;
-rightKerningGroup = J;
-unicode = 01C7;
-},
-{
-glyphname = uni01C8;
-lastChange = "2016-08-16 11:12:44 +0000";
-layers = (
-{
-components = (
-{
-name = L;
-},
-{
-name = j;
-transform = "{1, 0, 0, 1, 598, 0}";
-}
-);
-layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
-width = 889;
-},
-{
-components = (
-{
-name = L;
-},
-{
-name = j;
-transform = "{1, 0, 0, 1, 626, 0}";
-}
-);
-layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
-width = 913;
-}
-);
-leftKerningGroup = L;
-rightKerningGroup = j;
-unicode = 01C8;
-},
-{
-glyphname = uni01CA;
-lastChange = "2016-08-16 11:12:44 +0000";
-layers = (
-{
-components = (
-{
-name = N;
-},
-{
-name = J;
-transform = "{1, 0, 0, 1, 769, 0}";
-}
-);
-layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
-width = 1137;
-},
-{
-components = (
-{
-name = N;
-},
-{
-name = J;
-transform = "{1, 0, 0, 1, 749, 0}";
-}
-);
-layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
-width = 1189;
-}
-);
-leftKerningGroup = N;
-rightKerningGroup = J;
-unicode = 01CA;
-},
-{
-glyphname = uni01CB;
-lastChange = "2016-08-16 11:12:44 +0000";
-layers = (
-{
-components = (
-{
-name = N;
-},
-{
-name = j;
-transform = "{1, 0, 0, 1, 769, 0}";
-}
-);
-layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
-width = 1060;
-},
-{
-components = (
-{
-name = N;
-},
-{
-name = j;
-transform = "{1, 0, 0, 1, 749, 0}";
-}
-);
-layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
-width = 1036;
-}
-);
-leftKerningGroup = N;
-rightKerningGroup = j;
-unicode = 01CB;
-},
-{
-glyphname = uni01F1;
-lastChange = "2016-08-16 11:12:44 +0000";
-layers = (
-{
-components = (
-{
-name = D;
-},
-{
-name = Z;
-transform = "{1, 0, 0, 1, 764, 0}";
-}
-);
-layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
-width = 1413;
-},
-{
-components = (
-{
-name = D;
-},
-{
-name = Z;
-transform = "{1, 0, 0, 1, 770, 0}";
-}
-);
-layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
-width = 1439;
-}
-);
-leftKerningGroup = D;
-rightKerningGroup = Z;
-unicode = 01F1;
-},
-{
-glyphname = uni01F2;
-lastChange = "2016-08-16 11:12:44 +0000";
-layers = (
-{
-components = (
-{
-name = D;
-},
-{
-name = z;
-transform = "{1, 0, 0, 1, 764, 0}";
-}
-);
-layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
-width = 1238;
-},
-{
-components = (
-{
-name = D;
-},
-{
-name = z;
-transform = "{1, 0, 0, 1, 770, 0}";
-}
-);
-layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
-width = 1264;
-}
-);
-leftKerningGroup = D;
-rightKerningGroup = z;
-unicode = 01F2;
-},
-{
-glyphname = uni0218;
-lastChange = "2016-08-16 11:12:44 +0000";
-layers = (
-{
-components = (
-{
-name = S;
-},
-{
-name = commaaccent;
-transform = "{1, 0, 0, 1, 203, 0}";
-}
-);
-layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
-width = 577;
-},
-{
-components = (
-{
-name = S;
-},
-{
-name = commaaccent;
-transform = "{1, 0, 0, 1, 235, 0}";
-}
-);
-layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
-width = 581;
-}
-);
-leftKerningGroup = S;
-rightKerningGroup = S;
-unicode = 0218;
-},
-{
-glyphname = uni021A;
-lastChange = "2016-08-16 11:12:44 +0000";
-layers = (
-{
-components = (
-{
-name = T;
-},
-{
-name = commaaccent;
-transform = "{1, 0, 0, 1, 260, 0}";
-}
-);
-layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
-width = 681;
-},
-{
-components = (
-{
-name = T;
-},
-{
-name = commaaccent;
-transform = "{1, 0, 0, 1, 274, 0}";
-}
-);
-layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
-width = 701;
-}
-);
-leftKerningGroup = T;
-rightKerningGroup = T;
-unicode = 021A;
-},
-{
 glyphname = a;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:59 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{225, 0}";
+},
+{
+name = ogonek;
+position = "{447, 10}";
+},
+{
+name = top;
+position = "{329, 450}";
+}
+);
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
 paths = (
 {
 closed = 1;
 nodes = (
-"515 450 LINE",
-"418 450 LINE",
-"348 154 LINE SMOOTH",
-"341 125 OFFCURVE",
-"338 101 OFFCURVE",
-"338 81 CURVE SMOOTH",
-"338 8 OFFCURVE",
-"377 -13 OFFCURVE",
-"410 -13 CURVE SMOOTH",
-"475 -13 OFFCURVE",
-"526 68 OFFCURVE",
-"556 142 CURVE",
-"536 151 LINE",
-"502 71 OFFCURVE",
-"466 30 OFFCURVE",
-"443 30 CURVE SMOOTH",
-"432 30 OFFCURVE",
-"426 39 OFFCURVE",
-"426 59 CURVE SMOOTH",
-"426 77 OFFCURVE",
-"431 106 OFFCURVE",
-"441 147 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"398 389 LINE",
-"384 430 OFFCURVE",
-"359 462 OFFCURVE",
-"298 462 CURVE SMOOTH",
-"172 462 OFFCURVE",
-"43 328 OFFCURVE",
-"43 173 CURVE SMOOTH",
-"43 59 OFFCURVE",
-"112 -13 OFFCURVE",
-"197 -13 CURVE SMOOTH",
 "252 -13 OFFCURVE",
 "304 17 OFFCURVE",
 "334 70 CURVE",
@@ -9099,55 +11106,69 @@ nodes = (
 "386 321 OFFCURVE",
 "384 313 OFFCURVE",
 "383 298 CURVE",
-"404 389 LINE"
+"404 389 LINE",
+"398 389 LINE",
+"384 430 OFFCURVE",
+"359 462 OFFCURVE",
+"298 462 CURVE SMOOTH",
+"172 462 OFFCURVE",
+"43 328 OFFCURVE",
+"43 173 CURVE SMOOTH",
+"43 59 OFFCURVE",
+"112 -13 OFFCURVE",
+"197 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"475 -13 OFFCURVE",
+"526 68 OFFCURVE",
+"556 142 CURVE",
+"536 151 LINE",
+"502 71 OFFCURVE",
+"466 30 OFFCURVE",
+"443 30 CURVE SMOOTH",
+"432 30 OFFCURVE",
+"426 39 OFFCURVE",
+"426 59 CURVE SMOOTH",
+"426 77 OFFCURVE",
+"431 106 OFFCURVE",
+"441 147 CURVE SMOOTH",
+"515 450 LINE",
+"418 450 LINE",
+"348 154 LINE SMOOTH",
+"341 125 OFFCURVE",
+"338 101 OFFCURVE",
+"338 81 CURVE SMOOTH",
+"338 8 OFFCURVE",
+"377 -13 OFFCURVE",
+"410 -13 CURVE SMOOTH"
 );
 }
 );
 width = 554;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{241, 0}";
+},
+{
+name = ogonek;
+position = "{475, 10}";
+},
+{
+name = top;
+position = "{345, 450}";
+}
+);
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
 paths = (
 {
 closed = 1;
 nodes = (
-"560 450 LINE",
-"426 450 LINE",
-"352 153 LINE SMOOTH",
-"339 100 OFFCURVE",
-"336 86 OFFCURVE",
-"336 70 CURVE SMOOTH",
-"336 15 OFFCURVE",
-"371 -11 OFFCURVE",
-"423 -11 CURVE SMOOTH",
-"514 -11 OFFCURVE",
-"577 69 OFFCURVE",
-"603 152 CURVE",
-"578 161 LINE",
-"541 69 OFFCURVE",
-"500 41 OFFCURVE",
-"480 41 CURVE SMOOTH",
-"473 41 OFFCURVE",
-"468 45 OFFCURVE",
-"468 54 CURVE SMOOTH",
-"468 58 OFFCURVE",
-"469 70 OFFCURVE",
-"473 87 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"405 390 LINE",
-"384 439 OFFCURVE",
-"354 462 OFFCURVE",
-"305 462 CURVE SMOOTH",
-"174 462 OFFCURVE",
-"29 320 OFFCURVE",
-"29 166 CURVE SMOOTH",
-"29 54 OFFCURVE",
-"107 -11 OFFCURVE",
-"192 -11 CURVE SMOOTH",
 "257 -11 OFFCURVE",
 "305 32 OFFCURVE",
 "329 70 CURVE",
@@ -9168,7 +11189,44 @@ nodes = (
 "392 324 OFFCURVE",
 "390 312 OFFCURVE",
 "389 299 CURVE",
-"412 390 LINE"
+"412 390 LINE",
+"405 390 LINE",
+"384 439 OFFCURVE",
+"354 462 OFFCURVE",
+"305 462 CURVE SMOOTH",
+"174 462 OFFCURVE",
+"29 320 OFFCURVE",
+"29 166 CURVE SMOOTH",
+"29 54 OFFCURVE",
+"107 -11 OFFCURVE",
+"192 -11 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"514 -11 OFFCURVE",
+"577 69 OFFCURVE",
+"603 152 CURVE",
+"578 161 LINE",
+"541 69 OFFCURVE",
+"500 41 OFFCURVE",
+"480 41 CURVE SMOOTH",
+"473 41 OFFCURVE",
+"468 45 OFFCURVE",
+"468 54 CURVE SMOOTH",
+"468 58 OFFCURVE",
+"469 70 OFFCURVE",
+"473 87 CURVE SMOOTH",
+"560 450 LINE",
+"426 450 LINE",
+"352 153 LINE SMOOTH",
+"339 100 OFFCURVE",
+"336 86 OFFCURVE",
+"336 70 CURVE SMOOTH",
+"336 15 OFFCURVE",
+"371 -11 OFFCURVE",
+"423 -11 CURVE SMOOTH"
 );
 }
 );
@@ -9181,7 +11239,7 @@ unicode = 0061;
 },
 {
 glyphname = aacute;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:05:38 +0000";
 layers = (
 {
 components = (
@@ -9189,8 +11247,8 @@ components = (
 name = a;
 },
 {
-name = acute;
-transform = "{1, 0, 0, 1, 180, 0}";
+name = acutecomb;
+transform = "{1, 0, 0, 1, -30, 0}";
 }
 );
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -9202,8 +11260,8 @@ components = (
 name = a;
 },
 {
-name = acute;
-transform = "{1, 0, 0, 1, 189, 0}";
+name = acutecomb;
+transform = "{1, 0, 0, 1, -60, 0}";
 }
 );
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
@@ -9216,7 +11274,7 @@ unicode = 00E1;
 },
 {
 glyphname = abreve;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:05:38 +0000";
 layers = (
 {
 components = (
@@ -9224,8 +11282,8 @@ components = (
 name = a;
 },
 {
-name = breve;
-transform = "{1, 0, 0, 1, 90, 0}";
+name = brevecomb;
+transform = "{1, 0, 0, 1, -45, 0}";
 }
 );
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -9237,8 +11295,8 @@ components = (
 name = a;
 },
 {
-name = breve;
-transform = "{1, 0, 0, 1, 112, 0}";
+name = brevecomb;
+transform = "{1, 0, 0, 1, -36, 0}";
 }
 );
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
@@ -9250,8 +11308,8 @@ rightKerningGroup = a;
 unicode = 0103;
 },
 {
-glyphname = acircumflex;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = abreveacute;
+lastChange = "2016-08-22 14:17:55 +0000";
 layers = (
 {
 components = (
@@ -9259,8 +11317,8 @@ components = (
 name = a;
 },
 {
-name = circumflex;
-transform = "{1, 0, 0, 1, 116, 0}";
+name = brevecomb_acutecomb;
+transform = "{1, 0, 0, 1, -30, 0}";
 }
 );
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -9272,8 +11330,190 @@ components = (
 name = a;
 },
 {
-name = circumflex;
-transform = "{1, 0, 0, 1, 115, 0}";
+name = brevecomb_acutecomb;
+transform = "{1, 0, 0, 1, -12, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 586;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 1EAF;
+},
+{
+glyphname = abrevedotbelow;
+lastChange = "2016-08-22 14:17:55 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -16, 0}";
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, -45, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 554;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -9, 0}";
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, -36, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 586;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 1EB7;
+},
+{
+glyphname = abrevegrave;
+lastChange = "2016-08-22 14:17:55 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = brevecomb_gravecomb;
+transform = "{1, 0, 0, 1, -44, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 554;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = brevecomb_gravecomb;
+transform = "{1, 0, 0, 1, -25, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 586;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 1EB1;
+},
+{
+glyphname = abrevehookabove;
+lastChange = "2016-08-22 14:17:55 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = brevecomb_hookabovecomb;
+transform = "{1, 0, 0, 1, -48, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 554;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = brevecomb_hookabovecomb;
+transform = "{1, 0, 0, 1, -5, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 586;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 1EB3;
+},
+{
+glyphname = abrevetilde;
+lastChange = "2016-08-22 14:17:55 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = brevecomb_tildecomb;
+transform = "{1, 0, 0, 1, -45, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 554;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = brevecomb_tildecomb;
+transform = "{1, 0, 0, 1, -35, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 586;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 1EB5;
+},
+{
+glyphname = acircumflex;
+lastChange = "2016-08-22 14:17:55 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -43, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 554;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = circumflexcomb;
 }
 );
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
@@ -9285,8 +11525,8 @@ rightKerningGroup = a;
 unicode = 00E2;
 },
 {
-glyphname = adblgrave;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = acircumflexacute;
+lastChange = "2016-08-22 14:17:55 +0000";
 layers = (
 {
 components = (
@@ -9294,7 +11534,189 @@ components = (
 name = a;
 },
 {
-name = uni030F;
+name = circumflexcomb_acutecomb;
+transform = "{1, 0, 0, 1, -39, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 554;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = circumflexcomb_acutecomb;
+transform = "{1, 0, 0, 1, -22, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 586;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 1EA5;
+},
+{
+glyphname = acircumflexdotbelow;
+lastChange = "2016-08-22 14:17:55 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -16, 0}";
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -43, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 554;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -9, 0}";
+},
+{
+name = circumflexcomb;
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 586;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 1EAD;
+},
+{
+glyphname = acircumflexgrave;
+lastChange = "2016-08-22 14:17:55 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = circumflexcomb_gravecomb;
+transform = "{1, 0, 0, 1, -35, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 554;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = circumflexcomb_gravecomb;
+transform = "{1, 0, 0, 1, -18, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 586;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 1EA7;
+},
+{
+glyphname = acircumflexhookabove;
+lastChange = "2016-08-22 14:17:55 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = circumflexcomb_hookabovecomb;
+transform = "{1, 0, 0, 1, -41, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 554;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = circumflexcomb_hookabovecomb;
+transform = "{1, 0, 0, 1, -21, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 586;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 1EA9;
+},
+{
+glyphname = acircumflextilde;
+lastChange = "2016-08-22 14:17:55 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = circumflexcomb_tildecomb;
+transform = "{1, 0, 0, 1, -39, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 554;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = circumflexcomb_tildecomb;
+transform = "{1, 0, 0, 1, -24, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 586;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 1EAB;
+},
+{
+glyphname = adblgrave;
+lastChange = "2016-08-22 14:17:55 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = dblgravecomb;
 transform = "{1, 0, 0, 1, 43, 0}";
 }
 );
@@ -9307,7 +11729,7 @@ components = (
 name = a;
 },
 {
-name = uni030F;
+name = dblgravecomb;
 transform = "{1, 0, 0, 1, 60, 0}";
 }
 );
@@ -9321,7 +11743,7 @@ unicode = 0201;
 },
 {
 glyphname = adieresis;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:17:55 +0000";
 layers = (
 {
 components = (
@@ -9355,8 +11777,8 @@ rightKerningGroup = a;
 unicode = 00E4;
 },
 {
-glyphname = agrave;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = adotbelow;
+lastChange = "2016-08-22 14:17:55 +0000";
 layers = (
 {
 components = (
@@ -9364,8 +11786,8 @@ components = (
 name = a;
 },
 {
-name = grave;
-transform = "{1, 0, 0, 1, 95, 0}";
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -16, 0}";
 }
 );
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -9377,8 +11799,43 @@ components = (
 name = a;
 },
 {
-name = grave;
-transform = "{1, 0, 0, 1, 148, 0}";
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -9, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 586;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 1EA1;
+},
+{
+glyphname = agrave;
+lastChange = "2016-08-22 14:17:55 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, -19, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 554;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 29, 0}";
 }
 );
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
@@ -9390,8 +11847,8 @@ rightKerningGroup = a;
 unicode = 00E0;
 },
 {
-glyphname = ainvertedbreve;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = ahookabove;
+lastChange = "2016-08-22 14:17:55 +0000";
 layers = (
 {
 components = (
@@ -9399,7 +11856,42 @@ components = (
 name = a;
 },
 {
-name = uni0311;
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 6, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 554;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 13, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 586;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 1EA3;
+},
+{
+glyphname = ainvertedbreve;
+lastChange = "2016-08-22 14:17:55 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = breveinvertedcomb;
 transform = "{1, 0, 0, 1, 107, 0}";
 }
 );
@@ -9412,7 +11904,7 @@ components = (
 name = a;
 },
 {
-name = uni0311;
+name = breveinvertedcomb;
 transform = "{1, 0, 0, 1, 116, 0}";
 }
 );
@@ -9426,7 +11918,7 @@ unicode = 0203;
 },
 {
 glyphname = amacron;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:17:55 +0000";
 layers = (
 {
 components = (
@@ -9461,102 +11953,21 @@ unicode = 0101;
 },
 {
 glyphname = aogonek;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:17:55 +0000";
 layers = (
 {
-layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
-paths = (
+components = (
 {
-closed = 1;
-nodes = (
-"515 450 LINE",
-"418 450 LINE",
-"348 154 LINE SMOOTH",
-"341 125 OFFCURVE",
-"338 101 OFFCURVE",
-"338 81 CURVE SMOOTH",
-"338 8 OFFCURVE",
-"377 -13 OFFCURVE",
-"410 -13 CURVE SMOOTH",
-"475 -13 OFFCURVE",
-"526 68 OFFCURVE",
-"556 142 CURVE",
-"536 151 LINE",
-"502 71 OFFCURVE",
-"466 30 OFFCURVE",
-"443 30 CURVE SMOOTH",
-"432 30 OFFCURVE",
-"426 39 OFFCURVE",
-"426 59 CURVE SMOOTH",
-"426 77 OFFCURVE",
-"431 106 OFFCURVE",
-"441 147 CURVE SMOOTH"
-);
+name = a;
 },
 {
-closed = 1;
-nodes = (
-"398 389 LINE",
-"384 430 OFFCURVE",
-"359 462 OFFCURVE",
-"298 462 CURVE SMOOTH",
-"172 462 OFFCURVE",
-"43 328 OFFCURVE",
-"43 173 CURVE SMOOTH",
-"43 59 OFFCURVE",
-"112 -13 OFFCURVE",
-"197 -13 CURVE SMOOTH",
-"252 -13 OFFCURVE",
-"304 17 OFFCURVE",
-"334 70 CURVE",
-"340 70 LINE",
-"352 170 LINE",
-"310 52 OFFCURVE",
-"258 19 OFFCURVE",
-"217 19 CURVE SMOOTH",
-"176 19 OFFCURVE",
-"154 53 OFFCURVE",
-"154 117 CURVE SMOOTH",
-"154 218 OFFCURVE",
-"210 433 OFFCURVE",
-"310 433 CURVE SMOOTH",
-"354 433 OFFCURVE",
-"386 392 OFFCURVE",
-"386 335 CURVE SMOOTH",
-"386 321 OFFCURVE",
-"384 313 OFFCURVE",
-"383 298 CURVE",
-"404 389 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"323 -233 LINE SMOOTH",
-"364 -233 OFFCURVE",
-"409 -214 OFFCURVE",
-"436 -187 CURVE",
-"424 -171 LINE",
-"400 -186 OFFCURVE",
-"383 -192 OFFCURVE",
-"367 -192 CURVE SMOOTH",
-"343 -192 OFFCURVE",
-"329 -178 OFFCURVE",
-"329 -152 CURVE SMOOTH",
-"329 -103 OFFCURVE",
-"380 -44 OFFCURVE",
-"469 11 CURVE",
-"433 17 LINE",
-"320 -42 OFFCURVE",
-"246 -117 OFFCURVE",
-"246 -173 CURVE SMOOTH",
-"246 -209 OFFCURVE",
-"277 -233 OFFCURVE",
-"323 -233 CURVE SMOOTH"
-);
+alignment = -1;
+name = ogonek;
+transform = "{1, 0, 0, 1, 347, 0}";
 }
 );
-width = 554;
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 769;
 },
 {
 components = (
@@ -9578,7 +11989,7 @@ unicode = 0105;
 },
 {
 glyphname = aring;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:17:55 +0000";
 layers = (
 {
 components = (
@@ -9613,131 +12024,40 @@ unicode = 00E5;
 },
 {
 glyphname = aringacute;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:17:55 +0000";
 layers = (
 {
 components = (
 {
 name = a;
+},
+{
+name = ring;
+transform = "{1, 0, 0, 1, 163, -77}";
+},
+{
+name = acute;
+transform = "{1, 0, 0, 1, 290, 84}";
 }
 );
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
-paths = (
-{
-closed = 1;
-nodes = (
-"409 620 LINE",
-"560 711 LINE SMOOTH",
-"588 728 OFFCURVE",
-"600 748 OFFCURVE",
-"600 766 CURVE SMOOTH",
-"600 785 OFFCURVE",
-"588 804 OFFCURVE",
-"554 804 CURVE SMOOTH",
-"529 804 OFFCURVE",
-"507 794 OFFCURVE",
-"472 754 CURVE SMOOTH",
-"373 640 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"263 570 LINE SMOOTH",
-"263 513 OFFCURVE",
-"306 470 OFFCURVE",
-"363 470 CURVE SMOOTH",
-"420 470 OFFCURVE",
-"465 513 OFFCURVE",
-"465 570 CURVE SMOOTH",
-"465 627 OFFCURVE",
-"420 672 OFFCURVE",
-"363 672 CURVE SMOOTH",
-"306 672 OFFCURVE",
-"263 627 OFFCURVE",
-"263 570 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"306 570 LINE SMOOTH",
-"306 602 OFFCURVE",
-"332 627 OFFCURVE",
-"363 627 CURVE SMOOTH",
-"395 627 OFFCURVE",
-"420 602 OFFCURVE",
-"420 570 CURVE SMOOTH",
-"420 539 OFFCURVE",
-"395 513 OFFCURVE",
-"363 513 CURVE SMOOTH",
-"332 513 OFFCURVE",
-"306 539 OFFCURVE",
-"306 570 CURVE SMOOTH"
-);
-}
-);
 width = 554;
 },
 {
 components = (
 {
 name = a;
+},
+{
+name = ring;
+transform = "{1, 0, 0, 1, 167, -75}";
+},
+{
+name = acute;
+transform = "{1, 0, 0, 1, 282, 81}";
 }
 );
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
-paths = (
-{
-closed = 1;
-nodes = (
-"400 528 LINE SMOOTH",
-"452 528 OFFCURVE",
-"494 570 OFFCURVE",
-"494 622 CURVE SMOOTH",
-"494 649 OFFCURVE",
-"482 674 OFFCURVE",
-"463 691 CURVE",
-"582 751 LINE SMOOTH",
-"613 767 OFFCURVE",
-"623 777 OFFCURVE",
-"623 799 CURVE SMOOTH",
-"623 825 OFFCURVE",
-"607 847 OFFCURVE",
-"576 847 CURVE SMOOTH",
-"560 847 OFFCURVE",
-"542 841 OFFCURVE",
-"516 814 CURVE SMOOTH",
-"421 713 LINE",
-"414 714 OFFCURVE",
-"407 715 OFFCURVE",
-"400 715 CURVE SMOOTH",
-"349 715 OFFCURVE",
-"306 673 OFFCURVE",
-"306 622 CURVE SMOOTH",
-"306 570 OFFCURVE",
-"349 528 OFFCURVE",
-"400 528 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"400 662 LINE SMOOTH",
-"422 662 OFFCURVE",
-"441 644 OFFCURVE",
-"441 622 CURVE SMOOTH",
-"441 599 OFFCURVE",
-"423 580 OFFCURVE",
-"400 580 CURVE SMOOTH",
-"377 580 OFFCURVE",
-"359 600 OFFCURVE",
-"359 622 CURVE SMOOTH",
-"359 644 OFFCURVE",
-"378 662 OFFCURVE",
-"400 662 CURVE SMOOTH"
-);
-}
-);
 width = 586;
 }
 );
@@ -9747,7 +12067,7 @@ unicode = 01FB;
 },
 {
 glyphname = atilde;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:17:55 +0000";
 layers = (
 {
 components = (
@@ -9755,8 +12075,8 @@ components = (
 name = a;
 },
 {
-name = tilde;
-transform = "{1, 0, 0, 1, 76, 0}";
+name = tildecomb;
+transform = "{1, 0, 0, 1, -30, 0}";
 }
 );
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -9768,8 +12088,8 @@ components = (
 name = a;
 },
 {
-name = tilde;
-transform = "{1, 0, 0, 1, 77, 0}";
+name = tildecomb;
+transform = "{1, 0, 0, 1, -20, 0}";
 }
 );
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
@@ -9782,7 +12102,7 @@ unicode = 00E3;
 },
 {
 glyphname = ae;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:17:55 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -9790,13 +12110,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"625 462 LINE SMOOTH",
-"487 462 OFFCURVE",
-"362 314 OFFCURVE",
-"362 179 CURVE SMOOTH",
-"362 84 OFFCURVE",
-"424 -13 OFFCURVE",
-"548 -13 CURVE SMOOTH",
 "632 -13 OFFCURVE",
 "702 31 OFFCURVE",
 "751 119 CURVE",
@@ -9828,31 +12141,18 @@ nodes = (
 "765 341 CURVE SMOOTH",
 "765 413 OFFCURVE",
 "705 462 OFFCURVE",
-"625 462 CURVE SMOOTH"
+"625 462 CURVE SMOOTH",
+"487 462 OFFCURVE",
+"362 314 OFFCURVE",
+"362 179 CURVE SMOOTH",
+"362 84 OFFCURVE",
+"424 -13 OFFCURVE",
+"548 -13 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"517 450 LINE",
-"420 450 LINE",
-"337 102 LINE",
-"441 147 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"401 391 LINE",
-"387 431 OFFCURVE",
-"360 462 OFFCURVE",
-"301 462 CURVE SMOOTH",
-"175 462 OFFCURVE",
-"43 320 OFFCURVE",
-"43 164 CURVE SMOOTH",
-"43 53 OFFCURVE",
-"111 -13 OFFCURVE",
-"197 -13 CURVE SMOOTH",
 "267 -13 OFFCURVE",
 "329 31 OFFCURVE",
 "368 110 CURVE",
@@ -9874,7 +12174,26 @@ nodes = (
 "387 325 OFFCURVE",
 "387 313 OFFCURVE",
 "385 300 CURVE",
-"407 391 LINE"
+"407 391 LINE",
+"401 391 LINE",
+"387 431 OFFCURVE",
+"360 462 OFFCURVE",
+"301 462 CURVE SMOOTH",
+"175 462 OFFCURVE",
+"43 320 OFFCURVE",
+"43 164 CURVE SMOOTH",
+"43 53 OFFCURVE",
+"111 -13 OFFCURVE",
+"197 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"441 147 LINE",
+"517 450 LINE",
+"420 450 LINE",
+"337 102 LINE"
 );
 }
 );
@@ -9886,58 +12205,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"560 450 LINE",
-"426 450 LINE",
-"352 153 LINE",
-"473 97 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"405 390 LINE",
-"384 439 OFFCURVE",
-"354 462 OFFCURVE",
-"305 462 CURVE SMOOTH",
-"174 462 OFFCURVE",
-"29 320 OFFCURVE",
-"29 166 CURVE SMOOTH",
-"29 54 OFFCURVE",
-"107 -11 OFFCURVE",
-"192 -11 CURVE SMOOTH",
-"282 -11 OFFCURVE",
-"343 47 OFFCURVE",
-"377 100 CURVE",
-"384 100 LINE",
-"368 208 LINE",
-"336 76 OFFCURVE",
-"258 30 OFFCURVE",
-"213 30 CURVE SMOOTH",
-"183 30 OFFCURVE",
-"171 48 OFFCURVE",
-"171 107 CURVE SMOOTH",
-"171 256 OFFCURVE",
-"244 423 OFFCURVE",
-"326 423 CURVE SMOOTH",
-"358 423 OFFCURVE",
-"392 385 OFFCURVE",
-"392 333 CURVE SMOOTH",
-"392 324 OFFCURVE",
-"390 312 OFFCURVE",
-"389 299 CURVE",
-"412 390 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"665 462 LINE SMOOTH",
-"530 462 OFFCURVE",
-"368 319 OFFCURVE",
-"368 176 CURVE SMOOTH",
-"368 79 OFFCURVE",
-"437 -11 OFFCURVE",
-"569 -11 CURVE SMOOTH",
 "670 -11 OFFCURVE",
 "755 42 OFFCURVE",
 "808 129 CURVE",
@@ -9946,13 +12213,10 @@ nodes = (
 "649 29 OFFCURVE",
 "584 29 CURVE SMOOTH",
 "539 29 OFFCURVE",
-"511 43 OFFCURVE",
-"511 83 CURVE SMOOTH",
-"511 90 OFFCURVE",
-"512 99 OFFCURVE",
-"513 105 CURVE SMOOTH",
-"557 380 OFFCURVE",
-"600 432 OFFCURVE",
+"511 55 OFFCURVE",
+"511 95 CURVE SMOOTH",
+"511 196 OFFCURVE",
+"565 432 OFFCURVE",
 "652 432 CURVE SMOOTH",
 "693 432 OFFCURVE",
 "713 402 OFFCURVE",
@@ -9972,7 +12236,59 @@ nodes = (
 "826 344 CURVE SMOOTH",
 "826 413 OFFCURVE",
 "756 462 OFFCURVE",
-"665 462 CURVE SMOOTH"
+"665 462 CURVE SMOOTH",
+"530 462 OFFCURVE",
+"368 319 OFFCURVE",
+"368 176 CURVE SMOOTH",
+"368 79 OFFCURVE",
+"437 -11 OFFCURVE",
+"569 -11 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"282 -11 OFFCURVE",
+"343 47 OFFCURVE",
+"377 100 CURVE",
+"384 100 LINE",
+"376 154 LINE",
+"368 208 LINE",
+"336 76 OFFCURVE",
+"258 30 OFFCURVE",
+"213 30 CURVE SMOOTH",
+"183 30 OFFCURVE",
+"171 48 OFFCURVE",
+"171 107 CURVE SMOOTH",
+"171 256 OFFCURVE",
+"244 423 OFFCURVE",
+"326 423 CURVE SMOOTH",
+"358 423 OFFCURVE",
+"392 385 OFFCURVE",
+"392 333 CURVE SMOOTH",
+"392 324 OFFCURVE",
+"390 312 OFFCURVE",
+"389 299 CURVE",
+"412 390 LINE",
+"405 390 LINE",
+"384 439 OFFCURVE",
+"354 462 OFFCURVE",
+"305 462 CURVE SMOOTH",
+"174 462 OFFCURVE",
+"29 320 OFFCURVE",
+"29 166 CURVE SMOOTH",
+"29 54 OFFCURVE",
+"107 -11 OFFCURVE",
+"192 -11 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"473 97 LINE",
+"560 450 LINE",
+"426 450 LINE",
+"352 153 LINE"
 );
 }
 );
@@ -9980,12 +12296,12 @@ width = 847;
 }
 );
 leftKerningGroup = a;
-rightKerningGroup = e;
+rightKerningGroup = a;
 unicode = 00E6;
 },
 {
 glyphname = aeacute;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:17:55 +0000";
 layers = (
 {
 components = (
@@ -10015,35 +12331,29 @@ width = 847;
 }
 );
 leftKerningGroup = a;
-rightKerningGroup = e;
+rightKerningGroup = a;
 unicode = 01FD;
 },
 {
 glyphname = b;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:59 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{206, 0}";
+},
+{
+name = top;
+position = "{310, 450}";
+}
+);
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
 paths = (
 {
 closed = 1;
 nodes = (
-"94 729 LINE",
-"289 729 LINE",
-"289 754 LINE",
-"94 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"64 204 LINE SMOOTH",
-"54 163 OFFCURVE",
-"52 147 OFFCURVE",
-"52 131 CURVE SMOOTH",
-"52 49 OFFCURVE",
-"102 -13 OFFCURVE",
-"201 -13 CURVE SMOOTH",
 "350 -13 OFFCURVE",
 "487 127 OFFCURVE",
 "487 284 CURVE SMOOTH",
@@ -10071,34 +12381,44 @@ nodes = (
 "150 124 OFFCURVE",
 "153 138 CURVE SMOOTH",
 "301 754 LINE",
-"194 754 LINE"
+"194 754 LINE",
+"64 204 LINE SMOOTH",
+"54 163 OFFCURVE",
+"52 147 OFFCURVE",
+"52 131 CURVE SMOOTH",
+"52 49 OFFCURVE",
+"102 -13 OFFCURVE",
+"201 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"289 729 LINE",
+"289 754 LINE",
+"94 754 LINE",
+"94 729 LINE"
 );
 }
 );
 width = 516;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{218, 0}";
+},
+{
+name = top;
+position = "{322, 450}";
+}
+);
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
 paths = (
 {
 closed = 1;
 nodes = (
-"71 724 LINE",
-"286 724 LINE",
-"286 754 LINE",
-"71 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"40 204 LINE SMOOTH",
-"33 173 OFFCURVE",
-"32 146 OFFCURVE",
-"32 135 CURVE SMOOTH",
-"32 48 OFFCURVE",
-"95 -13 OFFCURVE",
-"200 -13 CURVE SMOOTH",
 "361 -13 OFFCURVE",
 "501 129 OFFCURVE",
 "501 284 CURVE SMOOTH",
@@ -10126,7 +12446,23 @@ nodes = (
 "156 134 OFFCURVE",
 "159 148 CURVE SMOOTH",
 "298 754 LINE",
-"171 754 LINE"
+"171 754 LINE",
+"40 204 LINE SMOOTH",
+"33 173 OFFCURVE",
+"32 146 OFFCURVE",
+"32 135 CURVE SMOOTH",
+"32 48 OFFCURVE",
+"95 -13 OFFCURVE",
+"200 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"286 724 LINE",
+"286 754 LINE",
+"71 754 LINE",
+"71 724 LINE"
 );
 }
 );
@@ -10137,15 +12473,40 @@ unicode = 0062;
 },
 {
 glyphname = c;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:59 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{183, 0}";
+},
+{
+name = top;
+position = "{287, 450}";
+}
+);
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
 paths = (
 {
 closed = 1;
 nodes = (
-"377 412 LINE SMOOTH",
+"312 -13 OFFCURVE",
+"379 34 OFFCURVE",
+"424 119 CURVE",
+"404 133 LINE",
+"355 47 OFFCURVE",
+"296 17 OFFCURVE",
+"240 17 CURVE SMOOTH",
+"173 17 OFFCURVE",
+"149 60 OFFCURVE",
+"149 134 CURVE SMOOTH",
+"149 240 OFFCURVE",
+"199 432 OFFCURVE",
+"326 432 CURVE SMOOTH",
+"348 432 OFFCURVE",
+"377 426 OFFCURVE",
+"377 412 CURVE SMOOTH",
 "377 398 OFFCURVE",
 "347 395 OFFCURVE",
 "347 359 CURVE SMOOTH",
@@ -10163,44 +12524,28 @@ nodes = (
 "44 191 CURVE SMOOTH",
 "44 89 OFFCURVE",
 "115 -13 OFFCURVE",
-"232 -13 CURVE SMOOTH",
-"312 -13 OFFCURVE",
-"379 34 OFFCURVE",
-"424 119 CURVE",
-"404 133 LINE",
-"355 47 OFFCURVE",
-"296 17 OFFCURVE",
-"240 17 CURVE SMOOTH",
-"173 17 OFFCURVE",
-"149 60 OFFCURVE",
-"149 134 CURVE SMOOTH",
-"149 240 OFFCURVE",
-"199 432 OFFCURVE",
-"326 432 CURVE SMOOTH",
-"348 432 OFFCURVE",
-"377 426 OFFCURVE",
-"377 412 CURVE SMOOTH"
+"232 -13 CURVE SMOOTH"
 );
 }
 );
 width = 470;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{188, 0}";
+},
+{
+name = top;
+position = "{292, 450}";
+}
+);
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
 paths = (
 {
 closed = 1;
 nodes = (
-"474 357 LINE SMOOTH",
-"474 414 OFFCURVE",
-"409 462 OFFCURVE",
-"318 462 CURVE SMOOTH",
-"162 462 OFFCURVE",
-"22 318 OFFCURVE",
-"22 177 CURVE SMOOTH",
-"22 78 OFFCURVE",
-"91 -11 OFFCURVE",
-"223 -11 CURVE SMOOTH",
 "324 -11 OFFCURVE",
 "409 42 OFFCURVE",
 "462 129 CURVE",
@@ -10208,11 +12553,8 @@ nodes = (
 "375 57 OFFCURVE",
 "303 29 OFFCURVE",
 "238 29 CURVE SMOOTH",
-"193 29 OFFCURVE",
-"165 43 OFFCURVE",
-"165 83 CURVE SMOOTH",
-"165 90 OFFCURVE",
-"166 99 OFFCURVE",
+"182 29 OFFCURVE",
+"158 50 OFFCURVE",
 "167 105 CURVE SMOOTH",
 "212 380 OFFCURVE",
 "257 432 OFFCURVE",
@@ -10228,7 +12570,16 @@ nodes = (
 "399 287 CURVE SMOOTH",
 "452 287 OFFCURVE",
 "474 323 OFFCURVE",
-"474 357 CURVE SMOOTH"
+"474 357 CURVE SMOOTH",
+"474 414 OFFCURVE",
+"409 462 OFFCURVE",
+"318 462 CURVE SMOOTH",
+"162 462 OFFCURVE",
+"22 318 OFFCURVE",
+"22 177 CURVE SMOOTH",
+"22 78 OFFCURVE",
+"91 -11 OFFCURVE",
+"223 -11 CURVE SMOOTH"
 );
 }
 );
@@ -10416,23 +12767,32 @@ unicode = 010B;
 },
 {
 glyphname = d;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:59 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{228, 0}";
+},
+{
+name = center;
+position = "{280, 225}";
+},
+{
+name = top;
+position = "{332, 450}";
+},
+{
+name = topright;
+position = "{592, 450}";
+}
+);
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
 paths = (
 {
 closed = 1;
 nodes = (
-"599 754 LINE",
-"492 754 LINE",
-"349 153 LINE SMOOTH",
-"341 121 OFFCURVE",
-"338 94 OFFCURVE",
-"338 74 CURVE SMOOTH",
-"338 11 OFFCURVE",
-"368 -13 OFFCURVE",
-"414 -13 CURVE SMOOTH",
 "498 -13 OFFCURVE",
 "549 68 OFFCURVE",
 "593 157 CURVE",
@@ -10445,31 +12805,21 @@ nodes = (
 "432 63 CURVE SMOOTH",
 "432 69 OFFCURVE",
 "433 80 OFFCURVE",
-"437 97 CURVE SMOOTH"
+"437 97 CURVE SMOOTH",
+"599 754 LINE",
+"492 754 LINE",
+"349 153 LINE SMOOTH",
+"341 121 OFFCURVE",
+"338 94 OFFCURVE",
+"338 74 CURVE SMOOTH",
+"338 11 OFFCURVE",
+"368 -13 OFFCURVE",
+"414 -13 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"392 729 LINE",
-"587 729 LINE",
-"587 754 LINE",
-"392 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"400 389 LINE",
-"383 431 OFFCURVE",
-"353 462 OFFCURVE",
-"295 462 CURVE SMOOTH",
-"173 462 OFFCURVE",
-"32 324 OFFCURVE",
-"32 169 CURVE SMOOTH",
-"32 54 OFFCURVE",
-"109 -13 OFFCURVE",
-"198 -13 CURVE SMOOTH",
 "263 -13 OFFCURVE",
 "308 23 OFFCURVE",
 "334 70 CURVE",
@@ -10490,27 +12840,55 @@ nodes = (
 "387 323 OFFCURVE",
 "386 311 OFFCURVE",
 "384 298 CURVE",
-"407 389 LINE"
+"407 389 LINE",
+"400 389 LINE",
+"383 431 OFFCURVE",
+"353 462 OFFCURVE",
+"295 462 CURVE SMOOTH",
+"173 462 OFFCURVE",
+"32 324 OFFCURVE",
+"32 169 CURVE SMOOTH",
+"32 54 OFFCURVE",
+"109 -13 OFFCURVE",
+"198 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"587 729 LINE",
+"587 754 LINE",
+"392 754 LINE",
+"392 729 LINE"
 );
 }
 );
 width = 560;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{253, 0}";
+},
+{
+name = center;
+position = "{305, 225}";
+},
+{
+name = top;
+position = "{357, 450}";
+},
+{
+name = topright;
+position = "{641, 450}";
+}
+);
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
 paths = (
 {
 closed = 1;
 nodes = (
-"648 754 LINE",
-"514 754 LINE",
-"369 153 LINE SMOOTH",
-"356 100 OFFCURVE",
-"353 86 OFFCURVE",
-"353 70 CURVE SMOOTH",
-"353 15 OFFCURVE",
-"388 -11 OFFCURVE",
-"440 -11 CURVE SMOOTH",
 "531 -11 OFFCURVE",
 "594 69 OFFCURVE",
 "620 152 CURVE",
@@ -10523,31 +12901,21 @@ nodes = (
 "485 54 CURVE SMOOTH",
 "485 58 OFFCURVE",
 "486 70 OFFCURVE",
-"490 87 CURVE SMOOTH"
+"490 87 CURVE SMOOTH",
+"648 754 LINE",
+"514 754 LINE",
+"369 153 LINE SMOOTH",
+"356 100 OFFCURVE",
+"353 86 OFFCURVE",
+"353 70 CURVE SMOOTH",
+"353 15 OFFCURVE",
+"388 -11 OFFCURVE",
+"440 -11 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"396 724 LINE",
-"591 724 LINE",
-"591 754 LINE",
-"396 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"422 389 LINE",
-"399 439 OFFCURVE",
-"365 462 OFFCURVE",
-"312 462 CURVE SMOOTH",
-"181 462 OFFCURVE",
-"36 324 OFFCURVE",
-"36 168 CURVE SMOOTH",
-"36 53 OFFCURVE",
-"114 -11 OFFCURVE",
-"199 -11 CURVE SMOOTH",
 "268 -11 OFFCURVE",
 "320 32 OFFCURVE",
 "346 70 CURVE",
@@ -10568,7 +12936,26 @@ nodes = (
 "409 322 OFFCURVE",
 "407 313 OFFCURVE",
 "406 298 CURVE",
-"429 389 LINE"
+"429 389 LINE",
+"422 389 LINE",
+"399 439 OFFCURVE",
+"365 462 OFFCURVE",
+"312 462 CURVE SMOOTH",
+"181 462 OFFCURVE",
+"36 324 OFFCURVE",
+"36 168 CURVE SMOOTH",
+"36 53 OFFCURVE",
+"114 -11 OFFCURVE",
+"199 -11 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"591 724 LINE",
+"591 754 LINE",
+"396 754 LINE",
+"396 724 LINE"
 );
 }
 );
@@ -10581,7 +12968,7 @@ unicode = 0064;
 },
 {
 glyphname = eth;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:49:52 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -10589,6 +12976,12 @@ paths = (
 {
 closed = 1;
 nodes = (
+"418 -13 OFFCURVE",
+"531 198 OFFCURVE",
+"531 390 CURVE SMOOTH",
+"531 585 OFFCURVE",
+"415 718 OFFCURVE",
+"257 752 CURVE",
 "242 725 LINE",
 "369 693 OFFCURVE",
 "421 623 OFFCURVE",
@@ -10605,22 +12998,12 @@ nodes = (
 "31 186 CURVE SMOOTH",
 "31 69 OFFCURVE",
 "114 -13 OFFCURVE",
-"231 -13 CURVE SMOOTH",
-"418 -13 OFFCURVE",
-"531 198 OFFCURVE",
-"531 390 CURVE SMOOTH",
-"531 585 OFFCURVE",
-"415 718 OFFCURVE",
-"257 752 CURVE"
+"231 -13 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"381 221 LINE SMOOTH",
-"349 72 OFFCURVE",
-"314 14 OFFCURVE",
-"230 14 CURVE SMOOTH",
 "184 14 OFFCURVE",
 "152 31 OFFCURVE",
 "152 125 CURVE SMOOTH",
@@ -10632,16 +13015,19 @@ nodes = (
 "403 384 CURVE",
 "400 321 OFFCURVE",
 "391 268 OFFCURVE",
-"381 221 CURVE SMOOTH"
+"381 221 CURVE SMOOTH",
+"349 72 OFFCURVE",
+"314 14 OFFCURVE",
+"230 14 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"267 561 LINE",
 "593 666 LINE",
 "584 695 LINE",
-"257 590 LINE"
+"257 590 LINE",
+"267 561 LINE"
 );
 }
 );
@@ -10653,58 +13039,57 @@ paths = (
 {
 closed = 1;
 nodes = (
-"279 754 LINE",
-"459 747 OFFCURVE",
-"592 593 OFFCURVE",
-"592 393 CURVE SMOOTH",
-"592 191 OFFCURVE",
 "447 -11 OFFCURVE",
-"241 -11 CURVE SMOOTH",
-"117 -11 OFFCURVE",
-"22 60 OFFCURVE",
-"22 179 CURVE SMOOTH",
-"22 328 OFFCURVE",
-"172 455 OFFCURVE",
-"328 455 CURVE SMOOTH",
-"370 455 OFFCURVE",
-"408 446 OFFCURVE",
-"431 431 CURVE",
-"435 432 LINE",
-"436 452 OFFCURVE",
-"438 458 OFFCURVE",
-"438 481 CURVE SMOOTH",
-"438 617 OFFCURVE",
+"592 191 OFFCURVE",
+"592 393 CURVE SMOOTH",
+"592 593 OFFCURVE",
+"459 747 OFFCURVE",
+"279 754 CURVE",
+"263 725 LINE",
 "373 708 OFFCURVE",
-"263 725 CURVE"
+"438 617 OFFCURVE",
+"438 481 CURVE SMOOTH",
+"438 458 OFFCURVE",
+"436 452 OFFCURVE",
+"435 432 CURVE",
+"431 431 LINE",
+"408 446 OFFCURVE",
+"370 455 OFFCURVE",
+"328 455 CURVE SMOOTH",
+"172 455 OFFCURVE",
+"22 328 OFFCURVE",
+"22 179 CURVE SMOOTH",
+"22 60 OFFCURVE",
+"117 -11 OFFCURVE",
+"241 -11 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"409 223 LINE SMOOTH",
-"419 264 OFFCURVE",
-"429 308 OFFCURVE",
-"429 364 CURVE",
-"420 390 OFFCURVE",
-"392 415 OFFCURVE",
-"352 415 CURVE SMOOTH",
-"249 415 OFFCURVE",
-"180 244 OFFCURVE",
-"180 127 CURVE SMOOTH",
-"180 60 OFFCURVE",
 "203 24 OFFCURVE",
-"263 24 CURVE SMOOTH",
-"332 24 OFFCURVE",
+"180 60 OFFCURVE",
+"180 127 CURVE SMOOTH",
+"180 244 OFFCURVE",
+"249 415 OFFCURVE",
+"352 415 CURVE SMOOTH",
+"392 415 OFFCURVE",
+"420 390 OFFCURVE",
+"429 364 CURVE",
+"429 308 OFFCURVE",
+"419 264 OFFCURVE",
+"409 223 CURVE SMOOTH",
 "371 73 OFFCURVE",
-"409 223 CURVE SMOOTH"
+"332 24 OFFCURVE",
+"263 24 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"253 600 LINE",
-"616 725 LINE",
 "627 682 LINE",
+"616 725 LINE",
+"253 600 LINE",
 "266 557 LINE"
 );
 }
@@ -10750,46 +13135,34 @@ unicode = 010F;
 },
 {
 glyphname = dcroat;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:14:32 +0000";
 layers = (
 {
 components = (
 {
 name = d;
+},
+{
+alignment = -1;
+name = strokeshortcomb;
+transform = "{1, 0, 0, 1, 343, 310}";
 }
 );
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
-paths = (
-{
-closed = 1;
-nodes = (
-"333 596 LINE",
-"628 596 LINE",
-"628 631 LINE",
-"333 631 LINE"
-);
-}
-);
 width = 560;
 },
 {
 components = (
 {
 name = d;
+},
+{
+alignment = -1;
+name = strokeshortcomb;
+transform = "{1, 0, 0, 1, 186, 365}";
 }
 );
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
-paths = (
-{
-closed = 1;
-nodes = (
-"372 586 LINE",
-"667 586 LINE",
-"667 621 LINE",
-"372 621 LINE"
-);
-}
-);
 width = 609;
 }
 );
@@ -10832,22 +13205,107 @@ rightKerningGroup = d;
 unicode = 1E0D;
 },
 {
-glyphname = e;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = dz;
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
+components = (
+{
+name = d;
+},
+{
+name = z;
+transform = "{1, 0, 0, 1, 560, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 1034;
+},
+{
+components = (
+{
+name = d;
+},
+{
+name = z;
+transform = "{1, 0, 0, 1, 609, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 1103;
+}
+);
+leftKerningGroup = d;
+rightKerningGroup = z;
+unicode = 01F3;
+},
+{
+glyphname = dzcaron;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+components = (
+{
+name = d;
+},
+{
+name = z;
+transform = "{1, 0, 0, 1, 560, 0}";
+},
+{
+name = caron;
+transform = "{1, 0, 0, 1, 627, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 1034;
+},
+{
+components = (
+{
+name = d;
+},
+{
+name = z;
+transform = "{1, 0, 0, 1, 609, 0}";
+},
+{
+name = caron;
+transform = "{1, 0, 0, 1, 644, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 1103;
+}
+);
+leftKerningGroup = d;
+rightKerningGroup = z;
+unicode = 01C6;
+},
+{
+glyphname = e;
+lastChange = "2016-08-22 13:41:59 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{181, 0}";
+},
+{
+name = ogonek;
+position = "{367, 10}";
+},
+{
+name = top;
+position = "{285, 450}";
+}
+);
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
 paths = (
 {
 closed = 1;
 nodes = (
-"311 462 LINE SMOOTH",
-"171 462 OFFCURVE",
-"33 325 OFFCURVE",
-"33 190 CURVE SMOOTH",
-"33 86 OFFCURVE",
-"115 -13 OFFCURVE",
-"240 -13 CURVE SMOOTH",
 "334 -13 OFFCURVE",
 "400 42 OFFCURVE",
 "443 119 CURVE",
@@ -10879,25 +13337,38 @@ nodes = (
 "454 344 CURVE SMOOTH",
 "454 413 OFFCURVE",
 "395 462 OFFCURVE",
-"311 462 CURVE SMOOTH"
+"311 462 CURVE SMOOTH",
+"171 462 OFFCURVE",
+"33 325 OFFCURVE",
+"33 190 CURVE SMOOTH",
+"33 86 OFFCURVE",
+"115 -13 OFFCURVE",
+"240 -13 CURVE SMOOTH"
 );
 }
 );
 width = 466;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{200, 0}";
+},
+{
+name = ogonek;
+position = "{402, 10}";
+},
+{
+name = top;
+position = "{304, 450}";
+}
+);
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
 paths = (
 {
 closed = 1;
 nodes = (
-"322 462 LINE SMOOTH",
-"170 462 OFFCURVE",
-"27 319 OFFCURVE",
-"27 177 CURVE SMOOTH",
-"27 79 OFFCURVE",
-"96 -11 OFFCURVE",
-"228 -11 CURVE SMOOTH",
 "329 -11 OFFCURVE",
 "414 42 OFFCURVE",
 "467 129 CURVE",
@@ -10905,11 +13376,8 @@ nodes = (
 "380 57 OFFCURVE",
 "308 29 OFFCURVE",
 "243 29 CURVE SMOOTH",
-"198 29 OFFCURVE",
-"170 43 OFFCURVE",
-"170 83 CURVE SMOOTH",
-"170 90 OFFCURVE",
-"171 99 OFFCURVE",
+"187 29 OFFCURVE",
+"163 50 OFFCURVE",
 "172 105 CURVE SMOOTH",
 "213 383 OFFCURVE",
 "268 432 OFFCURVE",
@@ -10932,7 +13400,13 @@ nodes = (
 "483 337 CURVE SMOOTH",
 "483 409 OFFCURVE",
 "414 462 OFFCURVE",
-"322 462 CURVE SMOOTH"
+"322 462 CURVE SMOOTH",
+"170 462 OFFCURVE",
+"27 319 OFFCURVE",
+"27 177 CURVE SMOOTH",
+"27 79 OFFCURVE",
+"96 -11 OFFCURVE",
+"228 -11 CURVE SMOOTH"
 );
 }
 );
@@ -10945,7 +13419,7 @@ unicode = 0065;
 },
 {
 glyphname = eacute;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:05:38 +0000";
 layers = (
 {
 components = (
@@ -10953,8 +13427,8 @@ components = (
 name = e;
 },
 {
-name = acute;
-transform = "{1, 0, 0, 1, 187, 0}";
+name = acutecomb;
+transform = "{1, 0, 0, 1, -74, 0}";
 }
 );
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -10966,8 +13440,8 @@ components = (
 name = e;
 },
 {
-name = acute;
-transform = "{1, 0, 0, 1, 136, 0}";
+name = acutecomb;
+transform = "{1, 0, 0, 1, -101, 0}";
 }
 );
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
@@ -11050,7 +13524,7 @@ unicode = 011B;
 },
 {
 glyphname = ecircumflex;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:18:07 +0000";
 layers = (
 {
 components = (
@@ -11058,8 +13532,8 @@ components = (
 name = e;
 },
 {
-name = circumflex;
-transform = "{1, 0, 0, 1, 102, 0}";
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -87, 0}";
 }
 );
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -11071,8 +13545,8 @@ components = (
 name = e;
 },
 {
-name = circumflex;
-transform = "{1, 0, 0, 1, 65, 0}";
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -41, 0}";
 }
 );
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
@@ -11084,8 +13558,8 @@ rightKerningGroup = e;
 unicode = 00EA;
 },
 {
-glyphname = edblgrave;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = ecircumflexacute;
+lastChange = "2016-08-22 14:18:07 +0000";
 layers = (
 {
 components = (
@@ -11093,7 +13567,190 @@ components = (
 name = e;
 },
 {
-name = uni030F;
+name = circumflexcomb_acutecomb;
+transform = "{1, 0, 0, 1, -83, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 466;
+},
+{
+components = (
+{
+name = e;
+},
+{
+name = circumflexcomb_acutecomb;
+transform = "{1, 0, 0, 1, -63, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 504;
+}
+);
+leftKerningGroup = e;
+rightKerningGroup = e;
+unicode = 1EBF;
+},
+{
+glyphname = ecircumflexdotbelow;
+lastChange = "2016-08-22 14:18:07 +0000";
+layers = (
+{
+components = (
+{
+name = e;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -60, 0}";
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -87, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 466;
+},
+{
+components = (
+{
+name = e;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -50, 0}";
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -41, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 504;
+}
+);
+leftKerningGroup = e;
+rightKerningGroup = e;
+unicode = 1EC7;
+},
+{
+glyphname = ecircumflexgrave;
+lastChange = "2016-08-22 14:18:07 +0000";
+layers = (
+{
+components = (
+{
+name = e;
+},
+{
+name = circumflexcomb_gravecomb;
+transform = "{1, 0, 0, 1, -79, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 466;
+},
+{
+components = (
+{
+name = e;
+},
+{
+name = circumflexcomb_gravecomb;
+transform = "{1, 0, 0, 1, -59, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 504;
+}
+);
+leftKerningGroup = e;
+rightKerningGroup = e;
+unicode = 1EC1;
+},
+{
+glyphname = ecircumflexhookabove;
+lastChange = "2016-08-22 14:18:07 +0000";
+layers = (
+{
+components = (
+{
+name = e;
+},
+{
+name = circumflexcomb_hookabovecomb;
+transform = "{1, 0, 0, 1, -85, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 466;
+},
+{
+components = (
+{
+name = e;
+},
+{
+name = circumflexcomb_hookabovecomb;
+transform = "{1, 0, 0, 1, -62, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 504;
+}
+);
+leftKerningGroup = e;
+rightKerningGroup = e;
+unicode = 1EC3;
+},
+{
+glyphname = ecircumflextilde;
+lastChange = "2016-08-22 14:18:07 +0000";
+layers = (
+{
+components = (
+{
+name = e;
+},
+{
+name = circumflexcomb_tildecomb;
+transform = "{1, 0, 0, 1, -83, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 466;
+},
+{
+components = (
+{
+name = e;
+},
+{
+name = circumflexcomb_tildecomb;
+transform = "{1, 0, 0, 1, -65, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 504;
+}
+);
+leftKerningGroup = e;
+rightKerningGroup = e;
+unicode = 1EC5;
+},
+{
+glyphname = edblgrave;
+lastChange = "2016-08-22 14:18:07 +0000";
+layers = (
+{
+components = (
+{
+name = e;
+},
+{
+name = dblgravecomb;
 transform = "{1, 0, 0, 1, 18, 0}";
 }
 );
@@ -11106,7 +13763,7 @@ components = (
 name = e;
 },
 {
-name = uni030F;
+name = dblgravecomb;
 transform = "{1, 0, 0, 1, 9, 0}";
 }
 );
@@ -11120,7 +13777,7 @@ unicode = 0205;
 },
 {
 glyphname = edieresis;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:18:07 +0000";
 layers = (
 {
 components = (
@@ -11155,7 +13812,7 @@ unicode = 00EB;
 },
 {
 glyphname = edotaccent;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:18:07 +0000";
 layers = (
 {
 components = (
@@ -11190,7 +13847,7 @@ unicode = 0117;
 },
 {
 glyphname = edotbelow;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:18:07 +0000";
 layers = (
 {
 components = (
@@ -11198,8 +13855,8 @@ components = (
 name = e;
 },
 {
-name = dotbelow;
-transform = "{1, 0, 0, 1, 171, 0}";
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -60, 0}";
 }
 );
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -11211,8 +13868,8 @@ components = (
 name = e;
 },
 {
-name = dotbelow;
-transform = "{1, 0, 0, 1, 191, 0}";
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -50, 0}";
 }
 );
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
@@ -11225,7 +13882,7 @@ unicode = 1EB9;
 },
 {
 glyphname = egrave;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:18:07 +0000";
 layers = (
 {
 components = (
@@ -11233,8 +13890,8 @@ components = (
 name = e;
 },
 {
-name = grave;
-transform = "{1, 0, 0, 1, 95, 0}";
+name = gravecomb;
+transform = "{1, 0, 0, 1, -63, 0}";
 }
 );
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -11246,8 +13903,8 @@ components = (
 name = e;
 },
 {
-name = grave;
-transform = "{1, 0, 0, 1, 96, 0}";
+name = gravecomb;
+transform = "{1, 0, 0, 1, -12, 0}";
 }
 );
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
@@ -11259,8 +13916,8 @@ rightKerningGroup = e;
 unicode = 00E8;
 },
 {
-glyphname = einvertedbreve;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = ehookabove;
+lastChange = "2016-08-22 14:18:07 +0000";
 layers = (
 {
 components = (
@@ -11268,7 +13925,42 @@ components = (
 name = e;
 },
 {
-name = uni0311;
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, -38, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 466;
+},
+{
+components = (
+{
+name = e;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, -28, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 504;
+}
+);
+leftKerningGroup = e;
+rightKerningGroup = e;
+unicode = 1EBB;
+},
+{
+glyphname = einvertedbreve;
+lastChange = "2016-08-22 14:18:07 +0000";
+layers = (
+{
+components = (
+{
+name = e;
+},
+{
+name = breveinvertedcomb;
 transform = "{1, 0, 0, 1, 105, 0}";
 }
 );
@@ -11281,7 +13973,7 @@ components = (
 name = e;
 },
 {
-name = uni0311;
+name = breveinvertedcomb;
 transform = "{1, 0, 0, 1, 72, 0}";
 }
 );
@@ -11295,7 +13987,7 @@ unicode = 0207;
 },
 {
 glyphname = emacron;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:18:07 +0000";
 layers = (
 {
 components = (
@@ -11330,7 +14022,7 @@ unicode = 0113;
 },
 {
 glyphname = eogonek;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:18:07 +0000";
 layers = (
 {
 components = (
@@ -11365,7 +14057,7 @@ unicode = 0119;
 },
 {
 glyphname = etilde;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:18:07 +0000";
 layers = (
 {
 components = (
@@ -11373,8 +14065,8 @@ components = (
 name = e;
 },
 {
-name = tilde;
-transform = "{1, 0, 0, 1, 63, 0}";
+name = tildecomb;
+transform = "{1, 0, 0, 1, -74, 0}";
 }
 );
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -11386,8 +14078,8 @@ components = (
 name = e;
 },
 {
-name = tilde;
-transform = "{1, 0, 0, 1, 64, 0}";
+name = tildecomb;
+transform = "{1, 0, 0, 1, -61, 0}";
 }
 );
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
@@ -11399,8 +14091,8 @@ rightKerningGroup = e;
 unicode = 1EBD;
 },
 {
-glyphname = f;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = schwa;
+lastChange = "2016-08-22 11:22:41 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -11408,6 +14100,124 @@ paths = (
 {
 closed = 1;
 nodes = (
+"318 -13 OFFCURVE",
+"456 120 OFFCURVE",
+"456 261 CURVE SMOOTH",
+"456 361 OFFCURVE",
+"387 462 OFFCURVE",
+"254 462 CURVE SMOOTH",
+"164 462 OFFCURVE",
+"98 415 OFFCURVE",
+"50 330 CURVE",
+"70 316 LINE",
+"122 402 OFFCURVE",
+"184 432 OFFCURVE",
+"242 432 CURVE SMOOTH",
+"305 432 OFFCURVE",
+"336 396 OFFCURVE",
+"336 302 CURVE SMOOTH",
+"336 182 OFFCURVE",
+"285 17 OFFCURVE",
+"185 17 CURVE SMOOTH",
+"148 17 OFFCURVE",
+"123 39 OFFCURVE",
+"123 92 CURVE SMOOTH",
+"123 162 OFFCURVE",
+"166 222 OFFCURVE",
+"285 222 CURVE SMOOTH",
+"312 222 OFFCURVE",
+"335 219 OFFCURVE",
+"358 212 CURVE",
+"363 237 LINE",
+"350 240 OFFCURVE",
+"290 248 OFFCURVE",
+"244 248 CURVE SMOOTH",
+"124 248 OFFCURVE",
+"35 192 OFFCURVE",
+"35 106 CURVE SMOOTH",
+"35 36 OFFCURVE",
+"94 -13 OFFCURVE",
+"178 -13 CURVE"
+);
+}
+);
+width = 486;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+paths = (
+{
+closed = 1;
+nodes = (
+"361 -11 OFFCURVE",
+"501 129 OFFCURVE",
+"501 267 CURVE SMOOTH",
+"501 367 OFFCURVE",
+"432 462 OFFCURVE",
+"303 462 CURVE SMOOTH",
+"202 462 OFFCURVE",
+"117 409 OFFCURVE",
+"64 322 CURVE",
+"89 303 LINE",
+"151 394 OFFCURVE",
+"223 422 OFFCURVE",
+"288 422 CURVE SMOOTH",
+"343 422 OFFCURVE",
+"365 393 OFFCURVE",
+"356 338 CURVE SMOOTH",
+"312 69 OFFCURVE",
+"271 19 OFFCURVE",
+"219 19 CURVE SMOOTH",
+"178 19 OFFCURVE",
+"158 49 OFFCURVE",
+"158 93 CURVE SMOOTH",
+"158 157 OFFCURVE",
+"201 211 OFFCURVE",
+"295 211 CURVE SMOOTH",
+"347 211 OFFCURVE",
+"370 211 OFFCURVE",
+"393 201 CURVE",
+"398 236 LINE",
+"387 239 OFFCURVE",
+"314 247 OFFCURVE",
+"264 247 CURVE SMOOTH",
+"120 247 OFFCURVE",
+"45 181 OFFCURVE",
+"45 108 CURVE SMOOTH",
+"45 38 OFFCURVE",
+"115 -11 OFFCURVE",
+"206 -11 CURVE SMOOTH"
+);
+}
+);
+width = 506;
+}
+);
+unicode = 0259;
+},
+{
+glyphname = f;
+lastChange = "2016-08-22 13:41:59 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{104, 0}";
+},
+{
+name = top;
+position = "{208, 450}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+paths = (
+{
+closed = 1;
+nodes = (
+"3 -324 OFFCURVE",
+"101 -256 OFFCURVE",
+"171 45 CURVE SMOOTH",
 "277 501 LINE SMOOTH",
 "319 682 OFFCURVE",
 "359 736 OFFCURVE",
@@ -11448,30 +14258,40 @@ nodes = (
 "-185 -251 CURVE SMOOTH",
 "-185 -293 OFFCURVE",
 "-140 -324 OFFCURVE",
-"-82 -324 CURVE SMOOTH",
-"3 -324 OFFCURVE",
-"101 -256 OFFCURVE",
-"171 45 CURVE SMOOTH"
+"-82 -324 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"62 425 LINE",
 "383 425 LINE",
 "383 450 LINE",
-"62 450 LINE"
+"62 450 LINE",
+"62 425 LINE"
 );
 }
 );
 width = 312;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{108, 0}";
+},
+{
+name = top;
+position = "{212, 450}";
+}
+);
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
 paths = (
 {
 closed = 1;
 nodes = (
+"35 -324 OFFCURVE",
+"153 -177 OFFCURVE",
+"223 175 CURVE SMOOTH",
 "288 501 LINE SMOOTH",
 "322 682 OFFCURVE",
 "361 736 OFFCURVE",
@@ -11512,19 +14332,16 @@ nodes = (
 "-193 -235 CURVE SMOOTH",
 "-193 -279 OFFCURVE",
 "-163 -324 OFFCURVE",
-"-92 -324 CURVE SMOOTH",
-"35 -324 OFFCURVE",
-"153 -177 OFFCURVE",
-"223 175 CURVE SMOOTH"
+"-92 -324 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"38 420 LINE",
 "399 420 LINE",
 "399 450 LINE",
-"38 450 LINE"
+"38 450 LINE",
+"38 420 LINE"
 );
 }
 );
@@ -11537,72 +14354,37 @@ unicode = 0066;
 },
 {
 glyphname = g;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:59 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{207, 0}";
+},
+{
+name = top;
+position = "{311, 450}";
+}
+);
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
 paths = (
 {
 closed = 1;
 nodes = (
-"231 156 LINE SMOOTH",
-"194 156 OFFCURVE",
-"183 186 OFFCURVE",
-"183 237 CURVE SMOOTH",
-"183 336 OFFCURVE",
-"224 442 OFFCURVE",
-"299 442 CURVE SMOOTH",
-"335 442 OFFCURVE",
-"347 418 OFFCURVE",
-"347 367 CURVE SMOOTH",
-"347 272 OFFCURVE",
-"305 156 OFFCURVE",
-"231 156 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"239 136 LINE SMOOTH",
-"344 136 OFFCURVE",
-"435 208 OFFCURVE",
-"435 319 CURVE SMOOTH",
-"435 401 OFFCURVE",
-"385 462 OFFCURVE",
-"292 462 CURVE SMOOTH",
-"187 462 OFFCURVE",
-"88 385 OFFCURVE",
-"88 281 CURVE SMOOTH",
-"88 213 OFFCURVE",
-"131 136 OFFCURVE",
-"239 136 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"431 282 LINE",
-"450 362 OFFCURVE",
-"461 409 OFFCURVE",
-"474 409 CURVE SMOOTH",
-"484 409 OFFCURVE",
-"488 382 OFFCURVE",
-"516 382 CURVE SMOOTH",
-"541 382 OFFCURVE",
-"553 404 OFFCURVE",
-"553 421 CURVE SMOOTH",
-"553 443 OFFCURVE",
-"535 462 OFFCURVE",
-"508 462 CURVE SMOOTH",
-"473 462 OFFCURVE",
-"449 430 OFFCURVE",
-"431 369 CURVE",
-"427 369 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"355 -326 OFFCURVE",
+"440 -197 OFFCURVE",
+"440 -80 CURVE SMOOTH",
+"440 -8 OFFCURVE",
+"407 47 OFFCURVE",
+"330 52 CURVE SMOOTH",
+"172 62 LINE SMOOTH",
+"93 67 OFFCURVE",
+"76 78 OFFCURVE",
+"76 105 CURVE SMOOTH",
+"76 137 OFFCURVE",
+"100 158 OFFCURVE",
+"143 166 CURVE",
 "145 197 LINE",
 "115 192 OFFCURVE",
 "4 156 OFFCURVE",
@@ -11629,93 +14411,97 @@ nodes = (
 "-56 -177 CURVE SMOOTH",
 "-56 -267 OFFCURVE",
 "25 -326 OFFCURVE",
-"158 -326 CURVE SMOOTH",
-"355 -326 OFFCURVE",
-"440 -197 OFFCURVE",
-"440 -80 CURVE SMOOTH",
-"440 -8 OFFCURVE",
-"407 47 OFFCURVE",
-"330 52 CURVE SMOOTH",
-"172 62 LINE SMOOTH",
-"93 67 OFFCURVE",
-"76 78 OFFCURVE",
-"76 105 CURVE SMOOTH",
-"76 137 OFFCURVE",
-"100 158 OFFCURVE",
-"143 166 CURVE"
+"158 -326 CURVE SMOOTH"
 );
-}
-);
-width = 517;
 },
-{
-layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
-paths = (
 {
 closed = 1;
 nodes = (
-"231 156 LINE SMOOTH",
-"198 156 OFFCURVE",
-"188 176 OFFCURVE",
-"188 220 CURVE SMOOTH",
-"188 308 OFFCURVE",
-"229 437 OFFCURVE",
-"314 437 CURVE SMOOTH",
-"348 437 OFFCURVE",
-"354 416 OFFCURVE",
-"354 382 CURVE SMOOTH",
-"354 300 OFFCURVE",
-"319 156 OFFCURVE",
+"344 136 OFFCURVE",
+"435 208 OFFCURVE",
+"435 319 CURVE SMOOTH",
+"435 401 OFFCURVE",
+"385 462 OFFCURVE",
+"292 462 CURVE SMOOTH",
+"187 462 OFFCURVE",
+"88 385 OFFCURVE",
+"88 281 CURVE SMOOTH",
+"88 213 OFFCURVE",
+"131 136 OFFCURVE",
+"239 136 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"194 156 OFFCURVE",
+"183 186 OFFCURVE",
+"183 237 CURVE SMOOTH",
+"183 336 OFFCURVE",
+"224 442 OFFCURVE",
+"299 442 CURVE SMOOTH",
+"335 442 OFFCURVE",
+"347 418 OFFCURVE",
+"347 367 CURVE SMOOTH",
+"347 272 OFFCURVE",
+"305 156 OFFCURVE",
 "231 156 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"243 131 LINE SMOOTH",
-"370 131 OFFCURVE",
-"476 204 OFFCURVE",
-"476 323 CURVE SMOOTH",
-"476 339 OFFCURVE",
-"474 349 OFFCURVE",
-"471 361 CURVE",
-"462 367 LINE",
-"437 414 OFFCURVE",
-"400 462 OFFCURVE",
-"305 462 CURVE SMOOTH",
-"185 462 OFFCURVE",
-"66 384 OFFCURVE",
-"66 275 CURVE SMOOTH",
-"66 204 OFFCURVE",
-"116 131 OFFCURVE",
-"243 131 CURVE SMOOTH"
+"450 362 OFFCURVE",
+"461 409 OFFCURVE",
+"474 409 CURVE SMOOTH",
+"484 409 OFFCURVE",
+"488 382 OFFCURVE",
+"516 382 CURVE SMOOTH",
+"541 382 OFFCURVE",
+"553 404 OFFCURVE",
+"553 421 CURVE SMOOTH",
+"553 443 OFFCURVE",
+"535 462 OFFCURVE",
+"508 462 CURVE SMOOTH",
+"473 462 OFFCURVE",
+"449 430 OFFCURVE",
+"431 369 CURVE",
+"427 369 LINE",
+"431 282 LINE"
 );
+}
+);
+width = 517;
 },
+{
+anchors = (
+{
+name = bottom;
+position = "{213, 0}";
+},
+{
+name = top;
+position = "{317, 450}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+paths = (
 {
 closed = 1;
 nodes = (
-"471 287 LINE",
-"485 367 OFFCURVE",
-"495 391 OFFCURVE",
-"506 391 CURVE SMOOTH",
-"513 391 OFFCURVE",
-"522 380 OFFCURVE",
-"542 380 CURVE SMOOTH",
-"573 380 OFFCURVE",
-"584 405 OFFCURVE",
-"584 423 CURVE SMOOTH",
-"584 445 OFFCURVE",
-"569 464 OFFCURVE",
-"539 464 CURVE SMOOTH",
-"501 464 OFFCURVE",
-"483 432 OFFCURVE",
-"463 374 CURVE",
-"459 374 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"366 -319 OFFCURVE",
+"459 -187 OFFCURVE",
+"459 -70 CURVE SMOOTH",
+"459 7 OFFCURVE",
+"419 56 OFFCURVE",
+"349 58 CURVE SMOOTH",
+"169 64 LINE SMOOTH",
+"88 67 OFFCURVE",
+"71 81 OFFCURVE",
+"71 108 CURVE SMOOTH",
+"71 138 OFFCURVE",
+"92 157 OFFCURVE",
+"140 166 CURVE",
 "142 197 LINE",
 "112 192 OFFCURVE",
 "1 154 OFFCURVE",
@@ -11737,29 +14523,68 @@ nodes = (
 "65 -58 OFFCURVE",
 "202 -16 CURVE",
 "171 -5 LINE",
-"128 -16 OFFCURVE",
-"85 -32 OFFCURVE",
-"57 -45 CURVE",
-"57 -49 LINE",
-"-37 -84 OFFCURVE",
-"-59 -130 OFFCURVE",
+"53 -35 OFFCURVE",
+"-59 -86 OFFCURVE",
 "-59 -176 CURVE SMOOTH",
 "-59 -263 OFFCURVE",
 "22 -319 OFFCURVE",
-"158 -319 CURVE SMOOTH",
-"366 -319 OFFCURVE",
-"459 -187 OFFCURVE",
-"459 -70 CURVE SMOOTH",
-"459 7 OFFCURVE",
-"419 56 OFFCURVE",
-"349 58 CURVE SMOOTH",
-"169 64 LINE SMOOTH",
-"88 67 OFFCURVE",
-"71 81 OFFCURVE",
-"71 108 CURVE SMOOTH",
-"71 138 OFFCURVE",
-"92 157 OFFCURVE",
-"140 166 CURVE"
+"158 -319 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"370 131 OFFCURVE",
+"476 204 OFFCURVE",
+"476 323 CURVE SMOOTH",
+"476 403 OFFCURVE",
+"391 462 OFFCURVE",
+"305 462 CURVE SMOOTH",
+"185 462 OFFCURVE",
+"66 384 OFFCURVE",
+"66 275 CURVE SMOOTH",
+"66 204 OFFCURVE",
+"116 131 OFFCURVE",
+"243 131 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"198 156 OFFCURVE",
+"188 176 OFFCURVE",
+"188 220 CURVE SMOOTH",
+"188 308 OFFCURVE",
+"229 437 OFFCURVE",
+"314 437 CURVE SMOOTH",
+"348 437 OFFCURVE",
+"354 416 OFFCURVE",
+"354 382 CURVE SMOOTH",
+"354 300 OFFCURVE",
+"319 156 OFFCURVE",
+"231 156 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"485 367 OFFCURVE",
+"495 391 OFFCURVE",
+"506 391 CURVE SMOOTH",
+"513 391 OFFCURVE",
+"522 380 OFFCURVE",
+"542 380 CURVE SMOOTH",
+"573 380 OFFCURVE",
+"584 405 OFFCURVE",
+"584 423 CURVE SMOOTH",
+"584 445 OFFCURVE",
+"569 464 OFFCURVE",
+"539 464 CURVE SMOOTH",
+"501 464 OFFCURVE",
+"483 432 OFFCURVE",
+"463 374 CURVE",
+"457 374 LINE",
+"471 287 LINE"
 );
 }
 );
@@ -11877,7 +14702,7 @@ unicode = 011D;
 },
 {
 glyphname = gcommaaccent;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 components = (
@@ -11885,7 +14710,7 @@ components = (
 name = g;
 },
 {
-name = commaaccent;
+name = commaaccentcomb;
 transform = "{-1, 0, 0, -1, 367, 489}";
 }
 );
@@ -11898,7 +14723,7 @@ components = (
 name = g;
 },
 {
-name = commaaccent;
+name = commaaccentcomb;
 transform = "{-1, 0, 0, -1, 357, 489}";
 }
 );
@@ -11947,49 +14772,37 @@ unicode = 0121;
 },
 {
 glyphname = h;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:59 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{225, 0}";
+},
+{
+name = center;
+position = "{277, 225}";
+},
+{
+name = top;
+position = "{329, 450}";
+}
+);
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
 paths = (
 {
 closed = 1;
 nodes = (
+"122 0 LINE",
 "304 754 LINE",
 "197 754 LINE",
-"19 0 LINE",
-"122 0 LINE"
+"19 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"98 729 LINE",
-"292 729 LINE",
-"292 754 LINE",
-"98 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"179 236 LINE",
-"209 342 OFFCURVE",
-"289 420 OFFCURVE",
-"349 420 CURVE SMOOTH",
-"371 420 OFFCURVE",
-"386 410 OFFCURVE",
-"386 387 CURVE SMOOTH",
-"386 379 OFFCURVE",
-"384 371 OFFCURVE",
-"382 361 CURVE SMOOTH",
-"316 87 LINE SMOOTH",
-"314 78 OFFCURVE",
-"312 67 OFFCURVE",
-"312 56 CURVE SMOOTH",
-"312 15 OFFCURVE",
-"341 -13 OFFCURVE",
-"388 -13 CURVE SMOOTH",
 "469 -13 OFFCURVE",
 "523 69 OFFCURVE",
 "562 157 CURVE",
@@ -12013,53 +14826,67 @@ nodes = (
 "321 462 OFFCURVE",
 "254 413 OFFCURVE",
 "214 363 CURVE",
-"207 363 LINE"
+"207 363 LINE",
+"179 236 LINE",
+"209 342 OFFCURVE",
+"289 420 OFFCURVE",
+"349 420 CURVE SMOOTH",
+"371 420 OFFCURVE",
+"386 410 OFFCURVE",
+"386 387 CURVE SMOOTH",
+"386 379 OFFCURVE",
+"384 371 OFFCURVE",
+"382 361 CURVE SMOOTH",
+"316 87 LINE SMOOTH",
+"314 78 OFFCURVE",
+"312 67 OFFCURVE",
+"312 56 CURVE SMOOTH",
+"312 15 OFFCURVE",
+"341 -13 OFFCURVE",
+"388 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"292 729 LINE",
+"292 754 LINE",
+"98 754 LINE",
+"98 729 LINE"
 );
 }
 );
 width = 554;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{240, 0}";
+},
+{
+name = center;
+position = "{292, 225}";
+},
+{
+name = top;
+position = "{344, 450}";
+}
+);
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
 paths = (
 {
 closed = 1;
 nodes = (
+"146 0 LINE",
 "334 754 LINE",
 "197 754 LINE",
-"13 0 LINE",
-"146 0 LINE"
+"13 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"103 724 LINE",
-"322 724 LINE",
-"322 754 LINE",
-"103 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"202 231 LINE",
-"234 343 OFFCURVE",
-"329 416 OFFCURVE",
-"373 416 CURVE SMOOTH",
-"388 416 OFFCURVE",
-"397 408 OFFCURVE",
-"397 393 CURVE SMOOTH",
-"397 384 OFFCURVE",
-"394 365 OFFCURVE",
-"392 356 CURVE SMOOTH",
-"328 107 LINE SMOOTH",
-"326 98 OFFCURVE",
-"324 88 OFFCURVE",
-"324 75 CURVE SMOOTH",
-"324 19 OFFCURVE",
-"360 -11 OFFCURVE",
-"422 -11 CURVE SMOOTH",
 "487 -11 OFFCURVE",
 "550 21 OFFCURVE",
 "596 146 CURVE",
@@ -12083,7 +14910,33 @@ nodes = (
 "339 462 OFFCURVE",
 "282 412 OFFCURVE",
 "242 362 CURVE",
-"235 362 LINE"
+"235 362 LINE",
+"202 231 LINE",
+"234 343 OFFCURVE",
+"329 416 OFFCURVE",
+"373 416 CURVE SMOOTH",
+"388 416 OFFCURVE",
+"397 408 OFFCURVE",
+"397 393 CURVE SMOOTH",
+"397 384 OFFCURVE",
+"394 365 OFFCURVE",
+"392 356 CURVE SMOOTH",
+"328 107 LINE SMOOTH",
+"326 98 OFFCURVE",
+"324 88 OFFCURVE",
+"324 75 CURVE SMOOTH",
+"324 19 OFFCURVE",
+"360 -11 OFFCURVE",
+"422 -11 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"322 724 LINE",
+"322 754 LINE",
+"103 754 LINE",
+"103 724 LINE"
 );
 }
 );
@@ -12096,7 +14949,7 @@ unicode = 0068;
 },
 {
 glyphname = hbar;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 components = (
@@ -12109,10 +14962,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"64 576 LINE",
 "389 576 LINE",
 "389 611 LINE",
-"64 611 LINE"
+"64 611 LINE",
+"64 576 LINE"
 );
 }
 );
@@ -12129,10 +14982,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"84 581 LINE",
 "409 581 LINE",
 "409 621 LINE",
-"84 621 LINE"
+"84 621 LINE",
+"84 581 LINE"
 );
 }
 );
@@ -12144,7 +14997,7 @@ unicode = 0127;
 },
 {
 glyphname = hcircumflex;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:15 +0000";
 layers = (
 {
 components = (
@@ -12152,7 +15005,7 @@ components = (
 name = h;
 },
 {
-name = circumflex.cap;
+name = circumflex.case;
 transform = "{1, 0, 0, 1, 10, 0}";
 }
 );
@@ -12165,7 +15018,7 @@ components = (
 name = h;
 },
 {
-name = circumflex.cap;
+name = circumflex.case;
 }
 );
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
@@ -12213,23 +15066,20 @@ unicode = 1E25;
 },
 {
 glyphname = i;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:50:11 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{104, 0}";
+}
+);
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
 paths = (
 {
 closed = 1;
 nodes = (
-"248 450 LINE",
-"141 450 LINE",
-"54 87 LINE SMOOTH",
-"52 78 OFFCURVE",
-"50 67 OFFCURVE",
-"50 56 CURVE SMOOTH",
-"50 15 OFFCURVE",
-"78 -13 OFFCURVE",
-"127 -13 CURVE SMOOTH",
 "213 -13 OFFCURVE",
 "271 73 OFFCURVE",
 "310 157 CURVE",
@@ -12242,25 +15092,30 @@ nodes = (
 "154 63 CURVE SMOOTH",
 "154 69 OFFCURVE",
 "155 80 OFFCURVE",
-"159 97 CURVE SMOOTH"
+"159 97 CURVE SMOOTH",
+"248 450 LINE",
+"141 450 LINE",
+"54 87 LINE SMOOTH",
+"52 78 OFFCURVE",
+"50 67 OFFCURVE",
+"50 56 CURVE SMOOTH",
+"50 15 OFFCURVE",
+"78 -13 OFFCURVE",
+"127 -13 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"47 425 LINE",
 "236 425 LINE",
 "236 450 LINE",
-"47 450 LINE"
+"47 450 LINE",
+"47 425 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"163 667 LINE SMOOTH",
-"163 631 OFFCURVE",
-"193 601 OFFCURVE",
-"229 601 CURVE SMOOTH",
 "265 601 OFFCURVE",
 "295 631 OFFCURVE",
 "295 667 CURVE SMOOTH",
@@ -12269,27 +15124,27 @@ nodes = (
 "229 733 CURVE SMOOTH",
 "193 733 OFFCURVE",
 "163 703 OFFCURVE",
-"163 667 CURVE SMOOTH"
+"163 667 CURVE SMOOTH",
+"163 631 OFFCURVE",
+"193 601 OFFCURVE",
+"229 601 CURVE SMOOTH"
 );
 }
 );
 width = 312;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{113, 0}";
+}
+);
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
 paths = (
 {
 closed = 1;
 nodes = (
-"279 450 LINE",
-"145 450 LINE",
-"71 153 LINE SMOOTH",
-"58 100 OFFCURVE",
-"55 86 OFFCURVE",
-"55 70 CURVE SMOOTH",
-"55 15 OFFCURVE",
-"90 -11 OFFCURVE",
-"142 -11 CURVE SMOOTH",
 "233 -11 OFFCURVE",
 "298 38 OFFCURVE",
 "335 147 CURVE",
@@ -12302,25 +15157,30 @@ nodes = (
 "190 54 CURVE SMOOTH",
 "190 58 OFFCURVE",
 "191 68 OFFCURVE",
-"195 87 CURVE SMOOTH"
+"195 87 CURVE SMOOTH",
+"279 450 LINE",
+"145 450 LINE",
+"71 153 LINE SMOOTH",
+"58 100 OFFCURVE",
+"55 86 OFFCURVE",
+"55 70 CURVE SMOOTH",
+"55 15 OFFCURVE",
+"90 -11 OFFCURVE",
+"142 -11 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"48 420 LINE",
 "222 420 LINE",
 "222 450 LINE",
-"48 450 LINE"
+"48 450 LINE",
+"48 420 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"167 656 LINE SMOOTH",
-"167 612 OFFCURVE",
-"202 577 OFFCURVE",
-"246 577 CURVE SMOOTH",
 "290 577 OFFCURVE",
 "325 612 OFFCURVE",
 "325 656 CURVE SMOOTH",
@@ -12329,7 +15189,10 @@ nodes = (
 "246 735 CURVE SMOOTH",
 "202 735 OFFCURVE",
 "167 700 OFFCURVE",
-"167 656 CURVE SMOOTH"
+"167 656 CURVE SMOOTH",
+"167 612 OFFCURVE",
+"202 577 OFFCURVE",
+"246 577 CURVE SMOOTH"
 );
 }
 );
@@ -12341,24 +15204,29 @@ rightKerningGroup = i;
 unicode = 0069;
 },
 {
-glyphname = dotlessi;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = idotless;
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{104, 0}";
+},
+{
+name = ogonek;
+position = "{229, 10}";
+},
+{
+name = top;
+position = "{208, 450}";
+}
+);
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
 paths = (
 {
 closed = 1;
 nodes = (
-"248 450 LINE",
-"141 450 LINE",
-"54 87 LINE SMOOTH",
-"52 78 OFFCURVE",
-"50 67 OFFCURVE",
-"50 56 CURVE SMOOTH",
-"50 15 OFFCURVE",
-"78 -13 OFFCURVE",
-"127 -13 CURVE SMOOTH",
 "213 -13 OFFCURVE",
 "271 73 OFFCURVE",
 "310 157 CURVE",
@@ -12371,36 +15239,50 @@ nodes = (
 "154 63 CURVE SMOOTH",
 "154 69 OFFCURVE",
 "155 80 OFFCURVE",
-"159 97 CURVE SMOOTH"
+"159 97 CURVE SMOOTH",
+"248 450 LINE",
+"141 450 LINE",
+"54 87 LINE SMOOTH",
+"52 78 OFFCURVE",
+"50 67 OFFCURVE",
+"50 56 CURVE SMOOTH",
+"50 15 OFFCURVE",
+"78 -13 OFFCURVE",
+"127 -13 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"47 425 LINE",
 "236 425 LINE",
 "236 450 LINE",
-"47 450 LINE"
+"47 450 LINE",
+"47 425 LINE"
 );
 }
 );
 width = 312;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{113, 0}";
+},
+{
+name = ogonek;
+position = "{245, 10}";
+},
+{
+name = top;
+position = "{217, 450}";
+}
+);
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
 paths = (
 {
 closed = 1;
 nodes = (
-"279 450 LINE",
-"145 450 LINE",
-"71 153 LINE SMOOTH",
-"58 100 OFFCURVE",
-"55 86 OFFCURVE",
-"55 70 CURVE SMOOTH",
-"55 15 OFFCURVE",
-"90 -11 OFFCURVE",
-"142 -11 CURVE SMOOTH",
 "233 -11 OFFCURVE",
 "298 38 OFFCURVE",
 "335 147 CURVE",
@@ -12413,16 +15295,25 @@ nodes = (
 "190 54 CURVE SMOOTH",
 "190 58 OFFCURVE",
 "191 68 OFFCURVE",
-"195 87 CURVE SMOOTH"
+"195 87 CURVE SMOOTH",
+"279 450 LINE",
+"145 450 LINE",
+"71 153 LINE SMOOTH",
+"58 100 OFFCURVE",
+"55 86 OFFCURVE",
+"55 70 CURVE SMOOTH",
+"55 15 OFFCURVE",
+"90 -11 OFFCURVE",
+"142 -11 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"48 420 LINE",
 "222 420 LINE",
 "222 450 LINE",
-"48 450 LINE"
+"48 450 LINE",
+"48 420 LINE"
 );
 }
 );
@@ -12433,16 +15324,16 @@ unicode = 0131;
 },
 {
 glyphname = iacute;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 components = (
 {
-name = acute;
-transform = "{1, 0, 0, 1, 49, 0}";
+name = acutecomb;
+transform = "{1, 0, 0, 1, -189, -42}";
 },
 {
-name = dotlessi;
+name = idotless;
 }
 );
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -12491,11 +15382,11 @@ nodes = (
 };
 components = (
 {
-name = acute;
-transform = "{1, 0, 0, 1, 94, 0}";
+name = acutecomb;
+transform = "{1, 0, 0, 1, -123, 0}";
 },
 {
-name = dotlessi;
+name = idotless;
 }
 );
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
@@ -12508,12 +15399,12 @@ unicode = 00ED;
 },
 {
 glyphname = ibreve;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 components = (
 {
-name = dotlessi;
+name = idotless;
 },
 {
 name = breve;
@@ -12526,7 +15417,7 @@ width = 316;
 {
 components = (
 {
-name = dotlessi;
+name = idotless;
 },
 {
 name = breve;
@@ -12543,12 +15434,12 @@ unicode = 012D;
 },
 {
 glyphname = icircumflex;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 components = (
 {
-name = dotlessi;
+name = idotless;
 },
 {
 name = circumflex;
@@ -12561,7 +15452,7 @@ width = 316;
 {
 components = (
 {
-name = dotlessi;
+name = idotless;
 },
 {
 name = circumflex;
@@ -12578,15 +15469,15 @@ unicode = 00EE;
 },
 {
 glyphname = idblgrave;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 components = (
 {
-name = dotlessi;
+name = idotless;
 },
 {
-name = uni030F;
+name = dblgravecomb;
 transform = "{1, 0, 0, 1, -128, 0}";
 }
 );
@@ -12596,10 +15487,10 @@ width = 316;
 {
 components = (
 {
-name = dotlessi;
+name = idotless;
 },
 {
-name = uni030F;
+name = dblgravecomb;
 transform = "{1, 0, 0, 1, -154, 0}";
 }
 );
@@ -12613,12 +15504,12 @@ unicode = 0209;
 },
 {
 glyphname = idieresis;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 components = (
 {
-name = dotlessi;
+name = idotless;
 },
 {
 name = dieresis;
@@ -12631,7 +15522,7 @@ width = 316;
 {
 components = (
 {
-name = dotlessi;
+name = idotless;
 },
 {
 name = dieresis;
@@ -12648,7 +15539,7 @@ unicode = 00EF;
 },
 {
 glyphname = idotbelow;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:05:38 +0000";
 layers = (
 {
 components = (
@@ -12656,8 +15547,8 @@ components = (
 name = i;
 },
 {
-name = dotbelow;
-transform = "{1, 0, 0, 1, 62, 0}";
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -137, 0}";
 }
 );
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -12669,8 +15560,8 @@ components = (
 name = i;
 },
 {
-name = dotbelow;
-transform = "{1, 0, 0, 1, 96, 0}";
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -137, 0}";
 }
 );
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
@@ -12683,16 +15574,16 @@ unicode = 1ECB;
 },
 {
 glyphname = igrave;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 components = (
 {
-name = grave;
-transform = "{1, 0, 0, 1, -102, 0}";
+name = gravecomb;
+transform = "{1, 0, 0, 1, -161, -26}";
 },
 {
-name = dotlessi;
+name = idotless;
 }
 );
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -12741,11 +15632,11 @@ nodes = (
 };
 components = (
 {
-name = grave;
-transform = "{1, 0, 0, 1, -59, 0}";
+name = gravecomb;
+transform = "{1, 0, 0, 1, -168, 0}";
 },
 {
-name = dotlessi;
+name = idotless;
 }
 );
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
@@ -12757,16 +15648,49 @@ rightKerningGroup = i;
 unicode = 00EC;
 },
 {
-glyphname = iinvertedbreve;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = ihookabove;
+lastChange = "2016-08-22 14:11:26 +0000";
 layers = (
 {
 components = (
 {
-name = dotlessi;
+name = idotless;
 },
 {
-name = uni0311;
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, -115, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 312;
+},
+{
+components = (
+{
+name = idotless;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, -115, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 330;
+}
+);
+unicode = 1EC9;
+},
+{
+glyphname = iinvertedbreve;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+components = (
+{
+name = idotless;
+},
+{
+name = breveinvertedcomb;
 transform = "{1, 0, 0, 1, -15, 0}";
 }
 );
@@ -12776,10 +15700,10 @@ width = 316;
 {
 components = (
 {
-name = dotlessi;
+name = idotless;
 },
 {
-name = uni0311;
+name = breveinvertedcomb;
 transform = "{1, 0, 0, 1, -23, 0}";
 }
 );
@@ -12793,7 +15717,7 @@ unicode = 020B;
 },
 {
 glyphname = ij;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:26:51 +0000";
 layers = (
 {
 components = (
@@ -12802,11 +15726,11 @@ name = i;
 },
 {
 name = j;
-transform = "{1, 0, 0, 1, 312, 0}";
+transform = "{1, 0, 0, 1, 304, 0}";
 }
 );
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
-width = 603;
+width = 595;
 },
 {
 components = (
@@ -12828,12 +15752,12 @@ unicode = 0133;
 },
 {
 glyphname = imacron;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 components = (
 {
-name = dotlessi;
+name = idotless;
 },
 {
 name = macron;
@@ -12846,7 +15770,7 @@ width = 316;
 {
 components = (
 {
-name = dotlessi;
+name = idotless;
 },
 {
 name = macron;
@@ -12898,12 +15822,12 @@ unicode = 012F;
 },
 {
 glyphname = itilde;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 components = (
 {
-name = dotlessi;
+name = idotless;
 },
 {
 name = tilde;
@@ -12916,7 +15840,7 @@ width = 316;
 {
 components = (
 {
-name = dotlessi;
+name = idotless;
 },
 {
 name = tilde;
@@ -12933,7 +15857,7 @@ unicode = 0129;
 },
 {
 glyphname = j;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:50:23 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -12941,6 +15865,9 @@ paths = (
 {
 closed = 1;
 nodes = (
+"13 -324 OFFCURVE",
+"102 -257 OFFCURVE",
+"129 -134 CURVE SMOOTH",
 "257 450 LINE",
 "150 450 LINE",
 "25 -152 LINE SMOOTH",
@@ -12961,28 +15888,21 @@ nodes = (
 "-166 -251 CURVE SMOOTH",
 "-166 -297 OFFCURVE",
 "-117 -324 OFFCURVE",
-"-67 -324 CURVE SMOOTH",
-"13 -324 OFFCURVE",
-"102 -257 OFFCURVE",
-"129 -134 CURVE SMOOTH"
+"-67 -324 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"56 425 LINE",
 "245 425 LINE",
 "245 450 LINE",
-"56 450 LINE"
+"56 450 LINE",
+"56 425 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"173 667 LINE SMOOTH",
-"173 631 OFFCURVE",
-"203 601 OFFCURVE",
-"239 601 CURVE SMOOTH",
 "275 601 OFFCURVE",
 "305 631 OFFCURVE",
 "305 667 CURVE SMOOTH",
@@ -12991,7 +15911,10 @@ nodes = (
 "239 733 CURVE SMOOTH",
 "203 733 OFFCURVE",
 "173 703 OFFCURVE",
-"173 667 CURVE SMOOTH"
+"173 667 CURVE SMOOTH",
+"173 631 OFFCURVE",
+"203 601 OFFCURVE",
+"239 601 CURVE SMOOTH"
 );
 }
 );
@@ -13003,6 +15926,9 @@ paths = (
 {
 closed = 1;
 nodes = (
+"10 -324 OFFCURVE",
+"116 -257 OFFCURVE",
+"173 -3 CURVE SMOOTH",
 "274 450 LINE",
 "137 450 LINE",
 "12 -110 LINE SMOOTH",
@@ -13023,28 +15949,21 @@ nodes = (
 "-189 -237 CURVE SMOOTH",
 "-189 -289 OFFCURVE",
 "-137 -324 OFFCURVE",
-"-75 -324 CURVE SMOOTH",
-"10 -324 OFFCURVE",
-"116 -257 OFFCURVE",
-"173 -3 CURVE SMOOTH"
+"-75 -324 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"43 420 LINE",
 "262 420 LINE",
 "262 450 LINE",
-"43 450 LINE"
+"43 450 LINE",
+"43 420 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"157 656 LINE SMOOTH",
-"157 612 OFFCURVE",
-"192 577 OFFCURVE",
-"236 577 CURVE SMOOTH",
 "280 577 OFFCURVE",
 "315 612 OFFCURVE",
 "315 656 CURVE SMOOTH",
@@ -13053,7 +15972,10 @@ nodes = (
 "236 735 CURVE SMOOTH",
 "192 735 OFFCURVE",
 "157 700 OFFCURVE",
-"157 656 CURVE SMOOTH"
+"157 656 CURVE SMOOTH",
+"157 612 OFFCURVE",
+"192 577 OFFCURVE",
+"236 577 CURVE SMOOTH"
 );
 }
 );
@@ -13065,8 +15987,8 @@ rightKerningGroup = j;
 unicode = 006A;
 },
 {
-glyphname = dotlessj;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = jdotless;
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -13074,6 +15996,9 @@ paths = (
 {
 closed = 1;
 nodes = (
+"13 -324 OFFCURVE",
+"102 -257 OFFCURVE",
+"129 -134 CURVE SMOOTH",
 "257 450 LINE",
 "150 450 LINE",
 "25 -152 LINE SMOOTH",
@@ -13094,19 +16019,16 @@ nodes = (
 "-166 -251 CURVE SMOOTH",
 "-166 -297 OFFCURVE",
 "-117 -324 OFFCURVE",
-"-67 -324 CURVE SMOOTH",
-"13 -324 OFFCURVE",
-"102 -257 OFFCURVE",
-"129 -134 CURVE SMOOTH"
+"-67 -324 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"56 425 LINE",
 "245 425 LINE",
 "245 450 LINE",
-"56 450 LINE"
+"56 450 LINE",
+"56 425 LINE"
 );
 }
 );
@@ -13118,6 +16040,9 @@ paths = (
 {
 closed = 1;
 nodes = (
+"10 -324 OFFCURVE",
+"116 -257 OFFCURVE",
+"173 -3 CURVE SMOOTH",
 "274 450 LINE",
 "137 450 LINE",
 "12 -110 LINE SMOOTH",
@@ -13138,19 +16063,16 @@ nodes = (
 "-189 -237 CURVE SMOOTH",
 "-189 -289 OFFCURVE",
 "-137 -324 OFFCURVE",
-"-75 -324 CURVE SMOOTH",
-"10 -324 OFFCURVE",
-"116 -257 OFFCURVE",
-"173 -3 CURVE SMOOTH"
+"-75 -324 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"43 420 LINE",
 "262 420 LINE",
 "262 450 LINE",
-"43 450 LINE"
+"43 450 LINE",
+"43 420 LINE"
 );
 }
 );
@@ -13161,12 +16083,12 @@ unicode = 0237;
 },
 {
 glyphname = jcircumflex;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 components = (
 {
-name = dotlessj;
+name = jdotless;
 },
 {
 name = circumflex;
@@ -13179,7 +16101,7 @@ width = 271;
 {
 components = (
 {
-name = dotlessj;
+name = jdotless;
 },
 {
 name = circumflex;
@@ -13196,48 +16118,33 @@ unicode = 0135;
 },
 {
 glyphname = k;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:59 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{210, 0}";
+},
+{
+name = top;
+position = "{314, 450}";
+}
+);
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
 paths = (
 {
 closed = 1;
 nodes = (
+"124 0 LINE",
 "296 754 LINE",
 "189 754 LINE",
-"21 0 LINE",
-"124 0 LINE"
+"21 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"95 729 LINE",
-"284 729 LINE",
-"284 754 LINE",
-"95 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"161 239 LINE",
-"169 237 OFFCURVE",
-"172 237 OFFCURVE",
-"179 237 CURVE SMOOTH",
-"216 237 OFFCURVE",
-"237 242 OFFCURVE",
-"273 264 CURVE",
-"282 257 OFFCURVE",
-"286 243 OFFCURVE",
-"286 227 CURVE SMOOTH",
-"286 181 OFFCURVE",
-"253 113 OFFCURVE",
-"253 65 CURVE SMOOTH",
-"253 11 OFFCURVE",
-"294 -13 OFFCURVE",
-"336 -13 CURVE SMOOTH",
 "399 -13 OFFCURVE",
 "451 41 OFFCURVE",
 "491 146 CURVE",
@@ -13275,37 +16182,64 @@ nodes = (
 "324 462 OFFCURVE",
 "314 346 OFFCURVE",
 "250 285 CURVE",
-"238 285 LINE SMOOTH",
-"218 285 OFFCURVE",
-"191 280 OFFCURVE",
-"168 275 CURVE"
+"224 285 OFFCURVE",
+"201 282 OFFCURVE",
+"168 275 CURVE",
+"161 239 LINE",
+"169 237 OFFCURVE",
+"172 237 OFFCURVE",
+"179 237 CURVE SMOOTH",
+"216 237 OFFCURVE",
+"237 242 OFFCURVE",
+"273 264 CURVE",
+"282 257 OFFCURVE",
+"286 243 OFFCURVE",
+"286 227 CURVE SMOOTH",
+"286 181 OFFCURVE",
+"253 113 OFFCURVE",
+"253 65 CURVE SMOOTH",
+"253 11 OFFCURVE",
+"294 -13 OFFCURVE",
+"336 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"284 729 LINE",
+"284 754 LINE",
+"95 754 LINE",
+"95 729 LINE"
 );
 }
 );
 width = 523;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{220, 0}";
+},
+{
+name = top;
+position = "{324, 450}";
+}
+);
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
 paths = (
 {
 closed = 1;
 nodes = (
-"204 236 LINE",
-"213 230 OFFCURVE",
-"222 227 OFFCURVE",
-"233 227 CURVE SMOOTH",
-"254 227 OFFCURVE",
-"280 237 OFFCURVE",
-"297 254 CURVE",
-"308 247 OFFCURVE",
-"312 238 OFFCURVE",
-"312 223 CURVE SMOOTH",
-"312 178 OFFCURVE",
-"277 130 OFFCURVE",
-"277 77 CURVE SMOOTH",
-"277 14 OFFCURVE",
-"327 -13 OFFCURVE",
-"378 -13 CURVE SMOOTH",
+"146 0 LINE",
+"334 754 LINE",
+"197 754 LINE",
+"13 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "444 -13 OFFCURVE",
 "499 32 OFFCURVE",
 "545 132 CURVE",
@@ -13345,25 +16279,32 @@ nodes = (
 "284 285 CURVE",
 "265 285 OFFCURVE",
 "232 280 OFFCURVE",
-"212 269 CURVE"
+"212 269 CURVE",
+"204 236 LINE",
+"213 230 OFFCURVE",
+"222 227 OFFCURVE",
+"233 227 CURVE SMOOTH",
+"254 227 OFFCURVE",
+"280 237 OFFCURVE",
+"297 254 CURVE",
+"308 247 OFFCURVE",
+"312 238 OFFCURVE",
+"312 223 CURVE SMOOTH",
+"312 178 OFFCURVE",
+"277 130 OFFCURVE",
+"277 77 CURVE SMOOTH",
+"277 14 OFFCURVE",
+"327 -13 OFFCURVE",
+"378 -13 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"334 754 LINE",
-"197 754 LINE",
-"13 0 LINE",
-"146 0 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"103 724 LINE",
 "322 724 LINE",
 "322 754 LINE",
-"103 754 LINE"
+"103 754 LINE",
+"103 724 LINE"
 );
 }
 );
@@ -13376,7 +16317,7 @@ unicode = 006B;
 },
 {
 glyphname = kcommaaccent;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 components = (
@@ -13384,7 +16325,7 @@ components = (
 name = k;
 },
 {
-name = commaaccent;
+name = commaaccentcomb;
 transform = "{1, 0, 0, 1, 154, 0}";
 }
 );
@@ -13397,7 +16338,7 @@ components = (
 name = k;
 },
 {
-name = commaaccent;
+name = commaaccentcomb;
 transform = "{1, 0, 0, 1, 195, 0}";
 }
 );
@@ -13411,7 +16352,7 @@ unicode = 0137;
 },
 {
 glyphname = kgreenlandic;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 11:30:29 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -13419,40 +16360,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"227 450 LINE",
-"121 450 LINE",
-"21 0 LINE",
-"124 0 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"26 425 LINE",
-"215 425 LINE",
-"215 450 LINE",
-"26 450 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"161 239 LINE",
-"169 237 OFFCURVE",
-"172 237 OFFCURVE",
-"179 237 CURVE SMOOTH",
-"216 237 OFFCURVE",
-"237 242 OFFCURVE",
-"273 264 CURVE",
-"282 257 OFFCURVE",
-"286 243 OFFCURVE",
-"286 227 CURVE SMOOTH",
-"286 181 OFFCURVE",
-"253 113 OFFCURVE",
-"253 65 CURVE SMOOTH",
-"253 11 OFFCURVE",
-"294 -13 OFFCURVE",
-"336 -13 CURVE SMOOTH",
 "399 -13 OFFCURVE",
 "451 41 OFFCURVE",
 "491 146 CURVE",
@@ -13490,10 +16397,43 @@ nodes = (
 "324 462 OFFCURVE",
 "314 346 OFFCURVE",
 "250 285 CURVE",
-"238 285 LINE SMOOTH",
-"218 285 OFFCURVE",
-"191 280 OFFCURVE",
-"168 275 CURVE"
+"224 285 OFFCURVE",
+"201 282 OFFCURVE",
+"168 275 CURVE",
+"161 239 LINE",
+"169 237 OFFCURVE",
+"172 237 OFFCURVE",
+"179 237 CURVE SMOOTH",
+"216 237 OFFCURVE",
+"237 242 OFFCURVE",
+"273 264 CURVE",
+"282 257 OFFCURVE",
+"286 243 OFFCURVE",
+"286 227 CURVE SMOOTH",
+"286 181 OFFCURVE",
+"253 113 OFFCURVE",
+"253 65 CURVE SMOOTH",
+"253 11 OFFCURVE",
+"294 -13 OFFCURVE",
+"336 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"124 0 LINE",
+"227 450 LINE",
+"121 450 LINE",
+"21 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"215 425 LINE",
+"215 450 LINE",
+"26 450 LINE",
+"26 425 LINE"
 );
 }
 );
@@ -13588,22 +16528,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"216 216 LINE",
-"225 207 OFFCURVE",
-"234 207 OFFCURVE",
-"245 207 CURVE SMOOTH",
-"266 207 OFFCURVE",
-"292 217 OFFCURVE",
-"309 234 CURVE",
-"320 227 OFFCURVE",
-"324 218 OFFCURVE",
-"324 203 CURVE SMOOTH",
-"324 164 OFFCURVE",
-"299 122 OFFCURVE",
-"299 77 CURVE SMOOTH",
-"299 14 OFFCURVE",
-"349 -13 OFFCURVE",
-"400 -13 CURVE SMOOTH",
 "466 -13 OFFCURVE",
 "521 32 OFFCURVE",
 "567 132 CURVE",
@@ -13643,25 +16567,41 @@ nodes = (
 "296 265 CURVE",
 "277 265 OFFCURVE",
 "244 260 OFFCURVE",
-"224 249 CURVE"
+"224 249 CURVE",
+"216 216 LINE",
+"225 207 OFFCURVE",
+"234 207 OFFCURVE",
+"245 207 CURVE SMOOTH",
+"266 207 OFFCURVE",
+"292 217 OFFCURVE",
+"309 234 CURVE",
+"320 227 OFFCURVE",
+"324 218 OFFCURVE",
+"324 203 CURVE SMOOTH",
+"324 164 OFFCURVE",
+"299 122 OFFCURVE",
+"299 77 CURVE SMOOTH",
+"299 14 OFFCURVE",
+"349 -13 OFFCURVE",
+"400 -13 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
+"168 0 LINE",
 "280 450 LINE",
 "143 450 LINE",
-"35 0 LINE",
-"168 0 LINE"
+"35 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"49 420 LINE",
 "268 420 LINE",
 "268 450 LINE",
-"49 450 LINE"
+"49 450 LINE",
+"49 420 LINE"
 );
 }
 );
@@ -13673,23 +16613,32 @@ unicode = 0138;
 },
 {
 glyphname = l;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:59 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{110, 0}";
+},
+{
+name = center;
+position = "{162, 225}";
+},
+{
+name = top;
+position = "{214, 450}";
+},
+{
+name = topright;
+position = "{356, 450}";
+}
+);
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
 paths = (
 {
 closed = 1;
 nodes = (
-"314 754 LINE",
-"207 754 LINE",
-"47 87 LINE SMOOTH",
-"45 78 OFFCURVE",
-"43 67 OFFCURVE",
-"43 56 CURVE SMOOTH",
-"43 15 OFFCURVE",
-"71 -13 OFFCURVE",
-"120 -13 CURVE SMOOTH",
 "209 -13 OFFCURVE",
 "268 73 OFFCURVE",
 "308 157 CURVE",
@@ -13702,36 +16651,54 @@ nodes = (
 "147 63 CURVE SMOOTH",
 "147 69 OFFCURVE",
 "148 80 OFFCURVE",
-"152 97 CURVE SMOOTH"
+"152 97 CURVE SMOOTH",
+"314 754 LINE",
+"207 754 LINE",
+"47 87 LINE SMOOTH",
+"45 78 OFFCURVE",
+"43 67 OFFCURVE",
+"43 56 CURVE SMOOTH",
+"43 15 OFFCURVE",
+"71 -13 OFFCURVE",
+"120 -13 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"107 729 LINE",
 "302 729 LINE",
 "302 754 LINE",
-"107 754 LINE"
+"107 754 LINE",
+"107 729 LINE"
 );
 }
 );
 width = 324;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{104, 0}";
+},
+{
+name = center;
+position = "{156, 225}";
+},
+{
+name = top;
+position = "{208, 450}";
+},
+{
+name = topright;
+position = "{344, 450}";
+}
+);
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
 paths = (
 {
 closed = 1;
 nodes = (
-"330 754 LINE",
-"196 754 LINE",
-"57 132 LINE SMOOTH",
-"52 108 OFFCURVE",
-"48 83 OFFCURVE",
-"48 67 CURVE SMOOTH",
-"48 26 OFFCURVE",
-"74 -11 OFFCURVE",
-"131 -11 CURVE SMOOTH",
 "199 -11 OFFCURVE",
 "258 43 OFFCURVE",
 "291 152 CURVE",
@@ -13744,16 +16711,25 @@ nodes = (
 "166 54 CURVE SMOOTH",
 "166 58 OFFCURVE",
 "167 70 OFFCURVE",
-"171 87 CURVE SMOOTH"
+"171 87 CURVE SMOOTH",
+"330 754 LINE",
+"196 754 LINE",
+"57 132 LINE SMOOTH",
+"52 108 OFFCURVE",
+"48 83 OFFCURVE",
+"48 67 CURVE SMOOTH",
+"48 26 OFFCURVE",
+"74 -11 OFFCURVE",
+"131 -11 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"118 724 LINE",
 "273 724 LINE",
 "273 754 LINE",
-"118 754 LINE"
+"118 754 LINE",
+"118 724 LINE"
 );
 }
 );
@@ -13766,7 +16742,7 @@ unicode = 006C;
 },
 {
 glyphname = lacute;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:15 +0000";
 layers = (
 {
 components = (
@@ -13774,7 +16750,7 @@ components = (
 name = l;
 },
 {
-name = acute.cap;
+name = acute.case;
 transform = "{1, 0, 0, 1, 56, 0}";
 }
 );
@@ -13787,7 +16763,7 @@ components = (
 name = l;
 },
 {
-name = acute.cap;
+name = acute.case;
 transform = "{1, 0, 0, 1, 75, 0}";
 }
 );
@@ -13835,7 +16811,7 @@ unicode = 013E;
 },
 {
 glyphname = lcommaaccent;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 components = (
@@ -13843,7 +16819,7 @@ components = (
 name = l;
 },
 {
-name = commaaccent;
+name = commaaccentcomb;
 transform = "{1, 0, 0, 1, 56, 0}";
 }
 );
@@ -13856,7 +16832,7 @@ components = (
 name = l;
 },
 {
-name = commaaccent;
+name = commaaccentcomb;
 transform = "{1, 0, 0, 1, 86, 0}";
 }
 );
@@ -13903,8 +16879,43 @@ leftKerningGroup = l;
 unicode = 0140;
 },
 {
+glyphname = lj;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+components = (
+{
+name = l;
+},
+{
+name = j;
+transform = "{1, 0, 0, 1, 324, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 615;
+},
+{
+components = (
+{
+name = l;
+},
+{
+name = j;
+transform = "{1, 0, 0, 1, 312, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 599;
+}
+);
+leftKerningGroup = l;
+rightKerningGroup = j;
+unicode = 01C9;
+},
+{
 glyphname = lslash;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 components = (
@@ -13917,10 +16928,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"30 287 LINE",
 "338 448 LINE",
 "338 488 LINE",
-"30 327 LINE"
+"30 327 LINE",
+"30 287 LINE"
 );
 }
 );
@@ -13937,10 +16948,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"-10 278 LINE",
 "331 439 LINE",
 "342 489 LINE",
-"1 328 LINE"
+"1 328 LINE",
+"-10 278 LINE"
 );
 }
 );
@@ -13951,49 +16962,24 @@ unicode = 0142;
 },
 {
 glyphname = m;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:59 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{354, 0}";
+},
+{
+name = top;
+position = "{458, 450}";
+}
+);
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
 paths = (
 {
 closed = 1;
 nodes = (
-"240 450 LINE",
-"133 450 LINE",
-"26 0 LINE",
-"129 0 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"39 425 LINE",
-"228 425 LINE",
-"228 450 LINE",
-"39 450 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"449 234 LINE",
-"476 339 OFFCURVE",
-"546 420 OFFCURVE",
-"604 420 CURVE SMOOTH",
-"625 420 OFFCURVE",
-"641 410 OFFCURVE",
-"641 385 CURVE SMOOTH",
-"641 377 OFFCURVE",
-"639 369 OFFCURVE",
-"637 359 CURVE SMOOTH",
-"572 87 LINE SMOOTH",
-"570 78 OFFCURVE",
-"568 67 OFFCURVE",
-"568 56 CURVE SMOOTH",
-"568 15 OFFCURVE",
-"597 -13 OFFCURVE",
-"644 -13 CURVE SMOOTH",
 "725 -13 OFFCURVE",
 "779 69 OFFCURVE",
 "818 157 CURVE",
@@ -14017,12 +17003,47 @@ nodes = (
 "580 462 OFFCURVE",
 "522 413 OFFCURVE",
 "484 361 CURVE",
-"477 361 LINE"
+"477 361 LINE",
+"449 234 LINE",
+"476 339 OFFCURVE",
+"546 420 OFFCURVE",
+"604 420 CURVE SMOOTH",
+"625 420 OFFCURVE",
+"641 410 OFFCURVE",
+"641 385 CURVE SMOOTH",
+"641 377 OFFCURVE",
+"639 369 OFFCURVE",
+"637 359 CURVE SMOOTH",
+"572 87 LINE SMOOTH",
+"570 78 OFFCURVE",
+"568 67 OFFCURVE",
+"568 56 CURVE SMOOTH",
+"568 15 OFFCURVE",
+"597 -13 OFFCURVE",
+"644 -13 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
+"129 0 LINE",
+"240 450 LINE",
+"133 450 LINE",
+"26 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"392 0 LINE",
+"474 336 LINE SMOOTH",
+"492 414 OFFCURVE",
+"464 462 OFFCURVE",
+"388 462 CURVE SMOOTH",
+"317 462 OFFCURVE",
+"259 413 OFFCURVE",
+"221 361 CURVE",
+"214 361 LINE",
 "186 234 LINE",
 "213 339 OFFCURVE",
 "283 420 OFFCURVE",
@@ -14033,65 +17054,37 @@ nodes = (
 "378 377 OFFCURVE",
 "376 369 OFFCURVE",
 "374 359 CURVE SMOOTH",
-"288 0 LINE",
-"392 0 LINE",
-"474 336 LINE SMOOTH",
-"478 353 OFFCURVE",
-"480 368 OFFCURVE",
-"480 380 CURVE SMOOTH",
-"480 438 OFFCURVE",
-"437 462 OFFCURVE",
-"388 462 CURVE SMOOTH",
-"317 462 OFFCURVE",
-"259 413 OFFCURVE",
-"221 361 CURVE",
-"214 361 LINE"
+"288 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"228 425 LINE",
+"228 450 LINE",
+"39 450 LINE",
+"39 425 LINE"
 );
 }
 );
 width = 812;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{349, 0}";
+},
+{
+name = top;
+position = "{453, 450}";
+}
+);
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
 paths = (
 {
 closed = 1;
 nodes = (
-"275 450 LINE",
-"138 450 LINE",
-"35 0 LINE",
-"168 0 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"44 420 LINE",
-"263 420 LINE",
-"263 450 LINE",
-"44 450 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"478 229 LINE",
-"502 340 OFFCURVE",
-"587 416 OFFCURVE",
-"620 416 CURVE SMOOTH",
-"631 416 OFFCURVE",
-"638 408 OFFCURVE",
-"638 394 CURVE SMOOTH",
-"638 384 OFFCURVE",
-"635 365 OFFCURVE",
-"633 356 CURVE SMOOTH",
-"569 107 LINE SMOOTH",
-"567 98 OFFCURVE",
-"565 88 OFFCURVE",
-"565 75 CURVE SMOOTH",
-"565 19 OFFCURVE",
-"601 -11 OFFCURVE",
-"663 -11 CURVE SMOOTH",
 "724 -11 OFFCURVE",
 "775 17 OFFCURVE",
 "818 126 CURVE",
@@ -14115,12 +17108,47 @@ nodes = (
 "597 462 OFFCURVE",
 "543 408 OFFCURVE",
 "507 351 CURVE",
-"500 351 LINE"
+"500 351 LINE",
+"478 229 LINE",
+"502 340 OFFCURVE",
+"587 416 OFFCURVE",
+"620 416 CURVE SMOOTH",
+"631 416 OFFCURVE",
+"638 408 OFFCURVE",
+"638 394 CURVE SMOOTH",
+"638 384 OFFCURVE",
+"635 365 OFFCURVE",
+"633 356 CURVE SMOOTH",
+"569 107 LINE SMOOTH",
+"567 98 OFFCURVE",
+"565 88 OFFCURVE",
+"565 75 CURVE SMOOTH",
+"565 19 OFFCURVE",
+"601 -11 OFFCURVE",
+"663 -11 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
+"168 0 LINE",
+"275 450 LINE",
+"138 450 LINE",
+"35 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"435 0 LINE",
+"502 339 LINE SMOOTH",
+"519 425 OFFCURVE",
+"472 462 OFFCURVE",
+"410 462 CURVE SMOOTH",
+"345 462 OFFCURVE",
+"297 422 OFFCURVE",
+"261 371 CURVE",
+"254 371 LINE",
 "222 246 LINE",
 "247 347 OFFCURVE",
 "326 416 OFFCURVE",
@@ -14131,16 +17159,16 @@ nodes = (
 "381 384 OFFCURVE",
 "378 365 OFFCURVE",
 "376 356 CURVE SMOOTH",
-"299 0 LINE",
-"435 0 LINE",
-"502 339 LINE",
-"502 426 OFFCURVE",
-"472 462 OFFCURVE",
-"410 462 CURVE SMOOTH",
-"345 462 OFFCURVE",
-"297 422 OFFCURVE",
-"261 371 CURVE",
-"254 371 LINE"
+"299 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"263 420 LINE",
+"263 450 LINE",
+"44 450 LINE",
+"44 420 LINE"
 );
 }
 );
@@ -14151,49 +17179,24 @@ unicode = 006D;
 },
 {
 glyphname = n;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:59 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{228, 0}";
+},
+{
+name = top;
+position = "{332, 450}";
+}
+);
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
 paths = (
 {
 closed = 1;
 nodes = (
-"240 450 LINE",
-"133 450 LINE",
-"26 0 LINE",
-"129 0 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"39 425 LINE",
-"228 425 LINE",
-"228 450 LINE",
-"39 450 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"187 234 LINE",
-"217 342 OFFCURVE",
-"292 420 OFFCURVE",
-"352 420 CURVE SMOOTH",
-"374 420 OFFCURVE",
-"389 410 OFFCURVE",
-"389 386 CURVE SMOOTH",
-"389 377 OFFCURVE",
-"387 369 OFFCURVE",
-"385 359 CURVE SMOOTH",
-"320 87 LINE SMOOTH",
-"318 78 OFFCURVE",
-"316 67 OFFCURVE",
-"316 56 CURVE SMOOTH",
-"316 15 OFFCURVE",
-"345 -13 OFFCURVE",
-"392 -13 CURVE SMOOTH",
 "473 -13 OFFCURVE",
 "527 69 OFFCURVE",
 "566 157 CURVE",
@@ -14217,13 +17220,58 @@ nodes = (
 "324 462 OFFCURVE",
 "262 413 OFFCURVE",
 "222 361 CURVE",
-"215 361 LINE"
+"215 361 LINE",
+"187 234 LINE",
+"217 342 OFFCURVE",
+"292 420 OFFCURVE",
+"352 420 CURVE SMOOTH",
+"374 420 OFFCURVE",
+"389 410 OFFCURVE",
+"389 386 CURVE SMOOTH",
+"389 377 OFFCURVE",
+"387 369 OFFCURVE",
+"385 359 CURVE SMOOTH",
+"320 87 LINE SMOOTH",
+"318 78 OFFCURVE",
+"316 67 OFFCURVE",
+"316 56 CURVE SMOOTH",
+"316 15 OFFCURVE",
+"345 -13 OFFCURVE",
+"392 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"129 0 LINE",
+"240 450 LINE",
+"133 450 LINE",
+"26 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"228 425 LINE",
+"228 450 LINE",
+"39 450 LINE",
+"39 425 LINE"
 );
 }
 );
 width = 560;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{244, 0}";
+},
+{
+name = top;
+position = "{348, 450}";
+}
+);
 background = {
 paths = (
 {
@@ -14297,41 +17345,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"280 450 LINE",
-"143 450 LINE",
-"35 0 LINE",
-"168 0 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"49 420 LINE",
-"268 420 LINE",
-"268 450 LINE",
-"49 450 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"224 229 LINE",
-"255 343 OFFCURVE",
-"355 416 OFFCURVE",
-"391 416 CURVE SMOOTH",
-"403 416 OFFCURVE",
-"410 408 OFFCURVE",
-"410 394 CURVE SMOOTH",
-"410 384 OFFCURVE",
-"407 365 OFFCURVE",
-"405 356 CURVE SMOOTH",
-"341 107 LINE SMOOTH",
-"339 98 OFFCURVE",
-"337 88 OFFCURVE",
-"337 75 CURVE SMOOTH",
-"337 19 OFFCURVE",
-"373 -11 OFFCURVE",
-"435 -11 CURVE SMOOTH",
 "500 -11 OFFCURVE",
 "563 21 OFFCURVE",
 "609 146 CURVE",
@@ -14355,7 +17368,42 @@ nodes = (
 "362 462 OFFCURVE",
 "302 408 OFFCURVE",
 "262 351 CURVE",
-"255 351 LINE"
+"255 351 LINE",
+"224 229 LINE",
+"255 343 OFFCURVE",
+"355 416 OFFCURVE",
+"391 416 CURVE SMOOTH",
+"403 416 OFFCURVE",
+"410 408 OFFCURVE",
+"410 394 CURVE SMOOTH",
+"410 384 OFFCURVE",
+"407 365 OFFCURVE",
+"405 356 CURVE SMOOTH",
+"341 107 LINE SMOOTH",
+"339 98 OFFCURVE",
+"337 88 OFFCURVE",
+"337 75 CURVE SMOOTH",
+"337 19 OFFCURVE",
+"373 -11 OFFCURVE",
+"435 -11 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"168 0 LINE",
+"280 450 LINE",
+"143 450 LINE",
+"35 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"268 420 LINE",
+"268 450 LINE",
+"49 450 LINE",
+"49 420 LINE"
 );
 }
 );
@@ -14403,7 +17451,7 @@ unicode = 0144;
 },
 {
 glyphname = napostrophe;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 components = (
@@ -14411,7 +17459,7 @@ components = (
 name = n;
 },
 {
-name = apostrophe;
+name = quoteright;
 transform = "{1, 0, 0, 1, -62, 3}";
 }
 );
@@ -14422,38 +17470,12 @@ width = 560;
 components = (
 {
 name = n;
+},
+{
+name = quoteright;
 }
 );
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
-paths = (
-{
-closed = 1;
-nodes = (
-"62 489 LINE",
-"168 528 OFFCURVE",
-"229 589 OFFCURVE",
-"229 662 CURVE SMOOTH",
-"229 709 OFFCURVE",
-"203 767 OFFCURVE",
-"138 767 CURVE SMOOTH",
-"94 767 OFFCURVE",
-"54 741 OFFCURVE",
-"54 693 CURVE SMOOTH",
-"54 663 OFFCURVE",
-"72 628 OFFCURVE",
-"112 628 CURVE SMOOTH",
-"154 628 OFFCURVE",
-"161 664 OFFCURVE",
-"172 664 CURVE SMOOTH",
-"177 664 OFFCURVE",
-"185 658 OFFCURVE",
-"185 642 CURVE SMOOTH",
-"185 599 OFFCURVE",
-"127 548 OFFCURVE",
-"44 517 CURVE"
-);
-}
-);
 width = 592;
 }
 );
@@ -14497,7 +17519,7 @@ unicode = 0148;
 },
 {
 glyphname = ncommaaccent;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 components = (
@@ -14505,7 +17527,7 @@ components = (
 name = n;
 },
 {
-name = commaaccent;
+name = commaaccentcomb;
 transform = "{1, 0, 0, 1, 206, 0}";
 }
 );
@@ -14518,7 +17540,7 @@ components = (
 name = n;
 },
 {
-name = commaaccent;
+name = commaaccentcomb;
 transform = "{1, 0, 0, 1, 226, 0}";
 }
 );
@@ -14567,7 +17589,7 @@ unicode = 1E45;
 },
 {
 glyphname = eng;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 11:45:51 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -14575,13 +17597,23 @@ paths = (
 {
 closed = 1;
 nodes = (
-"39 425 LINE",
-"127 425 LINE",
-"26 0 LINE",
-"129 0 LINE",
-"191 252 LINE SMOOTH",
-"213 341 OFFCURVE",
-"292 418 OFFCURVE",
+"259 -324 OFFCURVE",
+"346 -257 OFFCURVE",
+"375 -134 CURVE SMOOTH",
+"485 336 LINE SMOOTH",
+"489 354 OFFCURVE",
+"491 368 OFFCURVE",
+"491 380 CURVE SMOOTH",
+"491 438 OFFCURVE",
+"449 462 OFFCURVE",
+"398 462 CURVE SMOOTH",
+"324 462 OFFCURVE",
+"265 416 OFFCURVE",
+"225 364 CURVE",
+"214 364 LINE",
+"187 272 LINE",
+"243 363 OFFCURVE",
+"295 418 OFFCURVE",
 "352 418 CURVE SMOOTH",
 "374 418 OFFCURVE",
 "389 408 OFFCURVE",
@@ -14607,23 +17639,25 @@ nodes = (
 "80 -251 CURVE SMOOTH",
 "80 -297 OFFCURVE",
 "129 -324 OFFCURVE",
-"179 -324 CURVE SMOOTH",
-"259 -324 OFFCURVE",
-"346 -257 OFFCURVE",
-"375 -134 CURVE SMOOTH",
-"485 336 LINE SMOOTH",
-"489 354 OFFCURVE",
-"491 368 OFFCURVE",
-"491 380 CURVE SMOOTH",
-"491 438 OFFCURVE",
-"449 462 OFFCURVE",
-"398 462 CURVE SMOOTH",
-"324 462 OFFCURVE",
-"262 413 OFFCURVE",
-"222 361 CURVE",
-"218 361 LINE",
+"179 -324 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"129 0 LINE",
 "240 450 LINE",
-"39 450 LINE"
+"133 450 LINE",
+"26 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"210 425 LINE",
+"220 450 LINE",
+"39 450 LINE",
+"39 425 LINE"
 );
 }
 );
@@ -14635,24 +17669,20 @@ paths = (
 {
 closed = 1;
 nodes = (
-"280 450 LINE",
-"143 450 LINE",
-"35 0 LINE",
-"168 0 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"49 420 LINE",
-"268 420 LINE",
-"268 450 LINE",
-"49 450 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"298 -324 OFFCURVE",
+"404 -257 OFFCURVE",
+"461 -3 CURVE SMOOTH",
+"538 338 LINE SMOOTH",
+"542 355 OFFCURVE",
+"544 370 OFFCURVE",
+"544 382 CURVE SMOOTH",
+"544 438 OFFCURVE",
+"496 462 OFFCURVE",
+"442 462 CURVE SMOOTH",
+"362 462 OFFCURVE",
+"302 408 OFFCURVE",
+"262 351 CURVE",
+"255 351 LINE",
 "224 229 LINE",
 "255 343 OFFCURVE",
 "355 416 OFFCURVE",
@@ -14681,21 +17711,25 @@ nodes = (
 "99 -237 CURVE SMOOTH",
 "99 -289 OFFCURVE",
 "151 -324 OFFCURVE",
-"213 -324 CURVE SMOOTH",
-"298 -324 OFFCURVE",
-"404 -257 OFFCURVE",
-"461 -3 CURVE SMOOTH",
-"538 338 LINE SMOOTH",
-"542 355 OFFCURVE",
-"544 370 OFFCURVE",
-"544 382 CURVE SMOOTH",
-"544 438 OFFCURVE",
-"496 462 OFFCURVE",
-"442 462 CURVE SMOOTH",
-"362 462 OFFCURVE",
-"302 408 OFFCURVE",
-"262 351 CURVE",
-"255 351 LINE"
+"213 -324 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"168 0 LINE",
+"280 450 LINE",
+"143 450 LINE",
+"35 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"268 420 LINE",
+"268 450 LINE",
+"49 450 LINE",
+"49 420 LINE"
 );
 }
 );
@@ -14704,6 +17738,41 @@ width = 575;
 );
 leftKerningGroup = n;
 unicode = 014B;
+},
+{
+glyphname = nj;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+components = (
+{
+name = n;
+},
+{
+name = j;
+transform = "{1, 0, 0, 1, 560, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 851;
+},
+{
+components = (
+{
+name = n;
+},
+{
+name = j;
+transform = "{1, 0, 0, 1, 592, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 879;
+}
+);
+leftKerningGroup = n;
+rightKerningGroup = j;
+unicode = 01CC;
 },
 {
 glyphname = ntilde;
@@ -14742,33 +17811,36 @@ unicode = 00F1;
 },
 {
 glyphname = o;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:06:58 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{210, 0}";
+},
+{
+name = center;
+position = "{262, 225}";
+},
+{
+name = ogonek;
+position = "{420, 10}";
+},
+{
+name = top;
+position = "{314, 450}";
+},
+{
+name = topright;
+position = "{459, 397}";
+}
+);
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
 paths = (
 {
 closed = 1;
 nodes = (
-"213 12 LINE SMOOTH",
-"160 12 OFFCURVE",
-"141 52 OFFCURVE",
-"141 127 CURVE SMOOTH",
-"141 261 OFFCURVE",
-"201 437 OFFCURVE",
-"308 437 CURVE SMOOTH",
-"365 437 OFFCURVE",
-"382 388 OFFCURVE",
-"382 317 CURVE SMOOTH",
-"382 183 OFFCURVE",
-"322 12 OFFCURVE",
-"213 12 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"211 -13 LINE SMOOTH",
 "359 -13 OFFCURVE",
 "496 138 OFFCURVE",
 "496 280 CURVE SMOOTH",
@@ -14782,35 +17854,55 @@ nodes = (
 "101 -13 OFFCURVE",
 "211 -13 CURVE SMOOTH"
 );
+},
+{
+closed = 1;
+nodes = (
+"160 12 OFFCURVE",
+"141 52 OFFCURVE",
+"141 127 CURVE SMOOTH",
+"141 261 OFFCURVE",
+"201 437 OFFCURVE",
+"308 437 CURVE SMOOTH",
+"365 437 OFFCURVE",
+"382 388 OFFCURVE",
+"382 317 CURVE SMOOTH",
+"382 183 OFFCURVE",
+"322 12 OFFCURVE",
+"213 12 CURVE SMOOTH"
+);
 }
 );
 width = 524;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{226, 0}";
+},
+{
+name = center;
+position = "{278, 225}";
+},
+{
+name = ogonek;
+position = "{448, 10}";
+},
+{
+name = top;
+position = "{330, 450}";
+},
+{
+name = topright;
+position = "{482, 396}";
+}
+);
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
 paths = (
 {
 closed = 1;
 nodes = (
-"330 427 LINE SMOOTH",
-"372 427 OFFCURVE",
-"383 396 OFFCURVE",
-"383 337 CURVE SMOOTH",
-"383 200 OFFCURVE",
-"327 22 OFFCURVE",
-"225 22 CURVE SMOOTH",
-"183 22 OFFCURVE",
-"172 53 OFFCURVE",
-"172 112 CURVE SMOOTH",
-"172 249 OFFCURVE",
-"228 427 OFFCURVE",
-"330 427 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"222 -13 LINE SMOOTH",
 "386 -13 OFFCURVE",
 "533 137 OFFCURVE",
 "533 280 CURVE SMOOTH",
@@ -14824,6 +17916,23 @@ nodes = (
 "104 -13 OFFCURVE",
 "222 -13 CURVE SMOOTH"
 );
+},
+{
+closed = 1;
+nodes = (
+"183 22 OFFCURVE",
+"172 53 OFFCURVE",
+"172 112 CURVE SMOOTH",
+"172 249 OFFCURVE",
+"228 427 OFFCURVE",
+"330 427 CURVE SMOOTH",
+"372 427 OFFCURVE",
+"383 396 OFFCURVE",
+"383 337 CURVE SMOOTH",
+"383 200 OFFCURVE",
+"327 22 OFFCURVE",
+"225 22 CURVE SMOOTH"
+);
 }
 );
 width = 556;
@@ -14835,7 +17944,7 @@ unicode = 006F;
 },
 {
 glyphname = oacute;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:05:38 +0000";
 layers = (
 {
 components = (
@@ -14843,8 +17952,8 @@ components = (
 name = o;
 },
 {
-name = acute;
-transform = "{1, 0, 0, 1, 118, 0}";
+name = acutecomb;
+transform = "{1, 0, 0, 1, -45, 0}";
 }
 );
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -14856,8 +17965,8 @@ components = (
 name = o;
 },
 {
-name = acute;
-transform = "{1, 0, 0, 1, 141, 0}";
+name = acutecomb;
+transform = "{1, 0, 0, 1, -75, 0}";
 }
 );
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
@@ -14905,7 +18014,7 @@ unicode = 014F;
 },
 {
 glyphname = ocircumflex;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:05:38 +0000";
 layers = (
 {
 components = (
@@ -14913,8 +18022,8 @@ components = (
 name = o;
 },
 {
-name = circumflex;
-transform = "{1, 0, 0, 1, 97, 0}";
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -58, 0}";
 }
 );
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -14926,8 +18035,8 @@ components = (
 name = o;
 },
 {
-name = circumflex;
-transform = "{1, 0, 0, 1, 94, 0}";
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -15, 0}";
 }
 );
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
@@ -14939,8 +18048,8 @@ rightKerningGroup = o;
 unicode = 00F4;
 },
 {
-glyphname = odblgrave;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = ocircumflexacute;
+lastChange = "2016-08-22 14:18:21 +0000";
 layers = (
 {
 components = (
@@ -14948,7 +18057,190 @@ components = (
 name = o;
 },
 {
-name = uni030F;
+name = circumflexcomb_acutecomb;
+transform = "{1, 0, 0, 1, -54, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 524;
+},
+{
+components = (
+{
+name = o;
+},
+{
+name = circumflexcomb_acutecomb;
+transform = "{1, 0, 0, 1, -37, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 556;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 1ED1;
+},
+{
+glyphname = ocircumflexdotbelow;
+lastChange = "2016-08-22 14:18:21 +0000";
+layers = (
+{
+components = (
+{
+name = o;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -31, 0}";
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -58, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 524;
+},
+{
+components = (
+{
+name = o;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -24, 0}";
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -15, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 556;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 1ED9;
+},
+{
+glyphname = ocircumflexgrave;
+lastChange = "2016-08-22 14:18:21 +0000";
+layers = (
+{
+components = (
+{
+name = o;
+},
+{
+name = circumflexcomb_gravecomb;
+transform = "{1, 0, 0, 1, -50, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 524;
+},
+{
+components = (
+{
+name = o;
+},
+{
+name = circumflexcomb_gravecomb;
+transform = "{1, 0, 0, 1, -33, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 556;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 1ED3;
+},
+{
+glyphname = ocircumflexhookabove;
+lastChange = "2016-08-22 14:18:21 +0000";
+layers = (
+{
+components = (
+{
+name = o;
+},
+{
+name = circumflexcomb_hookabovecomb;
+transform = "{1, 0, 0, 1, -56, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 524;
+},
+{
+components = (
+{
+name = o;
+},
+{
+name = circumflexcomb_hookabovecomb;
+transform = "{1, 0, 0, 1, -36, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 556;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 1ED5;
+},
+{
+glyphname = ocircumflextilde;
+lastChange = "2016-08-22 14:18:21 +0000";
+layers = (
+{
+components = (
+{
+name = o;
+},
+{
+name = circumflexcomb_tildecomb;
+transform = "{1, 0, 0, 1, -54, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 524;
+},
+{
+components = (
+{
+name = o;
+},
+{
+name = circumflexcomb_tildecomb;
+transform = "{1, 0, 0, 1, -39, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 556;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 1ED7;
+},
+{
+glyphname = odblgrave;
+lastChange = "2016-08-22 14:18:21 +0000";
+layers = (
+{
+components = (
+{
+name = o;
+},
+{
+name = dblgravecomb;
 transform = "{1, 0, 0, 1, 33, 0}";
 }
 );
@@ -14961,7 +18253,7 @@ components = (
 name = o;
 },
 {
-name = uni030F;
+name = dblgravecomb;
 transform = "{1, 0, 0, 1, 43, 0}";
 }
 );
@@ -14975,7 +18267,7 @@ unicode = 020D;
 },
 {
 glyphname = odieresis;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:18:21 +0000";
 layers = (
 {
 components = (
@@ -15010,7 +18302,7 @@ unicode = 00F6;
 },
 {
 glyphname = odotbelow;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:18:21 +0000";
 layers = (
 {
 components = (
@@ -15018,8 +18310,8 @@ components = (
 name = o;
 },
 {
-name = dotbelow;
-transform = "{1, 0, 0, 1, 180, 0}";
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -31, 0}";
 }
 );
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -15031,8 +18323,8 @@ components = (
 name = o;
 },
 {
-name = dotbelow;
-transform = "{1, 0, 0, 1, 194, 0}";
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -24, 0}";
 }
 );
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
@@ -15045,7 +18337,7 @@ unicode = 1ECD;
 },
 {
 glyphname = ograve;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:18:21 +0000";
 layers = (
 {
 components = (
@@ -15053,8 +18345,8 @@ components = (
 name = o;
 },
 {
-name = grave;
-transform = "{1, 0, 0, 1, 96, 0}";
+name = gravecomb;
+transform = "{1, 0, 0, 1, -34, 0}";
 }
 );
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -15066,8 +18358,8 @@ components = (
 name = o;
 },
 {
-name = grave;
-transform = "{1, 0, 0, 1, 88, 0}";
+name = gravecomb;
+transform = "{1, 0, 0, 1, 14, 0}";
 }
 );
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
@@ -15079,8 +18371,253 @@ rightKerningGroup = o;
 unicode = 00F2;
 },
 {
+glyphname = ohookabove;
+lastChange = "2016-08-22 14:18:21 +0000";
+layers = (
+{
+components = (
+{
+name = o;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, -9, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 524;
+},
+{
+components = (
+{
+name = o;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, -2, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 556;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 1ECF;
+},
+{
+glyphname = ohorn;
+lastChange = "2016-08-22 14:18:21 +0000";
+layers = (
+{
+components = (
+{
+name = o;
+},
+{
+name = horncomb;
+transform = "{1, 0, 0, 1, 154, -53}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 524;
+},
+{
+components = (
+{
+name = o;
+},
+{
+name = horncomb;
+transform = "{1, 0, 0, 1, 169, -54}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 556;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 01A1;
+},
+{
+glyphname = ohornacute;
+lastChange = "2016-08-22 14:18:21 +0000";
+layers = (
+{
+components = (
+{
+name = ohorn;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -45, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 524;
+},
+{
+components = (
+{
+name = ohorn;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -75, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 556;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 1EDB;
+},
+{
+glyphname = ohorndotbelow;
+lastChange = "2016-08-22 14:18:21 +0000";
+layers = (
+{
+components = (
+{
+name = ohorn;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -31, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 524;
+},
+{
+components = (
+{
+name = ohorn;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -24, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 556;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 1EE3;
+},
+{
+glyphname = ohorngrave;
+lastChange = "2016-08-22 14:18:21 +0000";
+layers = (
+{
+components = (
+{
+name = ohorn;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, -34, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 524;
+},
+{
+components = (
+{
+name = ohorn;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 14, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 556;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 1EDD;
+},
+{
+glyphname = ohornhookabove;
+lastChange = "2016-08-22 14:18:21 +0000";
+layers = (
+{
+components = (
+{
+name = ohorn;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, -9, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 524;
+},
+{
+components = (
+{
+name = ohorn;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, -2, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 556;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 1EDF;
+},
+{
+glyphname = ohorntilde;
+lastChange = "2016-08-22 14:18:21 +0000";
+layers = (
+{
+components = (
+{
+name = ohorn;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, -45, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 524;
+},
+{
+components = (
+{
+name = ohorn;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, -35, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 556;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 1EE1;
+},
+{
 glyphname = ohungarumlaut;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:18:21 +0000";
 layers = (
 {
 components = (
@@ -15115,7 +18652,7 @@ unicode = 0151;
 },
 {
 glyphname = oinvertedbreve;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:18:21 +0000";
 layers = (
 {
 components = (
@@ -15123,7 +18660,7 @@ components = (
 name = o;
 },
 {
-name = uni0311;
+name = breveinvertedcomb;
 transform = "{1, 0, 0, 1, 100, 0}";
 }
 );
@@ -15136,7 +18673,7 @@ components = (
 name = o;
 },
 {
-name = uni0311;
+name = breveinvertedcomb;
 transform = "{1, 0, 0, 1, 110, 0}";
 }
 );
@@ -15150,7 +18687,7 @@ unicode = 020F;
 },
 {
 glyphname = omacron;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:18:21 +0000";
 layers = (
 {
 components = (
@@ -15185,7 +18722,7 @@ unicode = 014D;
 },
 {
 glyphname = oogonek;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:18:21 +0000";
 layers = (
 {
 components = (
@@ -15220,7 +18757,7 @@ unicode = 01EB;
 },
 {
 glyphname = oslash;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:18:21 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -15257,28 +18794,25 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"142 127 LINE SMOOTH",
-"142 261 OFFCURVE",
-"202 437 OFFCURVE",
-"309 437 CURVE SMOOTH",
-"354 437 OFFCURVE",
-"374 406 OFFCURVE",
-"380 359 CURVE",
-"142 104 LINE"
+"177 12 OFFCURVE",
+"156 31 OFFCURVE",
+"147 69 CURVE",
+"383 321 LINE",
+"383 156 OFFCURVE",
+"311 12 OFFCURVE",
+"214 12 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"214 12 LINE SMOOTH",
-"177 12 OFFCURVE",
-"156 31 OFFCURVE",
-"147 69 CURVE",
-"383 321 LINE",
-"383 317 LINE SMOOTH",
-"383 183 OFFCURVE",
-"323 12 OFFCURVE",
-"214 12 CURVE SMOOTH"
+"142 294 OFFCURVE",
+"214 437 OFFCURVE",
+"309 437 CURVE SMOOTH",
+"354 437 OFFCURVE",
+"374 406 OFFCURVE",
+"380 359 CURVE",
+"142 104 LINE"
 );
 }
 );
@@ -15319,7 +18853,6 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"225 22 LINE SMOOTH",
 "187 22 OFFCURVE",
 "174 47 OFFCURVE",
 "172 95 CURVE",
@@ -15332,25 +18865,26 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"330 427 LINE SMOOTH",
+"183 282 OFFCURVE",
+"238 427 OFFCURVE",
+"330 427 CURVE SMOOTH",
 "366 427 OFFCURVE",
 "379 404 OFFCURVE",
 "382 361 CURVE",
-"173 153 LINE",
-"183 282 OFFCURVE",
-"238 427 OFFCURVE",
-"330 427 CURVE SMOOTH"
+"173 153 LINE"
 );
 }
 );
 width = 556;
 }
 );
+leftKerningGroup = o;
+rightKerningGroup = o;
 unicode = 00F8;
 },
 {
 glyphname = oslashacute;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:18:21 +0000";
 layers = (
 {
 components = (
@@ -15379,11 +18913,13 @@ layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
 width = 556;
 }
 );
+leftKerningGroup = o;
+rightKerningGroup = o;
 unicode = 01FF;
 },
 {
 glyphname = otilde;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:05:38 +0000";
 layers = (
 {
 components = (
@@ -15391,8 +18927,8 @@ components = (
 name = o;
 },
 {
-name = tilde;
-transform = "{1, 0, 0, 1, 59, 0}";
+name = tildecomb;
+transform = "{1, 0, 0, 1, -45, 0}";
 }
 );
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -15404,8 +18940,8 @@ components = (
 name = o;
 },
 {
-name = tilde;
-transform = "{1, 0, 0, 1, 67, 0}";
+name = tildecomb;
+transform = "{1, 0, 0, 1, -35, 0}";
 }
 );
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
@@ -15418,7 +18954,7 @@ unicode = 00F5;
 },
 {
 glyphname = oe;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 11:48:08 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -15426,13 +18962,40 @@ paths = (
 {
 closed = 1;
 nodes = (
-"644 462 LINE SMOOTH",
-"508 462 OFFCURVE",
-"371 327 OFFCURVE",
-"371 184 CURVE SMOOTH",
-"371 83 OFFCURVE",
-"439 -13 OFFCURVE",
-"570 -13 CURVE SMOOTH",
+"360 -13 OFFCURVE",
+"497 132 OFFCURVE",
+"497 276 CURVE SMOOTH",
+"497 382 OFFCURVE",
+"423 462 OFFCURVE",
+"316 462 CURVE SMOOTH",
+"166 462 OFFCURVE",
+"28 307 OFFCURVE",
+"28 168 CURVE SMOOTH",
+"28 66 OFFCURVE",
+"102 -13 OFFCURVE",
+"211 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"160 12 OFFCURVE",
+"142 51 OFFCURVE",
+"142 122 CURVE SMOOTH",
+"142 254 OFFCURVE",
+"204 437 OFFCURVE",
+"311 437 CURVE SMOOTH",
+"366 437 OFFCURVE",
+"383 388 OFFCURVE",
+"383 314 CURVE SMOOTH",
+"383 174 OFFCURVE",
+"322 12 OFFCURVE",
+"213 12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
 "661 -13 OFFCURVE",
 "727 34 OFFCURVE",
 "775 119 CURVE",
@@ -15464,43 +19027,13 @@ nodes = (
 "786 338 CURVE SMOOTH",
 "786 412 OFFCURVE",
 "727 462 OFFCURVE",
-"644 462 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"213 12 LINE SMOOTH",
-"160 12 OFFCURVE",
-"142 51 OFFCURVE",
-"142 122 CURVE SMOOTH",
-"142 254 OFFCURVE",
-"204 437 OFFCURVE",
-"311 437 CURVE SMOOTH",
-"366 437 OFFCURVE",
-"383 388 OFFCURVE",
-"383 314 CURVE SMOOTH",
-"383 174 OFFCURVE",
-"322 12 OFFCURVE",
-"213 12 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"211 -13 LINE SMOOTH",
-"360 -13 OFFCURVE",
-"497 132 OFFCURVE",
-"497 276 CURVE SMOOTH",
-"497 382 OFFCURVE",
-"423 462 OFFCURVE",
-"316 462 CURVE SMOOTH",
-"166 462 OFFCURVE",
-"28 307 OFFCURVE",
-"28 168 CURVE SMOOTH",
-"28 66 OFFCURVE",
-"102 -13 OFFCURVE",
-"211 -13 CURVE SMOOTH"
+"644 462 CURVE SMOOTH",
+"508 462 OFFCURVE",
+"371 327 OFFCURVE",
+"371 184 CURVE SMOOTH",
+"371 83 OFFCURVE",
+"439 -13 OFFCURVE",
+"570 -13 CURVE SMOOTH"
 );
 }
 );
@@ -15512,13 +19045,40 @@ paths = (
 {
 closed = 1;
 nodes = (
-"656 462 LINE SMOOTH",
-"509 462 OFFCURVE",
-"367 319 OFFCURVE",
-"367 177 CURVE SMOOTH",
-"367 79 OFFCURVE",
-"435 -11 OFFCURVE",
-"562 -11 CURVE SMOOTH",
+"385 -13 OFFCURVE",
+"532 133 OFFCURVE",
+"532 274 CURVE SMOOTH",
+"532 379 OFFCURVE",
+"451 462 OFFCURVE",
+"332 462 CURVE SMOOTH",
+"173 462 OFFCURVE",
+"23 312 OFFCURVE",
+"23 170 CURVE SMOOTH",
+"23 65 OFFCURVE",
+"105 -13 OFFCURVE",
+"223 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"184 22 OFFCURVE",
+"173 53 OFFCURVE",
+"173 112 CURVE SMOOTH",
+"173 249 OFFCURVE",
+"231 427 OFFCURVE",
+"330 427 CURVE SMOOTH",
+"367 427 OFFCURVE",
+"382 403 OFFCURVE",
+"382 332 CURVE SMOOTH",
+"382 195 OFFCURVE",
+"326 22 OFFCURVE",
+"226 22 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
 "660 -11 OFFCURVE",
 "746 42 OFFCURVE",
 "799 129 CURVE",
@@ -15526,11 +19086,8 @@ nodes = (
 "712 57 OFFCURVE",
 "640 29 OFFCURVE",
 "575 29 CURVE SMOOTH",
-"530 29 OFFCURVE",
-"502 43 OFFCURVE",
-"502 83 CURVE SMOOTH",
-"502 90 OFFCURVE",
-"503 99 OFFCURVE",
+"519 29 OFFCURVE",
+"495 50 OFFCURVE",
 "504 105 CURVE SMOOTH",
 "545 384 OFFCURVE",
 "602 432 OFFCURVE",
@@ -15553,43 +19110,13 @@ nodes = (
 "815 337 CURVE SMOOTH",
 "815 409 OFFCURVE",
 "746 462 OFFCURVE",
-"656 462 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"330 427 LINE SMOOTH",
-"367 427 OFFCURVE",
-"382 403 OFFCURVE",
-"382 332 CURVE SMOOTH",
-"382 195 OFFCURVE",
-"326 22 OFFCURVE",
-"226 22 CURVE SMOOTH",
-"184 22 OFFCURVE",
-"173 53 OFFCURVE",
-"173 112 CURVE SMOOTH",
-"173 249 OFFCURVE",
-"231 427 OFFCURVE",
-"330 427 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"223 -13 LINE SMOOTH",
-"385 -13 OFFCURVE",
-"532 133 OFFCURVE",
-"532 274 CURVE SMOOTH",
-"532 379 OFFCURVE",
-"451 462 OFFCURVE",
-"332 462 CURVE SMOOTH",
-"173 462 OFFCURVE",
-"23 312 OFFCURVE",
-"23 170 CURVE SMOOTH",
-"23 65 OFFCURVE",
-"105 -13 OFFCURVE",
-"223 -13 CURVE SMOOTH"
+"656 462 CURVE SMOOTH",
+"509 462 OFFCURVE",
+"367 319 OFFCURVE",
+"367 177 CURVE SMOOTH",
+"367 79 OFFCURVE",
+"435 -11 OFFCURVE",
+"562 -11 CURVE SMOOTH"
 );
 }
 );
@@ -15602,45 +19129,42 @@ unicode = 0153;
 },
 {
 glyphname = p;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:59 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{236, 0}";
+},
+{
+name = top;
+position = "{340, 450}";
+}
+);
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
 paths = (
 {
 closed = 1;
 nodes = (
+"71 -314 LINE",
 "243 450 LINE",
 "136 450 LINE",
-"-32 -314 LINE",
-"71 -314 LINE"
+"-32 -314 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"42 425 LINE",
-"231 425 LINE",
-"231 450 LINE",
-"42 450 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"-112 -314 LINE",
 "171 -314 LINE",
 "171 -289 LINE",
-"-112 -289 LINE"
+"-112 -289 LINE",
+"-112 -314 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"159 50 LINE",
-"177 11 OFFCURVE",
-"210 -13 OFFCURVE",
-"262 -13 CURVE SMOOTH",
 "388 -13 OFFCURVE",
 "527 127 OFFCURVE",
 "527 282 CURVE SMOOTH",
@@ -15667,22 +19191,59 @@ nodes = (
 "170 116 OFFCURVE",
 "170 125 OFFCURVE",
 "172 138 CURVE",
-"152 50 LINE"
+"152 50 LINE",
+"159 50 LINE",
+"177 11 OFFCURVE",
+"210 -13 OFFCURVE",
+"262 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"231 425 LINE",
+"231 450 LINE",
+"42 450 LINE",
+"42 425 LINE"
 );
 }
 );
 width = 575;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{247, 0}";
+},
+{
+name = top;
+position = "{351, 450}";
+}
+);
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
 paths = (
 {
 closed = 1;
 nodes = (
-"177 62 LINE",
-"197 17 OFFCURVE",
-"232 -11 OFFCURVE",
-"296 -11 CURVE SMOOTH",
+"91 -282 LINE",
+"269 450 LINE",
+"132 450 LINE",
+"-42 -282 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"189 -309 LINE",
+"189 -279 LINE",
+"-115 -279 LINE",
+"-115 -309 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "441 -11 OFFCURVE",
 "564 130 OFFCURVE",
 "564 277 CURVE SMOOTH",
@@ -15709,34 +19270,20 @@ nodes = (
 "194 137 OFFCURVE",
 "195 150 OFFCURVE",
 "197 163 CURVE",
-"170 62 LINE"
+"170 62 LINE",
+"177 62 LINE",
+"197 17 OFFCURVE",
+"232 -11 OFFCURVE",
+"296 -11 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"269 450 LINE",
-"132 450 LINE",
-"-42 -282 LINE",
-"91 -282 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"38 420 LINE",
 "257 420 LINE",
 "257 450 LINE",
-"38 450 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"-115 -309 LINE",
-"189 -309 LINE",
-"189 -279 LINE",
-"-115 -279 LINE"
+"38 450 LINE",
+"38 420 LINE"
 );
 }
 );
@@ -15747,7 +19294,7 @@ unicode = 0070;
 },
 {
 glyphname = thorn;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -15755,22 +19302,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"114 729 LINE",
-"309 729 LINE",
-"309 754 LINE",
-"114 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"140 440 LINE",
-"77 163 OFFCURVE",
-"75 147 OFFCURVE",
-"75 131 CURVE SMOOTH",
-"75 49 OFFCURVE",
-"129 -13 OFFCURVE",
-"225 -13 CURVE SMOOTH",
 "373 -13 OFFCURVE",
 "507 124 OFFCURVE",
 "507 278 CURVE SMOOTH",
@@ -15798,25 +19329,41 @@ nodes = (
 "170 124 OFFCURVE",
 "173 138 CURVE SMOOTH",
 "321 754 LINE",
-"214 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"243 440 LINE",
+"214 754 LINE",
 "140 440 LINE",
-"-32 -314 LINE",
-"71 -314 LINE"
+"77 163 OFFCURVE",
+"75 147 OFFCURVE",
+"75 131 CURVE SMOOTH",
+"75 49 OFFCURVE",
+"129 -13 OFFCURVE",
+"225 -13 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"-112 -314 LINE",
 "171 -314 LINE",
 "171 -289 LINE",
-"-112 -289 LINE"
+"-112 -289 LINE",
+"-112 -314 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"71 -314 LINE",
+"243 440 LINE",
+"140 440 LINE",
+"-32 -314 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"309 729 LINE",
+"309 754 LINE",
+"114 754 LINE",
+"114 729 LINE"
 );
 }
 );
@@ -15828,22 +19375,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"105 724 LINE",
-"320 724 LINE",
-"320 754 LINE",
-"105 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"74 204 LINE SMOOTH",
-"67 173 OFFCURVE",
-"66 146 OFFCURVE",
-"66 135 CURVE SMOOTH",
-"66 48 OFFCURVE",
-"129 -13 OFFCURVE",
-"233 -13 CURVE SMOOTH",
 "396 -13 OFFCURVE",
 "536 129 OFFCURVE",
 "536 287 CURVE SMOOTH",
@@ -15871,25 +19402,41 @@ nodes = (
 "190 134 OFFCURVE",
 "193 148 CURVE SMOOTH",
 "332 754 LINE",
-"205 754 LINE"
+"205 754 LINE",
+"74 204 LINE SMOOTH",
+"67 173 OFFCURVE",
+"66 146 OFFCURVE",
+"66 135 CURVE SMOOTH",
+"66 48 OFFCURVE",
+"129 -13 OFFCURVE",
+"233 -13 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"193 148 LINE",
-"74 203 LINE",
-"-41 -282 LINE",
-"92 -282 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"-114 -309 LINE",
 "190 -309 LINE",
 "190 -279 LINE",
-"-114 -279 LINE"
+"-114 -279 LINE",
+"-114 -309 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"92 -282 LINE",
+"193 148 LINE",
+"74 203 LINE",
+"-41 -282 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"320 724 LINE",
+"320 754 LINE",
+"105 754 LINE",
+"105 724 LINE"
 );
 }
 );
@@ -15900,42 +19447,42 @@ unicode = 00FE;
 },
 {
 glyphname = q;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:59 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{218, 0}";
+},
+{
+name = top;
+position = "{322, 450}";
+}
+);
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
 paths = (
 {
 closed = 1;
 nodes = (
+"354 -314 LINE",
 "536 450 LINE",
 "429 450 LINE",
-"251 -314 LINE",
-"354 -314 LINE"
+"251 -314 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"171 -314 LINE",
 "438 -314 LINE",
 "438 -289 LINE",
-"171 -289 LINE"
+"171 -289 LINE",
+"171 -314 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"409 391 LINE",
-"391 433 OFFCURVE",
-"361 462 OFFCURVE",
-"305 462 CURVE SMOOTH",
-"184 462 OFFCURVE",
-"43 327 OFFCURVE",
-"43 172 CURVE SMOOTH",
-"43 57 OFFCURVE",
-"120 -13 OFFCURVE",
-"209 -13 CURVE SMOOTH",
 "273 -13 OFFCURVE",
 "319 23 OFFCURVE",
 "345 70 CURVE",
@@ -15956,28 +19503,56 @@ nodes = (
 "396 325 OFFCURVE",
 "396 313 OFFCURVE",
 "394 300 CURVE",
-"416 391 LINE"
+"416 391 LINE",
+"409 391 LINE",
+"391 433 OFFCURVE",
+"361 462 OFFCURVE",
+"305 462 CURVE SMOOTH",
+"184 462 OFFCURVE",
+"43 327 OFFCURVE",
+"43 172 CURVE SMOOTH",
+"43 57 OFFCURVE",
+"120 -13 OFFCURVE",
+"209 -13 CURVE SMOOTH"
 );
 }
 );
 width = 540;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{232, 0}";
+},
+{
+name = top;
+position = "{336, 450}";
+}
+);
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
 paths = (
 {
 closed = 1;
 nodes = (
-"418 391 LINE",
-"395 439 OFFCURVE",
-"365 462 OFFCURVE",
-"312 462 CURVE SMOOTH",
-"181 462 OFFCURVE",
-"35 320 OFFCURVE",
-"35 166 CURVE SMOOTH",
-"35 54 OFFCURVE",
-"113 -11 OFFCURVE",
-"198 -11 CURVE SMOOTH",
+"395 -282 LINE",
+"573 450 LINE",
+"436 450 LINE",
+"262 -282 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"479 -309 LINE",
+"479 -279 LINE",
+"176 -279 LINE",
+"176 -309 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "267 -11 OFFCURVE",
 "314 32 OFFCURVE",
 "340 70 CURVE",
@@ -15998,25 +19573,17 @@ nodes = (
 "405 324 OFFCURVE",
 "403 315 OFFCURVE",
 "402 300 CURVE",
-"425 391 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"573 450 LINE",
-"436 450 LINE",
-"262 -282 LINE",
-"395 -282 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"176 -309 LINE",
-"479 -309 LINE",
-"479 -279 LINE",
-"176 -279 LINE"
+"425 391 LINE",
+"418 391 LINE",
+"395 439 OFFCURVE",
+"365 462 OFFCURVE",
+"312 462 CURVE SMOOTH",
+"181 462 OFFCURVE",
+"35 320 OFFCURVE",
+"35 166 CURVE SMOOTH",
+"35 54 OFFCURVE",
+"113 -11 OFFCURVE",
+"198 -11 CURVE SMOOTH"
 );
 }
 );
@@ -16027,38 +19594,42 @@ unicode = 0071;
 },
 {
 glyphname = r;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:59 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{161, 0}";
+},
+{
+name = top;
+position = "{265, 450}";
+}
+);
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
 paths = (
 {
 closed = 1;
 nodes = (
+"155 0 LINE",
 "266 450 LINE",
 "159 450 LINE",
-"52 0 LINE",
-"155 0 LINE"
+"52 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"65 425 LINE",
 "254 425 LINE",
 "254 450 LINE",
-"65 450 LINE"
+"65 450 LINE",
+"65 425 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"384 462 LINE SMOOTH",
-"335 462 OFFCURVE",
-"284 415 OFFCURVE",
-"248 358 CURVE",
-"241 358 LINE",
-"203 195 LINE",
 "225 301 OFFCURVE",
 "295 395 OFFCURVE",
 "326 395 CURVE SMOOTH",
@@ -16070,37 +19641,51 @@ nodes = (
 "441 407 CURVE SMOOTH",
 "441 438 OFFCURVE",
 "419 462 OFFCURVE",
-"384 462 CURVE SMOOTH"
+"384 462 CURVE SMOOTH",
+"335 462 OFFCURVE",
+"284 415 OFFCURVE",
+"248 358 CURVE",
+"241 358 LINE",
+"203 195 LINE"
 );
 }
 );
 width = 425;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{167, 0}";
+},
+{
+name = top;
+position = "{271, 450}";
+}
+);
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
 paths = (
 {
 closed = 1;
 nodes = (
+"175 0 LINE",
 "287 450 LINE",
 "150 450 LINE",
-"42 0 LINE",
-"175 0 LINE"
+"42 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"56 420 LINE",
 "275 420 LINE",
 "275 450 LINE",
-"56 450 LINE"
+"56 450 LINE",
+"56 420 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"217 174 LINE",
 "234 244 OFFCURVE",
 "289 367 OFFCURVE",
 "326 367 CURVE SMOOTH",
@@ -16116,7 +19701,8 @@ nodes = (
 "355 462 OFFCURVE",
 "321 432 OFFCURVE",
 "272 367 CURVE",
-"264 367 LINE"
+"264 367 LINE",
+"217 174 LINE"
 );
 }
 );
@@ -16199,7 +19785,7 @@ unicode = 0159;
 },
 {
 glyphname = rcommaaccent;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 components = (
@@ -16207,7 +19793,7 @@ components = (
 name = r;
 },
 {
-name = commaaccent;
+name = commaaccentcomb;
 transform = "{1, 0, 0, 1, 88, 0}";
 }
 );
@@ -16220,7 +19806,7 @@ components = (
 name = r;
 },
 {
-name = commaaccent;
+name = commaaccentcomb;
 transform = "{1, 0, 0, 1, 130, 0}";
 }
 );
@@ -16234,7 +19820,7 @@ unicode = 0157;
 },
 {
 glyphname = rdblgrave;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 components = (
@@ -16242,7 +19828,7 @@ components = (
 name = r;
 },
 {
-name = uni030F;
+name = dblgravecomb;
 transform = "{1, 0, 0, 1, -41, 0}";
 }
 );
@@ -16255,7 +19841,7 @@ components = (
 name = r;
 },
 {
-name = uni030F;
+name = dblgravecomb;
 transform = "{1, 0, 0, 1, -62, 0}";
 }
 );
@@ -16304,7 +19890,7 @@ unicode = 1E5B;
 },
 {
 glyphname = rinvertedbreve;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 components = (
@@ -16312,7 +19898,7 @@ components = (
 name = r;
 },
 {
-name = uni0311;
+name = breveinvertedcomb;
 transform = "{1, 0, 0, 1, 43, 0}";
 }
 );
@@ -16325,7 +19911,7 @@ components = (
 name = r;
 },
 {
-name = uni0311;
+name = breveinvertedcomb;
 transform = "{1, 0, 0, 1, 52, 0}";
 }
 );
@@ -16339,39 +19925,24 @@ unicode = 0213;
 },
 {
 glyphname = s;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:50:53 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{136, 0}";
+},
+{
+name = top;
+position = "{240, 450}";
+}
+);
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
 paths = (
 {
 closed = 1;
 nodes = (
-"235 454 LINE SMOOTH",
-"130 454 OFFCURVE",
-"70 390 OFFCURVE",
-"70 317 CURVE SMOOTH",
-"70 186 OFFCURVE",
-"257 190 OFFCURVE",
-"257 95 CURVE SMOOTH",
-"257 52 OFFCURVE",
-"218 17 OFFCURVE",
-"137 17 CURVE SMOOTH",
-"86 17 OFFCURVE",
-"64 31 OFFCURVE",
-"64 48 CURVE SMOOTH",
-"64 64 OFFCURVE",
-"82 78 OFFCURVE",
-"82 102 CURVE SMOOTH",
-"82 122 OFFCURVE",
-"69 135 OFFCURVE",
-"45 135 CURVE SMOOTH",
-"16 135 OFFCURVE",
-"-4 116 OFFCURVE",
-"-4 83 CURVE SMOOTH",
-"-4 32 OFFCURVE",
-"46 -13 OFFCURVE",
-"135 -13 CURVE SMOOTH",
 "241 -13 OFFCURVE",
 "328 52 OFFCURVE",
 "328 144 CURVE SMOOTH",
@@ -16395,43 +19966,52 @@ nodes = (
 "352 375 CURVE SMOOTH",
 "352 420 OFFCURVE",
 "311 454 OFFCURVE",
-"235 454 CURVE SMOOTH"
+"235 454 CURVE SMOOTH",
+"130 454 OFFCURVE",
+"70 390 OFFCURVE",
+"70 317 CURVE SMOOTH",
+"70 186 OFFCURVE",
+"257 190 OFFCURVE",
+"257 95 CURVE SMOOTH",
+"257 52 OFFCURVE",
+"218 17 OFFCURVE",
+"137 17 CURVE SMOOTH",
+"86 17 OFFCURVE",
+"64 31 OFFCURVE",
+"64 48 CURVE SMOOTH",
+"64 64 OFFCURVE",
+"82 78 OFFCURVE",
+"82 102 CURVE SMOOTH",
+"82 122 OFFCURVE",
+"69 135 OFFCURVE",
+"45 135 CURVE SMOOTH",
+"16 135 OFFCURVE",
+"-4 116 OFFCURVE",
+"-4 83 CURVE SMOOTH",
+"-4 32 OFFCURVE",
+"46 -13 OFFCURVE",
+"135 -13 CURVE SMOOTH"
 );
 }
 );
 width = 375;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{154, 0}";
+},
+{
+name = top;
+position = "{258, 450}";
+}
+);
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
 paths = (
 {
 closed = 1;
 nodes = (
-"242 462 LINE SMOOTH",
-"141 462 OFFCURVE",
-"68 396 OFFCURVE",
-"68 315 CURVE SMOOTH",
-"68 182 OFFCURVE",
-"262 150 OFFCURVE",
-"262 75 CURVE SMOOTH",
-"262 48 OFFCURVE",
-"236 23 OFFCURVE",
-"172 23 CURVE SMOOTH",
-"125 23 OFFCURVE",
-"110 36 OFFCURVE",
-"110 50 CURVE SMOOTH",
-"110 64 OFFCURVE",
-"125 73 OFFCURVE",
-"125 96 CURVE SMOOTH",
-"125 123 OFFCURVE",
-"105 151 OFFCURVE",
-"64 151 CURVE SMOOTH",
-"30 151 OFFCURVE",
-"0 131 OFFCURVE",
-"0 90 CURVE SMOOTH",
-"0 32 OFFCURVE",
-"61 -11 OFFCURVE",
-"157 -11 CURVE SMOOTH",
 "272 -11 OFFCURVE",
 "356 51 OFFCURVE",
 "356 146 CURVE SMOOTH",
@@ -16455,7 +20035,31 @@ nodes = (
 "380 374 CURVE SMOOTH",
 "380 425 OFFCURVE",
 "317 462 OFFCURVE",
-"242 462 CURVE SMOOTH"
+"242 462 CURVE SMOOTH",
+"141 462 OFFCURVE",
+"68 396 OFFCURVE",
+"68 315 CURVE SMOOTH",
+"68 182 OFFCURVE",
+"262 150 OFFCURVE",
+"262 75 CURVE SMOOTH",
+"262 48 OFFCURVE",
+"236 23 OFFCURVE",
+"172 23 CURVE SMOOTH",
+"125 23 OFFCURVE",
+"110 36 OFFCURVE",
+"110 50 CURVE SMOOTH",
+"110 64 OFFCURVE",
+"125 73 OFFCURVE",
+"125 96 CURVE SMOOTH",
+"125 123 OFFCURVE",
+"105 151 OFFCURVE",
+"64 151 CURVE SMOOTH",
+"30 151 OFFCURVE",
+"0 131 OFFCURVE",
+"0 90 CURVE SMOOTH",
+"0 32 OFFCURVE",
+"61 -11 OFFCURVE",
+"157 -11 CURVE SMOOTH"
 );
 }
 );
@@ -16537,6 +20141,41 @@ rightKerningGroup = s;
 unicode = 0161;
 },
 {
+glyphname = scedilla;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+components = (
+{
+name = s;
+},
+{
+name = cedilla;
+transform = "{1, 0, 0, 1, 55, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 375;
+},
+{
+components = (
+{
+name = s;
+},
+{
+name = cedilla;
+transform = "{1, 0, 0, 1, 98, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 412;
+}
+);
+leftKerningGroup = s;
+rightKerningGroup = s;
+unicode = 015F;
+},
+{
 glyphname = scircumflex;
 lastChange = "2016-08-16 11:12:44 +0000";
 layers = (
@@ -16570,6 +20209,41 @@ width = 412;
 leftKerningGroup = s;
 rightKerningGroup = s;
 unicode = 015D;
+},
+{
+glyphname = scommaaccent;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+components = (
+{
+name = s;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 100, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 375;
+},
+{
+components = (
+{
+name = s;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 119, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 412;
+}
+);
+leftKerningGroup = s;
+rightKerningGroup = s;
+unicode = 0219;
 },
 {
 glyphname = sdotbelow;
@@ -16608,7 +20282,7 @@ unicode = 1E63;
 },
 {
 glyphname = germandbls;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -16616,6 +20290,9 @@ paths = (
 {
 closed = 1;
 nodes = (
+"-43 -324 OFFCURVE",
+"66 -304 OFFCURVE",
+"130 -1 CURVE SMOOTH",
 "261 615 LINE SMOOTH",
 "278 694 OFFCURVE",
 "314 736 OFFCURVE",
@@ -16684,10 +20361,7 @@ nodes = (
 "-225 -252 CURVE SMOOTH",
 "-225 -288 OFFCURVE",
 "-193 -324 OFFCURVE",
-"-107 -324 CURVE SMOOTH",
-"-43 -324 OFFCURVE",
-"66 -304 OFFCURVE",
-"130 -1 CURVE SMOOTH"
+"-107 -324 CURVE SMOOTH"
 );
 }
 );
@@ -16699,25 +20373,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"11 33 LINE SMOOTH",
-"-53 -268 OFFCURVE",
-"-69 -289 OFFCURVE",
-"-102 -289 CURVE SMOOTH",
-"-117 -289 OFFCURVE",
-"-125 -285 OFFCURVE",
-"-125 -272 CURVE SMOOTH",
-"-125 -256 OFFCURVE",
-"-112 -245 OFFCURVE",
-"-112 -224 CURVE SMOOTH",
-"-112 -198 OFFCURVE",
-"-132 -172 OFFCURVE",
-"-172 -172 CURVE SMOOTH",
-"-213 -172 OFFCURVE",
-"-234 -199 OFFCURVE",
-"-234 -236 CURVE SMOOTH",
-"-234 -279 OFFCURVE",
-"-205 -324 OFFCURVE",
-"-131 -324 CURVE SMOOTH",
 "2 -324 OFFCURVE",
 "126 -176 OFFCURVE",
 "200 175 CURVE SMOOTH",
@@ -16770,7 +20425,26 @@ nodes = (
 "406 763 CURVE SMOOTH",
 "266 763 OFFCURVE",
 "150 687 OFFCURVE",
-"121 550 CURVE SMOOTH"
+"121 550 CURVE SMOOTH",
+"11 33 LINE SMOOTH",
+"-53 -268 OFFCURVE",
+"-69 -289 OFFCURVE",
+"-102 -289 CURVE SMOOTH",
+"-117 -289 OFFCURVE",
+"-125 -285 OFFCURVE",
+"-125 -272 CURVE SMOOTH",
+"-125 -256 OFFCURVE",
+"-112 -245 OFFCURVE",
+"-112 -224 CURVE SMOOTH",
+"-112 -198 OFFCURVE",
+"-132 -172 OFFCURVE",
+"-172 -172 CURVE SMOOTH",
+"-213 -172 OFFCURVE",
+"-234 -199 OFFCURVE",
+"-234 -236 CURVE SMOOTH",
+"-234 -279 OFFCURVE",
+"-205 -324 OFFCURVE",
+"-131 -324 CURVE SMOOTH"
 );
 }
 );
@@ -16780,134 +20454,33 @@ width = 589;
 unicode = 00DF;
 },
 {
-glyphname = schwa;
-lastChange = "2016-08-16 11:12:44 +0000";
-layers = (
-{
-layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
-paths = (
-{
-closed = 1;
-nodes = (
-"178 -13 LINE",
-"318 -13 OFFCURVE",
-"456 120 OFFCURVE",
-"456 261 CURVE SMOOTH",
-"456 361 OFFCURVE",
-"387 462 OFFCURVE",
-"254 462 CURVE SMOOTH",
-"164 462 OFFCURVE",
-"98 415 OFFCURVE",
-"50 330 CURVE",
-"70 316 LINE",
-"122 402 OFFCURVE",
-"184 432 OFFCURVE",
-"242 432 CURVE SMOOTH",
-"305 432 OFFCURVE",
-"336 396 OFFCURVE",
-"336 302 CURVE SMOOTH",
-"336 182 OFFCURVE",
-"285 17 OFFCURVE",
-"185 17 CURVE SMOOTH",
-"148 17 OFFCURVE",
-"123 39 OFFCURVE",
-"123 92 CURVE SMOOTH",
-"123 162 OFFCURVE",
-"166 222 OFFCURVE",
-"285 222 CURVE SMOOTH",
-"312 222 OFFCURVE",
-"335 219 OFFCURVE",
-"358 212 CURVE",
-"363 237 LINE",
-"350 240 OFFCURVE",
-"290 248 OFFCURVE",
-"244 248 CURVE SMOOTH",
-"124 248 OFFCURVE",
-"35 192 OFFCURVE",
-"35 106 CURVE SMOOTH",
-"35 36 OFFCURVE",
-"94 -13 OFFCURVE",
-"178 -13 CURVE"
-);
-}
-);
-width = 486;
-},
-{
-layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
-paths = (
-{
-closed = 1;
-nodes = (
-"206 -11 LINE SMOOTH",
-"361 -11 OFFCURVE",
-"501 129 OFFCURVE",
-"501 267 CURVE SMOOTH",
-"501 367 OFFCURVE",
-"432 462 OFFCURVE",
-"303 462 CURVE SMOOTH",
-"202 462 OFFCURVE",
-"117 409 OFFCURVE",
-"64 322 CURVE",
-"89 303 LINE",
-"151 394 OFFCURVE",
-"223 422 OFFCURVE",
-"288 422 CURVE SMOOTH",
-"330 422 OFFCURVE",
-"358 405 OFFCURVE",
-"358 360 CURVE SMOOTH",
-"358 353 OFFCURVE",
-"357 344 OFFCURVE",
-"356 338 CURVE SMOOTH",
-"312 69 OFFCURVE",
-"271 19 OFFCURVE",
-"219 19 CURVE SMOOTH",
-"178 19 OFFCURVE",
-"158 49 OFFCURVE",
-"158 93 CURVE SMOOTH",
-"158 157 OFFCURVE",
-"201 211 OFFCURVE",
-"295 211 CURVE SMOOTH",
-"347 211 OFFCURVE",
-"370 211 OFFCURVE",
-"393 201 CURVE",
-"398 236 LINE",
-"387 239 OFFCURVE",
-"314 247 OFFCURVE",
-"264 247 CURVE SMOOTH",
-"120 247 OFFCURVE",
-"45 181 OFFCURVE",
-"45 108 CURVE SMOOTH",
-"45 38 OFFCURVE",
-"115 -11 OFFCURVE",
-"206 -11 CURVE SMOOTH"
-);
-}
-);
-width = 506;
-}
-);
-unicode = 0259;
-},
-{
 glyphname = t;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:59 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{112, 0}";
+},
+{
+name = center;
+position = "{164, 225}";
+},
+{
+name = top;
+position = "{216, 450}";
+},
+{
+name = topright;
+position = "{360, 450}";
+}
+);
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
 paths = (
 {
 closed = 1;
 nodes = (
-"275 563 LINE",
-"168 563 LINE",
-"53 87 LINE SMOOTH",
-"51 78 OFFCURVE",
-"49 67 OFFCURVE",
-"49 56 CURVE SMOOTH",
-"49 15 OFFCURVE",
-"77 -13 OFFCURVE",
-"126 -13 CURVE SMOOTH",
 "212 -13 OFFCURVE",
 "270 73 OFFCURVE",
 "309 157 CURVE",
@@ -16920,36 +20493,54 @@ nodes = (
 "153 63 CURVE SMOOTH",
 "153 69 OFFCURVE",
 "154 80 OFFCURVE",
-"158 97 CURVE SMOOTH"
+"158 97 CURVE SMOOTH",
+"275 563 LINE",
+"168 563 LINE",
+"53 87 LINE SMOOTH",
+"51 78 OFFCURVE",
+"49 67 OFFCURVE",
+"49 56 CURVE SMOOTH",
+"49 15 OFFCURVE",
+"77 -13 OFFCURVE",
+"126 -13 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"69 425 LINE",
 "336 425 LINE",
 "336 450 LINE",
-"69 450 LINE"
+"69 450 LINE",
+"69 425 LINE"
 );
 }
 );
 width = 328;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{122, 0}";
+},
+{
+name = center;
+position = "{174, 225}";
+},
+{
+name = top;
+position = "{226, 450}";
+},
+{
+name = topright;
+position = "{380, 450}";
+}
+);
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
 paths = (
 {
 closed = 1;
 nodes = (
-"293 574 LINE",
-"159 574 LINE",
-"59 132 LINE SMOOTH",
-"55 114 OFFCURVE",
-"50 84 OFFCURVE",
-"50 66 CURVE SMOOTH",
-"50 26 OFFCURVE",
-"75 -11 OFFCURVE",
-"140 -11 CURVE SMOOTH",
 "216 -11 OFFCURVE",
 "293 40 OFFCURVE",
 "332 142 CURVE",
@@ -16962,16 +20553,25 @@ nodes = (
 "176 55 CURVE SMOOTH",
 "176 59 OFFCURVE",
 "177 70 OFFCURVE",
-"181 87 CURVE SMOOTH"
+"181 87 CURVE SMOOTH",
+"293 574 LINE",
+"159 574 LINE",
+"59 132 LINE SMOOTH",
+"55 114 OFFCURVE",
+"50 84 OFFCURVE",
+"50 66 CURVE SMOOTH",
+"50 26 OFFCURVE",
+"75 -11 OFFCURVE",
+"140 -11 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"64 420 LINE",
 "360 420 LINE",
 "360 450 LINE",
-"64 450 LINE"
+"64 450 LINE",
+"64 420 LINE"
 );
 }
 );
@@ -16984,7 +20584,7 @@ unicode = 0074;
 },
 {
 glyphname = tbar;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 components = (
@@ -16997,10 +20597,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"19 277 LINE",
 "312 277 LINE",
 "312 312 LINE",
-"19 312 LINE"
+"19 312 LINE",
+"19 277 LINE"
 );
 }
 );
@@ -17017,10 +20617,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"39 277 LINE",
 "332 277 LINE",
 "332 312 LINE",
-"39 312 LINE"
+"39 312 LINE",
+"39 277 LINE"
 );
 }
 );
@@ -17064,6 +20664,76 @@ leftKerningGroup = t;
 unicode = 0165;
 },
 {
+glyphname = tcedilla;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+components = (
+{
+name = t;
+},
+{
+name = cedilla;
+transform = "{1, 0, 0, 1, 20, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 328;
+},
+{
+components = (
+{
+name = t;
+},
+{
+name = cedilla;
+transform = "{1, 0, 0, 1, 73, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 348;
+}
+);
+leftKerningGroup = t;
+rightKerningGroup = t;
+unicode = 0163;
+},
+{
+glyphname = tcommaaccent;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+components = (
+{
+name = t;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 97, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 328;
+},
+{
+components = (
+{
+name = t;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 141, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 348;
+}
+);
+leftKerningGroup = t;
+rightKerningGroup = t;
+unicode = 021B;
+},
+{
 glyphname = tdotbelow;
 lastChange = "2016-08-16 11:12:44 +0000";
 layers = (
@@ -17100,41 +20770,36 @@ unicode = 1E6D;
 },
 {
 glyphname = u;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:07:11 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{234, 0}";
+},
+{
+name = ogonek;
+position = "{462, 10}";
+},
+{
+name = top;
+position = "{338, 450}";
+},
+{
+name = topright;
+position = "{550, 397}";
+}
+);
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
 paths = (
 {
 closed = 1;
 nodes = (
-"514 450 LINE",
-"412 450 LINE",
-"341 154 LINE SMOOTH",
-"334 125 OFFCURVE",
-"331 101 OFFCURVE",
-"331 82 CURVE SMOOTH",
-"331 9 OFFCURVE",
-"373 -12 OFFCURVE",
-"412 -12 CURVE SMOOTH",
-"477 -12 OFFCURVE",
-"523 45 OFFCURVE",
-"564 142 CURVE",
-"544 151 LINE",
-"507 73 OFFCURVE",
-"472 30 OFFCURVE",
-"444 30 CURVE SMOOTH",
-"430 30 OFFCURVE",
-"424 41 OFFCURVE",
-"424 60 CURVE SMOOTH",
-"424 77 OFFCURVE",
-"429 106 OFFCURVE",
-"439 147 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
+"226 -12 OFFCURVE",
+"285 41 OFFCURVE",
+"327 96 CURVE",
+"334 96 LINE",
 "356 216 LINE",
 "327 113 OFFCURVE",
 "257 32 OFFCURVE",
@@ -17153,67 +20818,76 @@ nodes = (
 "56 70 CURVE SMOOTH",
 "56 12 OFFCURVE",
 "99 -12 OFFCURVE",
-"150 -12 CURVE SMOOTH",
-"226 -12 OFFCURVE",
-"285 41 OFFCURVE",
-"327 96 CURVE",
-"334 96 LINE"
+"150 -12 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"65 425 LINE",
 "224 425 LINE",
 "224 450 LINE",
-"65 450 LINE"
+"65 450 LINE",
+"65 425 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"477 -12 OFFCURVE",
+"523 45 OFFCURVE",
+"564 142 CURVE",
+"544 151 LINE",
+"507 73 OFFCURVE",
+"472 30 OFFCURVE",
+"444 30 CURVE SMOOTH",
+"430 30 OFFCURVE",
+"424 41 OFFCURVE",
+"424 60 CURVE SMOOTH",
+"424 77 OFFCURVE",
+"429 106 OFFCURVE",
+"439 147 CURVE SMOOTH",
+"514 450 LINE",
+"412 450 LINE",
+"341 154 LINE SMOOTH",
+"334 125 OFFCURVE",
+"331 101 OFFCURVE",
+"331 82 CURVE SMOOTH",
+"331 9 OFFCURVE",
+"373 -12 OFFCURVE",
+"412 -12 CURVE SMOOTH"
 );
 }
 );
 width = 571;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{247, 0}";
+},
+{
+name = ogonek;
+position = "{486, 10}";
+},
+{
+name = top;
+position = "{351, 450}";
+},
+{
+name = topright;
+position = "{590, 397}";
+}
+);
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
 paths = (
 {
 closed = 1;
 nodes = (
-"41 420 LINE",
-"215 420 LINE",
-"215 450 LINE",
-"41 450 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"559 450 LINE",
-"425 450 LINE",
-"351 153 LINE SMOOTH",
-"338 100 OFFCURVE",
-"335 86 OFFCURVE",
-"335 70 CURVE SMOOTH",
-"335 15 OFFCURVE",
-"370 -11 OFFCURVE",
-"422 -11 CURVE SMOOTH",
-"513 -11 OFFCURVE",
-"576 69 OFFCURVE",
-"602 152 CURVE",
-"577 161 LINE",
-"540 69 OFFCURVE",
-"499 41 OFFCURVE",
-"479 41 CURVE SMOOTH",
-"472 41 OFFCURVE",
-"467 45 OFFCURVE",
-"467 54 CURVE SMOOTH",
-"467 58 OFFCURVE",
-"468 70 OFFCURVE",
-"472 87 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
+"232 -11 OFFCURVE",
+"292 43 OFFCURVE",
+"332 98 CURVE",
+"339 98 LINE",
 "370 220 LINE",
 "339 108 OFFCURVE",
 "239 35 OFFCURVE",
@@ -17232,11 +20906,43 @@ nodes = (
 "50 69 CURVE SMOOTH",
 "50 13 OFFCURVE",
 "99 -11 OFFCURVE",
-"152 -11 CURVE SMOOTH",
-"232 -11 OFFCURVE",
-"292 43 OFFCURVE",
-"332 98 CURVE",
-"339 98 LINE"
+"152 -11 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"215 420 LINE",
+"215 450 LINE",
+"41 450 LINE",
+"41 420 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"513 -11 OFFCURVE",
+"576 69 OFFCURVE",
+"602 152 CURVE",
+"577 161 LINE",
+"540 69 OFFCURVE",
+"499 41 OFFCURVE",
+"479 41 CURVE SMOOTH",
+"472 41 OFFCURVE",
+"467 45 OFFCURVE",
+"467 54 CURVE SMOOTH",
+"467 58 OFFCURVE",
+"468 70 OFFCURVE",
+"472 87 CURVE SMOOTH",
+"559 450 LINE",
+"425 450 LINE",
+"351 153 LINE SMOOTH",
+"338 100 OFFCURVE",
+"335 86 OFFCURVE",
+"335 70 CURVE SMOOTH",
+"335 15 OFFCURVE",
+"370 -11 OFFCURVE",
+"422 -11 CURVE SMOOTH"
 );
 }
 );
@@ -17249,7 +20955,7 @@ unicode = 0075;
 },
 {
 glyphname = uacute;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:05:38 +0000";
 layers = (
 {
 components = (
@@ -17257,8 +20963,8 @@ components = (
 name = u;
 },
 {
-name = acute;
-transform = "{1, 0, 0, 1, 183, 0}";
+name = acutecomb;
+transform = "{1, 0, 0, 1, -21, 0}";
 }
 );
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -17270,8 +20976,8 @@ components = (
 name = u;
 },
 {
-name = acute;
-transform = "{1, 0, 0, 1, 197, 0}";
+name = acutecomb;
+transform = "{1, 0, 0, 1, -54, 0}";
 }
 );
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
@@ -17354,7 +21060,7 @@ unicode = 00FB;
 },
 {
 glyphname = udblgrave;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 components = (
@@ -17362,7 +21068,7 @@ components = (
 name = u;
 },
 {
-name = uni030F;
+name = dblgravecomb;
 transform = "{1, 0, 0, 1, -38, 0}";
 }
 );
@@ -17375,7 +21081,7 @@ components = (
 name = u;
 },
 {
-name = uni030F;
+name = dblgravecomb;
 transform = "{1, 0, 0, 1, 5, 0}";
 }
 );
@@ -17424,7 +21130,7 @@ unicode = 00FC;
 },
 {
 glyphname = udotbelow;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:06:03 +0000";
 layers = (
 {
 components = (
@@ -17432,8 +21138,8 @@ components = (
 name = u;
 },
 {
-name = dotbelow;
-transform = "{1, 0, 0, 1, 193, 0}";
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -7, 0}";
 }
 );
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -17445,8 +21151,8 @@ components = (
 name = u;
 },
 {
-name = dotbelow;
-transform = "{1, 0, 0, 1, 242, 0}";
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -3, 0}";
 }
 );
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
@@ -17459,7 +21165,7 @@ unicode = 1EE5;
 },
 {
 glyphname = ugrave;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:05:38 +0000";
 layers = (
 {
 components = (
@@ -17467,8 +21173,8 @@ components = (
 name = u;
 },
 {
-name = grave;
-transform = "{1, 0, 0, 1, 76, 0}";
+name = gravecomb;
+transform = "{1, 0, 0, 1, -10, 0}";
 }
 );
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -17480,8 +21186,8 @@ components = (
 name = u;
 },
 {
-name = grave;
-transform = "{1, 0, 0, 1, 88, 0}";
+name = gravecomb;
+transform = "{1, 0, 0, 1, 35, 0}";
 }
 );
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
@@ -17491,6 +21197,251 @@ width = 598;
 leftKerningGroup = u;
 rightKerningGroup = u;
 unicode = 00F9;
+},
+{
+glyphname = uhookabove;
+lastChange = "2016-08-22 14:18:32 +0000";
+layers = (
+{
+components = (
+{
+name = u;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 15, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 571;
+},
+{
+components = (
+{
+name = u;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 19, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 598;
+}
+);
+leftKerningGroup = u;
+rightKerningGroup = u;
+unicode = 1EE7;
+},
+{
+glyphname = uhorn;
+lastChange = "2016-08-22 14:18:32 +0000";
+layers = (
+{
+components = (
+{
+name = u;
+},
+{
+name = horncomb;
+transform = "{1, 0, 0, 1, 245, -53}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 571;
+},
+{
+components = (
+{
+name = u;
+},
+{
+name = horncomb;
+transform = "{1, 0, 0, 1, 277, -53}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 598;
+}
+);
+leftKerningGroup = u;
+rightKerningGroup = u;
+unicode = 01B0;
+},
+{
+glyphname = uhornacute;
+lastChange = "2016-08-22 14:18:32 +0000";
+layers = (
+{
+components = (
+{
+name = uhorn;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -21, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 571;
+},
+{
+components = (
+{
+name = uhorn;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -54, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 598;
+}
+);
+leftKerningGroup = u;
+rightKerningGroup = u;
+unicode = 1EE9;
+},
+{
+glyphname = uhorndotbelow;
+lastChange = "2016-08-22 14:18:32 +0000";
+layers = (
+{
+components = (
+{
+name = uhorn;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -7, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 571;
+},
+{
+components = (
+{
+name = uhorn;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -3, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 598;
+}
+);
+leftKerningGroup = u;
+rightKerningGroup = u;
+unicode = 1EF1;
+},
+{
+glyphname = uhorngrave;
+lastChange = "2016-08-22 14:18:32 +0000";
+layers = (
+{
+components = (
+{
+name = uhorn;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, -10, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 571;
+},
+{
+components = (
+{
+name = uhorn;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 35, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 598;
+}
+);
+leftKerningGroup = u;
+rightKerningGroup = u;
+unicode = 1EEB;
+},
+{
+glyphname = uhornhookabove;
+lastChange = "2016-08-22 14:18:32 +0000";
+layers = (
+{
+components = (
+{
+name = uhorn;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 15, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 571;
+},
+{
+components = (
+{
+name = uhorn;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 19, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 598;
+}
+);
+leftKerningGroup = u;
+rightKerningGroup = u;
+unicode = 1EED;
+},
+{
+glyphname = uhorntilde;
+lastChange = "2016-08-22 14:18:32 +0000";
+layers = (
+{
+components = (
+{
+name = uhorn;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, -21, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 571;
+},
+{
+components = (
+{
+name = uhorn;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, -14, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 598;
+}
+);
+leftKerningGroup = u;
+rightKerningGroup = u;
+unicode = 1EEF;
 },
 {
 glyphname = uhungarumlaut;
@@ -17529,7 +21480,7 @@ unicode = 0171;
 },
 {
 glyphname = uinvertedbreve;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 components = (
@@ -17537,7 +21488,7 @@ components = (
 name = u;
 },
 {
-name = uni0311;
+name = breveinvertedcomb;
 transform = "{1, 0, 0, 1, 82, 0}";
 }
 );
@@ -17550,7 +21501,7 @@ components = (
 name = u;
 },
 {
-name = uni0311;
+name = breveinvertedcomb;
 transform = "{1, 0, 0, 1, 116, 0}";
 }
 );
@@ -17596,294 +21547,6 @@ width = 598;
 leftKerningGroup = u;
 rightKerningGroup = u;
 unicode = 016B;
-},
-{
-glyphname = uni015F;
-lastChange = "2016-08-16 11:12:44 +0000";
-layers = (
-{
-components = (
-{
-name = s;
-},
-{
-name = cedilla;
-transform = "{1, 0, 0, 1, 55, 0}";
-}
-);
-layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
-width = 375;
-},
-{
-components = (
-{
-name = s;
-},
-{
-name = cedilla;
-transform = "{1, 0, 0, 1, 98, 0}";
-}
-);
-layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
-width = 412;
-}
-);
-leftKerningGroup = s;
-rightKerningGroup = s;
-unicode = 015F;
-},
-{
-glyphname = uni0163;
-lastChange = "2016-08-16 11:12:44 +0000";
-layers = (
-{
-components = (
-{
-name = t;
-},
-{
-name = cedilla;
-transform = "{1, 0, 0, 1, 20, 0}";
-}
-);
-layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
-width = 328;
-},
-{
-components = (
-{
-name = t;
-},
-{
-name = cedilla;
-transform = "{1, 0, 0, 1, 73, 0}";
-}
-);
-layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
-width = 348;
-}
-);
-leftKerningGroup = t;
-rightKerningGroup = t;
-unicode = 0163;
-},
-{
-glyphname = uni01C6;
-lastChange = "2016-08-16 11:12:44 +0000";
-layers = (
-{
-components = (
-{
-name = d;
-},
-{
-name = z;
-transform = "{1, 0, 0, 1, 560, 0}";
-},
-{
-name = caron;
-transform = "{1, 0, 0, 1, 627, 0}";
-}
-);
-layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
-width = 1034;
-},
-{
-components = (
-{
-name = d;
-},
-{
-name = z;
-transform = "{1, 0, 0, 1, 609, 0}";
-},
-{
-name = caron;
-transform = "{1, 0, 0, 1, 644, 0}";
-}
-);
-layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
-width = 1103;
-}
-);
-leftKerningGroup = d;
-rightKerningGroup = z;
-unicode = 01C6;
-},
-{
-glyphname = uni01C9;
-lastChange = "2016-08-16 11:12:44 +0000";
-layers = (
-{
-components = (
-{
-name = l;
-},
-{
-name = j;
-transform = "{1, 0, 0, 1, 324, 0}";
-}
-);
-layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
-width = 615;
-},
-{
-components = (
-{
-name = l;
-},
-{
-name = j;
-transform = "{1, 0, 0, 1, 312, 0}";
-}
-);
-layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
-width = 599;
-}
-);
-leftKerningGroup = l;
-rightKerningGroup = j;
-unicode = 01C9;
-},
-{
-glyphname = uni01CC;
-lastChange = "2016-08-16 11:12:44 +0000";
-layers = (
-{
-components = (
-{
-name = n;
-},
-{
-name = j;
-transform = "{1, 0, 0, 1, 560, 0}";
-}
-);
-layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
-width = 851;
-},
-{
-components = (
-{
-name = n;
-},
-{
-name = j;
-transform = "{1, 0, 0, 1, 592, 0}";
-}
-);
-layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
-width = 879;
-}
-);
-leftKerningGroup = n;
-rightKerningGroup = j;
-unicode = 01CC;
-},
-{
-glyphname = uni01F3;
-lastChange = "2016-08-16 11:12:44 +0000";
-layers = (
-{
-components = (
-{
-name = d;
-},
-{
-name = z;
-transform = "{1, 0, 0, 1, 560, 0}";
-}
-);
-layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
-width = 1034;
-},
-{
-components = (
-{
-name = d;
-},
-{
-name = z;
-transform = "{1, 0, 0, 1, 609, 0}";
-}
-);
-layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
-width = 1103;
-}
-);
-leftKerningGroup = d;
-rightKerningGroup = z;
-unicode = 01F3;
-},
-{
-glyphname = uni0219;
-lastChange = "2016-08-16 11:12:44 +0000";
-layers = (
-{
-components = (
-{
-name = s;
-},
-{
-name = commaaccent;
-transform = "{1, 0, 0, 1, 100, 0}";
-}
-);
-layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
-width = 375;
-},
-{
-components = (
-{
-name = s;
-},
-{
-name = commaaccent;
-transform = "{1, 0, 0, 1, 119, 0}";
-}
-);
-layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
-width = 412;
-}
-);
-leftKerningGroup = s;
-rightKerningGroup = s;
-unicode = 0219;
-},
-{
-glyphname = uni021B;
-lastChange = "2016-08-16 11:12:44 +0000";
-layers = (
-{
-components = (
-{
-name = t;
-},
-{
-name = commaaccent;
-transform = "{1, 0, 0, 1, 97, 0}";
-}
-);
-layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
-width = 328;
-},
-{
-components = (
-{
-name = t;
-},
-{
-name = commaaccent;
-transform = "{1, 0, 0, 1, 141, 0}";
-}
-);
-layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
-width = 348;
-}
-);
-leftKerningGroup = t;
-rightKerningGroup = t;
-unicode = 021B;
 },
 {
 glyphname = uogonek;
@@ -17957,7 +21620,7 @@ unicode = 016F;
 },
 {
 glyphname = utilde;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:05:38 +0000";
 layers = (
 {
 components = (
@@ -17965,8 +21628,8 @@ components = (
 name = u;
 },
 {
-name = tilde;
-transform = "{1, 0, 0, 1, 69, 0}";
+name = tildecomb;
+transform = "{1, 0, 0, 1, -21, 0}";
 }
 );
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -17978,8 +21641,8 @@ components = (
 name = u;
 },
 {
-name = tilde;
-transform = "{1, 0, 0, 1, 93, 0}";
+name = tildecomb;
+transform = "{1, 0, 0, 1, -14, 0}";
 }
 );
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
@@ -17992,15 +21655,36 @@ unicode = 0169;
 },
 {
 glyphname = v;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:51:38 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{198, 0}";
+},
+{
+name = top;
+position = "{302, 450}";
+}
+);
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
 paths = (
 {
 closed = 1;
 nodes = (
-"442 318 LINE SMOOTH",
+"383 -13 OFFCURVE",
+"481 242 OFFCURVE",
+"481 375 CURVE SMOOTH",
+"481 433 OFFCURVE",
+"462 462 OFFCURVE",
+"422 462 CURVE SMOOTH",
+"388 462 OFFCURVE",
+"371 440 OFFCURVE",
+"371 412 CURVE SMOOTH",
+"371 356 OFFCURVE",
+"442 382 OFFCURVE",
+"442 318 CURVE SMOOTH",
 "442 240 OFFCURVE",
 "344 29 OFFCURVE",
 "242 29 CURVE SMOOTH",
@@ -18036,31 +21720,40 @@ nodes = (
 "89 87 CURVE SMOOTH",
 "89 19 OFFCURVE",
 "140 -13 OFFCURVE",
-"203 -13 CURVE SMOOTH",
-"383 -13 OFFCURVE",
-"481 242 OFFCURVE",
-"481 375 CURVE SMOOTH",
-"481 433 OFFCURVE",
-"462 462 OFFCURVE",
-"422 462 CURVE SMOOTH",
-"388 462 OFFCURVE",
-"371 440 OFFCURVE",
-"371 412 CURVE SMOOTH",
-"371 356 OFFCURVE",
-"442 382 OFFCURVE",
-"442 318 CURVE SMOOTH"
+"203 -13 CURVE SMOOTH"
 );
 }
 );
 width = 500;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{204, 0}";
+},
+{
+name = top;
+position = "{308, 450}";
+}
+);
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
 paths = (
 {
 closed = 1;
 nodes = (
-"438 311 LINE SMOOTH",
+"384 -12 OFFCURVE",
+"482 226 OFFCURVE",
+"482 365 CURVE SMOOTH",
+"482 439 OFFCURVE",
+"453 467 OFFCURVE",
+"408 467 CURVE SMOOTH",
+"366 467 OFFCURVE",
+"343 443 OFFCURVE",
+"343 404 CURVE SMOOTH",
+"343 324 OFFCURVE",
+"438 367 OFFCURVE",
+"438 311 CURVE SMOOTH",
 "438 256 OFFCURVE",
 "354 40 OFFCURVE",
 "256 40 CURVE SMOOTH",
@@ -18096,19 +21789,7 @@ nodes = (
 "88 98 CURVE SMOOTH",
 "88 23 OFFCURVE",
 "138 -12 OFFCURVE",
-"206 -12 CURVE SMOOTH",
-"384 -12 OFFCURVE",
-"482 226 OFFCURVE",
-"482 365 CURVE SMOOTH",
-"482 439 OFFCURVE",
-"453 467 OFFCURVE",
-"408 467 CURVE SMOOTH",
-"366 467 OFFCURVE",
-"343 443 OFFCURVE",
-"343 404 CURVE SMOOTH",
-"343 324 OFFCURVE",
-"438 367 OFFCURVE",
-"438 311 CURVE SMOOTH"
+"206 -12 CURVE SMOOTH"
 );
 }
 );
@@ -18119,49 +21800,29 @@ unicode = 0076;
 },
 {
 glyphname = w;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:59 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{332, 0}";
+},
+{
+name = top;
+position = "{436, 450}";
+}
+);
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
 paths = (
 {
 closed = 1;
 nodes = (
-"709 315 LINE SMOOTH",
-"709 239 OFFCURVE",
-"628 29 OFFCURVE",
-"535 29 CURVE SMOOTH",
-"505 29 OFFCURVE",
-"489 51 OFFCURVE",
-"489 107 CURVE SMOOTH",
-"489 167 OFFCURVE",
-"506 272 OFFCURVE",
-"551 450 CURVE",
-"448 450 LINE",
-"400 227 OFFCURVE",
-"393 171 OFFCURVE",
-"393 132 CURVE SMOOTH",
-"393 34 OFFCURVE",
-"439 -13 OFFCURVE",
-"505 -13 CURVE SMOOTH",
-"659 -13 OFFCURVE",
-"748 242 OFFCURVE",
-"748 374 CURVE SMOOTH",
-"748 433 OFFCURVE",
-"729 462 OFFCURVE",
-"689 462 CURVE SMOOTH",
-"655 462 OFFCURVE",
-"638 440 OFFCURVE",
-"638 412 CURVE SMOOTH",
-"638 355 OFFCURVE",
-"709 384 OFFCURVE",
-"709 315 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"447 450 LINE SMOOTH",
+"277 -13 OFFCURVE",
+"358 78 OFFCURVE",
+"394 188 CURVE",
+"407 188 LINE",
+"447 450 LINE",
 "417 332 OFFCURVE",
 "327 29 OFFCURVE",
 "215 29 CURVE SMOOTH",
@@ -18197,25 +21858,63 @@ nodes = (
 "85 76 CURVE SMOOTH",
 "85 23 OFFCURVE",
 "121 -13 OFFCURVE",
-"181 -13 CURVE SMOOTH",
-"277 -13 OFFCURVE",
-"348 78 OFFCURVE",
-"394 188 CURVE",
-"398 188 LINE",
-"429 271 OFFCURVE",
-"448 386 OFFCURVE",
-"452 447 CURVE"
+"181 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"659 -13 OFFCURVE",
+"748 242 OFFCURVE",
+"748 374 CURVE SMOOTH",
+"748 433 OFFCURVE",
+"729 462 OFFCURVE",
+"689 462 CURVE SMOOTH",
+"655 462 OFFCURVE",
+"638 440 OFFCURVE",
+"638 412 CURVE SMOOTH",
+"638 355 OFFCURVE",
+"709 384 OFFCURVE",
+"709 315 CURVE SMOOTH",
+"709 239 OFFCURVE",
+"628 29 OFFCURVE",
+"535 29 CURVE SMOOTH",
+"505 29 OFFCURVE",
+"489 51 OFFCURVE",
+"489 107 CURVE SMOOTH",
+"489 167 OFFCURVE",
+"506 272 OFFCURVE",
+"551 450 CURVE",
+"448 450 LINE",
+"392 150 LINE SMOOTH",
+"374 52 OFFCURVE",
+"439 -13 OFFCURVE",
+"505 -13 CURVE SMOOTH"
 );
 }
 );
 width = 767;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{336, 0}";
+},
+{
+name = top;
+position = "{440, 450}";
+}
+);
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
 paths = (
 {
 closed = 1;
 nodes = (
+"315 -12 OFFCURVE",
+"379 140 OFFCURVE",
+"406 210 CURVE",
+"411 210 LINE",
 "447 450 LINE",
 "383 177 OFFCURVE",
 "292 40 OFFCURVE",
@@ -18252,17 +21951,12 @@ nodes = (
 "96 88 CURVE SMOOTH",
 "96 23 OFFCURVE",
 "144 -12 OFFCURVE",
-"199 -12 CURVE SMOOTH",
-"315 -12 OFFCURVE",
-"379 140 OFFCURVE",
-"406 210 CURVE",
-"411 210 LINE"
+"199 -12 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"516 -12 LINE SMOOTH",
 "666 -12 OFFCURVE",
 "760 239 OFFCURVE",
 "760 366 CURVE SMOOTH",
@@ -18281,17 +21975,13 @@ nodes = (
 "537 40 OFFCURVE",
 "523 59 OFFCURVE",
 "523 99 CURVE SMOOTH",
-"523 118 OFFCURVE",
-"526 162 OFFCURVE",
-"537 215 CURVE SMOOTH",
-"585 450 LINE",
+"523 158 OFFCURVE",
+"539 226 OFFCURVE",
+"585 450 CURVE",
 "447 450 LINE",
 "403 163 LINE SMOOTH",
-"401 150 OFFCURVE",
-"400 138 OFFCURVE",
-"400 126 CURVE SMOOTH",
-"400 44 OFFCURVE",
-"446 -12 OFFCURVE",
+"389 70 OFFCURVE",
+"429 -12 OFFCURVE",
 "516 -12 CURVE SMOOTH"
 );
 }
@@ -18445,14 +22135,34 @@ unicode = 1E81;
 },
 {
 glyphname = x;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:51:58 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{223, 0}";
+},
+{
+name = top;
+position = "{327, 450}";
+}
+);
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
 paths = (
 {
 closed = 1;
 nodes = (
+"428 -13 OFFCURVE",
+"472 53 OFFCURVE",
+"517 147 CURVE",
+"497 156 LINE",
+"454 68 OFFCURVE",
+"426 38 OFFCURVE",
+"401 38 CURVE SMOOTH",
+"382 38 OFFCURVE",
+"365 54 OFFCURVE",
+"360 82 CURVE SMOOTH",
 "310 364 LINE SMOOTH",
 "297 435 OFFCURVE",
 "272 462 OFFCURVE",
@@ -18470,46 +22180,12 @@ nodes = (
 "262 69 LINE SMOOTH",
 "274 8 OFFCURVE",
 "301 -13 OFFCURVE",
-"347 -13 CURVE SMOOTH",
-"428 -13 OFFCURVE",
-"472 53 OFFCURVE",
-"517 147 CURVE",
-"497 156 LINE",
-"454 68 OFFCURVE",
-"426 38 OFFCURVE",
-"401 38 CURVE SMOOTH",
-"382 38 OFFCURVE",
-"365 54 OFFCURVE",
-"360 82 CURVE SMOOTH"
+"347 -13 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"484 460 LINE SMOOTH",
-"429 460 OFFCURVE",
-"367 397 OFFCURVE",
-"325 310 CURVE",
-"314 310 LINE",
-"314 196 LINE",
-"333 297 OFFCURVE",
-"390 396 OFFCURVE",
-"426 396 CURVE SMOOTH",
-"444 396 OFFCURVE",
-"456 374 OFFCURVE",
-"485 374 CURVE SMOOTH",
-"514 374 OFFCURVE",
-"529 396 OFFCURVE",
-"529 417 CURVE SMOOTH",
-"529 436 OFFCURVE",
-"517 460 OFFCURVE",
-"484 460 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"51 -13 LINE SMOOTH",
 "103 -13 OFFCURVE",
 "169 51 OFFCURVE",
 "240 161 CURVE",
@@ -18528,16 +22204,58 @@ nodes = (
 "19 -13 OFFCURVE",
 "51 -13 CURVE SMOOTH"
 );
+},
+{
+closed = 1;
+nodes = (
+"333 297 OFFCURVE",
+"390 396 OFFCURVE",
+"426 396 CURVE SMOOTH",
+"444 396 OFFCURVE",
+"456 374 OFFCURVE",
+"485 374 CURVE SMOOTH",
+"514 374 OFFCURVE",
+"529 396 OFFCURVE",
+"529 417 CURVE SMOOTH",
+"529 436 OFFCURVE",
+"517 460 OFFCURVE",
+"484 460 CURVE SMOOTH",
+"429 460 OFFCURVE",
+"367 397 OFFCURVE",
+"325 310 CURVE",
+"314 310 LINE",
+"314 196 LINE"
+);
 }
 );
 width = 550;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{205, 0}";
+},
+{
+name = top;
+position = "{309, 450}";
+}
+);
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
 paths = (
 {
 closed = 1;
 nodes = (
+"406 -13 OFFCURVE",
+"446 53 OFFCURVE",
+"491 147 CURVE",
+"468 159 LINE",
+"425 73 OFFCURVE",
+"404 43 OFFCURVE",
+"379 43 CURVE SMOOTH",
+"367 43 OFFCURVE",
+"362 50 OFFCURVE",
+"359 67 CURVE SMOOTH",
 "303 364 LINE SMOOTH",
 "288 440 OFFCURVE",
 "256 462 OFFCURVE",
@@ -18555,46 +22273,12 @@ nodes = (
 "214 101 LINE SMOOTH",
 "230 17 OFFCURVE",
 "270 -13 OFFCURVE",
-"324 -13 CURVE SMOOTH",
-"406 -13 OFFCURVE",
-"446 53 OFFCURVE",
-"491 147 CURVE",
-"468 159 LINE",
-"425 73 OFFCURVE",
-"404 43 OFFCURVE",
-"379 43 CURVE SMOOTH",
-"367 43 OFFCURVE",
-"362 50 OFFCURVE",
-"359 67 CURVE SMOOTH"
+"324 -13 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"448 462 LINE SMOOTH",
-"406 462 OFFCURVE",
-"368 427 OFFCURVE",
-"312 342 CURVE",
-"301 342 LINE",
-"314 285 LINE",
-"329 330 OFFCURVE",
-"359 373 OFFCURVE",
-"383 373 CURVE SMOOTH",
-"403 373 OFFCURVE",
-"414 343 OFFCURVE",
-"450 343 CURVE SMOOTH",
-"487 343 OFFCURVE",
-"507 374 OFFCURVE",
-"507 404 CURVE SMOOTH",
-"507 437 OFFCURVE",
-"484 462 OFFCURVE",
-"448 462 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"41 -13 LINE SMOOTH",
 "83 -13 OFFCURVE",
 "125 21 OFFCURVE",
 "202 143 CURVE",
@@ -18613,6 +22297,28 @@ nodes = (
 "1 -13 OFFCURVE",
 "41 -13 CURVE SMOOTH"
 );
+},
+{
+closed = 1;
+nodes = (
+"329 330 OFFCURVE",
+"359 373 OFFCURVE",
+"383 373 CURVE SMOOTH",
+"403 373 OFFCURVE",
+"414 343 OFFCURVE",
+"450 343 CURVE SMOOTH",
+"487 343 OFFCURVE",
+"507 374 OFFCURVE",
+"507 404 CURVE SMOOTH",
+"507 437 OFFCURVE",
+"484 462 OFFCURVE",
+"448 462 CURVE SMOOTH",
+"406 462 OFFCURVE",
+"368 427 OFFCURVE",
+"312 342 CURVE",
+"301 342 LINE",
+"314 285 LINE"
+);
 }
 );
 width = 514;
@@ -18622,37 +22328,27 @@ unicode = 0078;
 },
 {
 glyphname = y;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:59 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{212, 0}";
+},
+{
+name = top;
+position = "{316, 450}";
+}
+);
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
 paths = (
 {
 closed = 1;
 nodes = (
-"239 390 LINE SMOOTH",
-"221 443 OFFCURVE",
-"200 462 OFFCURVE",
-"163 462 CURVE SMOOTH",
-"92 462 OFFCURVE",
-"58 397 OFFCURVE",
-"20 302 CURVE",
-"40 293 LINE",
-"77 378 OFFCURVE",
-"92 407 OFFCURVE",
-"112 407 CURVE SMOOTH",
-"124 407 OFFCURVE",
-"130 396 OFFCURVE",
-"139 367 CURVE SMOOTH",
-"263 -49 LINE",
-"333 82 LINE",
-"324 120 LINE",
-"320 120 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"130 -314 OFFCURVE",
+"246 -185 OFFCURVE",
+"331 61 CURVE SMOOTH",
 "432 352 LINE SMOOTH",
 "440 375 OFFCURVE",
 "449 381 OFFCURVE",
@@ -18682,44 +22378,54 @@ nodes = (
 "-21 -263 CURVE SMOOTH",
 "-21 -292 OFFCURVE",
 "1 -314 OFFCURVE",
-"39 -314 CURVE SMOOTH",
-"130 -314 OFFCURVE",
-"246 -185 OFFCURVE",
-"331 61 CURVE SMOOTH"
+"39 -314 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"333 82 LINE",
+"324 120 LINE",
+"320 120 LINE",
+"239 390 LINE SMOOTH",
+"221 443 OFFCURVE",
+"200 462 OFFCURVE",
+"163 462 CURVE SMOOTH",
+"92 462 OFFCURVE",
+"58 397 OFFCURVE",
+"20 302 CURVE",
+"40 293 LINE",
+"77 378 OFFCURVE",
+"92 407 OFFCURVE",
+"112 407 CURVE SMOOTH",
+"124 407 OFFCURVE",
+"130 396 OFFCURVE",
+"139 367 CURVE SMOOTH",
+"263 -49 LINE"
 );
 }
 );
 width = 527;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{222, 0}";
+},
+{
+name = top;
+position = "{326, 450}";
+}
+);
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
 paths = (
 {
 closed = 1;
 nodes = (
-"286 397 LINE SMOOTH",
-"268 449 OFFCURVE",
-"238 462 OFFCURVE",
-"200 462 CURVE SMOOTH",
-"113 462 OFFCURVE",
-"74 395 OFFCURVE",
-"25 297 CURVE",
-"55 283 LINE",
-"92 364 OFFCURVE",
-"109 390 OFFCURVE",
-"126 390 CURVE SMOOTH",
-"138 390 OFFCURVE",
-"143 379 OFFCURVE",
-"153 350 CURVE SMOOTH",
-"289 -25 LINE",
-"372 144 LINE",
-"363 182 LINE",
-"359 182 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"125 -314 OFFCURVE",
+"261 -150 OFFCURVE",
+"358 83 CURVE SMOOTH",
 "455 317 LINE SMOOTH",
 "467 346 OFFCURVE",
 "474 352 OFFCURVE",
@@ -18749,10 +22455,30 @@ nodes = (
 "-64 -237 CURVE SMOOTH",
 "-64 -277 OFFCURVE",
 "-34 -314 OFFCURVE",
-"19 -314 CURVE SMOOTH",
-"125 -314 OFFCURVE",
-"261 -150 OFFCURVE",
-"358 83 CURVE SMOOTH"
+"19 -314 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"372 144 LINE",
+"363 182 LINE",
+"359 182 LINE",
+"286 397 LINE SMOOTH",
+"268 449 OFFCURVE",
+"238 462 OFFCURVE",
+"200 462 CURVE SMOOTH",
+"113 462 OFFCURVE",
+"74 395 OFFCURVE",
+"25 297 CURVE",
+"55 283 LINE",
+"92 364 OFFCURVE",
+"109 390 OFFCURVE",
+"126 390 CURVE SMOOTH",
+"138 390 OFFCURVE",
+"143 379 OFFCURVE",
+"153 350 CURVE SMOOTH",
+"289 -25 LINE"
 );
 }
 );
@@ -18765,7 +22491,7 @@ unicode = 0079;
 },
 {
 glyphname = yacute;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:05:38 +0000";
 layers = (
 {
 components = (
@@ -18773,8 +22499,8 @@ components = (
 name = y;
 },
 {
-name = acute;
-transform = "{1, 0, 0, 1, 203, 0}";
+name = acutecomb;
+transform = "{1, 0, 0, 1, -43, 0}";
 }
 );
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -18786,8 +22512,8 @@ components = (
 name = y;
 },
 {
-name = acute;
-transform = "{1, 0, 0, 1, 222, 0}";
+name = acutecomb;
+transform = "{1, 0, 0, 1, -79, 0}";
 }
 );
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
@@ -18869,8 +22595,8 @@ rightKerningGroup = y;
 unicode = 00FF;
 },
 {
-glyphname = ygrave;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = ydotbelow;
+lastChange = "2016-08-22 14:18:41 +0000";
 layers = (
 {
 components = (
@@ -18878,8 +22604,8 @@ components = (
 name = y;
 },
 {
-name = grave;
-transform = "{1, 0, 0, 1, 79, 0}";
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -29, 0}";
 }
 );
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -18891,8 +22617,43 @@ components = (
 name = y;
 },
 {
-name = grave;
-transform = "{1, 0, 0, 1, 77, 0}";
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -28, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 547;
+}
+);
+leftKerningGroup = y;
+rightKerningGroup = y;
+unicode = 1EF5;
+},
+{
+glyphname = ygrave;
+lastChange = "2016-08-22 14:18:41 +0000";
+layers = (
+{
+components = (
+{
+name = y;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, -32, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 527;
+},
+{
+components = (
+{
+name = y;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 10, 0}";
 }
 );
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
@@ -18904,8 +22665,8 @@ rightKerningGroup = y;
 unicode = 1EF3;
 },
 {
-glyphname = ytilde;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = yhookabove;
+lastChange = "2016-08-22 14:18:41 +0000";
 layers = (
 {
 components = (
@@ -18913,8 +22674,8 @@ components = (
 name = y;
 },
 {
-name = tilde;
-transform = "{1, 0, 0, 1, 56, 0}";
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, -7, 0}";
 }
 );
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -18926,8 +22687,43 @@ components = (
 name = y;
 },
 {
-name = tilde;
-transform = "{1, 0, 0, 1, 85, 0}";
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, -6, 0}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 547;
+}
+);
+leftKerningGroup = y;
+rightKerningGroup = y;
+unicode = 1EF7;
+},
+{
+glyphname = ytilde;
+lastChange = "2016-08-22 14:05:38 +0000";
+layers = (
+{
+components = (
+{
+name = y;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, -43, 0}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 527;
+},
+{
+components = (
+{
+name = y;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, -39, 0}";
 }
 );
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
@@ -18940,143 +22736,157 @@ unicode = 1EF9;
 },
 {
 glyphname = z;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:41:59 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{185, 0}";
+},
+{
+name = top;
+position = "{289, 450}";
+}
+);
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
 paths = (
 {
 closed = 1;
 nodes = (
-"65 294 LINE",
-"139 450 LINE",
-"154 450 LINE",
-"267 415 OFFCURVE",
-"294 412 OFFCURVE",
-"396 412 CURVE SMOOTH",
-"423 412 OFFCURVE",
-"401 457 OFFCURVE",
-"435 457 CURVE SMOOTH",
-"446 457 OFFCURVE",
-"453 452 OFFCURVE",
-"453 441 CURVE SMOOTH",
-"453 434 OFFCURVE",
-"449 423 OFFCURVE",
-"407 382 CURVE SMOOTH",
-"133 120 LINE",
-"133 116 LINE",
-"219 116 OFFCURVE",
-"306 70 OFFCURVE",
-"350 70 CURVE SMOOTH",
-"376 70 OFFCURVE",
-"387 86 OFFCURVE",
-"387 99 CURVE SMOOTH",
-"387 127 OFFCURVE",
-"332 105 OFFCURVE",
-"332 148 CURVE SMOOTH",
-"332 173 OFFCURVE",
-"350 185 OFFCURVE",
-"368 185 CURVE SMOOTH",
-"396 185 OFFCURVE",
-"411 155 OFFCURVE",
-"411 120 CURVE SMOOTH",
-"411 46 OFFCURVE",
-"344 -13 OFFCURVE",
-"266 -13 CURVE SMOOTH",
-"188 -13 OFFCURVE",
-"112 47 OFFCURVE",
+"94 -8 OFFCURVE",
+"34 47 OFFCURVE",
 "77 47 CURVE SMOOTH",
-"43 47 OFFCURVE",
-"75 -8 OFFCURVE",
-"38 -8 CURVE SMOOTH",
-"23 -8 OFFCURVE",
-"17 1 OFFCURVE",
-"17 15 CURVE SMOOTH",
-"17 35 OFFCURVE",
-"32 60 OFFCURVE",
-"86 112 CURVE SMOOTH",
-"339 354 LINE",
-"337 357 LINE",
-"286 345 OFFCURVE",
-"244 339 OFFCURVE",
-"207 339 CURVE SMOOTH",
-"176 339 OFFCURVE",
+"112 47 OFFCURVE",
+"188 -13 OFFCURVE",
+"266 -13 CURVE SMOOTH",
+"344 -13 OFFCURVE",
+"411 46 OFFCURVE",
+"411 120 CURVE SMOOTH",
+"411 155 OFFCURVE",
+"396 185 OFFCURVE",
+"368 185 CURVE SMOOTH",
+"350 185 OFFCURVE",
+"332 173 OFFCURVE",
+"332 148 CURVE SMOOTH",
+"332 105 OFFCURVE",
+"387 127 OFFCURVE",
+"387 99 CURVE SMOOTH",
+"387 86 OFFCURVE",
+"376 70 OFFCURVE",
+"350 70 CURVE SMOOTH",
+"306 70 OFFCURVE",
+"219 116 OFFCURVE",
+"133 116 CURVE",
+"133 120 LINE",
+"407 382 LINE SMOOTH",
+"449 423 OFFCURVE",
+"453 434 OFFCURVE",
+"453 441 CURVE SMOOTH",
+"453 452 OFFCURVE",
+"446 457 OFFCURVE",
+"435 457 CURVE SMOOTH",
+"401 457 OFFCURVE",
+"423 412 OFFCURVE",
+"396 412 CURVE SMOOTH",
+"294 412 OFFCURVE",
+"267 415 OFFCURVE",
+"154 450 CURVE",
+"139 450 LINE",
+"65 294 LINE",
+"82 287 LINE",
+"118 354 LINE",
 "148 342 OFFCURVE",
-"118 354 CURVE",
-"82 287 LINE"
+"176 339 OFFCURVE",
+"207 339 CURVE SMOOTH",
+"244 339 OFFCURVE",
+"286 345 OFFCURVE",
+"337 357 CURVE",
+"339 354 LINE",
+"86 112 LINE SMOOTH",
+"32 60 OFFCURVE",
+"17 35 OFFCURVE",
+"17 15 CURVE SMOOTH",
+"17 1 OFFCURVE",
+"23 -8 OFFCURVE",
+"38 -8 CURVE SMOOTH"
 );
 }
 );
 width = 474;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{195, 0}";
+},
+{
+name = top;
+position = "{299, 450}";
+}
+);
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
 paths = (
 {
 closed = 1;
 nodes = (
-"54 264 LINE",
-"141 450 LINE",
-"166 450 LINE",
-"238 428 OFFCURVE",
-"333 417 OFFCURVE",
-"423 417 CURVE SMOOTH",
-"444 417 OFFCURVE",
-"427 462 OFFCURVE",
-"466 462 CURVE SMOOTH",
-"483 462 OFFCURVE",
-"492 454 OFFCURVE",
-"492 440 CURVE SMOOTH",
-"492 427 OFFCURVE",
-"484 413 OFFCURVE",
-"467 399 CURVE SMOOTH",
-"159 142 LINE",
-"159 138 LINE",
-"314 138 OFFCURVE",
-"342 103 OFFCURVE",
-"379 103 CURVE SMOOTH",
-"409 103 OFFCURVE",
-"419 126 OFFCURVE",
-"419 136 CURVE SMOOTH",
-"419 160 OFFCURVE",
-"350 142 OFFCURVE",
-"350 194 CURVE SMOOTH",
-"350 224 OFFCURVE",
-"374 239 OFFCURVE",
-"398 239 CURVE SMOOTH",
-"432 239 OFFCURVE",
-"452 208 OFFCURVE",
-"452 162 CURVE SMOOTH",
-"452 78 OFFCURVE",
-"385 -13 OFFCURVE",
-"290 -13 CURVE SMOOTH",
-"213 -13 OFFCURVE",
-"153 47 OFFCURVE",
+"107 -13 OFFCURVE",
+"54 47 OFFCURVE",
 "89 47 CURVE SMOOTH",
-"81 47 OFFCURVE",
-"77 46 OFFCURVE",
-"77 38 CURVE SMOOTH",
-"77 32 OFFCURVE",
-"80 22 OFFCURVE",
-"80 14 CURVE SMOOTH",
-"80 -2 OFFCURVE",
-"67 -13 OFFCURVE",
-"47 -13 CURVE SMOOTH",
-"23 -13 OFFCURVE",
-"9 2 OFFCURVE",
-"9 24 CURVE SMOOTH",
-"9 43 OFFCURVE",
-"19 62 OFFCURVE",
-"79 112 CURVE SMOOTH",
-"341 333 LINE",
-"339 336 LINE",
-"288 321 OFFCURVE",
-"234 315 OFFCURVE",
-"198 315 CURVE SMOOTH",
-"169 315 OFFCURVE",
+"153 47 OFFCURVE",
+"213 -13 OFFCURVE",
+"290 -13 CURVE SMOOTH",
+"385 -13 OFFCURVE",
+"452 78 OFFCURVE",
+"452 162 CURVE SMOOTH",
+"452 208 OFFCURVE",
+"432 239 OFFCURVE",
+"398 239 CURVE SMOOTH",
+"374 239 OFFCURVE",
+"350 224 OFFCURVE",
+"350 194 CURVE SMOOTH",
+"350 142 OFFCURVE",
+"419 160 OFFCURVE",
+"419 136 CURVE SMOOTH",
+"419 126 OFFCURVE",
+"409 103 OFFCURVE",
+"379 103 CURVE SMOOTH",
+"342 103 OFFCURVE",
+"314 138 OFFCURVE",
+"159 138 CURVE",
+"159 142 LINE",
+"467 399 LINE SMOOTH",
+"484 413 OFFCURVE",
+"492 427 OFFCURVE",
+"492 440 CURVE SMOOTH",
+"492 454 OFFCURVE",
+"483 462 OFFCURVE",
+"466 462 CURVE SMOOTH",
+"427 462 OFFCURVE",
+"444 417 OFFCURVE",
+"423 417 CURVE SMOOTH",
+"333 417 OFFCURVE",
+"238 428 OFFCURVE",
+"166 450 CURVE",
+"141 450 LINE",
+"54 264 LINE",
+"81 253 LINE",
+"118 326 LINE",
 "145 315 OFFCURVE",
-"118 326 CURVE",
-"81 253 LINE"
+"169 315 OFFCURVE",
+"198 315 CURVE SMOOTH",
+"234 315 OFFCURVE",
+"288 321 OFFCURVE",
+"339 336 CURVE",
+"341 333 LINE",
+"79 112 LINE SMOOTH",
+"19 62 OFFCURVE",
+"9 43 OFFCURVE",
+"9 24 CURVE SMOOTH",
+"9 2 OFFCURVE",
+"23 -13 OFFCURVE",
+"47 -13 CURVE SMOOTH"
 );
 }
 );
@@ -19229,7 +23039,7 @@ unicode = 1E93;
 },
 {
 glyphname = f_f;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -19237,6 +23047,9 @@ paths = (
 {
 closed = 1;
 nodes = (
+"3 -324 OFFCURVE",
+"101 -256 OFFCURVE",
+"171 45 CURVE SMOOTH",
 "265 453 LINE SMOOTH",
 "307 634 OFFCURVE",
 "348 688 OFFCURVE",
@@ -19277,24 +23090,15 @@ nodes = (
 "-185 -251 CURVE SMOOTH",
 "-185 -293 OFFCURVE",
 "-140 -324 OFFCURVE",
-"-82 -324 CURVE SMOOTH",
-"3 -324 OFFCURVE",
-"101 -256 OFFCURVE",
-"171 45 CURVE SMOOTH"
+"-82 -324 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"57 425 LINE",
-"378 425 LINE",
-"378 450 LINE",
-"57 450 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"288 -274 OFFCURVE",
+"384 -206 OFFCURVE",
+"456 95 CURVE SMOOTH",
 "553 501 LINE SMOOTH",
 "596 681 OFFCURVE",
 "636 736 OFFCURVE",
@@ -19335,19 +23139,25 @@ nodes = (
 "100 -201 CURVE SMOOTH",
 "100 -243 OFFCURVE",
 "145 -274 OFFCURVE",
-"203 -274 CURVE SMOOTH",
-"288 -274 OFFCURVE",
-"384 -206 OFFCURVE",
-"456 95 CURVE SMOOTH"
+"203 -274 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"333 425 LINE",
+"378 425 LINE",
+"378 450 LINE",
+"57 450 LINE",
+"57 425 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "654 425 LINE",
 "654 450 LINE",
-"333 450 LINE"
+"333 450 LINE",
+"333 425 LINE"
 );
 }
 );
@@ -19359,6 +23169,9 @@ paths = (
 {
 closed = 1;
 nodes = (
+"37 -324 OFFCURVE",
+"159 -182 OFFCURVE",
+"223 175 CURVE SMOOTH",
 "277 476 LINE SMOOTH",
 "307 655 OFFCURVE",
 "346 711 OFFCURVE",
@@ -19399,24 +23212,15 @@ nodes = (
 "-193 -235 CURVE SMOOTH",
 "-193 -279 OFFCURVE",
 "-163 -324 OFFCURVE",
-"-91 -324 CURVE SMOOTH",
-"37 -324 OFFCURVE",
-"159 -182 OFFCURVE",
-"223 175 CURVE SMOOTH"
+"-91 -324 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"25 420 LINE",
-"386 420 LINE",
-"386 450 LINE",
-"25 450 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"319 -289 OFFCURVE",
+"440 -143 OFFCURVE",
+"507 210 CURVE SMOOTH",
 "562 501 LINE SMOOTH",
 "595 684 OFFCURVE",
 "638 736 OFFCURVE",
@@ -19457,19 +23261,25 @@ nodes = (
 "91 -200 CURVE SMOOTH",
 "91 -244 OFFCURVE",
 "122 -289 OFFCURVE",
-"192 -289 CURVE SMOOTH",
-"319 -289 OFFCURVE",
-"440 -143 OFFCURVE",
-"507 210 CURVE SMOOTH"
+"192 -289 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"312 420 LINE",
+"386 420 LINE",
+"386 450 LINE",
+"25 450 LINE",
+"25 420 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "673 420 LINE",
 "673 450 LINE",
-"312 450 LINE"
+"312 450 LINE",
+"312 420 LINE"
 );
 }
 );
@@ -19478,11 +23288,10 @@ width = 594;
 );
 leftKerningGroup = f;
 rightKerningGroup = f;
-unicode = FB00;
 },
 {
 glyphname = f_f_i;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -19490,100 +23299,9 @@ paths = (
 {
 closed = 1;
 nodes = (
-"268 463 LINE SMOOTH",
-"307 634 OFFCURVE",
-"351 688 OFFCURVE",
-"409 688 CURVE SMOOTH",
-"430 688 OFFCURVE",
-"444 681 OFFCURVE",
-"444 670 CURVE SMOOTH",
-"444 657 OFFCURVE",
-"423 647 OFFCURVE",
-"423 621 CURVE SMOOTH",
-"423 596 OFFCURVE",
-"442 577 OFFCURVE",
-"473 577 CURVE SMOOTH",
-"507 577 OFFCURVE",
-"527 603 OFFCURVE",
-"527 633 CURVE SMOOTH",
-"527 684 OFFCURVE",
-"474 718 OFFCURVE",
-"416 718 CURVE SMOOTH",
-"309 718 OFFCURVE",
-"189 605 OFFCURVE",
-"147 402 CURVE SMOOTH",
-"35 -140 LINE SMOOTH",
-"11 -256 OFFCURVE",
-"-24 -294 OFFCURVE",
-"-68 -294 CURVE SMOOTH",
-"-88 -294 OFFCURVE",
-"-92 -287 OFFCURVE",
-"-92 -276 CURVE SMOOTH",
-"-92 -267 OFFCURVE",
-"-89 -256 OFFCURVE",
-"-89 -247 CURVE SMOOTH",
-"-89 -223 OFFCURVE",
-"-108 -203 OFFCURVE",
-"-136 -203 CURVE SMOOTH",
-"-164 -203 OFFCURVE",
-"-185 -223 OFFCURVE",
-"-185 -251 CURVE SMOOTH",
-"-185 -294 OFFCURVE",
-"-136 -324 OFFCURVE",
-"-88 -324 CURVE SMOOTH",
-"6 -324 OFFCURVE",
-"112 -210 OFFCURVE",
-"171 45 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"60 425 LINE",
-"381 425 LINE",
-"381 450 LINE",
-"60 450 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"788 450 LINE",
-"681 450 LINE",
-"594 87 LINE SMOOTH",
-"592 78 OFFCURVE",
-"590 67 OFFCURVE",
-"590 56 CURVE SMOOTH",
-"590 15 OFFCURVE",
-"618 -13 OFFCURVE",
-"667 -13 CURVE SMOOTH",
-"753 -13 OFFCURVE",
-"811 73 OFFCURVE",
-"850 157 CURVE",
-"830 166 LINE",
-"784 73 OFFCURVE",
-"748 38 OFFCURVE",
-"716 38 CURVE SMOOTH",
-"702 38 OFFCURVE",
-"694 45 OFFCURVE",
-"694 63 CURVE SMOOTH",
-"694 69 OFFCURVE",
-"695 80 OFFCURVE",
-"699 97 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"587 425 LINE",
-"776 425 LINE",
-"776 450 LINE",
-"587 450 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"277 -284 OFFCURVE",
+"377 -216 OFFCURVE",
+"445 85 CURVE SMOOTH",
 "542 511 LINE SMOOTH",
 "580 679 OFFCURVE",
 "628 736 OFFCURVE",
@@ -19624,19 +23342,110 @@ nodes = (
 "89 -211 CURVE SMOOTH",
 "89 -253 OFFCURVE",
 "134 -284 OFFCURVE",
-"192 -284 CURVE SMOOTH",
-"277 -284 OFFCURVE",
-"377 -216 OFFCURVE",
-"445 85 CURVE SMOOTH"
+"192 -284 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"322 425 LINE",
+"6 -324 OFFCURVE",
+"112 -210 OFFCURVE",
+"171 45 CURVE SMOOTH",
+"268 463 LINE SMOOTH",
+"307 634 OFFCURVE",
+"351 688 OFFCURVE",
+"409 688 CURVE SMOOTH",
+"430 688 OFFCURVE",
+"444 681 OFFCURVE",
+"444 670 CURVE SMOOTH",
+"444 657 OFFCURVE",
+"423 647 OFFCURVE",
+"423 621 CURVE SMOOTH",
+"423 596 OFFCURVE",
+"442 577 OFFCURVE",
+"473 577 CURVE SMOOTH",
+"507 577 OFFCURVE",
+"527 603 OFFCURVE",
+"527 633 CURVE SMOOTH",
+"527 684 OFFCURVE",
+"474 718 OFFCURVE",
+"416 718 CURVE SMOOTH",
+"309 718 OFFCURVE",
+"189 605 OFFCURVE",
+"147 402 CURVE SMOOTH",
+"35 -140 LINE SMOOTH",
+"11 -256 OFFCURVE",
+"-24 -294 OFFCURVE",
+"-68 -294 CURVE SMOOTH",
+"-88 -294 OFFCURVE",
+"-92 -287 OFFCURVE",
+"-92 -276 CURVE SMOOTH",
+"-92 -267 OFFCURVE",
+"-89 -256 OFFCURVE",
+"-89 -247 CURVE SMOOTH",
+"-89 -223 OFFCURVE",
+"-108 -203 OFFCURVE",
+"-136 -203 CURVE SMOOTH",
+"-164 -203 OFFCURVE",
+"-185 -223 OFFCURVE",
+"-185 -251 CURVE SMOOTH",
+"-185 -294 OFFCURVE",
+"-136 -324 OFFCURVE",
+"-88 -324 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"381 425 LINE",
+"381 450 LINE",
+"60 450 LINE",
+"60 425 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "643 425 LINE",
 "643 450 LINE",
-"322 450 LINE"
+"322 450 LINE",
+"322 425 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"753 -13 OFFCURVE",
+"811 73 OFFCURVE",
+"850 157 CURVE",
+"830 166 LINE",
+"784 73 OFFCURVE",
+"748 38 OFFCURVE",
+"716 38 CURVE SMOOTH",
+"702 38 OFFCURVE",
+"694 45 OFFCURVE",
+"694 63 CURVE SMOOTH",
+"694 69 OFFCURVE",
+"695 80 OFFCURVE",
+"699 97 CURVE SMOOTH",
+"788 450 LINE",
+"681 450 LINE",
+"594 87 LINE SMOOTH",
+"592 78 OFFCURVE",
+"590 67 OFFCURVE",
+"590 56 CURVE SMOOTH",
+"590 15 OFFCURVE",
+"618 -13 OFFCURVE",
+"667 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"776 425 LINE",
+"776 450 LINE",
+"587 450 LINE",
+"587 425 LINE"
 );
 }
 );
@@ -19648,100 +23457,9 @@ paths = (
 {
 closed = 1;
 nodes = (
-"277 476 LINE SMOOTH",
-"307 655 OFFCURVE",
-"346 711 OFFCURVE",
-"394 711 CURVE SMOOTH",
-"414 711 OFFCURVE",
-"421 701 OFFCURVE",
-"421 693 CURVE SMOOTH",
-"421 678 OFFCURVE",
-"400 665 OFFCURVE",
-"400 633 CURVE SMOOTH",
-"400 598 OFFCURVE",
-"425 575 OFFCURVE",
-"463 575 CURVE SMOOTH",
-"506 575 OFFCURVE",
-"526 604 OFFCURVE",
-"526 642 CURVE SMOOTH",
-"526 702 OFFCURVE",
-"475 741 OFFCURVE",
-"408 741 CURVE SMOOTH",
-"298 741 OFFCURVE",
-"167 638 OFFCURVE",
-"125 418 CURVE SMOOTH",
-"61 82 LINE SMOOTH",
-"-6 -269 OFFCURVE",
-"-28 -289 OFFCURVE",
-"-61 -289 CURVE SMOOTH",
-"-76 -289 OFFCURVE",
-"-84 -285 OFFCURVE",
-"-84 -272 CURVE SMOOTH",
-"-84 -256 OFFCURVE",
-"-71 -245 OFFCURVE",
-"-71 -224 CURVE SMOOTH",
-"-71 -198 OFFCURVE",
-"-91 -172 OFFCURVE",
-"-131 -172 CURVE SMOOTH",
-"-172 -172 OFFCURVE",
-"-193 -199 OFFCURVE",
-"-193 -235 CURVE SMOOTH",
-"-193 -279 OFFCURVE",
-"-163 -324 OFFCURVE",
-"-91 -324 CURVE SMOOTH",
-"37 -324 OFFCURVE",
-"159 -182 OFFCURVE",
-"223 175 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"27 420 LINE",
-"388 420 LINE",
-"388 450 LINE",
-"27 450 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"831 450 LINE",
-"697 450 LINE",
-"623 153 LINE SMOOTH",
-"610 100 OFFCURVE",
-"607 86 OFFCURVE",
-"607 70 CURVE SMOOTH",
-"607 15 OFFCURVE",
-"640 -11 OFFCURVE",
-"699 -11 CURVE SMOOTH",
-"778 -11 OFFCURVE",
-"850 35 OFFCURVE",
-"887 147 CURVE",
-"862 156 LINE",
-"821 65 OFFCURVE",
-"777 37 OFFCURVE",
-"756 37 CURVE SMOOTH",
-"748 37 OFFCURVE",
-"742 41 OFFCURVE",
-"742 52 CURVE SMOOTH",
-"742 57 OFFCURVE",
-"743 69 OFFCURVE",
-"747 87 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"600 420 LINE",
-"774 420 LINE",
-"774 450 LINE",
-"600 450 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"308 -289 OFFCURVE",
+"423 -145 OFFCURVE",
+"499 210 CURVE SMOOTH",
 "561 501 LINE",
 "597 681 OFFCURVE",
 "654 736 OFFCURVE",
@@ -19782,19 +23500,110 @@ nodes = (
 "82 -200 CURVE SMOOTH",
 "82 -244 OFFCURVE",
 "113 -289 OFFCURVE",
-"183 -289 CURVE SMOOTH",
-"308 -289 OFFCURVE",
-"423 -145 OFFCURVE",
-"499 210 CURVE SMOOTH"
+"183 -289 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"310 420 LINE",
+"37 -324 OFFCURVE",
+"159 -182 OFFCURVE",
+"223 175 CURVE SMOOTH",
+"277 476 LINE SMOOTH",
+"307 655 OFFCURVE",
+"346 711 OFFCURVE",
+"394 711 CURVE SMOOTH",
+"414 711 OFFCURVE",
+"421 701 OFFCURVE",
+"421 693 CURVE SMOOTH",
+"421 678 OFFCURVE",
+"400 665 OFFCURVE",
+"400 633 CURVE SMOOTH",
+"400 598 OFFCURVE",
+"425 575 OFFCURVE",
+"463 575 CURVE SMOOTH",
+"506 575 OFFCURVE",
+"526 604 OFFCURVE",
+"526 642 CURVE SMOOTH",
+"526 702 OFFCURVE",
+"475 741 OFFCURVE",
+"408 741 CURVE SMOOTH",
+"298 741 OFFCURVE",
+"167 638 OFFCURVE",
+"125 418 CURVE SMOOTH",
+"61 82 LINE SMOOTH",
+"-6 -269 OFFCURVE",
+"-28 -289 OFFCURVE",
+"-61 -289 CURVE SMOOTH",
+"-76 -289 OFFCURVE",
+"-84 -285 OFFCURVE",
+"-84 -272 CURVE SMOOTH",
+"-84 -256 OFFCURVE",
+"-71 -245 OFFCURVE",
+"-71 -224 CURVE SMOOTH",
+"-71 -198 OFFCURVE",
+"-91 -172 OFFCURVE",
+"-131 -172 CURVE SMOOTH",
+"-172 -172 OFFCURVE",
+"-193 -199 OFFCURVE",
+"-193 -235 CURVE SMOOTH",
+"-193 -279 OFFCURVE",
+"-163 -324 OFFCURVE",
+"-91 -324 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"388 420 LINE",
+"388 450 LINE",
+"27 450 LINE",
+"27 420 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "671 420 LINE",
 "671 450 LINE",
-"310 450 LINE"
+"310 450 LINE",
+"310 420 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"778 -11 OFFCURVE",
+"850 35 OFFCURVE",
+"887 147 CURVE",
+"862 156 LINE",
+"821 65 OFFCURVE",
+"777 37 OFFCURVE",
+"756 37 CURVE SMOOTH",
+"748 37 OFFCURVE",
+"742 41 OFFCURVE",
+"742 52 CURVE SMOOTH",
+"742 57 OFFCURVE",
+"743 69 OFFCURVE",
+"747 87 CURVE SMOOTH",
+"831 450 LINE",
+"697 450 LINE",
+"623 153 LINE SMOOTH",
+"610 100 OFFCURVE",
+"607 86 OFFCURVE",
+"607 70 CURVE SMOOTH",
+"607 15 OFFCURVE",
+"640 -11 OFFCURVE",
+"699 -11 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"774 420 LINE",
+"774 450 LINE",
+"600 450 LINE",
+"600 420 LINE"
 );
 }
 );
@@ -19803,11 +23612,10 @@ width = 882;
 );
 leftKerningGroup = f;
 rightKerningGroup = i;
-unicode = FB03;
 },
 {
 glyphname = f_f_l;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -19815,64 +23623,9 @@ paths = (
 {
 closed = 1;
 nodes = (
-"268 463 LINE SMOOTH",
-"307 632 OFFCURVE",
-"350 686 OFFCURVE",
-"408 686 CURVE SMOOTH",
-"429 686 OFFCURVE",
-"443 679 OFFCURVE",
-"443 668 CURVE SMOOTH",
-"443 655 OFFCURVE",
-"422 645 OFFCURVE",
-"422 619 CURVE SMOOTH",
-"422 594 OFFCURVE",
-"441 575 OFFCURVE",
-"472 575 CURVE SMOOTH",
-"506 575 OFFCURVE",
-"526 601 OFFCURVE",
-"526 631 CURVE SMOOTH",
-"526 682 OFFCURVE",
-"473 716 OFFCURVE",
-"415 716 CURVE SMOOTH",
-"308 716 OFFCURVE",
-"188 603 OFFCURVE",
-"147 402 CURVE SMOOTH",
-"35 -140 LINE SMOOTH",
-"11 -256 OFFCURVE",
-"-24 -294 OFFCURVE",
-"-68 -294 CURVE SMOOTH",
-"-88 -294 OFFCURVE",
-"-92 -287 OFFCURVE",
-"-92 -276 CURVE SMOOTH",
-"-92 -267 OFFCURVE",
-"-89 -256 OFFCURVE",
-"-89 -247 CURVE SMOOTH",
-"-89 -223 OFFCURVE",
-"-108 -203 OFFCURVE",
-"-136 -203 CURVE SMOOTH",
-"-164 -203 OFFCURVE",
-"-185 -223 OFFCURVE",
-"-185 -251 CURVE SMOOTH",
-"-185 -293 OFFCURVE",
-"-140 -324 OFFCURVE",
-"-82 -324 CURVE SMOOTH",
-"-2 -324 OFFCURVE",
-"100 -263 OFFCURVE",
-"171 45 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"60 425 LINE",
-"381 425 LINE",
-"381 450 LINE",
-"60 450 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"288 -274 OFFCURVE",
+"384 -206 OFFCURVE",
+"456 95 CURVE SMOOTH",
 "556 511 LINE SMOOTH",
 "597 686 OFFCURVE",
 "639 736 OFFCURVE",
@@ -19913,33 +23666,79 @@ nodes = (
 "100 -201 CURVE SMOOTH",
 "100 -243 OFFCURVE",
 "145 -274 OFFCURVE",
-"203 -274 CURVE SMOOTH",
-"288 -274 OFFCURVE",
-"384 -206 OFFCURVE",
-"456 95 CURVE SMOOTH"
+"203 -274 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"336 425 LINE",
+"-2 -324 OFFCURVE",
+"100 -263 OFFCURVE",
+"171 45 CURVE SMOOTH",
+"268 463 LINE SMOOTH",
+"307 632 OFFCURVE",
+"350 686 OFFCURVE",
+"408 686 CURVE SMOOTH",
+"429 686 OFFCURVE",
+"443 679 OFFCURVE",
+"443 668 CURVE SMOOTH",
+"443 655 OFFCURVE",
+"422 645 OFFCURVE",
+"422 619 CURVE SMOOTH",
+"422 594 OFFCURVE",
+"441 575 OFFCURVE",
+"472 575 CURVE SMOOTH",
+"506 575 OFFCURVE",
+"526 601 OFFCURVE",
+"526 631 CURVE SMOOTH",
+"526 682 OFFCURVE",
+"473 716 OFFCURVE",
+"415 716 CURVE SMOOTH",
+"308 716 OFFCURVE",
+"188 603 OFFCURVE",
+"147 402 CURVE SMOOTH",
+"35 -140 LINE SMOOTH",
+"11 -256 OFFCURVE",
+"-24 -294 OFFCURVE",
+"-68 -294 CURVE SMOOTH",
+"-88 -294 OFFCURVE",
+"-92 -287 OFFCURVE",
+"-92 -276 CURVE SMOOTH",
+"-92 -267 OFFCURVE",
+"-89 -256 OFFCURVE",
+"-89 -247 CURVE SMOOTH",
+"-89 -223 OFFCURVE",
+"-108 -203 OFFCURVE",
+"-136 -203 CURVE SMOOTH",
+"-164 -203 OFFCURVE",
+"-185 -223 OFFCURVE",
+"-185 -251 CURVE SMOOTH",
+"-185 -293 OFFCURVE",
+"-140 -324 OFFCURVE",
+"-82 -324 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"381 425 LINE",
+"381 450 LINE",
+"60 450 LINE",
+"60 425 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "657 425 LINE",
 "657 450 LINE",
-"336 450 LINE"
+"336 450 LINE",
+"336 425 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"885 764 LINE",
-"769 734 LINE",
-"615 87 LINE SMOOTH",
-"613 78 OFFCURVE",
-"611 67 OFFCURVE",
-"611 56 CURVE SMOOTH",
-"611 15 OFFCURVE",
-"639 -13 OFFCURVE",
-"689 -13 CURVE SMOOTH",
 "777 -13 OFFCURVE",
 "836 73 OFFCURVE",
 "876 157 CURVE",
@@ -19952,7 +23751,16 @@ nodes = (
 "715 63 CURVE SMOOTH",
 "715 69 OFFCURVE",
 "716 80 OFFCURVE",
-"720 97 CURVE SMOOTH"
+"720 97 CURVE SMOOTH",
+"885 764 LINE",
+"769 734 LINE",
+"615 87 LINE SMOOTH",
+"613 78 OFFCURVE",
+"611 67 OFFCURVE",
+"611 56 CURVE SMOOTH",
+"611 15 OFFCURVE",
+"639 -13 OFFCURVE",
+"689 -13 CURVE SMOOTH"
 );
 }
 );
@@ -19964,91 +23772,9 @@ paths = (
 {
 closed = 1;
 nodes = (
-"277 476 LINE SMOOTH",
-"307 655 OFFCURVE",
-"347 711 OFFCURVE",
-"395 711 CURVE SMOOTH",
-"415 711 OFFCURVE",
-"422 701 OFFCURVE",
-"422 693 CURVE SMOOTH",
-"422 678 OFFCURVE",
-"401 665 OFFCURVE",
-"401 633 CURVE SMOOTH",
-"401 598 OFFCURVE",
-"426 575 OFFCURVE",
-"464 575 CURVE SMOOTH",
-"507 575 OFFCURVE",
-"527 604 OFFCURVE",
-"527 642 CURVE SMOOTH",
-"527 702 OFFCURVE",
-"476 741 OFFCURVE",
-"409 741 CURVE SMOOTH",
-"299 741 OFFCURVE",
-"167 638 OFFCURVE",
-"125 418 CURVE SMOOTH",
-"61 82 LINE SMOOTH",
-"-6 -269 OFFCURVE",
-"-28 -289 OFFCURVE",
-"-61 -289 CURVE SMOOTH",
-"-76 -289 OFFCURVE",
-"-84 -285 OFFCURVE",
-"-84 -272 CURVE SMOOTH",
-"-84 -256 OFFCURVE",
-"-71 -245 OFFCURVE",
-"-71 -224 CURVE SMOOTH",
-"-71 -198 OFFCURVE",
-"-91 -172 OFFCURVE",
-"-131 -172 CURVE SMOOTH",
-"-172 -172 OFFCURVE",
-"-193 -199 OFFCURVE",
-"-193 -235 CURVE SMOOTH",
-"-193 -279 OFFCURVE",
-"-163 -324 OFFCURVE",
-"-91 -324 CURVE SMOOTH",
-"37 -324 OFFCURVE",
-"159 -182 OFFCURVE",
-"223 175 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"25 420 LINE",
-"386 420 LINE",
-"386 450 LINE",
-"25 450 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"906 766 LINE",
-"766 741 LINE",
-"630 132 LINE SMOOTH",
-"625 108 OFFCURVE",
-"621 83 OFFCURVE",
-"621 67 CURVE SMOOTH",
-"621 26 OFFCURVE",
-"647 -11 OFFCURVE",
-"704 -11 CURVE SMOOTH",
-"772 -11 OFFCURVE",
-"831 43 OFFCURVE",
-"864 152 CURVE",
-"839 161 LINE",
-"806 69 OFFCURVE",
-"769 41 OFFCURVE",
-"751 41 CURVE SMOOTH",
-"744 41 OFFCURVE",
-"739 45 OFFCURVE",
-"739 54 CURVE SMOOTH",
-"739 58 OFFCURVE",
-"740 70 OFFCURVE",
-"744 87 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
+"316 -289 OFFCURVE",
+"431 -142 OFFCURVE",
+"500 210 CURVE SMOOTH",
 "557 501 LINE SMOOTH",
 "591 682 OFFCURVE",
 "631 736 OFFCURVE",
@@ -20089,19 +23815,101 @@ nodes = (
 "84 -200 CURVE SMOOTH",
 "84 -244 OFFCURVE",
 "114 -289 OFFCURVE",
-"185 -289 CURVE SMOOTH",
-"316 -289 OFFCURVE",
-"431 -142 OFFCURVE",
-"500 210 CURVE SMOOTH"
+"185 -289 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"307 420 LINE",
+"37 -324 OFFCURVE",
+"159 -182 OFFCURVE",
+"223 175 CURVE SMOOTH",
+"277 476 LINE SMOOTH",
+"307 655 OFFCURVE",
+"347 711 OFFCURVE",
+"395 711 CURVE SMOOTH",
+"415 711 OFFCURVE",
+"422 701 OFFCURVE",
+"422 693 CURVE SMOOTH",
+"422 678 OFFCURVE",
+"401 665 OFFCURVE",
+"401 633 CURVE SMOOTH",
+"401 598 OFFCURVE",
+"426 575 OFFCURVE",
+"464 575 CURVE SMOOTH",
+"507 575 OFFCURVE",
+"527 604 OFFCURVE",
+"527 642 CURVE SMOOTH",
+"527 702 OFFCURVE",
+"476 741 OFFCURVE",
+"409 741 CURVE SMOOTH",
+"299 741 OFFCURVE",
+"167 638 OFFCURVE",
+"125 418 CURVE SMOOTH",
+"61 82 LINE SMOOTH",
+"-6 -269 OFFCURVE",
+"-28 -289 OFFCURVE",
+"-61 -289 CURVE SMOOTH",
+"-76 -289 OFFCURVE",
+"-84 -285 OFFCURVE",
+"-84 -272 CURVE SMOOTH",
+"-84 -256 OFFCURVE",
+"-71 -245 OFFCURVE",
+"-71 -224 CURVE SMOOTH",
+"-71 -198 OFFCURVE",
+"-91 -172 OFFCURVE",
+"-131 -172 CURVE SMOOTH",
+"-172 -172 OFFCURVE",
+"-193 -199 OFFCURVE",
+"-193 -235 CURVE SMOOTH",
+"-193 -279 OFFCURVE",
+"-163 -324 OFFCURVE",
+"-91 -324 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"386 420 LINE",
+"386 450 LINE",
+"25 450 LINE",
+"25 420 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "668 420 LINE",
 "668 450 LINE",
-"307 450 LINE"
+"307 450 LINE",
+"307 420 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"772 -11 OFFCURVE",
+"831 43 OFFCURVE",
+"864 152 CURVE",
+"839 161 LINE",
+"806 69 OFFCURVE",
+"769 41 OFFCURVE",
+"751 41 CURVE SMOOTH",
+"744 41 OFFCURVE",
+"739 45 OFFCURVE",
+"739 54 CURVE SMOOTH",
+"739 58 OFFCURVE",
+"740 70 OFFCURVE",
+"744 87 CURVE SMOOTH",
+"906 766 LINE",
+"766 741 LINE",
+"630 132 LINE SMOOTH",
+"625 108 OFFCURVE",
+"621 83 OFFCURVE",
+"621 67 CURVE SMOOTH",
+"621 26 OFFCURVE",
+"647 -11 OFFCURVE",
+"704 -11 CURVE SMOOTH"
 );
 }
 );
@@ -20110,11 +23918,10 @@ width = 885;
 );
 leftKerningGroup = f;
 rightKerningGroup = l;
-unicode = FB04;
 },
 {
 glyphname = f_i;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -20122,42 +23929,9 @@ paths = (
 {
 closed = 1;
 nodes = (
-"525 450 LINE",
-"418 450 LINE",
-"332 87 LINE SMOOTH",
-"330 78 OFFCURVE",
-"328 67 OFFCURVE",
-"328 56 CURVE SMOOTH",
-"328 15 OFFCURVE",
-"356 -13 OFFCURVE",
-"405 -13 CURVE SMOOTH",
-"491 -13 OFFCURVE",
-"549 73 OFFCURVE",
-"588 157 CURVE",
-"568 166 LINE",
-"522 73 OFFCURVE",
-"486 38 OFFCURVE",
-"454 38 CURVE SMOOTH",
-"440 38 OFFCURVE",
-"432 45 OFFCURVE",
-"432 63 CURVE SMOOTH",
-"432 69 OFFCURVE",
-"433 80 OFFCURVE",
-"437 97 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"324 425 LINE",
-"513 425 LINE",
-"513 450 LINE",
-"324 450 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"3 -324 OFFCURVE",
+"101 -256 OFFCURVE",
+"171 45 CURVE SMOOTH",
 "279 511 LINE SMOOTH",
 "319 684 OFFCURVE",
 "365 736 OFFCURVE",
@@ -20198,19 +23972,52 @@ nodes = (
 "-185 -251 CURVE SMOOTH",
 "-185 -293 OFFCURVE",
 "-140 -324 OFFCURVE",
-"-82 -324 CURVE SMOOTH",
-"3 -324 OFFCURVE",
-"101 -256 OFFCURVE",
-"171 45 CURVE SMOOTH"
+"-82 -324 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"59 425 LINE",
 "380 425 LINE",
 "380 450 LINE",
-"59 450 LINE"
+"59 450 LINE",
+"59 425 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"491 -13 OFFCURVE",
+"549 73 OFFCURVE",
+"588 157 CURVE",
+"568 166 LINE",
+"522 73 OFFCURVE",
+"486 38 OFFCURVE",
+"454 38 CURVE SMOOTH",
+"440 38 OFFCURVE",
+"432 45 OFFCURVE",
+"432 63 CURVE SMOOTH",
+"432 69 OFFCURVE",
+"433 80 OFFCURVE",
+"437 97 CURVE SMOOTH",
+"525 450 LINE",
+"418 450 LINE",
+"332 87 LINE SMOOTH",
+"330 78 OFFCURVE",
+"328 67 OFFCURVE",
+"328 56 CURVE SMOOTH",
+"328 15 OFFCURVE",
+"356 -13 OFFCURVE",
+"405 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"513 425 LINE",
+"513 450 LINE",
+"324 450 LINE",
+"324 425 LINE"
 );
 }
 );
@@ -20222,42 +24029,9 @@ paths = (
 {
 closed = 1;
 nodes = (
-"561 450 LINE",
-"427 450 LINE",
-"353 153 LINE SMOOTH",
-"340 100 OFFCURVE",
-"337 86 OFFCURVE",
-"337 70 CURVE SMOOTH",
-"337 15 OFFCURVE",
-"370 -11 OFFCURVE",
-"429 -11 CURVE SMOOTH",
-"508 -11 OFFCURVE",
-"580 35 OFFCURVE",
-"617 147 CURVE",
-"592 156 LINE",
-"551 65 OFFCURVE",
-"507 37 OFFCURVE",
-"486 37 CURVE SMOOTH",
-"478 37 OFFCURVE",
-"472 41 OFFCURVE",
-"472 52 CURVE SMOOTH",
-"472 57 OFFCURVE",
-"473 69 OFFCURVE",
-"477 87 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"330 420 LINE",
-"504 420 LINE",
-"504 450 LINE",
-"330 450 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"33 -324 OFFCURVE",
+"151 -181 OFFCURVE",
+"224 175 CURVE SMOOTH",
 "291 501 LINE SMOOTH",
 "327 681 OFFCURVE",
 "385 736 OFFCURVE",
@@ -20298,19 +24072,52 @@ nodes = (
 "-193 -235 CURVE SMOOTH",
 "-193 -279 OFFCURVE",
 "-163 -324 OFFCURVE",
-"-92 -324 CURVE SMOOTH",
-"33 -324 OFFCURVE",
-"151 -181 OFFCURVE",
-"224 175 CURVE SMOOTH"
+"-92 -324 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"40 420 LINE",
 "401 420 LINE",
 "401 450 LINE",
-"40 450 LINE"
+"40 450 LINE",
+"40 420 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"508 -11 OFFCURVE",
+"580 35 OFFCURVE",
+"617 147 CURVE",
+"592 156 LINE",
+"551 65 OFFCURVE",
+"507 37 OFFCURVE",
+"486 37 CURVE SMOOTH",
+"478 37 OFFCURVE",
+"472 41 OFFCURVE",
+"472 52 CURVE SMOOTH",
+"472 57 OFFCURVE",
+"473 69 OFFCURVE",
+"477 87 CURVE SMOOTH",
+"561 450 LINE",
+"427 450 LINE",
+"353 153 LINE SMOOTH",
+"340 100 OFFCURVE",
+"337 86 OFFCURVE",
+"337 70 CURVE SMOOTH",
+"337 15 OFFCURVE",
+"370 -11 OFFCURVE",
+"429 -11 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"504 420 LINE",
+"504 450 LINE",
+"330 450 LINE",
+"330 420 LINE"
 );
 }
 );
@@ -20319,11 +24126,10 @@ width = 612;
 );
 leftKerningGroup = f;
 rightKerningGroup = i;
-unicode = FB01;
 },
 {
 glyphname = f_l;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -20331,33 +24137,9 @@ paths = (
 {
 closed = 1;
 nodes = (
-"606 764 LINE",
-"491 732 LINE",
-"337 87 LINE SMOOTH",
-"335 78 OFFCURVE",
-"333 67 OFFCURVE",
-"333 56 CURVE SMOOTH",
-"333 15 OFFCURVE",
-"361 -13 OFFCURVE",
-"410 -13 CURVE SMOOTH",
-"499 -13 OFFCURVE",
-"558 73 OFFCURVE",
-"598 157 CURVE",
-"578 166 LINE",
-"530 73 OFFCURVE",
-"493 38 OFFCURVE",
-"459 38 CURVE SMOOTH",
-"445 38 OFFCURVE",
-"437 45 OFFCURVE",
-"437 63 CURVE SMOOTH",
-"437 69 OFFCURVE",
-"438 80 OFFCURVE",
-"442 97 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
+"3 -324 OFFCURVE",
+"101 -256 OFFCURVE",
+"171 45 CURVE SMOOTH",
 "279 511 LINE SMOOTH",
 "319 684 OFFCURVE",
 "362 736 OFFCURVE",
@@ -20398,19 +24180,43 @@ nodes = (
 "-185 -251 CURVE SMOOTH",
 "-185 -293 OFFCURVE",
 "-140 -324 OFFCURVE",
-"-82 -324 CURVE SMOOTH",
-"3 -324 OFFCURVE",
-"101 -256 OFFCURVE",
-"171 45 CURVE SMOOTH"
+"-82 -324 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"59 425 LINE",
 "364 425 LINE",
 "364 450 LINE",
-"59 450 LINE"
+"59 450 LINE",
+"59 425 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"499 -13 OFFCURVE",
+"558 73 OFFCURVE",
+"598 157 CURVE",
+"578 166 LINE",
+"530 73 OFFCURVE",
+"493 38 OFFCURVE",
+"459 38 CURVE SMOOTH",
+"445 38 OFFCURVE",
+"437 45 OFFCURVE",
+"437 63 CURVE SMOOTH",
+"437 69 OFFCURVE",
+"438 80 OFFCURVE",
+"442 97 CURVE SMOOTH",
+"606 764 LINE",
+"491 732 LINE",
+"337 87 LINE SMOOTH",
+"335 78 OFFCURVE",
+"333 67 OFFCURVE",
+"333 56 CURVE SMOOTH",
+"333 15 OFFCURVE",
+"361 -13 OFFCURVE",
+"410 -13 CURVE SMOOTH"
 );
 }
 );
@@ -20422,33 +24228,9 @@ paths = (
 {
 closed = 1;
 nodes = (
-"637 766 LINE",
-"497 741 LINE",
-"361 132 LINE SMOOTH",
-"356 108 OFFCURVE",
-"352 83 OFFCURVE",
-"352 67 CURVE SMOOTH",
-"352 26 OFFCURVE",
-"378 -11 OFFCURVE",
-"435 -11 CURVE SMOOTH",
-"503 -11 OFFCURVE",
-"562 43 OFFCURVE",
-"595 152 CURVE",
-"570 161 LINE",
-"537 69 OFFCURVE",
-"500 41 OFFCURVE",
-"482 41 CURVE SMOOTH",
-"475 41 OFFCURVE",
-"470 45 OFFCURVE",
-"470 54 CURVE SMOOTH",
-"470 58 OFFCURVE",
-"471 70 OFFCURVE",
-"475 87 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
+"35 -324 OFFCURVE",
+"153 -177 OFFCURVE",
+"223 175 CURVE SMOOTH",
 "288 501 LINE SMOOTH",
 "322 682 OFFCURVE",
 "362 736 OFFCURVE",
@@ -20489,19 +24271,43 @@ nodes = (
 "-193 -235 CURVE SMOOTH",
 "-193 -279 OFFCURVE",
 "-163 -324 OFFCURVE",
-"-92 -324 CURVE SMOOTH",
-"35 -324 OFFCURVE",
-"153 -177 OFFCURVE",
-"223 175 CURVE SMOOTH"
+"-92 -324 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"38 420 LINE",
 "399 420 LINE",
 "399 450 LINE",
-"38 450 LINE"
+"38 450 LINE",
+"38 420 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"503 -11 OFFCURVE",
+"562 43 OFFCURVE",
+"595 152 CURVE",
+"570 161 LINE",
+"537 69 OFFCURVE",
+"500 41 OFFCURVE",
+"482 41 CURVE SMOOTH",
+"475 41 OFFCURVE",
+"470 45 OFFCURVE",
+"470 54 CURVE SMOOTH",
+"470 58 OFFCURVE",
+"471 70 OFFCURVE",
+"475 87 CURVE SMOOTH",
+"637 766 LINE",
+"497 741 LINE",
+"361 132 LINE SMOOTH",
+"356 108 OFFCURVE",
+"352 83 OFFCURVE",
+"352 67 CURVE SMOOTH",
+"352 26 OFFCURVE",
+"378 -11 OFFCURVE",
+"435 -11 CURVE SMOOTH"
 );
 }
 );
@@ -20510,11 +24316,10 @@ width = 616;
 );
 leftKerningGroup = f;
 rightKerningGroup = l;
-unicode = FB02;
 },
 {
 glyphname = ordfeminine;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -20522,43 +24327,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"432 753 LINE",
-"359 753 LINE",
-"314 567 LINE SMOOTH",
-"309 548 OFFCURVE",
-"307 531 OFFCURVE",
-"307 519 CURVE SMOOTH",
-"307 471 OFFCURVE",
-"339 458 OFFCURVE",
-"362 458 CURVE SMOOTH",
-"409 458 OFFCURVE",
-"440 511 OFFCURVE",
-"460 559 CURVE",
-"437 565 LINE",
-"418 519 OFFCURVE",
-"399 496 OFFCURVE",
-"385 496 CURVE SMOOTH",
-"379 496 OFFCURVE",
-"375 501 OFFCURVE",
-"375 514 CURVE SMOOTH",
-"375 526 OFFCURVE",
-"378 539 OFFCURVE",
-"384 562 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"346 715 LINE",
-"337 743 OFFCURVE",
-"326 763 OFFCURVE",
-"289 763 CURVE SMOOTH",
-"211 763 OFFCURVE",
-"125 673 OFFCURVE",
-"125 573 CURVE SMOOTH",
-"125 500 OFFCURVE",
-"171 458 OFFCURVE",
-"224 458 CURVE SMOOTH",
 "260 458 OFFCURVE",
 "288 478 OFFCURVE",
 "305 512 CURVE",
@@ -20579,7 +24347,44 @@ nodes = (
 "337 671 OFFCURVE",
 "336 664 OFFCURVE",
 "336 655 CURVE",
-"350 715 LINE"
+"350 715 LINE",
+"346 715 LINE",
+"337 743 OFFCURVE",
+"326 763 OFFCURVE",
+"289 763 CURVE SMOOTH",
+"211 763 OFFCURVE",
+"125 673 OFFCURVE",
+"125 573 CURVE SMOOTH",
+"125 500 OFFCURVE",
+"171 458 OFFCURVE",
+"224 458 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"409 458 OFFCURVE",
+"440 511 OFFCURVE",
+"460 559 CURVE",
+"437 565 LINE",
+"418 519 OFFCURVE",
+"399 496 OFFCURVE",
+"385 496 CURVE SMOOTH",
+"379 496 OFFCURVE",
+"375 501 OFFCURVE",
+"375 514 CURVE SMOOTH",
+"375 526 OFFCURVE",
+"378 539 OFFCURVE",
+"384 562 CURVE SMOOTH",
+"432 753 LINE",
+"359 753 LINE",
+"314 567 LINE SMOOTH",
+"309 548 OFFCURVE",
+"307 531 OFFCURVE",
+"307 519 CURVE SMOOTH",
+"307 471 OFFCURVE",
+"339 458 OFFCURVE",
+"362 458 CURVE SMOOTH"
 );
 }
 );
@@ -20591,43 +24396,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"460 753 LINE",
-"372 753 LINE",
-"327 567 LINE SMOOTH",
-"322 548 OFFCURVE",
-"320 530 OFFCURVE",
-"320 519 CURVE SMOOTH",
-"320 470 OFFCURVE",
-"356 458 OFFCURVE",
-"384 458 CURVE SMOOTH",
-"432 458 OFFCURVE",
-"466 495 OFFCURVE",
-"488 559 CURVE",
-"465 565 LINE",
-"446 519 OFFCURVE",
-"427 496 OFFCURVE",
-"413 496 CURVE SMOOTH",
-"407 496 OFFCURVE",
-"403 501 OFFCURVE",
-"403 514 CURVE SMOOTH",
-"403 526 OFFCURVE",
-"406 539 OFFCURVE",
-"412 562 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"359 715 LINE",
-"349 743 OFFCURVE",
-"335 763 OFFCURVE",
-"296 763 CURVE SMOOTH",
-"212 763 OFFCURVE",
-"123 673 OFFCURVE",
-"123 573 CURVE SMOOTH",
-"123 500 OFFCURVE",
-"172 458 OFFCURVE",
-"229 458 CURVE SMOOTH",
 "269 458 OFFCURVE",
 "299 478 OFFCURVE",
 "318 512 CURVE",
@@ -20648,7 +24416,44 @@ nodes = (
 "350 661 OFFCURVE",
 "349 654 OFFCURVE",
 "349 645 CURVE",
-"363 715 LINE"
+"363 715 LINE",
+"359 715 LINE",
+"349 743 OFFCURVE",
+"335 763 OFFCURVE",
+"296 763 CURVE SMOOTH",
+"212 763 OFFCURVE",
+"123 673 OFFCURVE",
+"123 573 CURVE SMOOTH",
+"123 500 OFFCURVE",
+"172 458 OFFCURVE",
+"229 458 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"432 458 OFFCURVE",
+"466 495 OFFCURVE",
+"488 559 CURVE",
+"465 565 LINE",
+"446 519 OFFCURVE",
+"427 496 OFFCURVE",
+"413 496 CURVE SMOOTH",
+"407 496 OFFCURVE",
+"403 501 OFFCURVE",
+"403 514 CURVE SMOOTH",
+"403 526 OFFCURVE",
+"406 539 OFFCURVE",
+"412 562 CURVE SMOOTH",
+"460 753 LINE",
+"372 753 LINE",
+"327 567 LINE SMOOTH",
+"322 548 OFFCURVE",
+"320 530 OFFCURVE",
+"320 519 CURVE SMOOTH",
+"320 470 OFFCURVE",
+"356 458 OFFCURVE",
+"384 458 CURVE SMOOTH"
 );
 }
 );
@@ -20659,7 +24464,7 @@ unicode = 00AA;
 },
 {
 glyphname = ordmasculine;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:52:25 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -20667,25 +24472,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"245 484 LINE SMOOTH",
-"210 484 OFFCURVE",
-"199 506 OFFCURVE",
-"199 549 CURVE SMOOTH",
-"199 628 OFFCURVE",
-"231 737 OFFCURVE",
-"291 737 CURVE SMOOTH",
-"326 737 OFFCURVE",
-"337 706 OFFCURVE",
-"337 672 CURVE SMOOTH",
-"337 586 OFFCURVE",
-"305 484 OFFCURVE",
-"245 484 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"234 457 LINE SMOOTH",
 "332 457 OFFCURVE",
 "422 554 OFFCURVE",
 "422 645 CURVE SMOOTH",
@@ -20699,6 +24485,23 @@ nodes = (
 "163 457 OFFCURVE",
 "234 457 CURVE SMOOTH"
 );
+},
+{
+closed = 1;
+nodes = (
+"210 484 OFFCURVE",
+"199 506 OFFCURVE",
+"199 549 CURVE SMOOTH",
+"199 628 OFFCURVE",
+"231 737 OFFCURVE",
+"291 737 CURVE SMOOTH",
+"326 737 OFFCURVE",
+"337 706 OFFCURVE",
+"337 672 CURVE SMOOTH",
+"337 586 OFFCURVE",
+"305 484 OFFCURVE",
+"245 484 CURVE SMOOTH"
+);
 }
 );
 width = 346;
@@ -20709,25 +24512,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"257 484 LINE SMOOTH",
-"227 484 OFFCURVE",
-"216 506 OFFCURVE",
-"216 549 CURVE SMOOTH",
-"216 628 OFFCURVE",
-"248 737 OFFCURVE",
-"315 737 CURVE SMOOTH",
-"343 737 OFFCURVE",
-"354 706 OFFCURVE",
-"354 672 CURVE SMOOTH",
-"354 586 OFFCURVE",
-"322 484 OFFCURVE",
-"257 484 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"251 457 LINE SMOOTH",
 "358 457 OFFCURVE",
 "453 554 OFFCURVE",
 "453 645 CURVE SMOOTH",
@@ -20741,6 +24525,23 @@ nodes = (
 "170 457 OFFCURVE",
 "251 457 CURVE SMOOTH"
 );
+},
+{
+closed = 1;
+nodes = (
+"227 484 OFFCURVE",
+"216 506 OFFCURVE",
+"216 549 CURVE SMOOTH",
+"216 628 OFFCURVE",
+"248 737 OFFCURVE",
+"315 737 CURVE SMOOTH",
+"343 737 OFFCURVE",
+"354 706 OFFCURVE",
+"354 672 CURVE SMOOTH",
+"354 586 OFFCURVE",
+"322 484 OFFCURVE",
+"257 484 CURVE SMOOTH"
+);
 }
 );
 width = 374;
@@ -20749,8 +24550,8 @@ width = 374;
 unicode = 00BA;
 },
 {
-glyphname = uni0394;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = Delta;
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -20769,9 +24570,9 @@ nodes = (
 {
 closed = 1;
 nodes = (
+"279 570 LINE",
 "478 37 LINE",
-"67 37 LINE",
-"279 570 LINE"
+"67 37 LINE"
 );
 }
 );
@@ -20794,9 +24595,9 @@ nodes = (
 {
 closed = 1;
 nodes = (
+"278 527 LINE",
 "469 73 LINE",
-"93 73 LINE",
-"278 527 LINE"
+"93 73 LINE"
 );
 }
 );
@@ -20806,8 +24607,8 @@ width = 700;
 unicode = 0394;
 },
 {
-glyphname = uni03A9;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = Omega;
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -20815,32 +24616,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"730 174 LINE",
-"707 174 LINE",
-"686 109 OFFCURVE",
-"672 95 OFFCURVE",
-"630 95 CURVE SMOOTH",
-"508 95 LINE",
-"508 99 LINE",
-"607 187 OFFCURVE",
-"694 269 OFFCURVE",
-"694 421 CURVE SMOOTH",
-"694 607 OFFCURVE",
-"565 733 OFFCURVE",
-"387 733 CURVE SMOOTH",
-"208 733 OFFCURVE",
-"72 606 OFFCURVE",
-"72 412 CURVE SMOOTH",
-"72 249 OFFCURVE",
-"168 165 OFFCURVE",
-"251 100 CURVE",
-"251 96 LINE",
-"144 96 LINE SMOOTH",
-"100 96 OFFCURVE",
-"84 112 OFFCURVE",
-"62 174 CURVE",
-"38 174 LINE",
-"63 0 LINE",
 "335 0 LINE",
 "345 23 LINE",
 "257 156 OFFCURVE",
@@ -20856,7 +24631,31 @@ nodes = (
 "514 160 OFFCURVE",
 "421 23 CURVE",
 "430 0 LINE",
-"701 0 LINE"
+"701 0 LINE",
+"730 174 LINE",
+"707 174 LINE",
+"686 109 OFFCURVE",
+"672 95 OFFCURVE",
+"630 95 CURVE SMOOTH",
+"508 99 LINE",
+"607 187 OFFCURVE",
+"694 269 OFFCURVE",
+"694 421 CURVE SMOOTH",
+"694 607 OFFCURVE",
+"565 733 OFFCURVE",
+"387 733 CURVE SMOOTH",
+"208 733 OFFCURVE",
+"72 606 OFFCURVE",
+"72 412 CURVE SMOOTH",
+"72 249 OFFCURVE",
+"168 165 OFFCURVE",
+"251 100 CURVE",
+"144 96 LINE SMOOTH",
+"100 96 OFFCURVE",
+"84 112 OFFCURVE",
+"62 174 CURVE",
+"38 174 LINE",
+"63 0 LINE"
 );
 }
 );
@@ -20868,6 +24667,22 @@ paths = (
 {
 closed = 1;
 nodes = (
+"365 0 LINE",
+"375 26 LINE",
+"326 132 OFFCURVE",
+"263 268 OFFCURVE",
+"263 399 CURVE SMOOTH",
+"263 626 OFFCURVE",
+"323 694 OFFCURVE",
+"415 694 CURVE SMOOTH",
+"506 694 OFFCURVE",
+"572 615 OFFCURVE",
+"572 402 CURVE SMOOTH",
+"572 267 OFFCURVE",
+"500 123 OFFCURVE",
+"458 26 CURVE",
+"468 0 LINE",
+"756 0 LINE",
 "788 189 LINE",
 "747 189 LINE",
 "724 127 OFFCURVE",
@@ -20891,23 +24706,7 @@ nodes = (
 "111 128 OFFCURVE",
 "87 189 CURVE",
 "48 189 LINE",
-"75 0 LINE",
-"365 0 LINE",
-"375 26 LINE",
-"326 132 OFFCURVE",
-"263 268 OFFCURVE",
-"263 399 CURVE SMOOTH",
-"263 626 OFFCURVE",
-"323 694 OFFCURVE",
-"415 694 CURVE SMOOTH",
-"506 694 OFFCURVE",
-"572 615 OFFCURVE",
-"572 402 CURVE SMOOTH",
-"572 267 OFFCURVE",
-"500 123 OFFCURVE",
-"458 26 CURVE",
-"468 0 LINE",
-"756 0 LINE"
+"75 0 LINE"
 );
 }
 );
@@ -20917,8 +24716,8 @@ width = 782;
 unicode = 03A9;
 },
 {
-glyphname = uni03BC;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = mu;
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -20926,33 +24725,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"514 450 LINE",
-"412 450 LINE",
-"341 154 LINE SMOOTH",
-"334 125 OFFCURVE",
-"331 101 OFFCURVE",
-"331 82 CURVE SMOOTH",
-"331 9 OFFCURVE",
-"373 -12 OFFCURVE",
-"412 -12 CURVE SMOOTH",
-"477 -12 OFFCURVE",
-"523 45 OFFCURVE",
-"564 142 CURVE",
-"544 151 LINE",
-"507 73 OFFCURVE",
-"472 30 OFFCURVE",
-"444 30 CURVE SMOOTH",
-"430 30 OFFCURVE",
-"424 41 OFFCURVE",
-"424 60 CURVE SMOOTH",
-"424 77 OFFCURVE",
-"429 106 OFFCURVE",
-"439 147 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
+"226 -12 OFFCURVE",
+"285 41 OFFCURVE",
+"327 96 CURVE",
+"334 96 LINE",
 "356 216 LINE",
 "327 113 OFFCURVE",
 "257 32 OFFCURVE",
@@ -20971,32 +24747,12 @@ nodes = (
 "56 70 CURVE SMOOTH",
 "56 12 OFFCURVE",
 "99 -12 OFFCURVE",
-"150 -12 CURVE SMOOTH",
-"226 -12 OFFCURVE",
-"285 41 OFFCURVE",
-"327 96 CURVE",
-"334 96 LINE"
+"150 -12 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"65 425 LINE",
-"224 425 LINE",
-"224 450 LINE",
-"65 450 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"65 126 LINE",
-"29 -59 OFFCURVE",
-"-41 -153 OFFCURVE",
-"-41 -217 CURVE SMOOTH",
-"-41 -248 OFFCURVE",
-"-24 -261 OFFCURVE",
-"1 -261 CURVE SMOOTH",
 "37 -261 OFFCURVE",
 "68 -236 OFFCURVE",
 "68 -174 CURVE SMOOTH",
@@ -21006,7 +24762,50 @@ nodes = (
 "60 -45 OFFCURVE",
 "62 -16 OFFCURVE",
 "68 21 CURVE",
-"72 21 LINE"
+"72 21 LINE",
+"65 126 LINE",
+"29 -59 OFFCURVE",
+"-41 -153 OFFCURVE",
+"-41 -217 CURVE SMOOTH",
+"-41 -248 OFFCURVE",
+"-24 -261 OFFCURVE",
+"1 -261 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"224 425 LINE",
+"224 450 LINE",
+"65 450 LINE",
+"65 425 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"477 -12 OFFCURVE",
+"523 45 OFFCURVE",
+"564 142 CURVE",
+"544 151 LINE",
+"507 73 OFFCURVE",
+"472 30 OFFCURVE",
+"444 30 CURVE SMOOTH",
+"430 30 OFFCURVE",
+"424 41 OFFCURVE",
+"424 60 CURVE SMOOTH",
+"424 77 OFFCURVE",
+"429 106 OFFCURVE",
+"439 147 CURVE SMOOTH",
+"514 450 LINE",
+"412 450 LINE",
+"341 154 LINE SMOOTH",
+"334 125 OFFCURVE",
+"331 101 OFFCURVE",
+"331 82 CURVE SMOOTH",
+"331 9 OFFCURVE",
+"373 -12 OFFCURVE",
+"412 -12 CURVE SMOOTH"
 );
 }
 );
@@ -21086,42 +24885,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"41 420 LINE",
-"215 420 LINE",
-"215 450 LINE",
-"41 450 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"559 450 LINE",
-"425 450 LINE",
-"351 153 LINE SMOOTH",
-"338 100 OFFCURVE",
-"335 86 OFFCURVE",
-"335 70 CURVE SMOOTH",
-"335 15 OFFCURVE",
-"370 -11 OFFCURVE",
-"422 -11 CURVE SMOOTH",
-"513 -11 OFFCURVE",
-"576 69 OFFCURVE",
-"602 152 CURVE",
-"577 161 LINE",
-"540 69 OFFCURVE",
-"499 41 OFFCURVE",
-"479 41 CURVE SMOOTH",
-"472 41 OFFCURVE",
-"467 45 OFFCURVE",
-"467 54 CURVE SMOOTH",
-"467 58 OFFCURVE",
-"468 70 OFFCURVE",
-"472 87 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
+"232 -11 OFFCURVE",
+"292 43 OFFCURVE",
+"332 98 CURVE",
+"339 98 LINE",
 "370 220 LINE",
 "339 108 OFFCURVE",
 "239 35 OFFCURVE",
@@ -21140,23 +24907,12 @@ nodes = (
 "50 69 CURVE SMOOTH",
 "50 13 OFFCURVE",
 "99 -11 OFFCURVE",
-"152 -11 CURVE SMOOTH",
-"232 -11 OFFCURVE",
-"292 43 OFFCURVE",
-"332 98 CURVE",
-"339 98 LINE"
+"152 -11 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"54 104 LINE",
-"13 -90 OFFCURVE",
-"-49 -153 OFFCURVE",
-"-49 -220 CURVE SMOOTH",
-"-49 -252 OFFCURVE",
-"-34 -277 OFFCURVE",
-"5 -277 CURVE SMOOTH",
 "48 -277 OFFCURVE",
 "81 -246 OFFCURVE",
 "81 -174 CURVE SMOOTH",
@@ -21166,7 +24922,50 @@ nodes = (
 "76 -38 OFFCURVE",
 "76 -17 OFFCURVE",
 "78 8 CURVE",
-"82 8 LINE"
+"82 8 LINE",
+"54 104 LINE",
+"13 -90 OFFCURVE",
+"-49 -153 OFFCURVE",
+"-49 -220 CURVE SMOOTH",
+"-49 -252 OFFCURVE",
+"-34 -277 OFFCURVE",
+"5 -277 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"215 420 LINE",
+"215 450 LINE",
+"41 450 LINE",
+"41 420 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"513 -11 OFFCURVE",
+"576 69 OFFCURVE",
+"602 152 CURVE",
+"577 161 LINE",
+"540 69 OFFCURVE",
+"499 41 OFFCURVE",
+"479 41 CURVE SMOOTH",
+"472 41 OFFCURVE",
+"467 45 OFFCURVE",
+"467 54 CURVE SMOOTH",
+"467 58 OFFCURVE",
+"468 70 OFFCURVE",
+"472 87 CURVE SMOOTH",
+"559 450 LINE",
+"425 450 LINE",
+"351 153 LINE SMOOTH",
+"338 100 OFFCURVE",
+"335 86 OFFCURVE",
+"335 70 CURVE SMOOTH",
+"335 15 OFFCURVE",
+"370 -11 OFFCURVE",
+"422 -11 CURVE SMOOTH"
 );
 }
 );
@@ -21177,7 +24976,7 @@ unicode = 03BC;
 },
 {
 glyphname = pi;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 12:51:23 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -21185,22 +24984,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"567 496 LINE",
-"550 472 OFFCURVE",
-"534 465 OFFCURVE",
-"489 465 CURVE SMOOTH",
-"208 465 LINE SMOOTH",
-"124 465 OFFCURVE",
-"79 438 OFFCURVE",
-"19 362 CURVE",
-"36 340 LINE",
-"80 369 OFFCURVE",
-"105 377 OFFCURVE",
-"168 377 CURVE",
-"168 272 OFFCURVE",
-"145 116 OFFCURVE",
-"70 9 CURVE",
-"78 -13 LINE",
 "98 -12 OFFCURVE",
 "126 -5 OFFCURVE",
 "151 6 CURVE",
@@ -21229,7 +25012,25 @@ nodes = (
 "471 324 OFFCURVE",
 "476 377 CURVE",
 "531 377 LINE",
-"582 490 LINE"
+"582 490 LINE",
+"567 496 LINE",
+"550 472 OFFCURVE",
+"534 465 OFFCURVE",
+"489 465 CURVE SMOOTH",
+"395 465 OFFCURVE",
+"302 465 OFFCURVE",
+"208 465 CURVE SMOOTH",
+"124 465 OFFCURVE",
+"79 438 OFFCURVE",
+"19 362 CURVE",
+"36 340 LINE",
+"80 369 OFFCURVE",
+"105 377 OFFCURVE",
+"168 377 CURVE",
+"168 272 OFFCURVE",
+"145 116 OFFCURVE",
+"70 9 CURVE",
+"78 -13 LINE"
 );
 }
 );
@@ -21241,24 +25042,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"599 509 LINE",
-"579 476 OFFCURVE",
-"566 474 OFFCURVE",
-"518 474 CURVE SMOOTH",
-"459 474 OFFCURVE",
-"292 477 OFFCURVE",
-"249 477 CURVE SMOOTH",
-"133 477 OFFCURVE",
-"101 455 OFFCURVE",
-"29 361 CURVE",
-"48 325 LINE",
-"97 354 OFFCURVE",
-"125 363 OFFCURVE",
-"187 363 CURVE",
-"187 266 OFFCURVE",
-"160 118 OFFCURVE",
-"84 12 CURVE",
-"93 -14 LINE",
 "116 -12 OFFCURVE",
 "144 -6 OFFCURVE",
 "174 6 CURVE",
@@ -21287,7 +25070,25 @@ nodes = (
 "516 295 OFFCURVE",
 "522 363 CURVE",
 "590 363 LINE",
-"633 500 LINE"
+"633 500 LINE",
+"599 509 LINE",
+"579 476 OFFCURVE",
+"566 474 OFFCURVE",
+"518 474 CURVE SMOOTH",
+"459 474 OFFCURVE",
+"292 477 OFFCURVE",
+"249 477 CURVE SMOOTH",
+"133 477 OFFCURVE",
+"101 455 OFFCURVE",
+"29 361 CURVE",
+"48 325 LINE",
+"97 354 OFFCURVE",
+"125 363 OFFCURVE",
+"187 363 CURVE",
+"187 266 OFFCURVE",
+"160 118 OFFCURVE",
+"84 12 CURVE",
+"93 -14 LINE"
 );
 }
 );
@@ -21298,7 +25099,7 @@ unicode = 03C0;
 },
 {
 glyphname = zero;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:52:36 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -21306,7 +25107,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"268 -11 LINE SMOOTH",
 "456 -11 OFFCURVE",
 "602 249 OFFCURVE",
 "602 445 CURVE SMOOTH",
@@ -21324,19 +25124,18 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"425 680 LINE SMOOTH",
-"472 680 OFFCURVE",
-"498 641 OFFCURVE",
-"498 560 CURVE SMOOTH",
-"498 416 OFFCURVE",
-"416 14 OFFCURVE",
-"257 14 CURVE SMOOTH",
 "218 14 OFFCURVE",
 "182 38 OFFCURVE",
 "182 126 CURVE SMOOTH",
 "182 266 OFFCURVE",
 "272 680 OFFCURVE",
-"425 680 CURVE SMOOTH"
+"425 680 CURVE SMOOTH",
+"472 680 OFFCURVE",
+"498 641 OFFCURVE",
+"498 560 CURVE SMOOTH",
+"498 416 OFFCURVE",
+"416 14 OFFCURVE",
+"257 14 CURVE SMOOTH"
 );
 }
 );
@@ -21348,7 +25147,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"268 -11 LINE SMOOTH",
 "472 -11 OFFCURVE",
 "625 249 OFFCURVE",
 "625 443 CURVE SMOOTH",
@@ -21366,19 +25164,18 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"422 675 LINE SMOOTH",
-"459 675 OFFCURVE",
-"481 646 OFFCURVE",
-"481 566 CURVE SMOOTH",
-"481 423 OFFCURVE",
-"410 19 OFFCURVE",
-"264 19 CURVE SMOOTH",
 "236 19 OFFCURVE",
 "205 34 OFFCURVE",
 "205 123 CURVE SMOOTH",
 "205 263 OFFCURVE",
 "283 675 OFFCURVE",
-"422 675 CURVE SMOOTH"
+"422 675 CURVE SMOOTH",
+"459 675 OFFCURVE",
+"481 646 OFFCURVE",
+"481 566 CURVE SMOOTH",
+"481 423 OFFCURVE",
+"410 19 OFFCURVE",
+"264 19 CURVE SMOOTH"
 );
 }
 );
@@ -21389,7 +25186,7 @@ unicode = 0030;
 },
 {
 glyphname = one;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -21397,28 +25194,28 @@ paths = (
 {
 closed = 1;
 nodes = (
+"207 0 LINE",
 "359 706 LINE",
 "247 706 LINE",
-"99 0 LINE",
-"207 0 LINE"
+"99 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"123 681 LINE",
-"352 681 LINE",
-"352 706 LINE",
-"123 706 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"2 0 LINE",
 "336 0 LINE",
 "336 25 LINE",
-"2 25 LINE"
+"2 25 LINE",
+"2 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"352 681 LINE",
+"352 706 LINE",
+"123 706 LINE",
+"123 681 LINE"
 );
 }
 );
@@ -21430,28 +25227,28 @@ paths = (
 {
 closed = 1;
 nodes = (
+"253 0 LINE",
 "405 706 LINE",
 "253 706 LINE",
-"105 0 LINE",
-"253 0 LINE"
+"105 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"109 671 LINE",
-"378 671 LINE",
-"378 706 LINE",
-"109 706 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"-12 0 LINE",
 "392 0 LINE",
 "392 35 LINE",
-"-12 35 LINE"
+"-12 35 LINE",
+"-12 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"378 671 LINE",
+"378 706 LINE",
+"109 706 LINE",
+"109 671 LINE"
 );
 }
 );
@@ -21462,7 +25259,7 @@ unicode = 0031;
 },
 {
 glyphname = two;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -21470,7 +25267,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"15 0 LINE",
 "441 0 LINE",
 "487 188 LINE",
 "462 188 LINE",
@@ -21507,7 +25303,8 @@ nodes = (
 "428 445 OFFCURVE",
 "370 354 OFFCURVE",
 "267 265 CURVE SMOOTH",
-"27 58 LINE"
+"27 58 LINE",
+"15 0 LINE"
 );
 }
 );
@@ -21519,7 +25316,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"-6 0 LINE",
 "458 0 LINE",
 "514 218 LINE",
 "482 218 LINE",
@@ -21556,7 +25352,8 @@ nodes = (
 "400 449 OFFCURVE",
 "365 354 OFFCURVE",
 "218 244 CURVE SMOOTH",
-"16 93 LINE"
+"16 93 LINE",
+"-6 0 LINE"
 );
 }
 );
@@ -21567,7 +25364,7 @@ unicode = 0032;
 },
 {
 glyphname = three;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:52:45 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -21575,40 +25372,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"263 390 LINE SMOOTH",
-"238 390 OFFCURVE",
-"216 396 OFFCURVE",
-"204 396 CURVE SMOOTH",
-"190 396 OFFCURVE",
-"177 388 OFFCURVE",
-"177 375 CURVE SMOOTH",
-"177 363 OFFCURVE",
-"186 354 OFFCURVE",
-"206 354 CURVE SMOOTH",
-"225 354 OFFCURVE",
-"241 363 OFFCURVE",
-"250 363 CURVE SMOOTH",
-"337 363 OFFCURVE",
-"386 332 OFFCURVE",
-"386 237 CURVE SMOOTH",
-"386 153 OFFCURVE",
-"347 12 OFFCURVE",
-"208 12 CURVE SMOOTH",
-"149 12 OFFCURVE",
-"93 38 OFFCURVE",
-"93 62 CURVE SMOOTH",
-"93 88 OFFCURVE",
-"155 81 OFFCURVE",
-"155 132 CURVE SMOOTH",
-"155 162 OFFCURVE",
-"133 184 OFFCURVE",
-"100 184 CURVE SMOOTH",
-"60 184 OFFCURVE",
-"35 154 OFFCURVE",
-"35 112 CURVE SMOOTH",
-"35 50 OFFCURVE",
-"91 -13 OFFCURVE",
-"218 -13 CURVE SMOOTH",
 "390 -13 OFFCURVE",
 "512 103 OFFCURVE",
 "512 211 CURVE SMOOTH",
@@ -21642,7 +25405,40 @@ nodes = (
 "434 594 CURVE SMOOTH",
 "434 517 OFFCURVE",
 "378 390 OFFCURVE",
-"263 390 CURVE SMOOTH"
+"263 390 CURVE SMOOTH",
+"238 390 OFFCURVE",
+"216 396 OFFCURVE",
+"204 396 CURVE SMOOTH",
+"190 396 OFFCURVE",
+"177 388 OFFCURVE",
+"177 375 CURVE SMOOTH",
+"177 363 OFFCURVE",
+"186 354 OFFCURVE",
+"206 354 CURVE SMOOTH",
+"225 354 OFFCURVE",
+"241 363 OFFCURVE",
+"250 363 CURVE SMOOTH",
+"337 363 OFFCURVE",
+"386 332 OFFCURVE",
+"386 237 CURVE SMOOTH",
+"386 153 OFFCURVE",
+"347 12 OFFCURVE",
+"208 12 CURVE SMOOTH",
+"149 12 OFFCURVE",
+"93 38 OFFCURVE",
+"93 62 CURVE SMOOTH",
+"93 88 OFFCURVE",
+"155 81 OFFCURVE",
+"155 132 CURVE SMOOTH",
+"155 162 OFFCURVE",
+"133 184 OFFCURVE",
+"100 184 CURVE SMOOTH",
+"60 184 OFFCURVE",
+"35 154 OFFCURVE",
+"35 112 CURVE SMOOTH",
+"35 50 OFFCURVE",
+"91 -13 OFFCURVE",
+"218 -13 CURVE SMOOTH"
 );
 }
 );
@@ -21654,40 +25450,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"245 395 LINE SMOOTH",
-"222 395 OFFCURVE",
-"198 401 OFFCURVE",
-"187 401 CURVE SMOOTH",
-"173 401 OFFCURVE",
-"160 391 OFFCURVE",
-"160 374 CURVE SMOOTH",
-"160 360 OFFCURVE",
-"169 349 OFFCURVE",
-"192 349 CURVE SMOOTH",
-"212 349 OFFCURVE",
-"211 358 OFFCURVE",
-"245 358 CURVE SMOOTH",
-"319 358 OFFCURVE",
-"349 317 OFFCURVE",
-"349 220 CURVE SMOOTH",
-"349 74 OFFCURVE",
-"280 17 OFFCURVE",
-"197 17 CURVE SMOOTH",
-"148 17 OFFCURVE",
-"86 37 OFFCURVE",
-"86 63 CURVE SMOOTH",
-"86 89 OFFCURVE",
-"148 84 OFFCURVE",
-"148 136 CURVE SMOOTH",
-"148 171 OFFCURVE",
-"120 194 OFFCURVE",
-"85 194 CURVE SMOOTH",
-"40 194 OFFCURVE",
-"18 156 OFFCURVE",
-"18 114 CURVE SMOOTH",
-"18 48 OFFCURVE",
-"74 -13 OFFCURVE",
-"211 -13 CURVE SMOOTH",
 "386 -13 OFFCURVE",
 "515 86 OFFCURVE",
 "515 205 CURVE SMOOTH",
@@ -21721,7 +25483,40 @@ nodes = (
 "397 598 CURVE SMOOTH",
 "397 517 OFFCURVE",
 "346 395 OFFCURVE",
-"245 395 CURVE SMOOTH"
+"245 395 CURVE SMOOTH",
+"222 395 OFFCURVE",
+"198 401 OFFCURVE",
+"187 401 CURVE SMOOTH",
+"173 401 OFFCURVE",
+"160 391 OFFCURVE",
+"160 374 CURVE SMOOTH",
+"160 360 OFFCURVE",
+"169 349 OFFCURVE",
+"192 349 CURVE SMOOTH",
+"212 349 OFFCURVE",
+"211 358 OFFCURVE",
+"245 358 CURVE SMOOTH",
+"319 358 OFFCURVE",
+"349 317 OFFCURVE",
+"349 220 CURVE SMOOTH",
+"349 74 OFFCURVE",
+"280 17 OFFCURVE",
+"197 17 CURVE SMOOTH",
+"148 17 OFFCURVE",
+"86 37 OFFCURVE",
+"86 63 CURVE SMOOTH",
+"86 89 OFFCURVE",
+"148 84 OFFCURVE",
+"148 136 CURVE SMOOTH",
+"148 171 OFFCURVE",
+"120 194 OFFCURVE",
+"85 194 CURVE SMOOTH",
+"40 194 OFFCURVE",
+"18 156 OFFCURVE",
+"18 114 CURVE SMOOTH",
+"18 48 OFFCURVE",
+"74 -13 OFFCURVE",
+"211 -13 CURVE SMOOTH"
 );
 }
 );
@@ -21732,7 +25527,7 @@ unicode = 0033;
 },
 {
 glyphname = four;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -21740,42 +25535,32 @@ paths = (
 {
 closed = 1;
 nodes = (
-"518 706 LINE",
-"464 706 LINE",
-"385 605 LINE",
-"258 0 LINE",
-"366 0 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"35 199 LINE",
 "62 220 LINE",
 "62 224 LINE",
 "373 565 LINE",
 "377 565 LINE",
 "481 681 LINE",
 "464 706 LINE",
-"18 224 LINE"
+"18 224 LINE",
+"35 199 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"168 0 LINE",
 "463 0 LINE",
 "463 25 LINE",
-"168 25 LINE"
+"168 25 LINE",
+"168 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"18 196 LINE",
 "527 196 LINE",
 "527 224 LINE",
-"18 224 LINE"
+"18 224 LINE",
+"18 196 LINE"
 );
 },
 {
@@ -21785,6 +25570,16 @@ nodes = (
 "565 289 LINE",
 "540 289 LINE",
 "495 108 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"366 0 LINE",
+"518 706 LINE",
+"464 706 LINE",
+"385 605 LINE",
+"258 0 LINE"
 );
 }
 );
@@ -21796,42 +25591,32 @@ paths = (
 {
 closed = 1;
 nodes = (
-"534 706 LINE",
-"460 706 LINE",
-"357 585 LINE",
-"234 0 LINE",
-"382 0 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"31 199 LINE",
 "58 220 LINE",
 "58 224 LINE",
 "343 537 LINE",
 "347 537 LINE",
 "477 681 LINE",
 "460 706 LINE",
-"14 224 LINE"
+"14 224 LINE",
+"31 199 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"164 0 LINE",
 "469 0 LINE",
 "469 30 LINE",
-"164 30 LINE"
+"164 30 LINE",
+"164 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"14 191 LINE",
 "533 191 LINE",
 "533 224 LINE",
-"14 224 LINE"
+"14 224 LINE",
+"14 191 LINE"
 );
 },
 {
@@ -21842,6 +25627,16 @@ nodes = (
 "541 289 LINE",
 "496 108 LINE"
 );
+},
+{
+closed = 1;
+nodes = (
+"382 0 LINE",
+"534 706 LINE",
+"460 706 LINE",
+"357 585 LINE",
+"234 0 LINE"
+);
 }
 );
 width = 572;
@@ -21851,7 +25646,7 @@ unicode = 0034;
 },
 {
 glyphname = five;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -21859,6 +25654,15 @@ paths = (
 {
 closed = 1;
 nodes = (
+"398 -8 OFFCURVE",
+"546 113 OFFCURVE",
+"546 246 CURVE SMOOTH",
+"546 350 OFFCURVE",
+"454 428 OFFCURVE",
+"309 428 CURVE SMOOTH",
+"269 428 OFFCURVE",
+"231 422 OFFCURVE",
+"182 407 CURVE",
 "178 411 LINE",
 "238 617 LINE",
 "535 617 LINE",
@@ -21893,16 +25697,7 @@ nodes = (
 "52 120 CURVE SMOOTH",
 "52 69 OFFCURVE",
 "101 -8 OFFCURVE",
-"233 -8 CURVE SMOOTH",
-"398 -8 OFFCURVE",
-"546 113 OFFCURVE",
-"546 246 CURVE SMOOTH",
-"546 350 OFFCURVE",
-"454 428 OFFCURVE",
-"309 428 CURVE SMOOTH",
-"269 428 OFFCURVE",
-"231 422 OFFCURVE",
-"182 407 CURVE"
+"233 -8 CURVE SMOOTH"
 );
 }
 );
@@ -21914,6 +25709,15 @@ paths = (
 {
 closed = 1;
 nodes = (
+"415 -11 OFFCURVE",
+"547 116 OFFCURVE",
+"547 242 CURVE SMOOTH",
+"547 351 OFFCURVE",
+"448 428 OFFCURVE",
+"292 428 CURVE SMOOTH",
+"249 428 OFFCURVE",
+"212 422 OFFCURVE",
+"163 407 CURVE",
 "159 411 LINE",
 "207 575 LINE",
 "534 575 LINE",
@@ -21948,16 +25752,7 @@ nodes = (
 "33 125 CURVE SMOOTH",
 "33 64 OFFCURVE",
 "82 -11 OFFCURVE",
-"227 -11 CURVE SMOOTH",
-"415 -11 OFFCURVE",
-"547 116 OFFCURVE",
-"547 242 CURVE SMOOTH",
-"547 351 OFFCURVE",
-"448 428 OFFCURVE",
-"292 428 CURVE SMOOTH",
-"249 428 OFFCURVE",
-"212 422 OFFCURVE",
-"163 407 CURVE"
+"227 -11 CURVE SMOOTH"
 );
 }
 );
@@ -21968,7 +25763,7 @@ unicode = 0035;
 },
 {
 glyphname = six;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:52:55 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -21976,48 +25771,46 @@ paths = (
 {
 closed = 1;
 nodes = (
-"272 12 LINE",
-"421 12 OFFCURVE",
-"461 225 OFFCURVE",
-"461 324 CURVE SMOOTH",
-"461 401 OFFCURVE",
-"437 437 OFFCURVE",
-"379 437 CURVE SMOOTH",
-"329 437 OFFCURVE",
-"274 410 OFFCURVE",
-"219 352 CURVE",
-"201 306 OFFCURVE",
-"179 220 OFFCURVE",
-"179 142 CURVE SMOOTH",
-"179 47 OFFCURVE",
-"211 12 OFFCURVE",
-"272 12 CURVE SMOOTH"
+"441 -13 OFFCURVE",
+"576 137 OFFCURVE",
+"576 277 CURVE SMOOTH",
+"576 384 OFFCURVE",
+"498 462 OFFCURVE",
+"385 462 CURVE SMOOTH",
+"339 462 OFFCURVE",
+"301 449 OFFCURVE",
+"248 414 CURVE",
+"245 417 LINE",
+"274 548 OFFCURVE",
+"404 686 OFFCURVE",
+"582 706 CURVE",
+"582 731 LINE",
+"355 731 OFFCURVE",
+"72 477 OFFCURVE",
+"72 221 CURVE SMOOTH",
+"72 86 OFFCURVE",
+"150 -13 OFFCURVE",
+"280 -13 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"385 462 LINE SMOOTH",
-"498 462 OFFCURVE",
-"576 384 OFFCURVE",
-"576 277 CURVE SMOOTH",
-"576 137 OFFCURVE",
-"441 -13 OFFCURVE",
-"280 -13 CURVE SMOOTH",
-"150 -13 OFFCURVE",
-"72 86 OFFCURVE",
-"72 221 CURVE SMOOTH",
-"72 477 OFFCURVE",
-"355 731 OFFCURVE",
-"582 731 CURVE",
-"582 706 LINE",
-"404 686 OFFCURVE",
-"274 548 OFFCURVE",
-"245 417 CURVE",
-"248 414 LINE",
-"301 449 OFFCURVE",
-"339 462 OFFCURVE",
-"385 462 CURVE SMOOTH"
+"211 12 OFFCURVE",
+"179 47 OFFCURVE",
+"179 142 CURVE SMOOTH",
+"179 220 OFFCURVE",
+"201 306 OFFCURVE",
+"219 352 CURVE",
+"274 410 OFFCURVE",
+"329 437 OFFCURVE",
+"379 437 CURVE SMOOTH",
+"437 437 OFFCURVE",
+"461 401 OFFCURVE",
+"461 324 CURVE SMOOTH",
+"461 225 OFFCURVE",
+"421 12 OFFCURVE",
+"272 12 CURVE"
 );
 }
 );
@@ -22029,48 +25822,46 @@ paths = (
 {
 closed = 1;
 nodes = (
-"276 17 LINE SMOOTH",
-"402 17 OFFCURVE",
-"436 246 OFFCURVE",
-"436 342 CURVE SMOOTH",
-"436 391 OFFCURVE",
-"427 427 OFFCURVE",
-"377 427 CURVE SMOOTH",
-"337 427 OFFCURVE",
-"295 403 OFFCURVE",
-"252 352 CURVE",
-"234 308 OFFCURVE",
-"212 212 OFFCURVE",
-"212 123 CURVE SMOOTH",
-"212 54 OFFCURVE",
-"225 17 OFFCURVE",
-"276 17 CURVE SMOOTH"
+"451 -13 OFFCURVE",
+"596 127 OFFCURVE",
+"596 267 CURVE SMOOTH",
+"596 373 OFFCURVE",
+"514 462 OFFCURVE",
+"397 462 CURVE SMOOTH",
+"352 462 OFFCURVE",
+"315 449 OFFCURVE",
+"271 414 CURVE",
+"268 417 LINE",
+"297 543 OFFCURVE",
+"427 677 OFFCURVE",
+"605 696 CURVE",
+"605 731 LINE",
+"362 731 OFFCURVE",
+"55 503 OFFCURVE",
+"55 228 CURVE SMOOTH",
+"55 83 OFFCURVE",
+"141 -13 OFFCURVE",
+"281 -13 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"397 462 LINE SMOOTH",
-"514 462 OFFCURVE",
-"596 373 OFFCURVE",
-"596 267 CURVE SMOOTH",
-"596 127 OFFCURVE",
-"451 -13 OFFCURVE",
-"281 -13 CURVE SMOOTH",
-"141 -13 OFFCURVE",
-"55 83 OFFCURVE",
-"55 228 CURVE SMOOTH",
-"55 503 OFFCURVE",
-"362 731 OFFCURVE",
-"605 731 CURVE",
-"605 696 LINE",
-"427 677 OFFCURVE",
-"297 543 OFFCURVE",
-"268 417 CURVE",
-"271 414 LINE",
-"315 449 OFFCURVE",
-"352 462 OFFCURVE",
-"397 462 CURVE SMOOTH"
+"225 17 OFFCURVE",
+"212 54 OFFCURVE",
+"212 123 CURVE SMOOTH",
+"212 212 OFFCURVE",
+"234 308 OFFCURVE",
+"252 352 CURVE",
+"295 403 OFFCURVE",
+"337 427 OFFCURVE",
+"377 427 CURVE SMOOTH",
+"427 427 OFFCURVE",
+"436 391 OFFCURVE",
+"436 342 CURVE SMOOTH",
+"436 246 OFFCURVE",
+"402 17 OFFCURVE",
+"276 17 CURVE SMOOTH"
 );
 }
 );
@@ -22081,7 +25872,7 @@ unicode = 0036;
 },
 {
 glyphname = seven;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -22089,6 +25880,16 @@ paths = (
 {
 closed = 1;
 nodes = (
+"285 -10 OFFCURVE",
+"313 25 OFFCURVE",
+"313 78 CURVE SMOOTH",
+"313 102 OFFCURVE",
+"307 138 OFFCURVE",
+"307 165 CURVE SMOOTH",
+"307 213 OFFCURVE",
+"327 279 OFFCURVE",
+"397 378 CURVE SMOOTH",
+"610 681 LINE",
 "613 706 LINE",
 "192 706 LINE",
 "101 518 LINE",
@@ -22104,17 +25905,7 @@ nodes = (
 "179 60 CURVE SMOOTH",
 "179 9 OFFCURVE",
 "205 -10 OFFCURVE",
-"239 -10 CURVE SMOOTH",
-"285 -10 OFFCURVE",
-"313 25 OFFCURVE",
-"313 78 CURVE SMOOTH",
-"313 102 OFFCURVE",
-"307 138 OFFCURVE",
-"307 165 CURVE SMOOTH",
-"307 213 OFFCURVE",
-"327 279 OFFCURVE",
-"397 378 CURVE SMOOTH",
-"610 681 LINE"
+"239 -10 CURVE SMOOTH"
 );
 }
 );
@@ -22126,6 +25917,16 @@ paths = (
 {
 closed = 1;
 nodes = (
+"287 -10 OFFCURVE",
+"327 28 OFFCURVE",
+"327 90 CURVE SMOOTH",
+"327 122 OFFCURVE",
+"316 146 OFFCURVE",
+"316 192 CURVE SMOOTH",
+"316 232 OFFCURVE",
+"324 289 OFFCURVE",
+"392 378 CURVE SMOOTH",
+"615 671 LINE",
 "618 706 LINE",
 "177 706 LINE",
 "76 498 LINE",
@@ -22141,17 +25942,7 @@ nodes = (
 "142 77 CURVE SMOOTH",
 "142 14 OFFCURVE",
 "176 -10 OFFCURVE",
-"225 -10 CURVE SMOOTH",
-"287 -10 OFFCURVE",
-"327 28 OFFCURVE",
-"327 90 CURVE SMOOTH",
-"327 122 OFFCURVE",
-"316 146 OFFCURVE",
-"316 192 CURVE SMOOTH",
-"316 232 OFFCURVE",
-"324 289 OFFCURVE",
-"392 378 CURVE SMOOTH",
-"615 671 LINE"
+"225 -10 CURVE SMOOTH"
 );
 }
 );
@@ -22162,7 +25953,7 @@ unicode = 0037;
 },
 {
 glyphname = eight;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 12:56:48 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -22170,25 +25961,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"352 349 LINE SMOOTH",
-"414 349 OFFCURVE",
-"448 308 OFFCURVE",
-"448 233 CURVE SMOOTH",
-"448 154 OFFCURVE",
-"410 12 OFFCURVE",
-"277 12 CURVE SMOOTH",
-"212 12 OFFCURVE",
-"180 46 OFFCURVE",
-"180 126 CURVE SMOOTH",
-"180 246 OFFCURVE",
-"253 349 OFFCURVE",
-"352 349 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"283 -13 LINE SMOOTH",
 "443 -13 OFFCURVE",
 "569 90 OFFCURVE",
 "569 197 CURVE SMOOTH",
@@ -22206,39 +25978,55 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"423 690 LINE SMOOTH",
-"477 690 OFFCURVE",
-"506 656 OFFCURVE",
-"506 589 CURVE SMOOTH",
-"506 517 OFFCURVE",
-"473 374 OFFCURVE",
-"357 374 CURVE SMOOTH",
-"299 374 OFFCURVE",
-"265 409 OFFCURVE",
-"265 487 CURVE SMOOTH",
-"265 596 OFFCURVE",
-"332 690 OFFCURVE",
-"423 690 CURVE SMOOTH"
+"212 12 OFFCURVE",
+"180 46 OFFCURVE",
+"180 126 CURVE SMOOTH",
+"180 246 OFFCURVE",
+"253 349 OFFCURVE",
+"352 349 CURVE SMOOTH",
+"414 349 OFFCURVE",
+"448 308 OFFCURVE",
+"448 233 CURVE SMOOTH",
+"448 154 OFFCURVE",
+"410 12 OFFCURVE",
+"277 12 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
 "413 361 LINE",
-"413 365 LINE",
-"532 385 OFFCURVE",
-"617 474 OFFCURVE",
-"617 559 CURVE SMOOTH",
-"617 640 OFFCURVE",
-"539 711 OFFCURVE",
-"416 711 CURVE SMOOTH",
-"279 711 OFFCURVE",
-"156 624 OFFCURVE",
-"156 520 CURVE SMOOTH",
-"156 453 OFFCURVE",
-"207 394 OFFCURVE",
-"289 371 CURVE",
-"289 367 LINE"
+"532 381 OFFCURVE",
+"617 470 OFFCURVE",
+"617 555 CURVE SMOOTH",
+"617 636 OFFCURVE",
+"539 707 OFFCURVE",
+"416 707 CURVE",
+"279 707 OFFCURVE",
+"156 620 OFFCURVE",
+"156 516 CURVE SMOOTH",
+"156 449 OFFCURVE",
+"207 390 OFFCURVE",
+"289 367 CURVE",
+"289 363 LINE",
+"413 357 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"299 370 OFFCURVE",
+"265 405 OFFCURVE",
+"265 483 CURVE SMOOTH",
+"265 592 OFFCURVE",
+"332 686 OFFCURVE",
+"423 686 CURVE SMOOTH",
+"477 686 OFFCURVE",
+"506 652 OFFCURVE",
+"506 585 CURVE SMOOTH",
+"506 513 OFFCURVE",
+"473 370 OFFCURVE",
+"357 370 CURVE SMOOTH"
 );
 }
 );
@@ -22250,25 +26038,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"348 344 LINE SMOOTH",
-"397 344 OFFCURVE",
-"423 305 OFFCURVE",
-"423 235 CURVE SMOOTH",
-"423 156 OFFCURVE",
-"389 22 OFFCURVE",
-"278 22 CURVE SMOOTH",
-"226 22 OFFCURVE",
-"197 52 OFFCURVE",
-"197 126 CURVE SMOOTH",
-"197 242 OFFCURVE",
-"268 344 OFFCURVE",
-"348 344 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"281 -13 LINE SMOOTH",
 "451 -13 OFFCURVE",
 "580 90 OFFCURVE",
 "580 197 CURVE SMOOTH",
@@ -22286,25 +26055,23 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"423 685 LINE SMOOTH",
-"457 685 OFFCURVE",
-"481 667 OFFCURVE",
-"481 606 CURVE SMOOTH",
-"481 540 OFFCURVE",
-"453 384 OFFCURVE",
-"352 384 CURVE SMOOTH",
-"311 384 OFFCURVE",
-"292 410 OFFCURVE",
-"292 469 CURVE SMOOTH",
-"292 555 OFFCURVE",
-"332 685 OFFCURVE",
-"423 685 CURVE SMOOTH"
+"226 22 OFFCURVE",
+"197 52 OFFCURVE",
+"197 126 CURVE SMOOTH",
+"197 242 OFFCURVE",
+"268 344 OFFCURVE",
+"348 344 CURVE SMOOTH",
+"397 344 OFFCURVE",
+"423 305 OFFCURVE",
+"423 235 CURVE SMOOTH",
+"423 156 OFFCURVE",
+"389 22 OFFCURVE",
+"278 22 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"414 361 LINE",
 "414 365 LINE",
 "539 385 OFFCURVE",
 "628 474 OFFCURVE",
@@ -22318,7 +26085,25 @@ nodes = (
 "137 453 OFFCURVE",
 "192 393 OFFCURVE",
 "280 370 CURVE",
-"280 366 LINE"
+"280 366 LINE",
+"414 361 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"311 384 OFFCURVE",
+"292 410 OFFCURVE",
+"292 469 CURVE SMOOTH",
+"292 555 OFFCURVE",
+"332 685 OFFCURVE",
+"423 685 CURVE SMOOTH",
+"457 685 OFFCURVE",
+"481 667 OFFCURVE",
+"481 606 CURVE SMOOTH",
+"481 540 OFFCURVE",
+"453 384 OFFCURVE",
+"352 384 CURVE SMOOTH"
 );
 }
 );
@@ -22329,7 +26114,7 @@ unicode = 0038;
 },
 {
 glyphname = nine;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:53:04 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -22337,48 +26122,46 @@ paths = (
 {
 closed = 1;
 nodes = (
-"410 706 LINE",
-"261 706 OFFCURVE",
-"221 493 OFFCURVE",
-"221 394 CURVE SMOOTH",
-"221 317 OFFCURVE",
-"245 281 OFFCURVE",
-"303 281 CURVE SMOOTH",
-"353 281 OFFCURVE",
-"408 308 OFFCURVE",
-"463 366 CURVE",
-"481 412 OFFCURVE",
-"503 498 OFFCURVE",
-"503 576 CURVE SMOOTH",
-"503 671 OFFCURVE",
-"471 706 OFFCURVE",
-"410 706 CURVE"
+"327 -13 OFFCURVE",
+"610 241 OFFCURVE",
+"610 497 CURVE SMOOTH",
+"610 632 OFFCURVE",
+"532 731 OFFCURVE",
+"402 731 CURVE SMOOTH",
+"241 731 OFFCURVE",
+"106 581 OFFCURVE",
+"106 441 CURVE SMOOTH",
+"106 334 OFFCURVE",
+"184 256 OFFCURVE",
+"297 256 CURVE",
+"343 256 OFFCURVE",
+"381 269 OFFCURVE",
+"434 304 CURVE",
+"437 301 LINE",
+"408 170 OFFCURVE",
+"278 32 OFFCURVE",
+"100 12 CURVE",
+"100 -13 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"297 256 LINE",
-"184 256 OFFCURVE",
-"106 334 OFFCURVE",
-"106 441 CURVE SMOOTH",
-"106 581 OFFCURVE",
-"241 731 OFFCURVE",
-"402 731 CURVE SMOOTH",
-"532 731 OFFCURVE",
-"610 632 OFFCURVE",
-"610 497 CURVE SMOOTH",
-"610 241 OFFCURVE",
-"327 -13 OFFCURVE",
-"100 -13 CURVE",
-"100 12 LINE",
-"278 32 OFFCURVE",
-"408 170 OFFCURVE",
-"437 301 CURVE",
-"434 304 LINE",
-"381 269 OFFCURVE",
-"343 256 OFFCURVE",
-"297 256 CURVE"
+"245 281 OFFCURVE",
+"221 317 OFFCURVE",
+"221 394 CURVE SMOOTH",
+"221 493 OFFCURVE",
+"261 706 OFFCURVE",
+"410 706 CURVE",
+"471 706 OFFCURVE",
+"503 671 OFFCURVE",
+"503 576 CURVE SMOOTH",
+"503 498 OFFCURVE",
+"481 412 OFFCURVE",
+"463 366 CURVE",
+"408 308 OFFCURVE",
+"353 281 OFFCURVE",
+"303 281 CURVE SMOOTH"
 );
 }
 );
@@ -22390,48 +26173,46 @@ paths = (
 {
 closed = 1;
 nodes = (
-"417 701 LINE",
-"291 701 OFFCURVE",
-"257 472 OFFCURVE",
-"257 376 CURVE SMOOTH",
-"257 327 OFFCURVE",
-"266 291 OFFCURVE",
-"316 291 CURVE SMOOTH",
-"356 291 OFFCURVE",
-"398 315 OFFCURVE",
-"441 366 CURVE",
-"459 410 OFFCURVE",
-"481 506 OFFCURVE",
-"481 595 CURVE SMOOTH",
-"481 664 OFFCURVE",
-"468 701 OFFCURVE",
-"417 701 CURVE"
+"331 -13 OFFCURVE",
+"638 215 OFFCURVE",
+"638 490 CURVE SMOOTH",
+"638 635 OFFCURVE",
+"552 731 OFFCURVE",
+"412 731 CURVE SMOOTH",
+"242 731 OFFCURVE",
+"97 591 OFFCURVE",
+"97 451 CURVE SMOOTH",
+"97 345 OFFCURVE",
+"179 256 OFFCURVE",
+"296 256 CURVE",
+"341 256 OFFCURVE",
+"378 269 OFFCURVE",
+"422 304 CURVE",
+"425 301 LINE",
+"396 175 OFFCURVE",
+"266 41 OFFCURVE",
+"88 22 CURVE",
+"88 -13 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"296 256 LINE",
-"179 256 OFFCURVE",
-"97 345 OFFCURVE",
-"97 451 CURVE SMOOTH",
-"97 591 OFFCURVE",
-"242 731 OFFCURVE",
-"412 731 CURVE SMOOTH",
-"552 731 OFFCURVE",
-"638 635 OFFCURVE",
-"638 490 CURVE SMOOTH",
-"638 215 OFFCURVE",
-"331 -13 OFFCURVE",
-"88 -13 CURVE",
-"88 22 LINE",
-"266 41 OFFCURVE",
-"396 175 OFFCURVE",
-"425 301 CURVE",
-"422 304 LINE",
-"378 269 OFFCURVE",
-"341 256 OFFCURVE",
-"296 256 CURVE"
+"266 291 OFFCURVE",
+"257 327 OFFCURVE",
+"257 376 CURVE SMOOTH",
+"257 472 OFFCURVE",
+"291 701 OFFCURVE",
+"417 701 CURVE",
+"468 701 OFFCURVE",
+"481 664 OFFCURVE",
+"481 595 CURVE SMOOTH",
+"481 506 OFFCURVE",
+"459 410 OFFCURVE",
+"441 366 CURVE",
+"398 315 OFFCURVE",
+"356 291 OFFCURVE",
+"316 291 CURVE SMOOTH"
 );
 }
 );
@@ -22442,7 +26223,7 @@ unicode = 0039;
 },
 {
 glyphname = zero.denominator;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 background = {
@@ -22488,7 +26269,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"157 -5 LINE SMOOTH",
 "271 -5 OFFCURVE",
 "356 138 OFFCURVE",
 "356 245 CURVE SMOOTH",
@@ -22506,19 +26286,18 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"241 372 LINE SMOOTH",
-"260 372 OFFCURVE",
-"271 358 OFFCURVE",
-"271 314 CURVE SMOOTH",
-"271 235 OFFCURVE",
-"234 12 OFFCURVE",
-"156 12 CURVE SMOOTH",
 "142 12 OFFCURVE",
 "126 19 OFFCURVE",
 "126 68 CURVE SMOOTH",
 "126 145 OFFCURVE",
 "167 372 OFFCURVE",
-"241 372 CURVE SMOOTH"
+"241 372 CURVE SMOOTH",
+"260 372 OFFCURVE",
+"271 358 OFFCURVE",
+"271 314 CURVE SMOOTH",
+"271 235 OFFCURVE",
+"234 12 OFFCURVE",
+"156 12 CURVE SMOOTH"
 );
 }
 );
@@ -22530,7 +26309,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"167 -5 LINE SMOOTH",
 "281 -5 OFFCURVE",
 "366 138 OFFCURVE",
 "366 245 CURVE SMOOTH",
@@ -22548,19 +26326,18 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"251 372 LINE SMOOTH",
-"270 372 OFFCURVE",
-"281 358 OFFCURVE",
-"281 314 CURVE SMOOTH",
-"281 235 OFFCURVE",
-"244 12 OFFCURVE",
-"166 12 CURVE SMOOTH",
 "152 12 OFFCURVE",
 "136 19 OFFCURVE",
 "136 68 CURVE SMOOTH",
 "136 145 OFFCURVE",
 "177 372 OFFCURVE",
-"251 372 CURVE SMOOTH"
+"251 372 CURVE SMOOTH",
+"270 372 OFFCURVE",
+"281 358 OFFCURVE",
+"281 314 CURVE SMOOTH",
+"281 235 OFFCURVE",
+"244 12 OFFCURVE",
+"166 12 CURVE SMOOTH"
 );
 }
 );
@@ -22570,7 +26347,7 @@ width = 411;
 },
 {
 glyphname = one.denominator;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 background = {
@@ -22597,16 +26374,16 @@ paths = (
 {
 closed = 1;
 nodes = (
-"52 368 LINE",
-"128 368 LINE",
-"57 21 LINE",
-"-14 21 LINE",
-"-14 0 LINE",
 "217 0 LINE",
 "217 21 LINE",
 "143 21 LINE",
 "223 389 LINE",
-"52 389 LINE"
+"52 389 LINE",
+"52 368 LINE",
+"128 368 LINE",
+"57 21 LINE",
+"-14 21 LINE",
+"-14 0 LINE"
 );
 }
 );
@@ -22618,16 +26395,16 @@ paths = (
 {
 closed = 1;
 nodes = (
-"62 368 LINE",
-"138 368 LINE",
-"67 21 LINE",
-"-4 21 LINE",
-"-4 0 LINE",
 "227 0 LINE",
 "227 21 LINE",
 "153 21 LINE",
 "233 389 LINE",
-"62 389 LINE"
+"62 389 LINE",
+"62 368 LINE",
+"138 368 LINE",
+"67 21 LINE",
+"-4 21 LINE",
+"-4 0 LINE"
 );
 }
 );
@@ -22637,7 +26414,7 @@ width = 298;
 },
 {
 glyphname = two.denominator;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 background = {
@@ -22698,7 +26475,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"-1 0 LINE",
 "258 0 LINE",
 "290 126 LINE",
 "272 126 LINE",
@@ -22735,7 +26511,8 @@ nodes = (
 "220 248 OFFCURVE",
 "206 193 OFFCURVE",
 "117 131 CURVE SMOOTH",
-"12 58 LINE"
+"12 58 LINE",
+"-1 0 LINE"
 );
 }
 );
@@ -22747,7 +26524,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"9 0 LINE",
 "268 0 LINE",
 "300 126 LINE",
 "282 126 LINE",
@@ -22784,7 +26560,8 @@ nodes = (
 "230 248 OFFCURVE",
 "216 193 OFFCURVE",
 "127 131 CURVE SMOOTH",
-"22 58 LINE"
+"22 58 LINE",
+"9 0 LINE"
 );
 }
 );
@@ -22794,7 +26571,7 @@ width = 370;
 },
 {
 glyphname = three.denominator;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 background = {
@@ -22881,40 +26658,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"120 218 LINE SMOOTH",
-"108 218 OFFCURVE",
-"95 221 OFFCURVE",
-"89 221 CURVE SMOOTH",
-"81 221 OFFCURVE",
-"74 215 OFFCURVE",
-"74 205 CURVE SMOOTH",
-"74 197 OFFCURVE",
-"79 190 OFFCURVE",
-"92 190 CURVE SMOOTH",
-"103 190 OFFCURVE",
-"100 195 OFFCURVE",
-"122 195 CURVE SMOOTH",
-"161 195 OFFCURVE",
-"174 171 OFFCURVE",
-"174 117 CURVE SMOOTH",
-"174 25 OFFCURVE",
-"132 9 OFFCURVE",
-"95 9 CURVE SMOOTH",
-"70 9 OFFCURVE",
-"35 19 OFFCURVE",
-"35 34 CURVE SMOOTH",
-"35 48 OFFCURVE",
-"69 46 OFFCURVE",
-"69 75 CURVE SMOOTH",
-"69 95 OFFCURVE",
-"53 108 OFFCURVE",
-"33 108 CURVE SMOOTH",
-"8 108 OFFCURVE",
-"-3 85 OFFCURVE",
-"-3 62 CURVE SMOOTH",
-"-3 25 OFFCURVE",
-"27 -8 OFFCURVE",
-"104 -8 CURVE SMOOTH",
 "200 -8 OFFCURVE",
 "271 43 OFFCURVE",
 "271 111 CURVE SMOOTH",
@@ -22948,7 +26691,40 @@ nodes = (
 "201 329 CURVE SMOOTH",
 "201 284 OFFCURVE",
 "174 218 OFFCURVE",
-"120 218 CURVE SMOOTH"
+"120 218 CURVE SMOOTH",
+"108 218 OFFCURVE",
+"95 221 OFFCURVE",
+"89 221 CURVE SMOOTH",
+"81 221 OFFCURVE",
+"74 215 OFFCURVE",
+"74 205 CURVE SMOOTH",
+"74 197 OFFCURVE",
+"79 190 OFFCURVE",
+"92 190 CURVE SMOOTH",
+"103 190 OFFCURVE",
+"100 195 OFFCURVE",
+"122 195 CURVE SMOOTH",
+"161 195 OFFCURVE",
+"174 171 OFFCURVE",
+"174 117 CURVE SMOOTH",
+"174 25 OFFCURVE",
+"132 9 OFFCURVE",
+"95 9 CURVE SMOOTH",
+"70 9 OFFCURVE",
+"35 19 OFFCURVE",
+"35 34 CURVE SMOOTH",
+"35 48 OFFCURVE",
+"69 46 OFFCURVE",
+"69 75 CURVE SMOOTH",
+"69 95 OFFCURVE",
+"53 108 OFFCURVE",
+"33 108 CURVE SMOOTH",
+"8 108 OFFCURVE",
+"-3 85 OFFCURVE",
+"-3 62 CURVE SMOOTH",
+"-3 25 OFFCURVE",
+"27 -8 OFFCURVE",
+"104 -8 CURVE SMOOTH"
 );
 }
 );
@@ -22960,40 +26736,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"130 218 LINE SMOOTH",
-"118 218 OFFCURVE",
-"105 221 OFFCURVE",
-"99 221 CURVE SMOOTH",
-"91 221 OFFCURVE",
-"84 215 OFFCURVE",
-"84 205 CURVE SMOOTH",
-"84 197 OFFCURVE",
-"89 190 OFFCURVE",
-"102 190 CURVE SMOOTH",
-"113 190 OFFCURVE",
-"110 195 OFFCURVE",
-"132 195 CURVE SMOOTH",
-"171 195 OFFCURVE",
-"184 171 OFFCURVE",
-"184 117 CURVE SMOOTH",
-"184 25 OFFCURVE",
-"142 9 OFFCURVE",
-"105 9 CURVE SMOOTH",
-"80 9 OFFCURVE",
-"45 19 OFFCURVE",
-"45 34 CURVE SMOOTH",
-"45 48 OFFCURVE",
-"79 46 OFFCURVE",
-"79 75 CURVE SMOOTH",
-"79 95 OFFCURVE",
-"63 108 OFFCURVE",
-"43 108 CURVE SMOOTH",
-"18 108 OFFCURVE",
-"7 85 OFFCURVE",
-"7 62 CURVE SMOOTH",
-"7 25 OFFCURVE",
-"37 -8 OFFCURVE",
-"114 -8 CURVE SMOOTH",
 "210 -8 OFFCURVE",
 "281 43 OFFCURVE",
 "281 111 CURVE SMOOTH",
@@ -23027,7 +26769,40 @@ nodes = (
 "211 329 CURVE SMOOTH",
 "211 284 OFFCURVE",
 "184 218 OFFCURVE",
-"130 218 CURVE SMOOTH"
+"130 218 CURVE SMOOTH",
+"118 218 OFFCURVE",
+"105 221 OFFCURVE",
+"99 221 CURVE SMOOTH",
+"91 221 OFFCURVE",
+"84 215 OFFCURVE",
+"84 205 CURVE SMOOTH",
+"84 197 OFFCURVE",
+"89 190 OFFCURVE",
+"102 190 CURVE SMOOTH",
+"113 190 OFFCURVE",
+"110 195 OFFCURVE",
+"132 195 CURVE SMOOTH",
+"171 195 OFFCURVE",
+"184 171 OFFCURVE",
+"184 117 CURVE SMOOTH",
+"184 25 OFFCURVE",
+"142 9 OFFCURVE",
+"105 9 CURVE SMOOTH",
+"80 9 OFFCURVE",
+"45 19 OFFCURVE",
+"45 34 CURVE SMOOTH",
+"45 48 OFFCURVE",
+"79 46 OFFCURVE",
+"79 75 CURVE SMOOTH",
+"79 95 OFFCURVE",
+"63 108 OFFCURVE",
+"43 108 CURVE SMOOTH",
+"18 108 OFFCURVE",
+"7 85 OFFCURVE",
+"7 62 CURVE SMOOTH",
+"7 25 OFFCURVE",
+"37 -8 OFFCURVE",
+"114 -8 CURVE SMOOTH"
 );
 }
 );
@@ -23037,7 +26812,7 @@ width = 357;
 },
 {
 glyphname = four.denominator;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 background = {
@@ -23083,11 +26858,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"13 104 LINE",
-"152 104 LINE",
-"133 17 LINE",
-"95 17 LINE",
-"95 0 LINE",
 "263 0 LINE",
 "263 17 LINE",
 "220 17 LINE",
@@ -23101,7 +26871,12 @@ nodes = (
 "243 123 LINE",
 "300 389 LINE",
 "257 389 LINE",
-"13 123 LINE"
+"13 123 LINE",
+"13 104 LINE",
+"152 104 LINE",
+"133 17 LINE",
+"95 17 LINE",
+"95 0 LINE"
 );
 },
 {
@@ -23122,11 +26897,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"23 104 LINE",
-"162 104 LINE",
-"143 17 LINE",
-"105 17 LINE",
-"105 0 LINE",
 "273 0 LINE",
 "273 17 LINE",
 "230 17 LINE",
@@ -23140,7 +26910,12 @@ nodes = (
 "253 123 LINE",
 "310 389 LINE",
 "267 389 LINE",
-"23 123 LINE"
+"23 123 LINE",
+"23 104 LINE",
+"162 104 LINE",
+"143 17 LINE",
+"105 17 LINE",
+"105 0 LINE"
 );
 },
 {
@@ -23159,7 +26934,7 @@ width = 397;
 },
 {
 glyphname = five.denominator;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 background = {
@@ -23233,6 +27008,15 @@ paths = (
 {
 closed = 1;
 nodes = (
+"222 -6 OFFCURVE",
+"292 65 OFFCURVE",
+"292 134 CURVE SMOOTH",
+"292 195 OFFCURVE",
+"237 237 OFFCURVE",
+"150 237 CURVE SMOOTH",
+"126 237 OFFCURVE",
+"106 234 OFFCURVE",
+"79 225 CURVE",
 "77 228 LINE",
 "101 310 LINE",
 "284 310 LINE",
@@ -23267,16 +27051,7 @@ nodes = (
 "8 71 CURVE SMOOTH",
 "8 35 OFFCURVE",
 "35 -6 OFFCURVE",
-"116 -6 CURVE SMOOTH",
-"222 -6 OFFCURVE",
-"292 65 OFFCURVE",
-"292 134 CURVE SMOOTH",
-"292 195 OFFCURVE",
-"237 237 OFFCURVE",
-"150 237 CURVE SMOOTH",
-"126 237 OFFCURVE",
-"106 234 OFFCURVE",
-"79 225 CURVE"
+"116 -6 CURVE SMOOTH"
 );
 }
 );
@@ -23288,6 +27063,15 @@ paths = (
 {
 closed = 1;
 nodes = (
+"232 -6 OFFCURVE",
+"302 65 OFFCURVE",
+"302 134 CURVE SMOOTH",
+"302 195 OFFCURVE",
+"247 237 OFFCURVE",
+"160 237 CURVE SMOOTH",
+"136 237 OFFCURVE",
+"116 234 OFFCURVE",
+"89 225 CURVE",
 "87 228 LINE",
 "111 310 LINE",
 "294 310 LINE",
@@ -23322,16 +27106,7 @@ nodes = (
 "18 71 CURVE SMOOTH",
 "18 35 OFFCURVE",
 "45 -6 OFFCURVE",
-"126 -6 CURVE SMOOTH",
-"232 -6 OFFCURVE",
-"302 65 OFFCURVE",
-"302 134 CURVE SMOOTH",
-"302 195 OFFCURVE",
-"247 237 OFFCURVE",
-"160 237 CURVE SMOOTH",
-"136 237 OFFCURVE",
-"116 234 OFFCURVE",
-"89 225 CURVE"
+"126 -6 CURVE SMOOTH"
 );
 }
 );
@@ -23341,7 +27116,7 @@ width = 369;
 },
 {
 glyphname = six.denominator;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 background = {
@@ -23398,48 +27173,46 @@ paths = (
 {
 closed = 1;
 nodes = (
-"129 10 LINE SMOOTH",
-"194 10 OFFCURVE",
-"212 140 OFFCURVE",
-"212 192 CURVE SMOOTH",
-"212 214 OFFCURVE",
-"209 233 OFFCURVE",
-"183 233 CURVE SMOOTH",
-"163 233 OFFCURVE",
-"142 221 OFFCURVE",
-"120 194 CURVE",
-"110 170 OFFCURVE",
-"98 115 OFFCURVE",
-"98 64 CURVE SMOOTH",
-"98 31 OFFCURVE",
-"102 10 OFFCURVE",
-"129 10 CURVE SMOOTH"
+"225 -7 OFFCURVE",
+"306 68 OFFCURVE",
+"306 145 CURVE SMOOTH",
+"306 204 OFFCURVE",
+"261 255 OFFCURVE",
+"196 255 CURVE SMOOTH",
+"172 255 OFFCURVE",
+"152 247 OFFCURVE",
+"129 228 CURVE",
+"126 231 LINE",
+"142 299 OFFCURVE",
+"214 371 OFFCURVE",
+"312 382 CURVE",
+"312 403 LINE",
+"176 403 OFFCURVE",
+"5 282 OFFCURVE",
+"5 127 CURVE SMOOTH",
+"5 45 OFFCURVE",
+"53 -7 OFFCURVE",
+"131 -7 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"196 255 LINE SMOOTH",
-"261 255 OFFCURVE",
-"306 204 OFFCURVE",
-"306 145 CURVE SMOOTH",
-"306 68 OFFCURVE",
-"225 -7 OFFCURVE",
-"131 -7 CURVE SMOOTH",
-"53 -7 OFFCURVE",
-"5 45 OFFCURVE",
-"5 127 CURVE SMOOTH",
-"5 282 OFFCURVE",
-"176 403 OFFCURVE",
-"312 403 CURVE",
-"312 382 LINE",
-"214 371 OFFCURVE",
-"142 299 OFFCURVE",
-"126 231 CURVE",
-"129 228 LINE",
-"152 247 OFFCURVE",
-"172 255 OFFCURVE",
-"196 255 CURVE SMOOTH"
+"102 10 OFFCURVE",
+"98 31 OFFCURVE",
+"98 64 CURVE SMOOTH",
+"98 115 OFFCURVE",
+"110 170 OFFCURVE",
+"120 194 CURVE",
+"142 221 OFFCURVE",
+"163 233 OFFCURVE",
+"183 233 CURVE SMOOTH",
+"209 233 OFFCURVE",
+"212 214 OFFCURVE",
+"212 192 CURVE SMOOTH",
+"212 140 OFFCURVE",
+"194 10 OFFCURVE",
+"129 10 CURVE SMOOTH"
 );
 }
 );
@@ -23451,48 +27224,46 @@ paths = (
 {
 closed = 1;
 nodes = (
-"139 10 LINE SMOOTH",
-"204 10 OFFCURVE",
-"222 140 OFFCURVE",
-"222 192 CURVE SMOOTH",
-"222 214 OFFCURVE",
-"219 233 OFFCURVE",
-"193 233 CURVE SMOOTH",
-"173 233 OFFCURVE",
-"152 221 OFFCURVE",
-"130 194 CURVE",
-"120 170 OFFCURVE",
-"108 115 OFFCURVE",
-"108 64 CURVE SMOOTH",
-"108 31 OFFCURVE",
-"112 10 OFFCURVE",
-"139 10 CURVE SMOOTH"
+"235 -7 OFFCURVE",
+"316 68 OFFCURVE",
+"316 145 CURVE SMOOTH",
+"316 204 OFFCURVE",
+"271 255 OFFCURVE",
+"206 255 CURVE SMOOTH",
+"182 255 OFFCURVE",
+"162 247 OFFCURVE",
+"139 228 CURVE",
+"136 231 LINE",
+"152 299 OFFCURVE",
+"224 371 OFFCURVE",
+"322 382 CURVE",
+"322 403 LINE",
+"186 403 OFFCURVE",
+"15 282 OFFCURVE",
+"15 127 CURVE SMOOTH",
+"15 45 OFFCURVE",
+"63 -7 OFFCURVE",
+"141 -7 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"206 255 LINE SMOOTH",
-"271 255 OFFCURVE",
-"316 204 OFFCURVE",
-"316 145 CURVE SMOOTH",
-"316 68 OFFCURVE",
-"235 -7 OFFCURVE",
-"141 -7 CURVE SMOOTH",
-"63 -7 OFFCURVE",
-"15 45 OFFCURVE",
-"15 127 CURVE SMOOTH",
-"15 282 OFFCURVE",
-"186 403 OFFCURVE",
-"322 403 CURVE",
-"322 382 LINE",
-"224 371 OFFCURVE",
-"152 299 OFFCURVE",
-"136 231 CURVE",
-"139 228 LINE",
-"162 247 OFFCURVE",
-"182 255 OFFCURVE",
-"206 255 CURVE SMOOTH"
+"112 10 OFFCURVE",
+"108 31 OFFCURVE",
+"108 64 CURVE SMOOTH",
+"108 115 OFFCURVE",
+"120 170 OFFCURVE",
+"130 194 CURVE",
+"152 221 OFFCURVE",
+"173 233 OFFCURVE",
+"193 233 CURVE SMOOTH",
+"219 233 OFFCURVE",
+"222 214 OFFCURVE",
+"222 192 CURVE SMOOTH",
+"222 140 OFFCURVE",
+"204 10 OFFCURVE",
+"139 10 CURVE SMOOTH"
 );
 }
 );
@@ -23502,7 +27273,7 @@ width = 368;
 },
 {
 glyphname = seven.denominator;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 background = {
@@ -23544,6 +27315,16 @@ paths = (
 {
 closed = 1;
 nodes = (
+"164 -9 OFFCURVE",
+"188 13 OFFCURVE",
+"188 49 CURVE SMOOTH",
+"188 68 OFFCURVE",
+"181 79 OFFCURVE",
+"181 108 CURVE SMOOTH",
+"181 128 OFFCURVE",
+"184 158 OFFCURVE",
+"220 205 CURVE SMOOTH",
+"344 365 LINE",
 "345 386 LINE",
 "101 386 LINE",
 "45 268 LINE",
@@ -23559,17 +27340,7 @@ nodes = (
 "79 43 CURVE SMOOTH",
 "79 6 OFFCURVE",
 "99 -9 OFFCURVE",
-"128 -9 CURVE SMOOTH",
-"164 -9 OFFCURVE",
-"188 13 OFFCURVE",
-"188 49 CURVE SMOOTH",
-"188 68 OFFCURVE",
-"181 79 OFFCURVE",
-"181 108 CURVE SMOOTH",
-"181 128 OFFCURVE",
-"184 158 OFFCURVE",
-"220 205 CURVE SMOOTH",
-"344 365 LINE"
+"128 -9 CURVE SMOOTH"
 );
 }
 );
@@ -23581,6 +27352,16 @@ paths = (
 {
 closed = 1;
 nodes = (
+"174 -9 OFFCURVE",
+"198 13 OFFCURVE",
+"198 49 CURVE SMOOTH",
+"198 68 OFFCURVE",
+"191 79 OFFCURVE",
+"191 108 CURVE SMOOTH",
+"191 128 OFFCURVE",
+"194 158 OFFCURVE",
+"230 205 CURVE SMOOTH",
+"354 365 LINE",
 "355 386 LINE",
 "111 386 LINE",
 "55 268 LINE",
@@ -23596,17 +27377,7 @@ nodes = (
 "89 43 CURVE SMOOTH",
 "89 6 OFFCURVE",
 "109 -9 OFFCURVE",
-"138 -9 CURVE SMOOTH",
-"174 -9 OFFCURVE",
-"198 13 OFFCURVE",
-"198 49 CURVE SMOOTH",
-"198 68 OFFCURVE",
-"191 79 OFFCURVE",
-"191 108 CURVE SMOOTH",
-"191 128 OFFCURVE",
-"194 158 OFFCURVE",
-"230 205 CURVE SMOOTH",
-"354 365 LINE"
+"138 -9 CURVE SMOOTH"
 );
 }
 );
@@ -23616,7 +27387,7 @@ width = 355;
 },
 {
 glyphname = eight.denominator;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 background = {
@@ -23699,7 +27470,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"131 -9 LINE SMOOTH",
 "226 -9 OFFCURVE",
 "297 48 OFFCURVE",
 "297 107 CURVE SMOOTH",
@@ -23731,37 +27501,35 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"168 187 LINE SMOOTH",
-"192 187 OFFCURVE",
-"205 166 OFFCURVE",
-"205 128 CURVE SMOOTH",
-"205 84 OFFCURVE",
-"187 12 OFFCURVE",
-"130 12 CURVE SMOOTH",
 "104 12 OFFCURVE",
 "88 28 OFFCURVE",
 "88 67 CURVE SMOOTH",
 "88 131 OFFCURVE",
 "127 187 OFFCURVE",
-"168 187 CURVE SMOOTH"
+"168 187 CURVE SMOOTH",
+"192 187 OFFCURVE",
+"205 166 OFFCURVE",
+"205 128 CURVE SMOOTH",
+"205 84 OFFCURVE",
+"187 12 OFFCURVE",
+"130 12 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"209 375 LINE SMOOTH",
-"225 375 OFFCURVE",
-"237 368 OFFCURVE",
-"237 335 CURVE SMOOTH",
-"237 300 OFFCURVE",
-"223 212 OFFCURVE",
-"170 212 CURVE SMOOTH",
 "150 212 OFFCURVE",
 "142 224 OFFCURVE",
 "142 253 CURVE SMOOTH",
 "142 296 OFFCURVE",
 "159 375 OFFCURVE",
-"209 375 CURVE SMOOTH"
+"209 375 CURVE SMOOTH",
+"225 375 OFFCURVE",
+"237 368 OFFCURVE",
+"237 335 CURVE SMOOTH",
+"237 300 OFFCURVE",
+"223 212 OFFCURVE",
+"170 212 CURVE SMOOTH"
 );
 }
 );
@@ -23773,7 +27541,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"141 -9 LINE SMOOTH",
 "236 -9 OFFCURVE",
 "307 48 OFFCURVE",
 "307 107 CURVE SMOOTH",
@@ -23805,37 +27572,35 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"178 187 LINE SMOOTH",
-"202 187 OFFCURVE",
-"215 166 OFFCURVE",
-"215 128 CURVE SMOOTH",
-"215 84 OFFCURVE",
-"197 12 OFFCURVE",
-"140 12 CURVE SMOOTH",
 "114 12 OFFCURVE",
 "98 28 OFFCURVE",
 "98 67 CURVE SMOOTH",
 "98 131 OFFCURVE",
 "137 187 OFFCURVE",
-"178 187 CURVE SMOOTH"
+"178 187 CURVE SMOOTH",
+"202 187 OFFCURVE",
+"215 166 OFFCURVE",
+"215 128 CURVE SMOOTH",
+"215 84 OFFCURVE",
+"197 12 OFFCURVE",
+"140 12 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"219 375 LINE SMOOTH",
-"235 375 OFFCURVE",
-"247 368 OFFCURVE",
-"247 335 CURVE SMOOTH",
-"247 300 OFFCURVE",
-"233 212 OFFCURVE",
-"180 212 CURVE SMOOTH",
 "160 212 OFFCURVE",
 "152 224 OFFCURVE",
 "152 253 CURVE SMOOTH",
 "152 296 OFFCURVE",
 "169 375 OFFCURVE",
-"219 375 CURVE SMOOTH"
+"219 375 CURVE SMOOTH",
+"235 375 OFFCURVE",
+"247 368 OFFCURVE",
+"247 335 CURVE SMOOTH",
+"247 300 OFFCURVE",
+"233 212 OFFCURVE",
+"180 212 CURVE SMOOTH"
 );
 }
 );
@@ -23845,7 +27610,7 @@ width = 372;
 },
 {
 glyphname = nine.denominator;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 background = {
@@ -23902,48 +27667,46 @@ paths = (
 {
 closed = 1;
 nodes = (
-"207 383 LINE SMOOTH",
-"141 383 OFFCURVE",
-"123 254 OFFCURVE",
-"123 202 CURVE SMOOTH",
-"123 180 OFFCURVE",
-"126 160 OFFCURVE",
-"152 160 CURVE SMOOTH",
-"173 160 OFFCURVE",
-"194 173 OFFCURVE",
-"215 200 CURVE",
-"225 224 OFFCURVE",
-"237 278 OFFCURVE",
-"237 329 CURVE SMOOTH",
-"237 363 OFFCURVE",
-"233 383 OFFCURVE",
-"207 383 CURVE SMOOTH"
+"159 -9 OFFCURVE",
+"330 112 OFFCURVE",
+"330 267 CURVE SMOOTH",
+"330 349 OFFCURVE",
+"282 401 OFFCURVE",
+"204 401 CURVE SMOOTH",
+"110 401 OFFCURVE",
+"29 326 OFFCURVE",
+"29 248 CURVE SMOOTH",
+"29 190 OFFCURVE",
+"75 139 OFFCURVE",
+"139 139 CURVE SMOOTH",
+"164 139 OFFCURVE",
+"184 146 OFFCURVE",
+"206 166 CURVE",
+"208 163 LINE",
+"192 94 OFFCURVE",
+"121 22 OFFCURVE",
+"24 12 CURVE",
+"24 -9 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"139 139 LINE SMOOTH",
-"75 139 OFFCURVE",
-"29 190 OFFCURVE",
-"29 248 CURVE SMOOTH",
-"29 326 OFFCURVE",
-"110 401 OFFCURVE",
-"204 401 CURVE SMOOTH",
-"282 401 OFFCURVE",
-"330 349 OFFCURVE",
-"330 267 CURVE SMOOTH",
-"330 112 OFFCURVE",
-"159 -9 OFFCURVE",
-"24 -9 CURVE",
-"24 12 LINE",
-"121 22 OFFCURVE",
-"192 94 OFFCURVE",
-"208 163 CURVE",
-"206 166 LINE",
-"184 146 OFFCURVE",
-"164 139 OFFCURVE",
-"139 139 CURVE SMOOTH"
+"126 160 OFFCURVE",
+"123 180 OFFCURVE",
+"123 202 CURVE SMOOTH",
+"123 254 OFFCURVE",
+"141 383 OFFCURVE",
+"207 383 CURVE SMOOTH",
+"233 383 OFFCURVE",
+"237 363 OFFCURVE",
+"237 329 CURVE SMOOTH",
+"237 278 OFFCURVE",
+"225 224 OFFCURVE",
+"215 200 CURVE",
+"194 173 OFFCURVE",
+"173 160 OFFCURVE",
+"152 160 CURVE SMOOTH"
 );
 }
 );
@@ -23955,48 +27718,46 @@ paths = (
 {
 closed = 1;
 nodes = (
-"217 383 LINE SMOOTH",
-"151 383 OFFCURVE",
-"133 254 OFFCURVE",
-"133 202 CURVE SMOOTH",
-"133 180 OFFCURVE",
-"136 160 OFFCURVE",
-"162 160 CURVE SMOOTH",
-"183 160 OFFCURVE",
-"204 173 OFFCURVE",
-"225 200 CURVE",
-"235 224 OFFCURVE",
-"247 278 OFFCURVE",
-"247 329 CURVE SMOOTH",
-"247 363 OFFCURVE",
-"243 383 OFFCURVE",
-"217 383 CURVE SMOOTH"
+"169 -9 OFFCURVE",
+"340 112 OFFCURVE",
+"340 267 CURVE SMOOTH",
+"340 349 OFFCURVE",
+"292 401 OFFCURVE",
+"214 401 CURVE SMOOTH",
+"120 401 OFFCURVE",
+"39 326 OFFCURVE",
+"39 248 CURVE SMOOTH",
+"39 190 OFFCURVE",
+"85 139 OFFCURVE",
+"149 139 CURVE SMOOTH",
+"174 139 OFFCURVE",
+"194 146 OFFCURVE",
+"216 166 CURVE",
+"218 163 LINE",
+"202 94 OFFCURVE",
+"131 22 OFFCURVE",
+"34 12 CURVE",
+"34 -9 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"149 139 LINE SMOOTH",
-"85 139 OFFCURVE",
-"39 190 OFFCURVE",
-"39 248 CURVE SMOOTH",
-"39 326 OFFCURVE",
-"120 401 OFFCURVE",
-"214 401 CURVE SMOOTH",
-"292 401 OFFCURVE",
-"340 349 OFFCURVE",
-"340 267 CURVE SMOOTH",
-"340 112 OFFCURVE",
-"169 -9 OFFCURVE",
-"34 -9 CURVE",
-"34 12 LINE",
-"131 22 OFFCURVE",
-"202 94 OFFCURVE",
-"218 163 CURVE",
-"216 166 LINE",
-"194 146 OFFCURVE",
-"174 139 OFFCURVE",
-"149 139 CURVE SMOOTH"
+"136 160 OFFCURVE",
+"133 180 OFFCURVE",
+"133 202 CURVE SMOOTH",
+"133 254 OFFCURVE",
+"151 383 OFFCURVE",
+"217 383 CURVE SMOOTH",
+"243 383 OFFCURVE",
+"247 363 OFFCURVE",
+"247 329 CURVE SMOOTH",
+"247 278 OFFCURVE",
+"235 224 OFFCURVE",
+"225 200 CURVE",
+"204 173 OFFCURVE",
+"183 160 OFFCURVE",
+"162 160 CURVE SMOOTH"
 );
 }
 );
@@ -24006,7 +27767,7 @@ width = 368;
 },
 {
 glyphname = zero.numerator;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 background = {
@@ -24052,7 +27813,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"243 359 LINE SMOOTH",
 "357 359 OFFCURVE",
 "442 502 OFFCURVE",
 "442 609 CURVE SMOOTH",
@@ -24070,19 +27830,18 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"327 736 LINE SMOOTH",
-"346 736 OFFCURVE",
-"357 722 OFFCURVE",
-"357 678 CURVE SMOOTH",
-"357 599 OFFCURVE",
-"320 376 OFFCURVE",
-"242 376 CURVE SMOOTH",
 "228 376 OFFCURVE",
 "212 383 OFFCURVE",
 "212 432 CURVE SMOOTH",
 "212 509 OFFCURVE",
 "253 736 OFFCURVE",
-"327 736 CURVE SMOOTH"
+"327 736 CURVE SMOOTH",
+"346 736 OFFCURVE",
+"357 722 OFFCURVE",
+"357 678 CURVE SMOOTH",
+"357 599 OFFCURVE",
+"320 376 OFFCURVE",
+"242 376 CURVE SMOOTH"
 );
 }
 );
@@ -24094,7 +27853,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"253 359 LINE SMOOTH",
 "367 359 OFFCURVE",
 "452 502 OFFCURVE",
 "452 609 CURVE SMOOTH",
@@ -24112,19 +27870,18 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"337 736 LINE SMOOTH",
-"356 736 OFFCURVE",
-"367 722 OFFCURVE",
-"367 678 CURVE SMOOTH",
-"367 599 OFFCURVE",
-"330 376 OFFCURVE",
-"252 376 CURVE SMOOTH",
 "238 376 OFFCURVE",
 "222 383 OFFCURVE",
 "222 432 CURVE SMOOTH",
 "222 509 OFFCURVE",
 "263 736 OFFCURVE",
-"337 736 CURVE SMOOTH"
+"337 736 CURVE SMOOTH",
+"356 736 OFFCURVE",
+"367 722 OFFCURVE",
+"367 678 CURVE SMOOTH",
+"367 599 OFFCURVE",
+"330 376 OFFCURVE",
+"252 376 CURVE SMOOTH"
 );
 }
 );
@@ -24134,7 +27891,7 @@ width = 411;
 },
 {
 glyphname = one.numerator;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 background = {
@@ -24161,16 +27918,16 @@ paths = (
 {
 closed = 1;
 nodes = (
-"132 727 LINE",
-"208 727 LINE",
-"137 380 LINE",
-"66 380 LINE",
-"66 359 LINE",
 "297 359 LINE",
 "297 380 LINE",
 "223 380 LINE",
 "303 748 LINE",
-"132 748 LINE"
+"132 748 LINE",
+"132 727 LINE",
+"208 727 LINE",
+"137 380 LINE",
+"66 380 LINE",
+"66 359 LINE"
 );
 }
 );
@@ -24182,16 +27939,16 @@ paths = (
 {
 closed = 1;
 nodes = (
-"142 727 LINE",
-"218 727 LINE",
-"147 380 LINE",
-"76 380 LINE",
-"76 359 LINE",
 "307 359 LINE",
 "307 380 LINE",
 "233 380 LINE",
 "313 748 LINE",
-"142 748 LINE"
+"142 748 LINE",
+"142 727 LINE",
+"218 727 LINE",
+"147 380 LINE",
+"76 380 LINE",
+"76 359 LINE"
 );
 }
 );
@@ -24201,7 +27958,7 @@ width = 298;
 },
 {
 glyphname = two.numerator;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 background = {
@@ -24262,7 +28019,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"81 358 LINE",
 "340 358 LINE",
 "372 484 LINE",
 "354 484 LINE",
@@ -24299,7 +28055,8 @@ nodes = (
 "302 606 OFFCURVE",
 "288 551 OFFCURVE",
 "199 489 CURVE SMOOTH",
-"94 416 LINE"
+"94 416 LINE",
+"81 358 LINE"
 );
 }
 );
@@ -24311,7 +28068,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"91 358 LINE",
 "350 358 LINE",
 "382 484 LINE",
 "364 484 LINE",
@@ -24348,7 +28104,8 @@ nodes = (
 "312 606 OFFCURVE",
 "298 551 OFFCURVE",
 "209 489 CURVE SMOOTH",
-"104 416 LINE"
+"104 416 LINE",
+"91 358 LINE"
 );
 }
 );
@@ -24358,7 +28115,7 @@ width = 370;
 },
 {
 glyphname = three.numerator;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 background = {
@@ -24445,40 +28202,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"208 577 LINE SMOOTH",
-"196 577 OFFCURVE",
-"183 580 OFFCURVE",
-"177 580 CURVE SMOOTH",
-"169 580 OFFCURVE",
-"162 574 OFFCURVE",
-"162 564 CURVE SMOOTH",
-"162 556 OFFCURVE",
-"167 549 OFFCURVE",
-"180 549 CURVE SMOOTH",
-"191 549 OFFCURVE",
-"188 554 OFFCURVE",
-"210 554 CURVE SMOOTH",
-"249 554 OFFCURVE",
-"262 530 OFFCURVE",
-"262 476 CURVE SMOOTH",
-"262 384 OFFCURVE",
-"220 368 OFFCURVE",
-"183 368 CURVE SMOOTH",
-"158 368 OFFCURVE",
-"123 378 OFFCURVE",
-"123 393 CURVE SMOOTH",
-"123 407 OFFCURVE",
-"157 405 OFFCURVE",
-"157 434 CURVE SMOOTH",
-"157 454 OFFCURVE",
-"141 467 OFFCURVE",
-"121 467 CURVE SMOOTH",
-"96 467 OFFCURVE",
-"85 444 OFFCURVE",
-"85 421 CURVE SMOOTH",
-"85 384 OFFCURVE",
-"115 351 OFFCURVE",
-"192 351 CURVE SMOOTH",
 "288 351 OFFCURVE",
 "359 402 OFFCURVE",
 "359 470 CURVE SMOOTH",
@@ -24512,7 +28235,40 @@ nodes = (
 "289 688 CURVE SMOOTH",
 "289 643 OFFCURVE",
 "262 577 OFFCURVE",
-"208 577 CURVE SMOOTH"
+"208 577 CURVE SMOOTH",
+"196 577 OFFCURVE",
+"183 580 OFFCURVE",
+"177 580 CURVE SMOOTH",
+"169 580 OFFCURVE",
+"162 574 OFFCURVE",
+"162 564 CURVE SMOOTH",
+"162 556 OFFCURVE",
+"167 549 OFFCURVE",
+"180 549 CURVE SMOOTH",
+"191 549 OFFCURVE",
+"188 554 OFFCURVE",
+"210 554 CURVE SMOOTH",
+"249 554 OFFCURVE",
+"262 530 OFFCURVE",
+"262 476 CURVE SMOOTH",
+"262 384 OFFCURVE",
+"220 368 OFFCURVE",
+"183 368 CURVE SMOOTH",
+"158 368 OFFCURVE",
+"123 378 OFFCURVE",
+"123 393 CURVE SMOOTH",
+"123 407 OFFCURVE",
+"157 405 OFFCURVE",
+"157 434 CURVE SMOOTH",
+"157 454 OFFCURVE",
+"141 467 OFFCURVE",
+"121 467 CURVE SMOOTH",
+"96 467 OFFCURVE",
+"85 444 OFFCURVE",
+"85 421 CURVE SMOOTH",
+"85 384 OFFCURVE",
+"115 351 OFFCURVE",
+"192 351 CURVE SMOOTH"
 );
 }
 );
@@ -24524,40 +28280,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"218 577 LINE SMOOTH",
-"206 577 OFFCURVE",
-"193 580 OFFCURVE",
-"187 580 CURVE SMOOTH",
-"179 580 OFFCURVE",
-"172 574 OFFCURVE",
-"172 564 CURVE SMOOTH",
-"172 556 OFFCURVE",
-"177 549 OFFCURVE",
-"190 549 CURVE SMOOTH",
-"201 549 OFFCURVE",
-"198 554 OFFCURVE",
-"220 554 CURVE SMOOTH",
-"259 554 OFFCURVE",
-"272 530 OFFCURVE",
-"272 476 CURVE SMOOTH",
-"272 384 OFFCURVE",
-"230 368 OFFCURVE",
-"193 368 CURVE SMOOTH",
-"168 368 OFFCURVE",
-"133 378 OFFCURVE",
-"133 393 CURVE SMOOTH",
-"133 407 OFFCURVE",
-"167 405 OFFCURVE",
-"167 434 CURVE SMOOTH",
-"167 454 OFFCURVE",
-"151 467 OFFCURVE",
-"131 467 CURVE SMOOTH",
-"106 467 OFFCURVE",
-"95 444 OFFCURVE",
-"95 421 CURVE SMOOTH",
-"95 384 OFFCURVE",
-"125 351 OFFCURVE",
-"202 351 CURVE SMOOTH",
 "298 351 OFFCURVE",
 "369 402 OFFCURVE",
 "369 470 CURVE SMOOTH",
@@ -24591,7 +28313,40 @@ nodes = (
 "299 688 CURVE SMOOTH",
 "299 643 OFFCURVE",
 "272 577 OFFCURVE",
-"218 577 CURVE SMOOTH"
+"218 577 CURVE SMOOTH",
+"206 577 OFFCURVE",
+"193 580 OFFCURVE",
+"187 580 CURVE SMOOTH",
+"179 580 OFFCURVE",
+"172 574 OFFCURVE",
+"172 564 CURVE SMOOTH",
+"172 556 OFFCURVE",
+"177 549 OFFCURVE",
+"190 549 CURVE SMOOTH",
+"201 549 OFFCURVE",
+"198 554 OFFCURVE",
+"220 554 CURVE SMOOTH",
+"259 554 OFFCURVE",
+"272 530 OFFCURVE",
+"272 476 CURVE SMOOTH",
+"272 384 OFFCURVE",
+"230 368 OFFCURVE",
+"193 368 CURVE SMOOTH",
+"168 368 OFFCURVE",
+"133 378 OFFCURVE",
+"133 393 CURVE SMOOTH",
+"133 407 OFFCURVE",
+"167 405 OFFCURVE",
+"167 434 CURVE SMOOTH",
+"167 454 OFFCURVE",
+"151 467 OFFCURVE",
+"131 467 CURVE SMOOTH",
+"106 467 OFFCURVE",
+"95 444 OFFCURVE",
+"95 421 CURVE SMOOTH",
+"95 384 OFFCURVE",
+"125 351 OFFCURVE",
+"202 351 CURVE SMOOTH"
 );
 }
 );
@@ -24601,7 +28356,7 @@ width = 357;
 },
 {
 glyphname = four.numerator;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 background = {
@@ -24647,11 +28402,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"97 463 LINE",
-"236 463 LINE",
-"217 376 LINE",
-"179 376 LINE",
-"179 359 LINE",
 "347 359 LINE",
 "347 376 LINE",
 "304 376 LINE",
@@ -24665,7 +28415,12 @@ nodes = (
 "327 482 LINE",
 "384 748 LINE",
 "341 748 LINE",
-"97 482 LINE"
+"97 482 LINE",
+"97 463 LINE",
+"236 463 LINE",
+"217 376 LINE",
+"179 376 LINE",
+"179 359 LINE"
 );
 },
 {
@@ -24686,11 +28441,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"107 463 LINE",
-"246 463 LINE",
-"227 376 LINE",
-"189 376 LINE",
-"189 359 LINE",
 "357 359 LINE",
 "357 376 LINE",
 "314 376 LINE",
@@ -24704,7 +28454,12 @@ nodes = (
 "337 482 LINE",
 "394 748 LINE",
 "351 748 LINE",
-"107 482 LINE"
+"107 482 LINE",
+"107 463 LINE",
+"246 463 LINE",
+"227 376 LINE",
+"189 376 LINE",
+"189 359 LINE"
 );
 },
 {
@@ -24723,7 +28478,7 @@ width = 397;
 },
 {
 glyphname = five.numerator;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 background = {
@@ -24797,6 +28552,15 @@ paths = (
 {
 closed = 1;
 nodes = (
+"312 358 OFFCURVE",
+"382 429 OFFCURVE",
+"382 498 CURVE SMOOTH",
+"382 559 OFFCURVE",
+"327 601 OFFCURVE",
+"240 601 CURVE SMOOTH",
+"216 601 OFFCURVE",
+"196 598 OFFCURVE",
+"169 589 CURVE",
 "167 592 LINE",
 "191 674 LINE",
 "374 674 LINE",
@@ -24831,16 +28595,7 @@ nodes = (
 "98 435 CURVE SMOOTH",
 "98 399 OFFCURVE",
 "125 358 OFFCURVE",
-"206 358 CURVE SMOOTH",
-"312 358 OFFCURVE",
-"382 429 OFFCURVE",
-"382 498 CURVE SMOOTH",
-"382 559 OFFCURVE",
-"327 601 OFFCURVE",
-"240 601 CURVE SMOOTH",
-"216 601 OFFCURVE",
-"196 598 OFFCURVE",
-"169 589 CURVE"
+"206 358 CURVE SMOOTH"
 );
 }
 );
@@ -24852,6 +28607,15 @@ paths = (
 {
 closed = 1;
 nodes = (
+"322 358 OFFCURVE",
+"392 429 OFFCURVE",
+"392 498 CURVE SMOOTH",
+"392 559 OFFCURVE",
+"337 601 OFFCURVE",
+"250 601 CURVE SMOOTH",
+"226 601 OFFCURVE",
+"206 598 OFFCURVE",
+"179 589 CURVE",
 "177 592 LINE",
 "201 674 LINE",
 "384 674 LINE",
@@ -24886,16 +28650,7 @@ nodes = (
 "108 435 CURVE SMOOTH",
 "108 399 OFFCURVE",
 "135 358 OFFCURVE",
-"216 358 CURVE SMOOTH",
-"322 358 OFFCURVE",
-"392 429 OFFCURVE",
-"392 498 CURVE SMOOTH",
-"392 559 OFFCURVE",
-"337 601 OFFCURVE",
-"250 601 CURVE SMOOTH",
-"226 601 OFFCURVE",
-"206 598 OFFCURVE",
-"179 589 CURVE"
+"216 358 CURVE SMOOTH"
 );
 }
 );
@@ -24905,7 +28660,7 @@ width = 369;
 },
 {
 glyphname = six.numerator;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 background = {
@@ -24962,48 +28717,46 @@ paths = (
 {
 closed = 1;
 nodes = (
-"219 367 LINE SMOOTH",
-"284 367 OFFCURVE",
-"302 497 OFFCURVE",
-"302 549 CURVE SMOOTH",
-"302 571 OFFCURVE",
-"299 590 OFFCURVE",
-"273 590 CURVE SMOOTH",
-"253 590 OFFCURVE",
-"232 578 OFFCURVE",
-"210 551 CURVE",
-"200 527 OFFCURVE",
-"188 472 OFFCURVE",
-"188 421 CURVE SMOOTH",
-"188 388 OFFCURVE",
-"192 367 OFFCURVE",
-"219 367 CURVE SMOOTH"
+"315 350 OFFCURVE",
+"396 425 OFFCURVE",
+"396 502 CURVE SMOOTH",
+"396 561 OFFCURVE",
+"351 612 OFFCURVE",
+"286 612 CURVE SMOOTH",
+"262 612 OFFCURVE",
+"242 604 OFFCURVE",
+"219 585 CURVE",
+"216 588 LINE",
+"232 656 OFFCURVE",
+"304 728 OFFCURVE",
+"402 739 CURVE",
+"402 760 LINE",
+"266 760 OFFCURVE",
+"95 639 OFFCURVE",
+"95 484 CURVE SMOOTH",
+"95 402 OFFCURVE",
+"143 350 OFFCURVE",
+"221 350 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"286 612 LINE SMOOTH",
-"351 612 OFFCURVE",
-"396 561 OFFCURVE",
-"396 502 CURVE SMOOTH",
-"396 425 OFFCURVE",
-"315 350 OFFCURVE",
-"221 350 CURVE SMOOTH",
-"143 350 OFFCURVE",
-"95 402 OFFCURVE",
-"95 484 CURVE SMOOTH",
-"95 639 OFFCURVE",
-"266 760 OFFCURVE",
-"402 760 CURVE",
-"402 739 LINE",
-"304 728 OFFCURVE",
-"232 656 OFFCURVE",
-"216 588 CURVE",
-"219 585 LINE",
-"242 604 OFFCURVE",
-"262 612 OFFCURVE",
-"286 612 CURVE SMOOTH"
+"192 367 OFFCURVE",
+"188 388 OFFCURVE",
+"188 421 CURVE SMOOTH",
+"188 472 OFFCURVE",
+"200 527 OFFCURVE",
+"210 551 CURVE",
+"232 578 OFFCURVE",
+"253 590 OFFCURVE",
+"273 590 CURVE SMOOTH",
+"299 590 OFFCURVE",
+"302 571 OFFCURVE",
+"302 549 CURVE SMOOTH",
+"302 497 OFFCURVE",
+"284 367 OFFCURVE",
+"219 367 CURVE SMOOTH"
 );
 }
 );
@@ -25015,48 +28768,46 @@ paths = (
 {
 closed = 1;
 nodes = (
-"229 367 LINE SMOOTH",
-"294 367 OFFCURVE",
-"312 497 OFFCURVE",
-"312 549 CURVE SMOOTH",
-"312 571 OFFCURVE",
-"309 590 OFFCURVE",
-"283 590 CURVE SMOOTH",
-"263 590 OFFCURVE",
-"242 578 OFFCURVE",
-"220 551 CURVE",
-"210 527 OFFCURVE",
-"198 472 OFFCURVE",
-"198 421 CURVE SMOOTH",
-"198 388 OFFCURVE",
-"202 367 OFFCURVE",
-"229 367 CURVE SMOOTH"
+"325 350 OFFCURVE",
+"406 425 OFFCURVE",
+"406 502 CURVE SMOOTH",
+"406 561 OFFCURVE",
+"361 612 OFFCURVE",
+"296 612 CURVE SMOOTH",
+"272 612 OFFCURVE",
+"252 604 OFFCURVE",
+"229 585 CURVE",
+"226 588 LINE",
+"242 656 OFFCURVE",
+"314 728 OFFCURVE",
+"412 739 CURVE",
+"412 760 LINE",
+"276 760 OFFCURVE",
+"105 639 OFFCURVE",
+"105 484 CURVE SMOOTH",
+"105 402 OFFCURVE",
+"153 350 OFFCURVE",
+"231 350 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"296 612 LINE SMOOTH",
-"361 612 OFFCURVE",
-"406 561 OFFCURVE",
-"406 502 CURVE SMOOTH",
-"406 425 OFFCURVE",
-"325 350 OFFCURVE",
-"231 350 CURVE SMOOTH",
-"153 350 OFFCURVE",
-"105 402 OFFCURVE",
-"105 484 CURVE SMOOTH",
-"105 639 OFFCURVE",
-"276 760 OFFCURVE",
-"412 760 CURVE",
-"412 739 LINE",
-"314 728 OFFCURVE",
-"242 656 OFFCURVE",
-"226 588 CURVE",
-"229 585 LINE",
-"252 604 OFFCURVE",
-"272 612 OFFCURVE",
-"296 612 CURVE SMOOTH"
+"202 367 OFFCURVE",
+"198 388 OFFCURVE",
+"198 421 CURVE SMOOTH",
+"198 472 OFFCURVE",
+"210 527 OFFCURVE",
+"220 551 CURVE",
+"242 578 OFFCURVE",
+"263 590 OFFCURVE",
+"283 590 CURVE SMOOTH",
+"309 590 OFFCURVE",
+"312 571 OFFCURVE",
+"312 549 CURVE SMOOTH",
+"312 497 OFFCURVE",
+"294 367 OFFCURVE",
+"229 367 CURVE SMOOTH"
 );
 }
 );
@@ -25066,7 +28817,7 @@ width = 368;
 },
 {
 glyphname = seven.numerator;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 background = {
@@ -25108,6 +28859,16 @@ paths = (
 {
 closed = 1;
 nodes = (
+"254 349 OFFCURVE",
+"278 371 OFFCURVE",
+"278 407 CURVE SMOOTH",
+"278 426 OFFCURVE",
+"271 437 OFFCURVE",
+"271 466 CURVE SMOOTH",
+"271 486 OFFCURVE",
+"274 516 OFFCURVE",
+"310 563 CURVE SMOOTH",
+"434 723 LINE",
 "435 744 LINE",
 "191 744 LINE",
 "135 626 LINE",
@@ -25123,17 +28884,7 @@ nodes = (
 "169 401 CURVE SMOOTH",
 "169 364 OFFCURVE",
 "189 349 OFFCURVE",
-"218 349 CURVE SMOOTH",
-"254 349 OFFCURVE",
-"278 371 OFFCURVE",
-"278 407 CURVE SMOOTH",
-"278 426 OFFCURVE",
-"271 437 OFFCURVE",
-"271 466 CURVE SMOOTH",
-"271 486 OFFCURVE",
-"274 516 OFFCURVE",
-"310 563 CURVE SMOOTH",
-"434 723 LINE"
+"218 349 CURVE SMOOTH"
 );
 }
 );
@@ -25145,6 +28896,16 @@ paths = (
 {
 closed = 1;
 nodes = (
+"264 349 OFFCURVE",
+"288 371 OFFCURVE",
+"288 407 CURVE SMOOTH",
+"288 426 OFFCURVE",
+"281 437 OFFCURVE",
+"281 466 CURVE SMOOTH",
+"281 486 OFFCURVE",
+"284 516 OFFCURVE",
+"320 563 CURVE SMOOTH",
+"444 723 LINE",
 "445 744 LINE",
 "201 744 LINE",
 "145 626 LINE",
@@ -25160,17 +28921,7 @@ nodes = (
 "179 401 CURVE SMOOTH",
 "179 364 OFFCURVE",
 "199 349 OFFCURVE",
-"228 349 CURVE SMOOTH",
-"264 349 OFFCURVE",
-"288 371 OFFCURVE",
-"288 407 CURVE SMOOTH",
-"288 426 OFFCURVE",
-"281 437 OFFCURVE",
-"281 466 CURVE SMOOTH",
-"281 486 OFFCURVE",
-"284 516 OFFCURVE",
-"320 563 CURVE SMOOTH",
-"444 723 LINE"
+"228 349 CURVE SMOOTH"
 );
 }
 );
@@ -25180,7 +28931,7 @@ width = 355;
 },
 {
 glyphname = eight.numerator;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 background = {
@@ -25263,7 +29014,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"218 349 LINE SMOOTH",
 "313 349 OFFCURVE",
 "384 406 OFFCURVE",
 "384 465 CURVE SMOOTH",
@@ -25295,37 +29045,35 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"255 545 LINE SMOOTH",
-"279 545 OFFCURVE",
-"292 524 OFFCURVE",
-"292 486 CURVE SMOOTH",
-"292 442 OFFCURVE",
-"274 370 OFFCURVE",
-"217 370 CURVE SMOOTH",
 "191 370 OFFCURVE",
 "175 386 OFFCURVE",
 "175 425 CURVE SMOOTH",
 "175 489 OFFCURVE",
 "214 545 OFFCURVE",
-"255 545 CURVE SMOOTH"
+"255 545 CURVE SMOOTH",
+"279 545 OFFCURVE",
+"292 524 OFFCURVE",
+"292 486 CURVE SMOOTH",
+"292 442 OFFCURVE",
+"274 370 OFFCURVE",
+"217 370 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"296 733 LINE SMOOTH",
-"312 733 OFFCURVE",
-"324 726 OFFCURVE",
-"324 693 CURVE SMOOTH",
-"324 658 OFFCURVE",
-"310 570 OFFCURVE",
-"257 570 CURVE SMOOTH",
 "237 570 OFFCURVE",
 "229 582 OFFCURVE",
 "229 611 CURVE SMOOTH",
 "229 654 OFFCURVE",
 "246 733 OFFCURVE",
-"296 733 CURVE SMOOTH"
+"296 733 CURVE SMOOTH",
+"312 733 OFFCURVE",
+"324 726 OFFCURVE",
+"324 693 CURVE SMOOTH",
+"324 658 OFFCURVE",
+"310 570 OFFCURVE",
+"257 570 CURVE SMOOTH"
 );
 }
 );
@@ -25337,7 +29085,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"228 349 LINE SMOOTH",
 "323 349 OFFCURVE",
 "394 406 OFFCURVE",
 "394 465 CURVE SMOOTH",
@@ -25369,37 +29116,35 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"265 545 LINE SMOOTH",
-"289 545 OFFCURVE",
-"302 524 OFFCURVE",
-"302 486 CURVE SMOOTH",
-"302 442 OFFCURVE",
-"284 370 OFFCURVE",
-"227 370 CURVE SMOOTH",
 "201 370 OFFCURVE",
 "185 386 OFFCURVE",
 "185 425 CURVE SMOOTH",
 "185 489 OFFCURVE",
 "224 545 OFFCURVE",
-"265 545 CURVE SMOOTH"
+"265 545 CURVE SMOOTH",
+"289 545 OFFCURVE",
+"302 524 OFFCURVE",
+"302 486 CURVE SMOOTH",
+"302 442 OFFCURVE",
+"284 370 OFFCURVE",
+"227 370 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"306 733 LINE SMOOTH",
-"322 733 OFFCURVE",
-"334 726 OFFCURVE",
-"334 693 CURVE SMOOTH",
-"334 658 OFFCURVE",
-"320 570 OFFCURVE",
-"267 570 CURVE SMOOTH",
 "247 570 OFFCURVE",
 "239 582 OFFCURVE",
 "239 611 CURVE SMOOTH",
 "239 654 OFFCURVE",
 "256 733 OFFCURVE",
-"306 733 CURVE SMOOTH"
+"306 733 CURVE SMOOTH",
+"322 733 OFFCURVE",
+"334 726 OFFCURVE",
+"334 693 CURVE SMOOTH",
+"334 658 OFFCURVE",
+"320 570 OFFCURVE",
+"267 570 CURVE SMOOTH"
 );
 }
 );
@@ -25409,7 +29154,7 @@ width = 372;
 },
 {
 glyphname = nine.numerator;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 background = {
@@ -25466,48 +29211,46 @@ paths = (
 {
 closed = 1;
 nodes = (
-"297 742 LINE SMOOTH",
-"231 742 OFFCURVE",
-"213 613 OFFCURVE",
-"213 561 CURVE SMOOTH",
-"213 539 OFFCURVE",
-"216 519 OFFCURVE",
-"242 519 CURVE SMOOTH",
-"263 519 OFFCURVE",
-"284 532 OFFCURVE",
-"305 559 CURVE",
-"315 583 OFFCURVE",
-"327 637 OFFCURVE",
-"327 688 CURVE SMOOTH",
-"327 722 OFFCURVE",
-"323 742 OFFCURVE",
-"297 742 CURVE SMOOTH"
+"249 350 OFFCURVE",
+"420 471 OFFCURVE",
+"420 626 CURVE SMOOTH",
+"420 708 OFFCURVE",
+"372 760 OFFCURVE",
+"294 760 CURVE SMOOTH",
+"200 760 OFFCURVE",
+"119 685 OFFCURVE",
+"119 607 CURVE SMOOTH",
+"119 549 OFFCURVE",
+"165 498 OFFCURVE",
+"229 498 CURVE SMOOTH",
+"254 498 OFFCURVE",
+"274 505 OFFCURVE",
+"296 525 CURVE",
+"299 522 LINE",
+"283 453 OFFCURVE",
+"211 381 OFFCURVE",
+"114 371 CURVE",
+"114 350 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"229 498 LINE SMOOTH",
-"165 498 OFFCURVE",
-"119 549 OFFCURVE",
-"119 607 CURVE SMOOTH",
-"119 685 OFFCURVE",
-"200 760 OFFCURVE",
-"294 760 CURVE SMOOTH",
-"372 760 OFFCURVE",
-"420 708 OFFCURVE",
-"420 626 CURVE SMOOTH",
-"420 471 OFFCURVE",
-"249 350 OFFCURVE",
-"114 350 CURVE",
-"114 371 LINE",
-"211 381 OFFCURVE",
-"283 453 OFFCURVE",
-"299 522 CURVE",
-"296 525 LINE",
-"274 505 OFFCURVE",
-"254 498 OFFCURVE",
-"229 498 CURVE SMOOTH"
+"216 519 OFFCURVE",
+"213 539 OFFCURVE",
+"213 561 CURVE SMOOTH",
+"213 613 OFFCURVE",
+"231 742 OFFCURVE",
+"297 742 CURVE SMOOTH",
+"323 742 OFFCURVE",
+"327 722 OFFCURVE",
+"327 688 CURVE SMOOTH",
+"327 637 OFFCURVE",
+"315 583 OFFCURVE",
+"305 559 CURVE",
+"284 532 OFFCURVE",
+"263 519 OFFCURVE",
+"242 519 CURVE SMOOTH"
 );
 }
 );
@@ -25519,48 +29262,46 @@ paths = (
 {
 closed = 1;
 nodes = (
-"307 742 LINE SMOOTH",
-"241 742 OFFCURVE",
-"223 613 OFFCURVE",
-"223 561 CURVE SMOOTH",
-"223 539 OFFCURVE",
-"226 519 OFFCURVE",
-"252 519 CURVE SMOOTH",
-"273 519 OFFCURVE",
-"294 532 OFFCURVE",
-"315 559 CURVE",
-"325 583 OFFCURVE",
-"337 637 OFFCURVE",
-"337 688 CURVE SMOOTH",
-"337 722 OFFCURVE",
-"333 742 OFFCURVE",
-"307 742 CURVE SMOOTH"
+"259 350 OFFCURVE",
+"430 471 OFFCURVE",
+"430 626 CURVE SMOOTH",
+"430 708 OFFCURVE",
+"382 760 OFFCURVE",
+"304 760 CURVE SMOOTH",
+"210 760 OFFCURVE",
+"129 685 OFFCURVE",
+"129 607 CURVE SMOOTH",
+"129 549 OFFCURVE",
+"175 498 OFFCURVE",
+"239 498 CURVE SMOOTH",
+"264 498 OFFCURVE",
+"284 505 OFFCURVE",
+"306 525 CURVE",
+"309 522 LINE",
+"293 453 OFFCURVE",
+"221 381 OFFCURVE",
+"124 371 CURVE",
+"124 350 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"239 498 LINE SMOOTH",
-"175 498 OFFCURVE",
-"129 549 OFFCURVE",
-"129 607 CURVE SMOOTH",
-"129 685 OFFCURVE",
-"210 760 OFFCURVE",
-"304 760 CURVE SMOOTH",
-"382 760 OFFCURVE",
-"430 708 OFFCURVE",
-"430 626 CURVE SMOOTH",
-"430 471 OFFCURVE",
-"259 350 OFFCURVE",
-"124 350 CURVE",
-"124 371 LINE",
-"221 381 OFFCURVE",
-"293 453 OFFCURVE",
-"309 522 CURVE",
-"306 525 LINE",
-"284 505 OFFCURVE",
-"264 498 OFFCURVE",
-"239 498 CURVE SMOOTH"
+"226 519 OFFCURVE",
+"223 539 OFFCURVE",
+"223 561 CURVE SMOOTH",
+"223 613 OFFCURVE",
+"241 742 OFFCURVE",
+"307 742 CURVE SMOOTH",
+"333 742 OFFCURVE",
+"337 722 OFFCURVE",
+"337 688 CURVE SMOOTH",
+"337 637 OFFCURVE",
+"325 583 OFFCURVE",
+"315 559 CURVE",
+"294 532 OFFCURVE",
+"273 519 OFFCURVE",
+"252 519 CURVE SMOOTH"
 );
 }
 );
@@ -25570,7 +29311,7 @@ width = 368;
 },
 {
 glyphname = zeroinferior;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:57:29 +0000";
 layers = (
 {
 background = {
@@ -25616,7 +29357,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"131 -105 LINE SMOOTH",
 "245 -105 OFFCURVE",
 "330 38 OFFCURVE",
 "330 145 CURVE SMOOTH",
@@ -25634,19 +29374,18 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"215 272 LINE SMOOTH",
-"234 272 OFFCURVE",
-"245 258 OFFCURVE",
-"245 214 CURVE SMOOTH",
-"245 135 OFFCURVE",
-"208 -88 OFFCURVE",
-"130 -88 CURVE SMOOTH",
 "116 -88 OFFCURVE",
 "100 -81 OFFCURVE",
 "100 -32 CURVE SMOOTH",
 "100 45 OFFCURVE",
 "141 272 OFFCURVE",
-"215 272 CURVE SMOOTH"
+"215 272 CURVE SMOOTH",
+"234 272 OFFCURVE",
+"245 258 OFFCURVE",
+"245 214 CURVE SMOOTH",
+"245 135 OFFCURVE",
+"208 -88 OFFCURVE",
+"130 -88 CURVE SMOOTH"
 );
 }
 );
@@ -25658,7 +29397,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"141 -105 LINE SMOOTH",
 "255 -105 OFFCURVE",
 "340 38 OFFCURVE",
 "340 145 CURVE SMOOTH",
@@ -25676,19 +29414,18 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"225 272 LINE SMOOTH",
-"244 272 OFFCURVE",
-"255 258 OFFCURVE",
-"255 214 CURVE SMOOTH",
-"255 135 OFFCURVE",
-"218 -88 OFFCURVE",
-"140 -88 CURVE SMOOTH",
 "126 -88 OFFCURVE",
 "110 -81 OFFCURVE",
 "110 -32 CURVE SMOOTH",
 "110 45 OFFCURVE",
 "151 272 OFFCURVE",
-"225 272 CURVE SMOOTH"
+"225 272 CURVE SMOOTH",
+"244 272 OFFCURVE",
+"255 258 OFFCURVE",
+"255 214 CURVE SMOOTH",
+"255 135 OFFCURVE",
+"218 -88 OFFCURVE",
+"140 -88 CURVE SMOOTH"
 );
 }
 );
@@ -25699,7 +29436,7 @@ unicode = 2080;
 },
 {
 glyphname = oneinferior;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 background = {
@@ -25726,16 +29463,16 @@ paths = (
 {
 closed = 1;
 nodes = (
-"53 268 LINE",
-"129 268 LINE",
-"58 -79 LINE",
-"-13 -79 LINE",
-"-13 -100 LINE",
 "218 -100 LINE",
 "218 -79 LINE",
 "144 -79 LINE",
 "224 289 LINE",
-"53 289 LINE"
+"53 289 LINE",
+"53 268 LINE",
+"129 268 LINE",
+"58 -79 LINE",
+"-13 -79 LINE",
+"-13 -100 LINE"
 );
 }
 );
@@ -25747,16 +29484,16 @@ paths = (
 {
 closed = 1;
 nodes = (
-"63 268 LINE",
-"139 268 LINE",
-"68 -79 LINE",
-"-3 -79 LINE",
-"-3 -100 LINE",
 "228 -100 LINE",
 "228 -79 LINE",
 "154 -79 LINE",
 "234 289 LINE",
-"63 289 LINE"
+"63 289 LINE",
+"63 268 LINE",
+"139 268 LINE",
+"68 -79 LINE",
+"-3 -79 LINE",
+"-3 -100 LINE"
 );
 }
 );
@@ -25767,7 +29504,7 @@ unicode = 2081;
 },
 {
 glyphname = twoinferior;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 background = {
@@ -25828,7 +29565,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"-24 -100 LINE",
 "235 -100 LINE",
 "267 26 LINE",
 "249 26 LINE",
@@ -25865,7 +29601,8 @@ nodes = (
 "197 148 OFFCURVE",
 "183 93 OFFCURVE",
 "94 31 CURVE SMOOTH",
-"-11 -42 LINE"
+"-11 -42 LINE",
+"-24 -100 LINE"
 );
 }
 );
@@ -25877,7 +29614,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"-14 -100 LINE",
 "245 -100 LINE",
 "277 26 LINE",
 "259 26 LINE",
@@ -25914,7 +29650,8 @@ nodes = (
 "207 148 OFFCURVE",
 "193 93 OFFCURVE",
 "104 31 CURVE SMOOTH",
-"-1 -42 LINE"
+"-1 -42 LINE",
+"-14 -100 LINE"
 );
 }
 );
@@ -25925,7 +29662,7 @@ unicode = 2082;
 },
 {
 glyphname = threeinferior;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:57:37 +0000";
 layers = (
 {
 background = {
@@ -26012,40 +29749,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"100 118 LINE SMOOTH",
-"88 118 OFFCURVE",
-"75 121 OFFCURVE",
-"69 121 CURVE SMOOTH",
-"61 121 OFFCURVE",
-"54 115 OFFCURVE",
-"54 105 CURVE SMOOTH",
-"54 97 OFFCURVE",
-"59 90 OFFCURVE",
-"72 90 CURVE SMOOTH",
-"83 90 OFFCURVE",
-"80 95 OFFCURVE",
-"102 95 CURVE SMOOTH",
-"141 95 OFFCURVE",
-"154 71 OFFCURVE",
-"154 17 CURVE SMOOTH",
-"154 -75 OFFCURVE",
-"112 -91 OFFCURVE",
-"75 -91 CURVE SMOOTH",
-"50 -91 OFFCURVE",
-"15 -81 OFFCURVE",
-"15 -66 CURVE SMOOTH",
-"15 -52 OFFCURVE",
-"49 -54 OFFCURVE",
-"49 -25 CURVE SMOOTH",
-"49 -5 OFFCURVE",
-"33 8 OFFCURVE",
-"13 8 CURVE SMOOTH",
-"-12 8 OFFCURVE",
-"-23 -15 OFFCURVE",
-"-23 -38 CURVE SMOOTH",
-"-23 -75 OFFCURVE",
-"7 -108 OFFCURVE",
-"84 -108 CURVE SMOOTH",
 "180 -108 OFFCURVE",
 "251 -57 OFFCURVE",
 "251 11 CURVE SMOOTH",
@@ -26079,7 +29782,40 @@ nodes = (
 "181 229 CURVE SMOOTH",
 "181 184 OFFCURVE",
 "154 118 OFFCURVE",
-"100 118 CURVE SMOOTH"
+"100 118 CURVE SMOOTH",
+"88 118 OFFCURVE",
+"75 121 OFFCURVE",
+"69 121 CURVE SMOOTH",
+"61 121 OFFCURVE",
+"54 115 OFFCURVE",
+"54 105 CURVE SMOOTH",
+"54 97 OFFCURVE",
+"59 90 OFFCURVE",
+"72 90 CURVE SMOOTH",
+"83 90 OFFCURVE",
+"80 95 OFFCURVE",
+"102 95 CURVE SMOOTH",
+"141 95 OFFCURVE",
+"154 71 OFFCURVE",
+"154 17 CURVE SMOOTH",
+"154 -75 OFFCURVE",
+"112 -91 OFFCURVE",
+"75 -91 CURVE SMOOTH",
+"50 -91 OFFCURVE",
+"15 -81 OFFCURVE",
+"15 -66 CURVE SMOOTH",
+"15 -52 OFFCURVE",
+"49 -54 OFFCURVE",
+"49 -25 CURVE SMOOTH",
+"49 -5 OFFCURVE",
+"33 8 OFFCURVE",
+"13 8 CURVE SMOOTH",
+"-12 8 OFFCURVE",
+"-23 -15 OFFCURVE",
+"-23 -38 CURVE SMOOTH",
+"-23 -75 OFFCURVE",
+"7 -108 OFFCURVE",
+"84 -108 CURVE SMOOTH"
 );
 }
 );
@@ -26091,40 +29827,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"110 118 LINE SMOOTH",
-"98 118 OFFCURVE",
-"85 121 OFFCURVE",
-"79 121 CURVE SMOOTH",
-"71 121 OFFCURVE",
-"64 115 OFFCURVE",
-"64 105 CURVE SMOOTH",
-"64 97 OFFCURVE",
-"69 90 OFFCURVE",
-"82 90 CURVE SMOOTH",
-"93 90 OFFCURVE",
-"90 95 OFFCURVE",
-"112 95 CURVE SMOOTH",
-"151 95 OFFCURVE",
-"164 71 OFFCURVE",
-"164 17 CURVE SMOOTH",
-"164 -75 OFFCURVE",
-"122 -91 OFFCURVE",
-"85 -91 CURVE SMOOTH",
-"60 -91 OFFCURVE",
-"25 -81 OFFCURVE",
-"25 -66 CURVE SMOOTH",
-"25 -52 OFFCURVE",
-"59 -54 OFFCURVE",
-"59 -25 CURVE SMOOTH",
-"59 -5 OFFCURVE",
-"43 8 OFFCURVE",
-"23 8 CURVE SMOOTH",
-"-2 8 OFFCURVE",
-"-13 -15 OFFCURVE",
-"-13 -38 CURVE SMOOTH",
-"-13 -75 OFFCURVE",
-"17 -108 OFFCURVE",
-"94 -108 CURVE SMOOTH",
 "190 -108 OFFCURVE",
 "261 -57 OFFCURVE",
 "261 11 CURVE SMOOTH",
@@ -26158,7 +29860,40 @@ nodes = (
 "191 229 CURVE SMOOTH",
 "191 184 OFFCURVE",
 "164 118 OFFCURVE",
-"110 118 CURVE SMOOTH"
+"110 118 CURVE SMOOTH",
+"98 118 OFFCURVE",
+"85 121 OFFCURVE",
+"79 121 CURVE SMOOTH",
+"71 121 OFFCURVE",
+"64 115 OFFCURVE",
+"64 105 CURVE SMOOTH",
+"64 97 OFFCURVE",
+"69 90 OFFCURVE",
+"82 90 CURVE SMOOTH",
+"93 90 OFFCURVE",
+"90 95 OFFCURVE",
+"112 95 CURVE SMOOTH",
+"151 95 OFFCURVE",
+"164 71 OFFCURVE",
+"164 17 CURVE SMOOTH",
+"164 -75 OFFCURVE",
+"122 -91 OFFCURVE",
+"85 -91 CURVE SMOOTH",
+"60 -91 OFFCURVE",
+"25 -81 OFFCURVE",
+"25 -66 CURVE SMOOTH",
+"25 -52 OFFCURVE",
+"59 -54 OFFCURVE",
+"59 -25 CURVE SMOOTH",
+"59 -5 OFFCURVE",
+"43 8 OFFCURVE",
+"23 8 CURVE SMOOTH",
+"-2 8 OFFCURVE",
+"-13 -15 OFFCURVE",
+"-13 -38 CURVE SMOOTH",
+"-13 -75 OFFCURVE",
+"17 -108 OFFCURVE",
+"94 -108 CURVE SMOOTH"
 );
 }
 );
@@ -26169,7 +29904,7 @@ unicode = 2083;
 },
 {
 glyphname = fourinferior;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 background = {
@@ -26215,11 +29950,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"-5 4 LINE",
-"134 4 LINE",
-"115 -83 LINE",
-"77 -83 LINE",
-"77 -100 LINE",
 "245 -100 LINE",
 "245 -83 LINE",
 "202 -83 LINE",
@@ -26233,7 +29963,12 @@ nodes = (
 "225 23 LINE",
 "282 289 LINE",
 "239 289 LINE",
-"-5 23 LINE"
+"-5 23 LINE",
+"-5 4 LINE",
+"134 4 LINE",
+"115 -83 LINE",
+"77 -83 LINE",
+"77 -100 LINE"
 );
 },
 {
@@ -26254,11 +29989,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"5 4 LINE",
-"144 4 LINE",
-"125 -83 LINE",
-"87 -83 LINE",
-"87 -100 LINE",
 "255 -100 LINE",
 "255 -83 LINE",
 "212 -83 LINE",
@@ -26272,7 +30002,12 @@ nodes = (
 "235 23 LINE",
 "292 289 LINE",
 "249 289 LINE",
-"5 23 LINE"
+"5 23 LINE",
+"5 4 LINE",
+"144 4 LINE",
+"125 -83 LINE",
+"87 -83 LINE",
+"87 -100 LINE"
 );
 },
 {
@@ -26292,7 +30027,7 @@ unicode = 2084;
 },
 {
 glyphname = fiveinferior;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 background = {
@@ -26366,6 +30101,15 @@ paths = (
 {
 closed = 1;
 nodes = (
+"204 -106 OFFCURVE",
+"274 -35 OFFCURVE",
+"274 34 CURVE SMOOTH",
+"274 95 OFFCURVE",
+"219 137 OFFCURVE",
+"132 137 CURVE SMOOTH",
+"108 137 OFFCURVE",
+"88 134 OFFCURVE",
+"61 125 CURVE",
 "59 128 LINE",
 "83 210 LINE",
 "266 210 LINE",
@@ -26400,16 +30144,7 @@ nodes = (
 "-10 -29 CURVE SMOOTH",
 "-10 -65 OFFCURVE",
 "17 -106 OFFCURVE",
-"98 -106 CURVE SMOOTH",
-"204 -106 OFFCURVE",
-"274 -35 OFFCURVE",
-"274 34 CURVE SMOOTH",
-"274 95 OFFCURVE",
-"219 137 OFFCURVE",
-"132 137 CURVE SMOOTH",
-"108 137 OFFCURVE",
-"88 134 OFFCURVE",
-"61 125 CURVE"
+"98 -106 CURVE SMOOTH"
 );
 }
 );
@@ -26421,6 +30156,15 @@ paths = (
 {
 closed = 1;
 nodes = (
+"214 -106 OFFCURVE",
+"284 -35 OFFCURVE",
+"284 34 CURVE SMOOTH",
+"284 95 OFFCURVE",
+"229 137 OFFCURVE",
+"142 137 CURVE SMOOTH",
+"118 137 OFFCURVE",
+"98 134 OFFCURVE",
+"71 125 CURVE",
 "69 128 LINE",
 "93 210 LINE",
 "276 210 LINE",
@@ -26455,16 +30199,7 @@ nodes = (
 "0 -29 CURVE SMOOTH",
 "0 -65 OFFCURVE",
 "27 -106 OFFCURVE",
-"108 -106 CURVE SMOOTH",
-"214 -106 OFFCURVE",
-"284 -35 OFFCURVE",
-"284 34 CURVE SMOOTH",
-"284 95 OFFCURVE",
-"229 137 OFFCURVE",
-"142 137 CURVE SMOOTH",
-"118 137 OFFCURVE",
-"98 134 OFFCURVE",
-"71 125 CURVE"
+"108 -106 CURVE SMOOTH"
 );
 }
 );
@@ -26475,7 +30210,7 @@ unicode = 2085;
 },
 {
 glyphname = sixinferior;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:57:47 +0000";
 layers = (
 {
 background = {
@@ -26532,48 +30267,46 @@ paths = (
 {
 closed = 1;
 nodes = (
-"108 -90 LINE SMOOTH",
-"173 -90 OFFCURVE",
-"191 40 OFFCURVE",
-"191 92 CURVE SMOOTH",
-"191 114 OFFCURVE",
-"188 133 OFFCURVE",
-"162 133 CURVE SMOOTH",
-"142 133 OFFCURVE",
-"121 121 OFFCURVE",
-"99 94 CURVE",
-"89 70 OFFCURVE",
-"77 15 OFFCURVE",
-"77 -36 CURVE SMOOTH",
-"77 -69 OFFCURVE",
-"81 -90 OFFCURVE",
-"108 -90 CURVE SMOOTH"
+"204 -107 OFFCURVE",
+"285 -32 OFFCURVE",
+"285 45 CURVE SMOOTH",
+"285 104 OFFCURVE",
+"240 155 OFFCURVE",
+"175 155 CURVE SMOOTH",
+"151 155 OFFCURVE",
+"131 147 OFFCURVE",
+"108 128 CURVE",
+"105 131 LINE",
+"121 199 OFFCURVE",
+"193 271 OFFCURVE",
+"291 282 CURVE",
+"291 303 LINE",
+"155 303 OFFCURVE",
+"-16 182 OFFCURVE",
+"-16 27 CURVE SMOOTH",
+"-16 -55 OFFCURVE",
+"32 -107 OFFCURVE",
+"110 -107 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"175 155 LINE SMOOTH",
-"240 155 OFFCURVE",
-"285 104 OFFCURVE",
-"285 45 CURVE SMOOTH",
-"285 -32 OFFCURVE",
-"204 -107 OFFCURVE",
-"110 -107 CURVE SMOOTH",
-"32 -107 OFFCURVE",
-"-16 -55 OFFCURVE",
-"-16 27 CURVE SMOOTH",
-"-16 182 OFFCURVE",
-"155 303 OFFCURVE",
-"291 303 CURVE",
-"291 282 LINE",
-"193 271 OFFCURVE",
-"121 199 OFFCURVE",
-"105 131 CURVE",
-"108 128 LINE",
-"131 147 OFFCURVE",
-"151 155 OFFCURVE",
-"175 155 CURVE SMOOTH"
+"81 -90 OFFCURVE",
+"77 -69 OFFCURVE",
+"77 -36 CURVE SMOOTH",
+"77 15 OFFCURVE",
+"89 70 OFFCURVE",
+"99 94 CURVE",
+"121 121 OFFCURVE",
+"142 133 OFFCURVE",
+"162 133 CURVE SMOOTH",
+"188 133 OFFCURVE",
+"191 114 OFFCURVE",
+"191 92 CURVE SMOOTH",
+"191 40 OFFCURVE",
+"173 -90 OFFCURVE",
+"108 -90 CURVE SMOOTH"
 );
 }
 );
@@ -26585,48 +30318,46 @@ paths = (
 {
 closed = 1;
 nodes = (
-"118 -90 LINE SMOOTH",
-"183 -90 OFFCURVE",
-"201 40 OFFCURVE",
-"201 92 CURVE SMOOTH",
-"201 114 OFFCURVE",
-"198 133 OFFCURVE",
-"172 133 CURVE SMOOTH",
-"152 133 OFFCURVE",
-"131 121 OFFCURVE",
-"109 94 CURVE",
-"99 70 OFFCURVE",
-"87 15 OFFCURVE",
-"87 -36 CURVE SMOOTH",
-"87 -69 OFFCURVE",
-"91 -90 OFFCURVE",
-"118 -90 CURVE SMOOTH"
+"214 -107 OFFCURVE",
+"295 -32 OFFCURVE",
+"295 45 CURVE SMOOTH",
+"295 104 OFFCURVE",
+"250 155 OFFCURVE",
+"185 155 CURVE SMOOTH",
+"161 155 OFFCURVE",
+"141 147 OFFCURVE",
+"118 128 CURVE",
+"115 131 LINE",
+"131 199 OFFCURVE",
+"203 271 OFFCURVE",
+"301 282 CURVE",
+"301 303 LINE",
+"165 303 OFFCURVE",
+"-6 182 OFFCURVE",
+"-6 27 CURVE SMOOTH",
+"-6 -55 OFFCURVE",
+"42 -107 OFFCURVE",
+"120 -107 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"185 155 LINE SMOOTH",
-"250 155 OFFCURVE",
-"295 104 OFFCURVE",
-"295 45 CURVE SMOOTH",
-"295 -32 OFFCURVE",
-"214 -107 OFFCURVE",
-"120 -107 CURVE SMOOTH",
-"42 -107 OFFCURVE",
-"-6 -55 OFFCURVE",
-"-6 27 CURVE SMOOTH",
-"-6 182 OFFCURVE",
-"165 303 OFFCURVE",
-"301 303 CURVE",
-"301 282 LINE",
-"203 271 OFFCURVE",
-"131 199 OFFCURVE",
-"115 131 CURVE",
-"118 128 LINE",
-"141 147 OFFCURVE",
-"161 155 OFFCURVE",
-"185 155 CURVE SMOOTH"
+"91 -90 OFFCURVE",
+"87 -69 OFFCURVE",
+"87 -36 CURVE SMOOTH",
+"87 15 OFFCURVE",
+"99 70 OFFCURVE",
+"109 94 CURVE",
+"131 121 OFFCURVE",
+"152 133 OFFCURVE",
+"172 133 CURVE SMOOTH",
+"198 133 OFFCURVE",
+"201 114 OFFCURVE",
+"201 92 CURVE SMOOTH",
+"201 40 OFFCURVE",
+"183 -90 OFFCURVE",
+"118 -90 CURVE SMOOTH"
 );
 }
 );
@@ -26637,7 +30368,7 @@ unicode = 2086;
 },
 {
 glyphname = seveninferior;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 background = {
@@ -26679,6 +30410,16 @@ paths = (
 {
 closed = 1;
 nodes = (
+"142 -109 OFFCURVE",
+"166 -87 OFFCURVE",
+"166 -51 CURVE SMOOTH",
+"166 -32 OFFCURVE",
+"159 -21 OFFCURVE",
+"159 8 CURVE SMOOTH",
+"159 28 OFFCURVE",
+"162 58 OFFCURVE",
+"198 105 CURVE SMOOTH",
+"322 265 LINE",
 "323 286 LINE",
 "79 286 LINE",
 "23 168 LINE",
@@ -26694,17 +30435,7 @@ nodes = (
 "57 -57 CURVE SMOOTH",
 "57 -94 OFFCURVE",
 "77 -109 OFFCURVE",
-"106 -109 CURVE SMOOTH",
-"142 -109 OFFCURVE",
-"166 -87 OFFCURVE",
-"166 -51 CURVE SMOOTH",
-"166 -32 OFFCURVE",
-"159 -21 OFFCURVE",
-"159 8 CURVE SMOOTH",
-"159 28 OFFCURVE",
-"162 58 OFFCURVE",
-"198 105 CURVE SMOOTH",
-"322 265 LINE"
+"106 -109 CURVE SMOOTH"
 );
 }
 );
@@ -26716,6 +30447,16 @@ paths = (
 {
 closed = 1;
 nodes = (
+"152 -109 OFFCURVE",
+"176 -87 OFFCURVE",
+"176 -51 CURVE SMOOTH",
+"176 -32 OFFCURVE",
+"169 -21 OFFCURVE",
+"169 8 CURVE SMOOTH",
+"169 28 OFFCURVE",
+"172 58 OFFCURVE",
+"208 105 CURVE SMOOTH",
+"332 265 LINE",
 "333 286 LINE",
 "89 286 LINE",
 "33 168 LINE",
@@ -26731,17 +30472,7 @@ nodes = (
 "67 -57 CURVE SMOOTH",
 "67 -94 OFFCURVE",
 "87 -109 OFFCURVE",
-"116 -109 CURVE SMOOTH",
-"152 -109 OFFCURVE",
-"176 -87 OFFCURVE",
-"176 -51 CURVE SMOOTH",
-"176 -32 OFFCURVE",
-"169 -21 OFFCURVE",
-"169 8 CURVE SMOOTH",
-"169 28 OFFCURVE",
-"172 58 OFFCURVE",
-"208 105 CURVE SMOOTH",
-"332 265 LINE"
+"116 -109 CURVE SMOOTH"
 );
 }
 );
@@ -26752,7 +30483,7 @@ unicode = 2087;
 },
 {
 glyphname = eightinferior;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:57:59 +0000";
 layers = (
 {
 background = {
@@ -26835,7 +30566,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"109 -109 LINE SMOOTH",
 "204 -109 OFFCURVE",
 "275 -52 OFFCURVE",
 "275 7 CURVE SMOOTH",
@@ -26867,37 +30597,35 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"146 87 LINE SMOOTH",
-"170 87 OFFCURVE",
-"183 66 OFFCURVE",
-"183 28 CURVE SMOOTH",
-"183 -16 OFFCURVE",
-"165 -88 OFFCURVE",
-"108 -88 CURVE SMOOTH",
 "82 -88 OFFCURVE",
 "66 -72 OFFCURVE",
 "66 -33 CURVE SMOOTH",
 "66 31 OFFCURVE",
 "105 87 OFFCURVE",
-"146 87 CURVE SMOOTH"
+"146 87 CURVE SMOOTH",
+"170 87 OFFCURVE",
+"183 66 OFFCURVE",
+"183 28 CURVE SMOOTH",
+"183 -16 OFFCURVE",
+"165 -88 OFFCURVE",
+"108 -88 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"187 275 LINE SMOOTH",
-"203 275 OFFCURVE",
-"215 268 OFFCURVE",
-"215 235 CURVE SMOOTH",
-"215 200 OFFCURVE",
-"201 112 OFFCURVE",
-"148 112 CURVE SMOOTH",
 "128 112 OFFCURVE",
 "120 124 OFFCURVE",
 "120 153 CURVE SMOOTH",
 "120 196 OFFCURVE",
 "137 275 OFFCURVE",
-"187 275 CURVE SMOOTH"
+"187 275 CURVE SMOOTH",
+"203 275 OFFCURVE",
+"215 268 OFFCURVE",
+"215 235 CURVE SMOOTH",
+"215 200 OFFCURVE",
+"201 112 OFFCURVE",
+"148 112 CURVE SMOOTH"
 );
 }
 );
@@ -26909,7 +30637,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"119 -109 LINE SMOOTH",
 "214 -109 OFFCURVE",
 "285 -52 OFFCURVE",
 "285 7 CURVE SMOOTH",
@@ -26941,37 +30668,35 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"156 87 LINE SMOOTH",
-"180 87 OFFCURVE",
-"193 66 OFFCURVE",
-"193 28 CURVE SMOOTH",
-"193 -16 OFFCURVE",
-"175 -88 OFFCURVE",
-"118 -88 CURVE SMOOTH",
 "92 -88 OFFCURVE",
 "76 -72 OFFCURVE",
 "76 -33 CURVE SMOOTH",
 "76 31 OFFCURVE",
 "115 87 OFFCURVE",
-"156 87 CURVE SMOOTH"
+"156 87 CURVE SMOOTH",
+"180 87 OFFCURVE",
+"193 66 OFFCURVE",
+"193 28 CURVE SMOOTH",
+"193 -16 OFFCURVE",
+"175 -88 OFFCURVE",
+"118 -88 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"197 275 LINE SMOOTH",
-"213 275 OFFCURVE",
-"225 268 OFFCURVE",
-"225 235 CURVE SMOOTH",
-"225 200 OFFCURVE",
-"211 112 OFFCURVE",
-"158 112 CURVE SMOOTH",
 "138 112 OFFCURVE",
 "130 124 OFFCURVE",
 "130 153 CURVE SMOOTH",
 "130 196 OFFCURVE",
 "147 275 OFFCURVE",
-"197 275 CURVE SMOOTH"
+"197 275 CURVE SMOOTH",
+"213 275 OFFCURVE",
+"225 268 OFFCURVE",
+"225 235 CURVE SMOOTH",
+"225 200 OFFCURVE",
+"211 112 OFFCURVE",
+"158 112 CURVE SMOOTH"
 );
 }
 );
@@ -26982,7 +30707,7 @@ unicode = 2088;
 },
 {
 glyphname = nineinferior;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:58:11 +0000";
 layers = (
 {
 background = {
@@ -27039,48 +30764,46 @@ paths = (
 {
 closed = 1;
 nodes = (
-"187 283 LINE SMOOTH",
-"121 283 OFFCURVE",
-"103 154 OFFCURVE",
-"103 102 CURVE SMOOTH",
-"103 80 OFFCURVE",
-"106 60 OFFCURVE",
-"132 60 CURVE SMOOTH",
-"153 60 OFFCURVE",
-"174 73 OFFCURVE",
-"195 100 CURVE",
-"205 124 OFFCURVE",
-"217 178 OFFCURVE",
-"217 229 CURVE SMOOTH",
-"217 263 OFFCURVE",
-"213 283 OFFCURVE",
-"187 283 CURVE SMOOTH"
+"139 -109 OFFCURVE",
+"310 12 OFFCURVE",
+"310 167 CURVE SMOOTH",
+"310 249 OFFCURVE",
+"262 301 OFFCURVE",
+"184 301 CURVE SMOOTH",
+"90 301 OFFCURVE",
+"9 226 OFFCURVE",
+"9 148 CURVE SMOOTH",
+"9 90 OFFCURVE",
+"55 39 OFFCURVE",
+"119 39 CURVE SMOOTH",
+"144 39 OFFCURVE",
+"164 46 OFFCURVE",
+"186 66 CURVE",
+"188 63 LINE",
+"172 -6 OFFCURVE",
+"101 -78 OFFCURVE",
+"4 -88 CURVE",
+"4 -109 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"119 39 LINE SMOOTH",
-"55 39 OFFCURVE",
-"9 90 OFFCURVE",
-"9 148 CURVE SMOOTH",
-"9 226 OFFCURVE",
-"90 301 OFFCURVE",
-"184 301 CURVE SMOOTH",
-"262 301 OFFCURVE",
-"310 249 OFFCURVE",
-"310 167 CURVE SMOOTH",
-"310 12 OFFCURVE",
-"139 -109 OFFCURVE",
-"4 -109 CURVE",
-"4 -88 LINE",
-"101 -78 OFFCURVE",
-"172 -6 OFFCURVE",
-"188 63 CURVE",
-"186 66 LINE",
-"164 46 OFFCURVE",
-"144 39 OFFCURVE",
-"119 39 CURVE SMOOTH"
+"106 60 OFFCURVE",
+"103 80 OFFCURVE",
+"103 102 CURVE SMOOTH",
+"103 154 OFFCURVE",
+"121 283 OFFCURVE",
+"187 283 CURVE SMOOTH",
+"213 283 OFFCURVE",
+"217 263 OFFCURVE",
+"217 229 CURVE SMOOTH",
+"217 178 OFFCURVE",
+"205 124 OFFCURVE",
+"195 100 CURVE",
+"174 73 OFFCURVE",
+"153 60 OFFCURVE",
+"132 60 CURVE SMOOTH"
 );
 }
 );
@@ -27092,48 +30815,46 @@ paths = (
 {
 closed = 1;
 nodes = (
-"197 283 LINE SMOOTH",
-"131 283 OFFCURVE",
-"113 154 OFFCURVE",
-"113 102 CURVE SMOOTH",
-"113 80 OFFCURVE",
-"116 60 OFFCURVE",
-"142 60 CURVE SMOOTH",
-"163 60 OFFCURVE",
-"184 73 OFFCURVE",
-"205 100 CURVE",
-"215 124 OFFCURVE",
-"227 178 OFFCURVE",
-"227 229 CURVE SMOOTH",
-"227 263 OFFCURVE",
-"223 283 OFFCURVE",
-"197 283 CURVE SMOOTH"
+"149 -109 OFFCURVE",
+"320 12 OFFCURVE",
+"320 167 CURVE SMOOTH",
+"320 249 OFFCURVE",
+"272 301 OFFCURVE",
+"194 301 CURVE SMOOTH",
+"100 301 OFFCURVE",
+"19 226 OFFCURVE",
+"19 148 CURVE SMOOTH",
+"19 90 OFFCURVE",
+"65 39 OFFCURVE",
+"129 39 CURVE SMOOTH",
+"154 39 OFFCURVE",
+"174 46 OFFCURVE",
+"196 66 CURVE",
+"198 63 LINE",
+"182 -6 OFFCURVE",
+"111 -78 OFFCURVE",
+"14 -88 CURVE",
+"14 -109 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"129 39 LINE SMOOTH",
-"65 39 OFFCURVE",
-"19 90 OFFCURVE",
-"19 148 CURVE SMOOTH",
-"19 226 OFFCURVE",
-"100 301 OFFCURVE",
-"194 301 CURVE SMOOTH",
-"272 301 OFFCURVE",
-"320 249 OFFCURVE",
-"320 167 CURVE SMOOTH",
-"320 12 OFFCURVE",
-"149 -109 OFFCURVE",
-"14 -109 CURVE",
-"14 -88 LINE",
-"111 -78 OFFCURVE",
-"182 -6 OFFCURVE",
-"198 63 CURVE",
-"196 66 LINE",
-"174 46 OFFCURVE",
-"154 39 OFFCURVE",
-"129 39 CURVE SMOOTH"
+"116 60 OFFCURVE",
+"113 80 OFFCURVE",
+"113 102 CURVE SMOOTH",
+"113 154 OFFCURVE",
+"131 283 OFFCURVE",
+"197 283 CURVE SMOOTH",
+"223 283 OFFCURVE",
+"227 263 OFFCURVE",
+"227 229 CURVE SMOOTH",
+"227 178 OFFCURVE",
+"215 124 OFFCURVE",
+"205 100 CURVE",
+"184 73 OFFCURVE",
+"163 60 OFFCURVE",
+"142 60 CURVE SMOOTH"
 );
 }
 );
@@ -27144,7 +30865,7 @@ unicode = 2089;
 },
 {
 glyphname = zerosuperior;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:58:20 +0000";
 layers = (
 {
 background = {
@@ -27190,7 +30911,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"263 459 LINE SMOOTH",
 "377 459 OFFCURVE",
 "462 602 OFFCURVE",
 "462 709 CURVE SMOOTH",
@@ -27208,19 +30928,18 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"347 836 LINE SMOOTH",
-"366 836 OFFCURVE",
-"377 822 OFFCURVE",
-"377 778 CURVE SMOOTH",
-"377 699 OFFCURVE",
-"340 476 OFFCURVE",
-"262 476 CURVE SMOOTH",
 "248 476 OFFCURVE",
 "232 483 OFFCURVE",
 "232 532 CURVE SMOOTH",
 "232 609 OFFCURVE",
 "273 836 OFFCURVE",
-"347 836 CURVE SMOOTH"
+"347 836 CURVE SMOOTH",
+"366 836 OFFCURVE",
+"377 822 OFFCURVE",
+"377 778 CURVE SMOOTH",
+"377 699 OFFCURVE",
+"340 476 OFFCURVE",
+"262 476 CURVE SMOOTH"
 );
 }
 );
@@ -27232,7 +30951,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"273 459 LINE SMOOTH",
 "387 459 OFFCURVE",
 "472 602 OFFCURVE",
 "472 709 CURVE SMOOTH",
@@ -27250,19 +30968,18 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"357 836 LINE SMOOTH",
-"376 836 OFFCURVE",
-"387 822 OFFCURVE",
-"387 778 CURVE SMOOTH",
-"387 699 OFFCURVE",
-"350 476 OFFCURVE",
-"272 476 CURVE SMOOTH",
 "258 476 OFFCURVE",
 "242 483 OFFCURVE",
 "242 532 CURVE SMOOTH",
 "242 609 OFFCURVE",
 "283 836 OFFCURVE",
-"357 836 CURVE SMOOTH"
+"357 836 CURVE SMOOTH",
+"376 836 OFFCURVE",
+"387 822 OFFCURVE",
+"387 778 CURVE SMOOTH",
+"387 699 OFFCURVE",
+"350 476 OFFCURVE",
+"272 476 CURVE SMOOTH"
 );
 }
 );
@@ -27273,7 +30990,7 @@ unicode = 2070;
 },
 {
 glyphname = onesuperior;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 background = {
@@ -27300,16 +31017,16 @@ paths = (
 {
 closed = 1;
 nodes = (
-"152 827 LINE",
-"228 827 LINE",
-"157 480 LINE",
-"86 480 LINE",
-"86 459 LINE",
 "317 459 LINE",
 "317 480 LINE",
 "243 480 LINE",
 "323 848 LINE",
-"152 848 LINE"
+"152 848 LINE",
+"152 827 LINE",
+"228 827 LINE",
+"157 480 LINE",
+"86 480 LINE",
+"86 459 LINE"
 );
 }
 );
@@ -27321,16 +31038,16 @@ paths = (
 {
 closed = 1;
 nodes = (
-"162 827 LINE",
-"238 827 LINE",
-"167 480 LINE",
-"96 480 LINE",
-"96 459 LINE",
 "327 459 LINE",
 "327 480 LINE",
 "253 480 LINE",
 "333 848 LINE",
-"162 848 LINE"
+"162 848 LINE",
+"162 827 LINE",
+"238 827 LINE",
+"167 480 LINE",
+"96 480 LINE",
+"96 459 LINE"
 );
 }
 );
@@ -27341,7 +31058,7 @@ unicode = 00B9;
 },
 {
 glyphname = twosuperior;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 background = {
@@ -27402,7 +31119,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"101 458 LINE",
 "360 458 LINE",
 "392 584 LINE",
 "374 584 LINE",
@@ -27439,7 +31155,8 @@ nodes = (
 "322 706 OFFCURVE",
 "308 651 OFFCURVE",
 "219 589 CURVE SMOOTH",
-"114 516 LINE"
+"114 516 LINE",
+"101 458 LINE"
 );
 }
 );
@@ -27451,7 +31168,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"111 458 LINE",
 "370 458 LINE",
 "402 584 LINE",
 "384 584 LINE",
@@ -27488,7 +31204,8 @@ nodes = (
 "332 706 OFFCURVE",
 "318 651 OFFCURVE",
 "229 589 CURVE SMOOTH",
-"124 516 LINE"
+"124 516 LINE",
+"111 458 LINE"
 );
 }
 );
@@ -27499,7 +31216,7 @@ unicode = 00B2;
 },
 {
 glyphname = threesuperior;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:58:29 +0000";
 layers = (
 {
 background = {
@@ -27586,40 +31303,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"228 677 LINE SMOOTH",
-"216 677 OFFCURVE",
-"203 680 OFFCURVE",
-"197 680 CURVE SMOOTH",
-"189 680 OFFCURVE",
-"182 674 OFFCURVE",
-"182 664 CURVE SMOOTH",
-"182 656 OFFCURVE",
-"187 649 OFFCURVE",
-"200 649 CURVE SMOOTH",
-"211 649 OFFCURVE",
-"208 654 OFFCURVE",
-"230 654 CURVE SMOOTH",
-"269 654 OFFCURVE",
-"282 630 OFFCURVE",
-"282 576 CURVE SMOOTH",
-"282 484 OFFCURVE",
-"240 468 OFFCURVE",
-"203 468 CURVE SMOOTH",
-"178 468 OFFCURVE",
-"143 478 OFFCURVE",
-"143 493 CURVE SMOOTH",
-"143 507 OFFCURVE",
-"177 505 OFFCURVE",
-"177 534 CURVE SMOOTH",
-"177 554 OFFCURVE",
-"161 567 OFFCURVE",
-"141 567 CURVE SMOOTH",
-"116 567 OFFCURVE",
-"105 544 OFFCURVE",
-"105 521 CURVE SMOOTH",
-"105 484 OFFCURVE",
-"135 451 OFFCURVE",
-"212 451 CURVE SMOOTH",
 "308 451 OFFCURVE",
 "379 502 OFFCURVE",
 "379 570 CURVE SMOOTH",
@@ -27653,7 +31336,40 @@ nodes = (
 "309 788 CURVE SMOOTH",
 "309 743 OFFCURVE",
 "282 677 OFFCURVE",
-"228 677 CURVE SMOOTH"
+"228 677 CURVE SMOOTH",
+"216 677 OFFCURVE",
+"203 680 OFFCURVE",
+"197 680 CURVE SMOOTH",
+"189 680 OFFCURVE",
+"182 674 OFFCURVE",
+"182 664 CURVE SMOOTH",
+"182 656 OFFCURVE",
+"187 649 OFFCURVE",
+"200 649 CURVE SMOOTH",
+"211 649 OFFCURVE",
+"208 654 OFFCURVE",
+"230 654 CURVE SMOOTH",
+"269 654 OFFCURVE",
+"282 630 OFFCURVE",
+"282 576 CURVE SMOOTH",
+"282 484 OFFCURVE",
+"240 468 OFFCURVE",
+"203 468 CURVE SMOOTH",
+"178 468 OFFCURVE",
+"143 478 OFFCURVE",
+"143 493 CURVE SMOOTH",
+"143 507 OFFCURVE",
+"177 505 OFFCURVE",
+"177 534 CURVE SMOOTH",
+"177 554 OFFCURVE",
+"161 567 OFFCURVE",
+"141 567 CURVE SMOOTH",
+"116 567 OFFCURVE",
+"105 544 OFFCURVE",
+"105 521 CURVE SMOOTH",
+"105 484 OFFCURVE",
+"135 451 OFFCURVE",
+"212 451 CURVE SMOOTH"
 );
 }
 );
@@ -27665,40 +31381,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"238 677 LINE SMOOTH",
-"226 677 OFFCURVE",
-"213 680 OFFCURVE",
-"207 680 CURVE SMOOTH",
-"199 680 OFFCURVE",
-"192 674 OFFCURVE",
-"192 664 CURVE SMOOTH",
-"192 656 OFFCURVE",
-"197 649 OFFCURVE",
-"210 649 CURVE SMOOTH",
-"221 649 OFFCURVE",
-"218 654 OFFCURVE",
-"240 654 CURVE SMOOTH",
-"279 654 OFFCURVE",
-"292 630 OFFCURVE",
-"292 576 CURVE SMOOTH",
-"292 484 OFFCURVE",
-"250 468 OFFCURVE",
-"213 468 CURVE SMOOTH",
-"188 468 OFFCURVE",
-"153 478 OFFCURVE",
-"153 493 CURVE SMOOTH",
-"153 507 OFFCURVE",
-"187 505 OFFCURVE",
-"187 534 CURVE SMOOTH",
-"187 554 OFFCURVE",
-"171 567 OFFCURVE",
-"151 567 CURVE SMOOTH",
-"126 567 OFFCURVE",
-"115 544 OFFCURVE",
-"115 521 CURVE SMOOTH",
-"115 484 OFFCURVE",
-"145 451 OFFCURVE",
-"222 451 CURVE SMOOTH",
 "318 451 OFFCURVE",
 "389 502 OFFCURVE",
 "389 570 CURVE SMOOTH",
@@ -27732,7 +31414,40 @@ nodes = (
 "319 788 CURVE SMOOTH",
 "319 743 OFFCURVE",
 "292 677 OFFCURVE",
-"238 677 CURVE SMOOTH"
+"238 677 CURVE SMOOTH",
+"226 677 OFFCURVE",
+"213 680 OFFCURVE",
+"207 680 CURVE SMOOTH",
+"199 680 OFFCURVE",
+"192 674 OFFCURVE",
+"192 664 CURVE SMOOTH",
+"192 656 OFFCURVE",
+"197 649 OFFCURVE",
+"210 649 CURVE SMOOTH",
+"221 649 OFFCURVE",
+"218 654 OFFCURVE",
+"240 654 CURVE SMOOTH",
+"279 654 OFFCURVE",
+"292 630 OFFCURVE",
+"292 576 CURVE SMOOTH",
+"292 484 OFFCURVE",
+"250 468 OFFCURVE",
+"213 468 CURVE SMOOTH",
+"188 468 OFFCURVE",
+"153 478 OFFCURVE",
+"153 493 CURVE SMOOTH",
+"153 507 OFFCURVE",
+"187 505 OFFCURVE",
+"187 534 CURVE SMOOTH",
+"187 554 OFFCURVE",
+"171 567 OFFCURVE",
+"151 567 CURVE SMOOTH",
+"126 567 OFFCURVE",
+"115 544 OFFCURVE",
+"115 521 CURVE SMOOTH",
+"115 484 OFFCURVE",
+"145 451 OFFCURVE",
+"222 451 CURVE SMOOTH"
 );
 }
 );
@@ -27743,7 +31458,7 @@ unicode = 00B3;
 },
 {
 glyphname = foursuperior;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 background = {
@@ -27789,11 +31504,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"117 563 LINE",
-"256 563 LINE",
-"237 476 LINE",
-"199 476 LINE",
-"199 459 LINE",
 "367 459 LINE",
 "367 476 LINE",
 "324 476 LINE",
@@ -27807,7 +31517,12 @@ nodes = (
 "347 582 LINE",
 "404 848 LINE",
 "361 848 LINE",
-"117 582 LINE"
+"117 582 LINE",
+"117 563 LINE",
+"256 563 LINE",
+"237 476 LINE",
+"199 476 LINE",
+"199 459 LINE"
 );
 },
 {
@@ -27828,11 +31543,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"127 563 LINE",
-"266 563 LINE",
-"247 476 LINE",
-"209 476 LINE",
-"209 459 LINE",
 "377 459 LINE",
 "377 476 LINE",
 "334 476 LINE",
@@ -27846,7 +31556,12 @@ nodes = (
 "357 582 LINE",
 "414 848 LINE",
 "371 848 LINE",
-"127 582 LINE"
+"127 582 LINE",
+"127 563 LINE",
+"266 563 LINE",
+"247 476 LINE",
+"209 476 LINE",
+"209 459 LINE"
 );
 },
 {
@@ -27866,7 +31581,7 @@ unicode = 2074;
 },
 {
 glyphname = fivesuperior;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 background = {
@@ -27940,6 +31655,15 @@ paths = (
 {
 closed = 1;
 nodes = (
+"332 458 OFFCURVE",
+"402 529 OFFCURVE",
+"402 598 CURVE SMOOTH",
+"402 659 OFFCURVE",
+"347 701 OFFCURVE",
+"260 701 CURVE SMOOTH",
+"236 701 OFFCURVE",
+"216 698 OFFCURVE",
+"189 689 CURVE",
 "187 692 LINE",
 "211 774 LINE",
 "394 774 LINE",
@@ -27974,16 +31698,7 @@ nodes = (
 "118 535 CURVE SMOOTH",
 "118 499 OFFCURVE",
 "145 458 OFFCURVE",
-"226 458 CURVE SMOOTH",
-"332 458 OFFCURVE",
-"402 529 OFFCURVE",
-"402 598 CURVE SMOOTH",
-"402 659 OFFCURVE",
-"347 701 OFFCURVE",
-"260 701 CURVE SMOOTH",
-"236 701 OFFCURVE",
-"216 698 OFFCURVE",
-"189 689 CURVE"
+"226 458 CURVE SMOOTH"
 );
 }
 );
@@ -27995,6 +31710,15 @@ paths = (
 {
 closed = 1;
 nodes = (
+"342 458 OFFCURVE",
+"412 529 OFFCURVE",
+"412 598 CURVE SMOOTH",
+"412 659 OFFCURVE",
+"357 701 OFFCURVE",
+"270 701 CURVE SMOOTH",
+"246 701 OFFCURVE",
+"226 698 OFFCURVE",
+"199 689 CURVE",
 "197 692 LINE",
 "221 774 LINE",
 "404 774 LINE",
@@ -28029,16 +31753,7 @@ nodes = (
 "128 535 CURVE SMOOTH",
 "128 499 OFFCURVE",
 "155 458 OFFCURVE",
-"236 458 CURVE SMOOTH",
-"342 458 OFFCURVE",
-"412 529 OFFCURVE",
-"412 598 CURVE SMOOTH",
-"412 659 OFFCURVE",
-"357 701 OFFCURVE",
-"270 701 CURVE SMOOTH",
-"246 701 OFFCURVE",
-"226 698 OFFCURVE",
-"199 689 CURVE"
+"236 458 CURVE SMOOTH"
 );
 }
 );
@@ -28049,7 +31764,7 @@ unicode = 2075;
 },
 {
 glyphname = sixsuperior;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:58:40 +0000";
 layers = (
 {
 background = {
@@ -28106,48 +31821,46 @@ paths = (
 {
 closed = 1;
 nodes = (
-"239 467 LINE SMOOTH",
-"304 467 OFFCURVE",
-"322 597 OFFCURVE",
-"322 649 CURVE SMOOTH",
-"322 671 OFFCURVE",
-"319 690 OFFCURVE",
-"293 690 CURVE SMOOTH",
-"273 690 OFFCURVE",
-"252 678 OFFCURVE",
-"230 651 CURVE",
-"220 627 OFFCURVE",
-"208 572 OFFCURVE",
-"208 521 CURVE SMOOTH",
-"208 488 OFFCURVE",
-"212 467 OFFCURVE",
-"239 467 CURVE SMOOTH"
+"335 450 OFFCURVE",
+"416 525 OFFCURVE",
+"416 602 CURVE SMOOTH",
+"416 661 OFFCURVE",
+"371 712 OFFCURVE",
+"306 712 CURVE SMOOTH",
+"282 712 OFFCURVE",
+"262 704 OFFCURVE",
+"239 685 CURVE",
+"236 688 LINE",
+"252 756 OFFCURVE",
+"324 828 OFFCURVE",
+"422 839 CURVE",
+"422 860 LINE",
+"286 860 OFFCURVE",
+"115 739 OFFCURVE",
+"115 584 CURVE SMOOTH",
+"115 502 OFFCURVE",
+"163 450 OFFCURVE",
+"241 450 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"306 712 LINE SMOOTH",
-"371 712 OFFCURVE",
-"416 661 OFFCURVE",
-"416 602 CURVE SMOOTH",
-"416 525 OFFCURVE",
-"335 450 OFFCURVE",
-"241 450 CURVE SMOOTH",
-"163 450 OFFCURVE",
-"115 502 OFFCURVE",
-"115 584 CURVE SMOOTH",
-"115 739 OFFCURVE",
-"286 860 OFFCURVE",
-"422 860 CURVE",
-"422 839 LINE",
-"324 828 OFFCURVE",
-"252 756 OFFCURVE",
-"236 688 CURVE",
-"239 685 LINE",
-"262 704 OFFCURVE",
-"282 712 OFFCURVE",
-"306 712 CURVE SMOOTH"
+"212 467 OFFCURVE",
+"208 488 OFFCURVE",
+"208 521 CURVE SMOOTH",
+"208 572 OFFCURVE",
+"220 627 OFFCURVE",
+"230 651 CURVE",
+"252 678 OFFCURVE",
+"273 690 OFFCURVE",
+"293 690 CURVE SMOOTH",
+"319 690 OFFCURVE",
+"322 671 OFFCURVE",
+"322 649 CURVE SMOOTH",
+"322 597 OFFCURVE",
+"304 467 OFFCURVE",
+"239 467 CURVE SMOOTH"
 );
 }
 );
@@ -28159,48 +31872,46 @@ paths = (
 {
 closed = 1;
 nodes = (
-"249 467 LINE SMOOTH",
-"314 467 OFFCURVE",
-"332 597 OFFCURVE",
-"332 649 CURVE SMOOTH",
-"332 671 OFFCURVE",
-"329 690 OFFCURVE",
-"303 690 CURVE SMOOTH",
-"283 690 OFFCURVE",
-"262 678 OFFCURVE",
-"240 651 CURVE",
-"230 627 OFFCURVE",
-"218 572 OFFCURVE",
-"218 521 CURVE SMOOTH",
-"218 488 OFFCURVE",
-"222 467 OFFCURVE",
-"249 467 CURVE SMOOTH"
+"345 450 OFFCURVE",
+"426 525 OFFCURVE",
+"426 602 CURVE SMOOTH",
+"426 661 OFFCURVE",
+"381 712 OFFCURVE",
+"316 712 CURVE SMOOTH",
+"292 712 OFFCURVE",
+"272 704 OFFCURVE",
+"249 685 CURVE",
+"246 688 LINE",
+"262 756 OFFCURVE",
+"334 828 OFFCURVE",
+"432 839 CURVE",
+"432 860 LINE",
+"296 860 OFFCURVE",
+"125 739 OFFCURVE",
+"125 584 CURVE SMOOTH",
+"125 502 OFFCURVE",
+"173 450 OFFCURVE",
+"251 450 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"316 712 LINE SMOOTH",
-"381 712 OFFCURVE",
-"426 661 OFFCURVE",
-"426 602 CURVE SMOOTH",
-"426 525 OFFCURVE",
-"345 450 OFFCURVE",
-"251 450 CURVE SMOOTH",
-"173 450 OFFCURVE",
-"125 502 OFFCURVE",
-"125 584 CURVE SMOOTH",
-"125 739 OFFCURVE",
-"296 860 OFFCURVE",
-"432 860 CURVE",
-"432 839 LINE",
-"334 828 OFFCURVE",
-"262 756 OFFCURVE",
-"246 688 CURVE",
-"249 685 LINE",
-"272 704 OFFCURVE",
-"292 712 OFFCURVE",
-"316 712 CURVE SMOOTH"
+"222 467 OFFCURVE",
+"218 488 OFFCURVE",
+"218 521 CURVE SMOOTH",
+"218 572 OFFCURVE",
+"230 627 OFFCURVE",
+"240 651 CURVE",
+"262 678 OFFCURVE",
+"283 690 OFFCURVE",
+"303 690 CURVE SMOOTH",
+"329 690 OFFCURVE",
+"332 671 OFFCURVE",
+"332 649 CURVE SMOOTH",
+"332 597 OFFCURVE",
+"314 467 OFFCURVE",
+"249 467 CURVE SMOOTH"
 );
 }
 );
@@ -28211,7 +31922,7 @@ unicode = 2076;
 },
 {
 glyphname = sevensuperior;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 background = {
@@ -28253,6 +31964,16 @@ paths = (
 {
 closed = 1;
 nodes = (
+"274 449 OFFCURVE",
+"298 471 OFFCURVE",
+"298 507 CURVE SMOOTH",
+"298 526 OFFCURVE",
+"291 537 OFFCURVE",
+"291 566 CURVE SMOOTH",
+"291 586 OFFCURVE",
+"294 616 OFFCURVE",
+"330 663 CURVE SMOOTH",
+"454 823 LINE",
 "455 844 LINE",
 "211 844 LINE",
 "155 726 LINE",
@@ -28268,17 +31989,7 @@ nodes = (
 "189 501 CURVE SMOOTH",
 "189 464 OFFCURVE",
 "209 449 OFFCURVE",
-"238 449 CURVE SMOOTH",
-"274 449 OFFCURVE",
-"298 471 OFFCURVE",
-"298 507 CURVE SMOOTH",
-"298 526 OFFCURVE",
-"291 537 OFFCURVE",
-"291 566 CURVE SMOOTH",
-"291 586 OFFCURVE",
-"294 616 OFFCURVE",
-"330 663 CURVE SMOOTH",
-"454 823 LINE"
+"238 449 CURVE SMOOTH"
 );
 }
 );
@@ -28290,6 +32001,16 @@ paths = (
 {
 closed = 1;
 nodes = (
+"284 449 OFFCURVE",
+"308 471 OFFCURVE",
+"308 507 CURVE SMOOTH",
+"308 526 OFFCURVE",
+"301 537 OFFCURVE",
+"301 566 CURVE SMOOTH",
+"301 586 OFFCURVE",
+"304 616 OFFCURVE",
+"340 663 CURVE SMOOTH",
+"464 823 LINE",
 "465 844 LINE",
 "221 844 LINE",
 "165 726 LINE",
@@ -28305,17 +32026,7 @@ nodes = (
 "199 501 CURVE SMOOTH",
 "199 464 OFFCURVE",
 "219 449 OFFCURVE",
-"248 449 CURVE SMOOTH",
-"284 449 OFFCURVE",
-"308 471 OFFCURVE",
-"308 507 CURVE SMOOTH",
-"308 526 OFFCURVE",
-"301 537 OFFCURVE",
-"301 566 CURVE SMOOTH",
-"301 586 OFFCURVE",
-"304 616 OFFCURVE",
-"340 663 CURVE SMOOTH",
-"464 823 LINE"
+"248 449 CURVE SMOOTH"
 );
 }
 );
@@ -28326,7 +32037,7 @@ unicode = 2077;
 },
 {
 glyphname = eightsuperior;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:58:54 +0000";
 layers = (
 {
 background = {
@@ -28409,7 +32120,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"238 449 LINE SMOOTH",
 "333 449 OFFCURVE",
 "404 506 OFFCURVE",
 "404 565 CURVE SMOOTH",
@@ -28441,37 +32151,35 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"275 645 LINE SMOOTH",
-"299 645 OFFCURVE",
-"312 624 OFFCURVE",
-"312 586 CURVE SMOOTH",
-"312 542 OFFCURVE",
-"294 470 OFFCURVE",
-"237 470 CURVE SMOOTH",
 "211 470 OFFCURVE",
 "195 486 OFFCURVE",
 "195 525 CURVE SMOOTH",
 "195 589 OFFCURVE",
 "234 645 OFFCURVE",
-"275 645 CURVE SMOOTH"
+"275 645 CURVE SMOOTH",
+"299 645 OFFCURVE",
+"312 624 OFFCURVE",
+"312 586 CURVE SMOOTH",
+"312 542 OFFCURVE",
+"294 470 OFFCURVE",
+"237 470 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"316 833 LINE SMOOTH",
-"332 833 OFFCURVE",
-"344 826 OFFCURVE",
-"344 793 CURVE SMOOTH",
-"344 758 OFFCURVE",
-"330 670 OFFCURVE",
-"277 670 CURVE SMOOTH",
 "257 670 OFFCURVE",
 "249 682 OFFCURVE",
 "249 711 CURVE SMOOTH",
 "249 754 OFFCURVE",
 "266 833 OFFCURVE",
-"316 833 CURVE SMOOTH"
+"316 833 CURVE SMOOTH",
+"332 833 OFFCURVE",
+"344 826 OFFCURVE",
+"344 793 CURVE SMOOTH",
+"344 758 OFFCURVE",
+"330 670 OFFCURVE",
+"277 670 CURVE SMOOTH"
 );
 }
 );
@@ -28483,7 +32191,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"248 449 LINE SMOOTH",
 "343 449 OFFCURVE",
 "414 506 OFFCURVE",
 "414 565 CURVE SMOOTH",
@@ -28515,37 +32222,35 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"285 645 LINE SMOOTH",
-"309 645 OFFCURVE",
-"322 624 OFFCURVE",
-"322 586 CURVE SMOOTH",
-"322 542 OFFCURVE",
-"304 470 OFFCURVE",
-"247 470 CURVE SMOOTH",
 "221 470 OFFCURVE",
 "205 486 OFFCURVE",
 "205 525 CURVE SMOOTH",
 "205 589 OFFCURVE",
 "244 645 OFFCURVE",
-"285 645 CURVE SMOOTH"
+"285 645 CURVE SMOOTH",
+"309 645 OFFCURVE",
+"322 624 OFFCURVE",
+"322 586 CURVE SMOOTH",
+"322 542 OFFCURVE",
+"304 470 OFFCURVE",
+"247 470 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"326 833 LINE SMOOTH",
-"342 833 OFFCURVE",
-"354 826 OFFCURVE",
-"354 793 CURVE SMOOTH",
-"354 758 OFFCURVE",
-"340 670 OFFCURVE",
-"287 670 CURVE SMOOTH",
 "267 670 OFFCURVE",
 "259 682 OFFCURVE",
 "259 711 CURVE SMOOTH",
 "259 754 OFFCURVE",
 "276 833 OFFCURVE",
-"326 833 CURVE SMOOTH"
+"326 833 CURVE SMOOTH",
+"342 833 OFFCURVE",
+"354 826 OFFCURVE",
+"354 793 CURVE SMOOTH",
+"354 758 OFFCURVE",
+"340 670 OFFCURVE",
+"287 670 CURVE SMOOTH"
 );
 }
 );
@@ -28556,7 +32261,7 @@ unicode = 2078;
 },
 {
 glyphname = ninesuperior;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:59:03 +0000";
 layers = (
 {
 background = {
@@ -28613,48 +32318,46 @@ paths = (
 {
 closed = 1;
 nodes = (
-"317 842 LINE SMOOTH",
-"251 842 OFFCURVE",
-"233 713 OFFCURVE",
-"233 661 CURVE SMOOTH",
-"233 639 OFFCURVE",
-"236 619 OFFCURVE",
-"262 619 CURVE SMOOTH",
-"283 619 OFFCURVE",
-"304 632 OFFCURVE",
-"325 659 CURVE",
-"335 683 OFFCURVE",
-"347 737 OFFCURVE",
-"347 788 CURVE SMOOTH",
-"347 822 OFFCURVE",
-"343 842 OFFCURVE",
-"317 842 CURVE SMOOTH"
+"269 450 OFFCURVE",
+"440 571 OFFCURVE",
+"440 726 CURVE SMOOTH",
+"440 808 OFFCURVE",
+"392 860 OFFCURVE",
+"314 860 CURVE SMOOTH",
+"220 860 OFFCURVE",
+"139 785 OFFCURVE",
+"139 707 CURVE SMOOTH",
+"139 649 OFFCURVE",
+"185 598 OFFCURVE",
+"249 598 CURVE SMOOTH",
+"274 598 OFFCURVE",
+"294 605 OFFCURVE",
+"316 625 CURVE",
+"319 622 LINE",
+"303 553 OFFCURVE",
+"231 481 OFFCURVE",
+"134 471 CURVE",
+"134 450 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"249 598 LINE SMOOTH",
-"185 598 OFFCURVE",
-"139 649 OFFCURVE",
-"139 707 CURVE SMOOTH",
-"139 785 OFFCURVE",
-"220 860 OFFCURVE",
-"314 860 CURVE SMOOTH",
-"392 860 OFFCURVE",
-"440 808 OFFCURVE",
-"440 726 CURVE SMOOTH",
-"440 571 OFFCURVE",
-"269 450 OFFCURVE",
-"134 450 CURVE",
-"134 471 LINE",
-"231 481 OFFCURVE",
-"303 553 OFFCURVE",
-"319 622 CURVE",
-"316 625 LINE",
-"294 605 OFFCURVE",
-"274 598 OFFCURVE",
-"249 598 CURVE SMOOTH"
+"236 619 OFFCURVE",
+"233 639 OFFCURVE",
+"233 661 CURVE SMOOTH",
+"233 713 OFFCURVE",
+"251 842 OFFCURVE",
+"317 842 CURVE SMOOTH",
+"343 842 OFFCURVE",
+"347 822 OFFCURVE",
+"347 788 CURVE SMOOTH",
+"347 737 OFFCURVE",
+"335 683 OFFCURVE",
+"325 659 CURVE",
+"304 632 OFFCURVE",
+"283 619 OFFCURVE",
+"262 619 CURVE SMOOTH"
 );
 }
 );
@@ -28666,48 +32369,46 @@ paths = (
 {
 closed = 1;
 nodes = (
-"327 842 LINE SMOOTH",
-"261 842 OFFCURVE",
-"243 713 OFFCURVE",
-"243 661 CURVE SMOOTH",
-"243 639 OFFCURVE",
-"246 619 OFFCURVE",
-"272 619 CURVE SMOOTH",
-"293 619 OFFCURVE",
-"314 632 OFFCURVE",
-"335 659 CURVE",
-"345 683 OFFCURVE",
-"357 737 OFFCURVE",
-"357 788 CURVE SMOOTH",
-"357 822 OFFCURVE",
-"353 842 OFFCURVE",
-"327 842 CURVE SMOOTH"
+"279 450 OFFCURVE",
+"450 571 OFFCURVE",
+"450 726 CURVE SMOOTH",
+"450 808 OFFCURVE",
+"402 860 OFFCURVE",
+"324 860 CURVE SMOOTH",
+"230 860 OFFCURVE",
+"149 785 OFFCURVE",
+"149 707 CURVE SMOOTH",
+"149 649 OFFCURVE",
+"195 598 OFFCURVE",
+"259 598 CURVE SMOOTH",
+"284 598 OFFCURVE",
+"304 605 OFFCURVE",
+"326 625 CURVE",
+"329 622 LINE",
+"313 553 OFFCURVE",
+"241 481 OFFCURVE",
+"144 471 CURVE",
+"144 450 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"259 598 LINE SMOOTH",
-"195 598 OFFCURVE",
-"149 649 OFFCURVE",
-"149 707 CURVE SMOOTH",
-"149 785 OFFCURVE",
-"230 860 OFFCURVE",
-"324 860 CURVE SMOOTH",
-"402 860 OFFCURVE",
-"450 808 OFFCURVE",
-"450 726 CURVE SMOOTH",
-"450 571 OFFCURVE",
-"279 450 OFFCURVE",
-"144 450 CURVE",
-"144 471 LINE",
-"241 481 OFFCURVE",
-"313 553 OFFCURVE",
-"329 622 CURVE",
-"326 625 LINE",
-"304 605 OFFCURVE",
-"284 598 OFFCURVE",
-"259 598 CURVE SMOOTH"
+"246 619 OFFCURVE",
+"243 639 OFFCURVE",
+"243 661 CURVE SMOOTH",
+"243 713 OFFCURVE",
+"261 842 OFFCURVE",
+"327 842 CURVE SMOOTH",
+"353 842 OFFCURVE",
+"357 822 OFFCURVE",
+"357 788 CURVE SMOOTH",
+"357 737 OFFCURVE",
+"345 683 OFFCURVE",
+"335 659 CURVE",
+"314 632 OFFCURVE",
+"293 619 OFFCURVE",
+"272 619 CURVE SMOOTH"
 );
 }
 );
@@ -28718,7 +32419,7 @@ unicode = 2079;
 },
 {
 glyphname = fraction;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -28726,10 +32427,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"446 753 LINE",
-"-144 0 LINE",
 "-85 0 LINE",
-"505 753 LINE"
+"505 753 LINE",
+"446 753 LINE",
+"-144 0 LINE"
 );
 }
 );
@@ -28741,10 +32442,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"446 753 LINE",
-"-144 0 LINE",
 "-85 0 LINE",
-"505 753 LINE"
+"505 753 LINE",
+"446 753 LINE",
+"-144 0 LINE"
 );
 }
 );
@@ -28755,13 +32456,14 @@ unicode = 2044;
 },
 {
 glyphname = onehalf;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:59:21 +0000";
 layers = (
 {
 components = (
 {
+alignment = -1;
 name = fraction;
-transform = "{1, 0, 0, 1, 304, 0}";
+transform = "{1, 0, 0, 1, 319, 0}";
 },
 {
 name = one.numerator;
@@ -28778,8 +32480,9 @@ width = 913;
 {
 components = (
 {
+alignment = -1;
 name = fraction;
-transform = "{1, 0, 0, 1, 304, 0}";
+transform = "{1, 0, 0, 1, 331, 0}";
 },
 {
 name = one.numerator;
@@ -29013,13 +32716,14 @@ unicode = 215B;
 },
 {
 glyphname = threeeighths;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:59:47 +0000";
 layers = (
 {
 components = (
 {
+alignment = -1;
 name = fraction;
-transform = "{1, 0, 0, 1, 314, 0}";
+transform = "{1, 0, 0, 1, 327, 0}";
 },
 {
 name = three.numerator;
@@ -29036,8 +32740,9 @@ width = 913;
 {
 components = (
 {
+alignment = -1;
 name = fraction;
-transform = "{1, 0, 0, 1, 314, 0}";
+transform = "{1, 0, 0, 1, 341, 0}";
 },
 {
 name = three.numerator;
@@ -29142,7 +32847,7 @@ unicode = 215E;
 },
 {
 glyphname = asterisk;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:01:51 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -29150,41 +32855,11 @@ paths = (
 {
 closed = 1;
 nodes = (
-"117 633 LINE",
-"117 612 OFFCURVE",
-"125 599 OFFCURVE",
-"140 590 CURVE SMOOTH",
-"176 568 OFFCURVE",
-"210 578 OFFCURVE",
-"264 551 CURVE",
-"264 547 LINE",
-"203 520 OFFCURVE",
-"171 530 OFFCURVE",
-"131 508 CURVE SMOOTH",
-"112 498 OFFCURVE",
-"97 484 OFFCURVE",
-"97 460 CURVE SMOOTH",
-"97 437 OFFCURVE",
-"110 419 OFFCURVE",
-"138 419 CURVE SMOOTH",
-"189 419 OFFCURVE",
-"204 480 OFFCURVE",
-"276 522 CURVE",
-"280 520 LINE",
-"266 455 OFFCURVE",
-"233 421 OFFCURVE",
-"233 379 CURVE SMOOTH",
-"233 354 OFFCURVE",
-"245 336 OFFCURVE",
-"273 336 CURVE SMOOTH",
 "306 336 OFFCURVE",
 "324 361 OFFCURVE",
 "327 390 CURVE SMOOTH",
-"327 393 OFFCURVE",
-"328 397 OFFCURVE",
-"328 400 CURVE SMOOTH",
-"328 431 OFFCURVE",
-"312 460 OFFCURVE",
+"327 403 OFFCURVE",
+"312 490 OFFCURVE",
 "312 511 CURVE",
 "312 520 LINE",
 "375 482 OFFCURVE",
@@ -29193,18 +32868,12 @@ nodes = (
 "461 419 OFFCURVE",
 "480 447 OFFCURVE",
 "480 467 CURVE SMOOTH",
-"480 488 OFFCURVE",
-"472 501 OFFCURVE",
-"457 510 CURVE SMOOTH",
-"426 529 OFFCURVE",
-"388 521 OFFCURVE",
+"480 534 OFFCURVE",
+"412 509 OFFCURVE",
 "335 547 CURVE",
 "335 551 LINE",
-"396 577 OFFCURVE",
-"429 572 OFFCURVE",
-"465 588 CURVE SMOOTH",
-"487 598 OFFCURVE",
-"500 613 OFFCURVE",
+"411 583 OFFCURVE",
+"500 575 OFFCURVE",
 "500 631 CURVE SMOOTH",
 "500 655 OFFCURVE",
 "489 679 OFFCURVE",
@@ -29221,17 +32890,39 @@ nodes = (
 "292 763 OFFCURVE",
 "271 741 OFFCURVE",
 "271 701 CURVE SMOOTH",
-"271 669 OFFCURVE",
-"287 641 OFFCURVE",
-"287 587 CURVE",
-"287 578 LINE",
+"271 670 OFFCURVE",
+"287 642 OFFCURVE",
+"287 578 CURVE",
 "283 576 LINE",
 "220 618 OFFCURVE",
 "218 679 OFFCURVE",
 "168 679 CURVE SMOOTH",
 "133 679 OFFCURVE",
 "117 655 OFFCURVE",
-"117 633 CURVE SMOOTH"
+"117 633 CURVE SMOOTH",
+"117 612 OFFCURVE",
+"125 599 OFFCURVE",
+"140 590 CURVE SMOOTH",
+"176 568 OFFCURVE",
+"210 578 OFFCURVE",
+"264 551 CURVE",
+"264 547 LINE",
+"184 512 OFFCURVE",
+"97 526 OFFCURVE",
+"97 460 CURVE SMOOTH",
+"97 437 OFFCURVE",
+"110 419 OFFCURVE",
+"138 419 CURVE SMOOTH",
+"189 419 OFFCURVE",
+"204 480 OFFCURVE",
+"276 522 CURVE",
+"280 520 LINE",
+"266 455 OFFCURVE",
+"233 421 OFFCURVE",
+"233 379 CURVE SMOOTH",
+"233 354 OFFCURVE",
+"245 336 OFFCURVE",
+"273 336 CURVE SMOOTH"
 );
 }
 );
@@ -29243,30 +32934,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"115 631 LINE SMOOTH",
-"115 611 OFFCURVE",
-"124 591 OFFCURVE",
-"147 580 CURVE SMOOTH",
-"179 564 OFFCURVE",
-"217 577 OFFCURVE",
-"275 551 CURVE",
-"268 547 LINE",
-"212 525 OFFCURVE",
-"94 535 OFFCURVE",
-"94 459 CURVE SMOOTH",
-"94 430 OFFCURVE",
-"112 409 OFFCURVE",
-"145 409 CURVE SMOOTH",
-"203 409 OFFCURVE",
-"210 476 OFFCURVE",
-"284 522 CURVE",
-"287 520 LINE",
-"272 455 OFFCURVE",
-"234 434 OFFCURVE",
-"234 390 CURVE SMOOTH",
-"234 357 OFFCURVE",
-"255 336 OFFCURVE",
-"288 336 CURVE SMOOTH",
 "323 336 OFFCURVE",
 "348 361 OFFCURVE",
 "348 395 CURVE SMOOTH",
@@ -29290,10 +32957,9 @@ nodes = (
 "518 656 OFFCURVE",
 "507 689 OFFCURVE",
 "469 689 CURVE SMOOTH",
-"415 689 OFFCURVE",
-"401 620 OFFCURVE",
-"329 576 CURVE",
-"326 578 LINE",
+"414 689 OFFCURVE",
+"409 624 OFFCURVE",
+"326 578 CURVE",
 "339 629 OFFCURVE",
 "387 670 OFFCURVE",
 "387 716 CURVE SMOOTH",
@@ -29312,7 +32978,30 @@ nodes = (
 "176 689 CURVE SMOOTH",
 "145 689 OFFCURVE",
 "115 667 OFFCURVE",
-"115 631 CURVE SMOOTH"
+"115 631 CURVE SMOOTH",
+"115 611 OFFCURVE",
+"124 591 OFFCURVE",
+"147 580 CURVE SMOOTH",
+"179 564 OFFCURVE",
+"217 577 OFFCURVE",
+"275 551 CURVE",
+"268 547 LINE",
+"212 525 OFFCURVE",
+"94 535 OFFCURVE",
+"94 459 CURVE SMOOTH",
+"94 430 OFFCURVE",
+"112 409 OFFCURVE",
+"145 409 CURVE SMOOTH",
+"203 409 OFFCURVE",
+"210 476 OFFCURVE",
+"284 522 CURVE",
+"287 520 LINE",
+"272 455 OFFCURVE",
+"234 434 OFFCURVE",
+"234 390 CURVE SMOOTH",
+"234 357 OFFCURVE",
+"255 336 OFFCURVE",
+"288 336 CURVE SMOOTH"
 );
 }
 );
@@ -29323,7 +33012,7 @@ unicode = 002A;
 },
 {
 glyphname = backslash;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -29331,10 +33020,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"70 753 LINE",
-"149 0 LINE",
 "208 0 LINE",
-"129 753 LINE"
+"129 753 LINE",
+"70 753 LINE",
+"149 0 LINE"
 );
 }
 );
@@ -29346,10 +33035,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"78 754 LINE",
-"128 0 LINE",
 "207 0 LINE",
-"157 754 LINE"
+"157 754 LINE",
+"78 754 LINE",
+"128 0 LINE"
 );
 }
 );
@@ -29360,7 +33049,7 @@ unicode = 005C;
 },
 {
 glyphname = periodcentered;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:00:05 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -29368,10 +33057,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"26 251 LINE SMOOTH",
-"26 213 OFFCURVE",
-"55 184 OFFCURVE",
-"93 184 CURVE SMOOTH",
 "131 184 OFFCURVE",
 "161 213 OFFCURVE",
 "161 251 CURVE SMOOTH",
@@ -29380,7 +33065,10 @@ nodes = (
 "93 319 CURVE SMOOTH",
 "55 319 OFFCURVE",
 "26 289 OFFCURVE",
-"26 251 CURVE SMOOTH"
+"26 251 CURVE SMOOTH",
+"26 213 OFFCURVE",
+"55 184 OFFCURVE",
+"93 184 CURVE SMOOTH"
 );
 }
 );
@@ -29392,10 +33080,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"26 254 LINE SMOOTH",
-"26 206 OFFCURVE",
-"65 167 OFFCURVE",
-"113 167 CURVE SMOOTH",
 "161 167 OFFCURVE",
 "200 206 OFFCURVE",
 "200 254 CURVE SMOOTH",
@@ -29404,7 +33088,10 @@ nodes = (
 "113 341 CURVE SMOOTH",
 "65 341 OFFCURVE",
 "26 302 OFFCURVE",
-"26 254 CURVE SMOOTH"
+"26 254 CURVE SMOOTH",
+"26 206 OFFCURVE",
+"65 167 OFFCURVE",
+"113 167 CURVE SMOOTH"
 );
 }
 );
@@ -29415,7 +33102,7 @@ unicode = 00B7;
 },
 {
 glyphname = bullet;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:00:12 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -29423,19 +33110,18 @@ paths = (
 {
 closed = 1;
 nodes = (
-"235 495 LINE SMOOTH",
-"165 495 OFFCURVE",
-"120 443 OFFCURVE",
-"120 380 CURVE SMOOTH",
-"120 317 OFFCURVE",
-"165 265 OFFCURVE",
-"235 265 CURVE SMOOTH",
 "305 265 OFFCURVE",
 "350 317 OFFCURVE",
 "350 380 CURVE SMOOTH",
 "350 443 OFFCURVE",
 "305 495 OFFCURVE",
-"235 495 CURVE SMOOTH"
+"235 495 CURVE SMOOTH",
+"165 495 OFFCURVE",
+"120 443 OFFCURVE",
+"120 380 CURVE SMOOTH",
+"120 317 OFFCURVE",
+"165 265 OFFCURVE",
+"235 265 CURVE SMOOTH"
 );
 }
 );
@@ -29447,19 +33133,18 @@ paths = (
 {
 closed = 1;
 nodes = (
-"250 495 LINE SMOOTH",
-"180 495 OFFCURVE",
-"135 443 OFFCURVE",
-"135 380 CURVE SMOOTH",
-"135 317 OFFCURVE",
-"180 265 OFFCURVE",
-"250 265 CURVE SMOOTH",
 "320 265 OFFCURVE",
 "365 317 OFFCURVE",
 "365 380 CURVE SMOOTH",
 "365 443 OFFCURVE",
 "320 495 OFFCURVE",
-"250 495 CURVE SMOOTH"
+"250 495 CURVE SMOOTH",
+"180 495 OFFCURVE",
+"135 443 OFFCURVE",
+"135 380 CURVE SMOOTH",
+"135 317 OFFCURVE",
+"180 265 OFFCURVE",
+"250 265 CURVE SMOOTH"
 );
 }
 );
@@ -29470,7 +33155,7 @@ unicode = 2022;
 },
 {
 glyphname = colon;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:00:26 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -29478,28 +33163,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"41 54 LINE SMOOTH",
-"41 16 OFFCURVE",
-"70 -13 OFFCURVE",
-"108 -13 CURVE SMOOTH",
-"146 -13 OFFCURVE",
-"176 16 OFFCURVE",
-"176 54 CURVE SMOOTH",
-"176 92 OFFCURVE",
-"146 122 OFFCURVE",
-"108 122 CURVE SMOOTH",
-"70 122 OFFCURVE",
-"41 92 OFFCURVE",
-"41 54 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"103 386 LINE SMOOTH",
-"103 348 OFFCURVE",
-"132 319 OFFCURVE",
-"170 319 CURVE SMOOTH",
 "208 319 OFFCURVE",
 "238 348 OFFCURVE",
 "238 386 CURVE SMOOTH",
@@ -29508,7 +33171,27 @@ nodes = (
 "170 454 CURVE SMOOTH",
 "132 454 OFFCURVE",
 "103 424 OFFCURVE",
-"103 386 CURVE SMOOTH"
+"103 386 CURVE SMOOTH",
+"103 348 OFFCURVE",
+"132 319 OFFCURVE",
+"170 319 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"146 -13 OFFCURVE",
+"176 16 OFFCURVE",
+"176 54 CURVE SMOOTH",
+"176 92 OFFCURVE",
+"146 122 OFFCURVE",
+"108 122 CURVE SMOOTH",
+"70 122 OFFCURVE",
+"41 92 OFFCURVE",
+"41 54 CURVE SMOOTH",
+"41 16 OFFCURVE",
+"70 -13 OFFCURVE",
+"108 -13 CURVE SMOOTH"
 );
 }
 );
@@ -29541,28 +33224,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"5 74 LINE SMOOTH",
-"5 26 OFFCURVE",
-"43 -12 OFFCURVE",
-"91 -12 CURVE SMOOTH",
-"140 -12 OFFCURVE",
-"178 26 OFFCURVE",
-"178 74 CURVE SMOOTH",
-"178 123 OFFCURVE",
-"140 161 OFFCURVE",
-"91 161 CURVE SMOOTH",
-"43 161 OFFCURVE",
-"5 123 OFFCURVE",
-"5 74 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"63 363 LINE SMOOTH",
-"63 315 OFFCURVE",
-"101 277 OFFCURVE",
-"149 277 CURVE SMOOTH",
 "198 277 OFFCURVE",
 "236 315 OFFCURVE",
 "236 363 CURVE SMOOTH",
@@ -29571,7 +33232,27 @@ nodes = (
 "149 450 CURVE SMOOTH",
 "101 450 OFFCURVE",
 "63 412 OFFCURVE",
-"63 363 CURVE SMOOTH"
+"63 363 CURVE SMOOTH",
+"63 315 OFFCURVE",
+"101 277 OFFCURVE",
+"149 277 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"140 -12 OFFCURVE",
+"178 26 OFFCURVE",
+"178 74 CURVE SMOOTH",
+"178 123 OFFCURVE",
+"140 161 OFFCURVE",
+"91 161 CURVE SMOOTH",
+"43 161 OFFCURVE",
+"5 123 OFFCURVE",
+"5 74 CURVE SMOOTH",
+"5 26 OFFCURVE",
+"43 -12 OFFCURVE",
+"91 -12 CURVE SMOOTH"
 );
 }
 );
@@ -29582,7 +33263,7 @@ unicode = 003A;
 },
 {
 glyphname = comma;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -29590,7 +33271,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"-15 -168 LINE",
 "79 -120 OFFCURVE",
 "142 -51 OFFCURVE",
 "142 19 CURVE SMOOTH",
@@ -29611,7 +33291,8 @@ nodes = (
 "106 -6 CURVE SMOOTH",
 "106 -45 OFFCURVE",
 "66 -98 OFFCURVE",
-"-28 -145 CURVE"
+"-28 -145 CURVE",
+"-15 -168 LINE"
 );
 }
 );
@@ -29644,7 +33325,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"3 -196 LINE",
 "132 -136 OFFCURVE",
 "206 -49 OFFCURVE",
 "206 33 CURVE SMOOTH",
@@ -29665,7 +33345,8 @@ nodes = (
 "159 5 CURVE SMOOTH",
 "159 -52 OFFCURVE",
 "90 -117 OFFCURVE",
-"-10 -173 CURVE"
+"-10 -173 CURVE",
+"3 -196 LINE"
 );
 }
 );
@@ -29676,7 +33357,7 @@ unicode = 002C;
 },
 {
 glyphname = ellipsis;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:00:44 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -29684,46 +33365,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"-18 54 LINE SMOOTH",
-"-18 16 OFFCURVE",
-"11 -13 OFFCURVE",
-"49 -13 CURVE SMOOTH",
-"87 -13 OFFCURVE",
-"117 16 OFFCURVE",
-"117 54 CURVE SMOOTH",
-"117 92 OFFCURVE",
-"87 122 OFFCURVE",
-"49 122 CURVE SMOOTH",
-"11 122 OFFCURVE",
-"-18 92 OFFCURVE",
-"-18 54 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"171 54 LINE SMOOTH",
-"171 16 OFFCURVE",
-"200 -13 OFFCURVE",
-"238 -13 CURVE SMOOTH",
-"276 -13 OFFCURVE",
-"306 16 OFFCURVE",
-"306 54 CURVE SMOOTH",
-"306 92 OFFCURVE",
-"276 122 OFFCURVE",
-"238 122 CURVE SMOOTH",
-"200 122 OFFCURVE",
-"171 92 OFFCURVE",
-"171 54 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"360 54 LINE SMOOTH",
-"360 16 OFFCURVE",
-"389 -13 OFFCURVE",
-"427 -13 CURVE SMOOTH",
 "465 -13 OFFCURVE",
 "495 16 OFFCURVE",
 "495 54 CURVE SMOOTH",
@@ -29732,7 +33373,44 @@ nodes = (
 "427 122 CURVE SMOOTH",
 "389 122 OFFCURVE",
 "360 92 OFFCURVE",
-"360 54 CURVE SMOOTH"
+"360 54 CURVE SMOOTH",
+"360 16 OFFCURVE",
+"389 -13 OFFCURVE",
+"427 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"87 -13 OFFCURVE",
+"117 16 OFFCURVE",
+"117 54 CURVE SMOOTH",
+"117 92 OFFCURVE",
+"87 122 OFFCURVE",
+"49 122 CURVE SMOOTH",
+"11 122 OFFCURVE",
+"-18 92 OFFCURVE",
+"-18 54 CURVE SMOOTH",
+"-18 16 OFFCURVE",
+"11 -13 OFFCURVE",
+"49 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"276 -13 OFFCURVE",
+"306 16 OFFCURVE",
+"306 54 CURVE SMOOTH",
+"306 92 OFFCURVE",
+"276 122 OFFCURVE",
+"238 122 CURVE SMOOTH",
+"200 122 OFFCURVE",
+"171 92 OFFCURVE",
+"171 54 CURVE SMOOTH",
+"171 16 OFFCURVE",
+"200 -13 OFFCURVE",
+"238 -13 CURVE SMOOTH"
 );
 }
 );
@@ -29744,46 +33422,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"5 74 LINE SMOOTH",
-"5 26 OFFCURVE",
-"43 -12 OFFCURVE",
-"91 -12 CURVE SMOOTH",
-"140 -12 OFFCURVE",
-"178 26 OFFCURVE",
-"178 74 CURVE SMOOTH",
-"178 123 OFFCURVE",
-"140 161 OFFCURVE",
-"91 161 CURVE SMOOTH",
-"43 161 OFFCURVE",
-"5 123 OFFCURVE",
-"5 74 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"245 74 LINE SMOOTH",
-"245 26 OFFCURVE",
-"283 -12 OFFCURVE",
-"331 -12 CURVE SMOOTH",
-"380 -12 OFFCURVE",
-"418 26 OFFCURVE",
-"418 74 CURVE SMOOTH",
-"418 123 OFFCURVE",
-"380 161 OFFCURVE",
-"331 161 CURVE SMOOTH",
-"283 161 OFFCURVE",
-"245 123 OFFCURVE",
-"245 74 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"485 74 LINE SMOOTH",
-"485 26 OFFCURVE",
-"523 -12 OFFCURVE",
-"571 -12 CURVE SMOOTH",
 "620 -12 OFFCURVE",
 "658 26 OFFCURVE",
 "658 74 CURVE SMOOTH",
@@ -29792,7 +33430,44 @@ nodes = (
 "571 161 CURVE SMOOTH",
 "523 161 OFFCURVE",
 "485 123 OFFCURVE",
-"485 74 CURVE SMOOTH"
+"485 74 CURVE SMOOTH",
+"485 26 OFFCURVE",
+"523 -12 OFFCURVE",
+"571 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"140 -12 OFFCURVE",
+"178 26 OFFCURVE",
+"178 74 CURVE SMOOTH",
+"178 123 OFFCURVE",
+"140 161 OFFCURVE",
+"91 161 CURVE SMOOTH",
+"43 161 OFFCURVE",
+"5 123 OFFCURVE",
+"5 74 CURVE SMOOTH",
+"5 26 OFFCURVE",
+"43 -12 OFFCURVE",
+"91 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"380 -12 OFFCURVE",
+"418 26 OFFCURVE",
+"418 74 CURVE SMOOTH",
+"418 123 OFFCURVE",
+"380 161 OFFCURVE",
+"331 161 CURVE SMOOTH",
+"283 161 OFFCURVE",
+"245 123 OFFCURVE",
+"245 74 CURVE SMOOTH",
+"245 26 OFFCURVE",
+"283 -12 OFFCURVE",
+"331 -12 CURVE SMOOTH"
 );
 }
 );
@@ -29803,7 +33478,7 @@ unicode = 2026;
 },
 {
 glyphname = exclam;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:00:53 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -29811,10 +33486,27 @@ paths = (
 {
 closed = 1;
 nodes = (
-"61 53 LINE SMOOTH",
-"61 17 OFFCURVE",
-"91 -13 OFFCURVE",
-"127 -13 CURVE SMOOTH",
+"175 224 LINE",
+"226 494 OFFCURVE",
+"326 618 OFFCURVE",
+"326 693 CURVE SMOOTH",
+"326 730 OFFCURVE",
+"302 763 OFFCURVE",
+"257 763 CURVE SMOOTH",
+"212 763 OFFCURVE",
+"183 731 OFFCURVE",
+"183 661 CURVE SMOOTH",
+"183 648 OFFCURVE",
+"184 613 OFFCURVE",
+"184 579 CURVE SMOOTH",
+"184 502 OFFCURVE",
+"179 397 OFFCURVE",
+"150 224 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
 "163 -13 OFFCURVE",
 "193 17 OFFCURVE",
 "193 53 CURVE SMOOTH",
@@ -29823,28 +33515,10 @@ nodes = (
 "127 119 CURVE SMOOTH",
 "91 119 OFFCURVE",
 "61 89 OFFCURVE",
-"61 53 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"150 224 LINE",
-"179 397 OFFCURVE",
-"184 502 OFFCURVE",
-"184 579 CURVE SMOOTH",
-"184 613 OFFCURVE",
-"183 648 OFFCURVE",
-"183 661 CURVE SMOOTH",
-"183 731 OFFCURVE",
-"212 763 OFFCURVE",
-"257 763 CURVE SMOOTH",
-"302 763 OFFCURVE",
-"326 730 OFFCURVE",
-"326 693 CURVE SMOOTH",
-"326 618 OFFCURVE",
-"226 494 OFFCURVE",
-"175 224 CURVE"
+"61 53 CURVE SMOOTH",
+"61 17 OFFCURVE",
+"91 -13 OFFCURVE",
+"127 -13 CURVE SMOOTH"
 );
 }
 );
@@ -29856,10 +33530,27 @@ paths = (
 {
 closed = 1;
 nodes = (
-"42 74 LINE SMOOTH",
-"42 26 OFFCURVE",
-"80 -12 OFFCURVE",
-"128 -12 CURVE SMOOTH",
+"176 224 LINE",
+"230 488 OFFCURVE",
+"337 604 OFFCURVE",
+"337 687 CURVE SMOOTH",
+"337 730 OFFCURVE",
+"309 763 OFFCURVE",
+"261 763 CURVE SMOOTH",
+"213 763 OFFCURVE",
+"170 731 OFFCURVE",
+"170 637 CURVE SMOOTH",
+"170 617 OFFCURVE",
+"172 557 OFFCURVE",
+"172 502 CURVE SMOOTH",
+"172 424 OFFCURVE",
+"167 330 OFFCURVE",
+"146 224 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
 "177 -12 OFFCURVE",
 "215 26 OFFCURVE",
 "215 74 CURVE SMOOTH",
@@ -29868,28 +33559,10 @@ nodes = (
 "128 161 CURVE SMOOTH",
 "80 161 OFFCURVE",
 "42 123 OFFCURVE",
-"42 74 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"146 224 LINE",
-"167 330 OFFCURVE",
-"172 424 OFFCURVE",
-"172 502 CURVE SMOOTH",
-"172 557 OFFCURVE",
-"170 617 OFFCURVE",
-"170 637 CURVE SMOOTH",
-"170 731 OFFCURVE",
-"213 763 OFFCURVE",
-"261 763 CURVE SMOOTH",
-"309 763 OFFCURVE",
-"337 730 OFFCURVE",
-"337 687 CURVE SMOOTH",
-"337 604 OFFCURVE",
-"230 488 OFFCURVE",
-"176 224 CURVE"
+"42 74 CURVE SMOOTH",
+"42 26 OFFCURVE",
+"80 -12 OFFCURVE",
+"128 -12 CURVE SMOOTH"
 );
 }
 );
@@ -29927,7 +33600,7 @@ unicode = 00A1;
 },
 {
 glyphname = numbersign;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -29935,37 +33608,37 @@ paths = (
 {
 closed = 1;
 nodes = (
-"226 763 LINE",
-"106 0 LINE",
-"154 0 LINE",
-"274 763 LINE"
+"371 0 LINE",
+"491 763 LINE",
+"443 763 LINE",
+"323 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"29 236 LINE",
 "527 236 LINE",
 "527 276 LINE",
-"29 276 LINE"
+"29 276 LINE",
+"29 236 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"443 763 LINE",
-"323 0 LINE",
-"371 0 LINE",
-"491 763 LINE"
+"154 0 LINE",
+"274 763 LINE",
+"226 763 LINE",
+"106 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"78 475 LINE",
 "576 475 LINE",
 "576 515 LINE",
-"78 515 LINE"
+"78 515 LINE",
+"78 475 LINE"
 );
 }
 );
@@ -29977,37 +33650,37 @@ paths = (
 {
 closed = 1;
 nodes = (
-"228 763 LINE",
-"108 0 LINE",
 "172 0 LINE",
-"292 763 LINE"
+"292 763 LINE",
+"228 763 LINE",
+"108 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"39 232 LINE",
 "537 232 LINE",
 "537 281 LINE",
-"39 281 LINE"
+"39 281 LINE",
+"39 232 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"445 763 LINE",
-"325 0 LINE",
 "381 0 LINE",
-"501 763 LINE"
+"501 763 LINE",
+"445 763 LINE",
+"325 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"88 470 LINE",
 "586 470 LINE",
 "586 520 LINE",
-"88 520 LINE"
+"88 520 LINE",
+"88 470 LINE"
 );
 }
 );
@@ -30018,7 +33691,7 @@ unicode = 0023;
 },
 {
 glyphname = period;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:01:07 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -30026,10 +33699,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"-18 54 LINE SMOOTH",
-"-18 16 OFFCURVE",
-"11 -13 OFFCURVE",
-"49 -13 CURVE SMOOTH",
 "87 -13 OFFCURVE",
 "117 16 OFFCURVE",
 "117 54 CURVE SMOOTH",
@@ -30038,7 +33707,10 @@ nodes = (
 "49 122 CURVE SMOOTH",
 "11 122 OFFCURVE",
 "-18 92 OFFCURVE",
-"-18 54 CURVE SMOOTH"
+"-18 54 CURVE SMOOTH",
+"-18 16 OFFCURVE",
+"11 -13 OFFCURVE",
+"49 -13 CURVE SMOOTH"
 );
 }
 );
@@ -30050,10 +33722,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"5 74 LINE SMOOTH",
-"5 26 OFFCURVE",
-"43 -12 OFFCURVE",
-"91 -12 CURVE SMOOTH",
 "140 -12 OFFCURVE",
 "178 26 OFFCURVE",
 "178 74 CURVE SMOOTH",
@@ -30062,7 +33730,10 @@ nodes = (
 "91 161 CURVE SMOOTH",
 "43 161 OFFCURVE",
 "5 123 OFFCURVE",
-"5 74 CURVE SMOOTH"
+"5 74 CURVE SMOOTH",
+"5 26 OFFCURVE",
+"43 -12 OFFCURVE",
+"91 -12 CURVE SMOOTH"
 );
 }
 );
@@ -30073,29 +33744,11 @@ unicode = 002E;
 },
 {
 glyphname = question;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:01:14 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
 paths = (
-{
-closed = 1;
-nodes = (
-"89 53 LINE SMOOTH",
-"89 17 OFFCURVE",
-"119 -13 OFFCURVE",
-"155 -13 CURVE SMOOTH",
-"191 -13 OFFCURVE",
-"221 17 OFFCURVE",
-"221 53 CURVE SMOOTH",
-"221 89 OFFCURVE",
-"191 119 OFFCURVE",
-"155 119 CURVE SMOOTH",
-"119 119 OFFCURVE",
-"89 89 OFFCURVE",
-"89 53 CURVE SMOOTH"
-);
-},
 {
 closed = 1;
 nodes = (
@@ -30131,6 +33784,23 @@ nodes = (
 "175 241 OFFCURVE",
 "177 224 CURVE"
 );
+},
+{
+closed = 1;
+nodes = (
+"191 -13 OFFCURVE",
+"221 17 OFFCURVE",
+"221 53 CURVE SMOOTH",
+"221 89 OFFCURVE",
+"191 119 OFFCURVE",
+"155 119 CURVE SMOOTH",
+"119 119 OFFCURVE",
+"89 89 OFFCURVE",
+"89 53 CURVE SMOOTH",
+"89 17 OFFCURVE",
+"119 -13 OFFCURVE",
+"155 -13 CURVE SMOOTH"
+);
 }
 );
 width = 459;
@@ -30138,24 +33808,6 @@ width = 459;
 {
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
 paths = (
-{
-closed = 1;
-nodes = (
-"82 74 LINE SMOOTH",
-"82 26 OFFCURVE",
-"120 -12 OFFCURVE",
-"168 -12 CURVE SMOOTH",
-"217 -12 OFFCURVE",
-"255 26 OFFCURVE",
-"255 74 CURVE SMOOTH",
-"255 123 OFFCURVE",
-"217 161 OFFCURVE",
-"168 161 CURVE SMOOTH",
-"120 161 OFFCURVE",
-"82 123 OFFCURVE",
-"82 74 CURVE SMOOTH"
-);
-},
 {
 closed = 1;
 nodes = (
@@ -30190,6 +33842,23 @@ nodes = (
 "178 256 OFFCURVE",
 "179 241 OFFCURVE",
 "181 224 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"217 -12 OFFCURVE",
+"255 26 OFFCURVE",
+"255 74 CURVE SMOOTH",
+"255 123 OFFCURVE",
+"217 161 OFFCURVE",
+"168 161 CURVE SMOOTH",
+"120 161 OFFCURVE",
+"82 123 OFFCURVE",
+"82 74 CURVE SMOOTH",
+"82 26 OFFCURVE",
+"120 -12 OFFCURVE",
+"168 -12 CURVE SMOOTH"
 );
 }
 );
@@ -30235,27 +33904,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"193 463 LINE",
-"223 637 OFFCURVE",
-"295 659 OFFCURVE",
-"295 716 CURVE SMOOTH",
-"295 748 OFFCURVE",
-"272 763 OFFCURVE",
-"241 763 CURVE SMOOTH",
-"196 763 OFFCURVE",
-"167 730 OFFCURVE",
-"167 686 CURVE SMOOTH",
-"167 657 OFFCURVE",
-"180 630 OFFCURVE",
-"180 573 CURVE SMOOTH",
-"180 546 OFFCURVE",
-"177 511 OFFCURVE",
-"167 463 CURVE"
-);
-},
-{
-closed = 1;
-nodes = (
 "364 463 LINE",
 "394 637 OFFCURVE",
 "466 659 OFFCURVE",
@@ -30273,6 +33921,27 @@ nodes = (
 "348 511 OFFCURVE",
 "338 463 CURVE"
 );
+},
+{
+closed = 1;
+nodes = (
+"193 463 LINE",
+"223 637 OFFCURVE",
+"295 659 OFFCURVE",
+"295 716 CURVE SMOOTH",
+"295 748 OFFCURVE",
+"272 763 OFFCURVE",
+"241 763 CURVE SMOOTH",
+"196 763 OFFCURVE",
+"167 730 OFFCURVE",
+"167 686 CURVE SMOOTH",
+"167 657 OFFCURVE",
+"180 630 OFFCURVE",
+"180 573 CURVE SMOOTH",
+"180 546 OFFCURVE",
+"177 511 OFFCURVE",
+"167 463 CURVE"
+);
 }
 );
 width = 395;
@@ -30280,27 +33949,6 @@ width = 395;
 {
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
 paths = (
-{
-closed = 1;
-nodes = (
-"175 403 LINE",
-"214 613 OFFCURVE",
-"301 622 OFFCURVE",
-"301 697 CURVE SMOOTH",
-"301 739 OFFCURVE",
-"272 763 OFFCURVE",
-"232 763 CURVE SMOOTH",
-"181 763 OFFCURVE",
-"133 723 OFFCURVE",
-"133 670 CURVE SMOOTH",
-"133 631 OFFCURVE",
-"158 594 OFFCURVE",
-"158 518 CURVE SMOOTH",
-"158 488 OFFCURVE",
-"154 451 OFFCURVE",
-"144 403 CURVE"
-);
-},
 {
 closed = 1;
 nodes = (
@@ -30320,6 +33968,27 @@ nodes = (
 "361 488 OFFCURVE",
 "357 451 OFFCURVE",
 "347 403 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"175 403 LINE",
+"214 613 OFFCURVE",
+"301 622 OFFCURVE",
+"301 697 CURVE SMOOTH",
+"301 739 OFFCURVE",
+"272 763 OFFCURVE",
+"232 763 CURVE SMOOTH",
+"181 763 OFFCURVE",
+"133 723 OFFCURVE",
+"133 670 CURVE SMOOTH",
+"133 631 OFFCURVE",
+"158 594 OFFCURVE",
+"158 518 CURVE SMOOTH",
+"158 488 OFFCURVE",
+"154 451 OFFCURVE",
+"144 403 CURVE"
 );
 }
 );
@@ -30391,7 +34060,7 @@ unicode = 0027;
 },
 {
 glyphname = semicolon;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:01:26 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -30399,7 +34068,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"15 -168 LINE",
 "109 -120 OFFCURVE",
 "172 -51 OFFCURVE",
 "172 19 CURVE SMOOTH",
@@ -30420,16 +34088,13 @@ nodes = (
 "136 -6 CURVE SMOOTH",
 "136 -45 OFFCURVE",
 "96 -98 OFFCURVE",
-"2 -145 CURVE"
+"2 -145 CURVE",
+"15 -168 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"77 386 LINE SMOOTH",
-"77 348 OFFCURVE",
-"106 319 OFFCURVE",
-"144 319 CURVE SMOOTH",
 "182 319 OFFCURVE",
 "212 348 OFFCURVE",
 "212 386 CURVE SMOOTH",
@@ -30438,7 +34103,10 @@ nodes = (
 "144 454 CURVE SMOOTH",
 "106 454 OFFCURVE",
 "77 424 OFFCURVE",
-"77 386 CURVE SMOOTH"
+"77 386 CURVE SMOOTH",
+"77 348 OFFCURVE",
+"106 319 OFFCURVE",
+"144 319 CURVE SMOOTH"
 );
 }
 );
@@ -30471,7 +34139,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"4 -196 LINE",
 "133 -136 OFFCURVE",
 "207 -49 OFFCURVE",
 "207 33 CURVE SMOOTH",
@@ -30492,16 +34159,13 @@ nodes = (
 "160 5 CURVE SMOOTH",
 "160 -52 OFFCURVE",
 "91 -117 OFFCURVE",
-"-9 -173 CURVE"
+"-9 -173 CURVE",
+"4 -196 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"64 363 LINE SMOOTH",
-"64 315 OFFCURVE",
-"102 277 OFFCURVE",
-"150 277 CURVE SMOOTH",
 "199 277 OFFCURVE",
 "237 315 OFFCURVE",
 "237 363 CURVE SMOOTH",
@@ -30510,7 +34174,10 @@ nodes = (
 "150 450 CURVE SMOOTH",
 "102 450 OFFCURVE",
 "64 412 OFFCURVE",
-"64 363 CURVE SMOOTH"
+"64 363 CURVE SMOOTH",
+"64 315 OFFCURVE",
+"102 277 OFFCURVE",
+"150 277 CURVE SMOOTH"
 );
 }
 );
@@ -30521,7 +34188,7 @@ unicode = 003B;
 },
 {
 glyphname = slash;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -30529,10 +34196,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"327 753 LINE",
-"-43 0 LINE",
 "16 0 LINE",
-"386 753 LINE"
+"386 753 LINE",
+"327 753 LINE",
+"-43 0 LINE"
 );
 }
 );
@@ -30544,10 +34211,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"307 753 LINE",
-"-43 0 LINE",
 "36 0 LINE",
-"386 753 LINE"
+"386 753 LINE",
+"307 753 LINE",
+"-43 0 LINE"
 );
 }
 );
@@ -30558,7 +34225,7 @@ unicode = 002F;
 },
 {
 glyphname = underscore;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -30566,10 +34233,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"-62 -114 LINE",
 "476 -114 LINE",
 "476 -70 LINE",
-"-62 -70 LINE"
+"-62 -70 LINE",
+"-62 -114 LINE"
 );
 }
 );
@@ -30581,10 +34248,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"-91 -124 LINE",
 "493 -124 LINE",
 "493 -70 LINE",
-"-91 -70 LINE"
+"-91 -70 LINE",
+"-91 -124 LINE"
 );
 }
 );
@@ -30595,7 +34262,7 @@ unicode = 005F;
 },
 {
 glyphname = braceleft;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -30603,19 +34270,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"48 304 LINE",
-"83 304 OFFCURVE",
-"98 291 OFFCURVE",
-"98 255 CURVE SMOOTH",
-"98 237 OFFCURVE",
-"93 213 OFFCURVE",
-"58 52 CURVE SMOOTH",
-"50 13 OFFCURVE",
-"45 -18 OFFCURVE",
-"45 -42 CURVE SMOOTH",
-"45 -104 OFFCURVE",
-"88 -130 OFFCURVE",
-"217 -130 CURVE",
 "222 -105 LINE",
 "172 -105 OFFCURVE",
 "151 -80 OFFCURVE",
@@ -30644,7 +34298,20 @@ nodes = (
 "145 443 LINE SMOOTH",
 "124 349 OFFCURVE",
 "103 321 OFFCURVE",
-"51 321 CURVE"
+"51 321 CURVE",
+"48 304 LINE",
+"83 304 OFFCURVE",
+"98 291 OFFCURVE",
+"98 255 CURVE SMOOTH",
+"98 237 OFFCURVE",
+"93 213 OFFCURVE",
+"58 52 CURVE SMOOTH",
+"50 13 OFFCURVE",
+"45 -18 OFFCURVE",
+"45 -42 CURVE SMOOTH",
+"45 -104 OFFCURVE",
+"88 -130 OFFCURVE",
+"217 -130 CURVE"
 );
 }
 );
@@ -30656,19 +34323,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"34 299 LINE",
-"74 299 OFFCURVE",
-"84 283 OFFCURVE",
-"84 244 CURVE SMOOTH",
-"84 227 OFFCURVE",
-"82 215 OFFCURVE",
-"47 52 CURVE SMOOTH",
-"40 19 OFFCURVE",
-"34 -11 OFFCURVE",
-"34 -34 CURVE SMOOTH",
-"34 -103 OFFCURVE",
-"89 -130 OFFCURVE",
-"228 -130 CURVE",
 "234 -100 LINE",
 "186 -100 OFFCURVE",
 "167 -86 OFFCURVE",
@@ -30697,7 +34351,20 @@ nodes = (
 "130 443 LINE SMOOTH",
 "111 353 OFFCURVE",
 "91 326 OFFCURVE",
-"39 326 CURVE"
+"39 326 CURVE",
+"34 299 LINE",
+"74 299 OFFCURVE",
+"84 283 OFFCURVE",
+"84 244 CURVE SMOOTH",
+"84 227 OFFCURVE",
+"82 215 OFFCURVE",
+"47 52 CURVE SMOOTH",
+"40 19 OFFCURVE",
+"34 -11 OFFCURVE",
+"34 -34 CURVE SMOOTH",
+"34 -103 OFFCURVE",
+"89 -130 OFFCURVE",
+"228 -130 CURVE"
 );
 }
 );
@@ -30708,7 +34375,7 @@ unicode = 007B;
 },
 {
 glyphname = braceright;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -30716,6 +34383,13 @@ paths = (
 {
 closed = 1;
 nodes = (
+"120 -130 OFFCURVE",
+"157 -82 OFFCURVE",
+"186 52 CURVE SMOOTH",
+"214 181 LINE SMOOTH",
+"235 275 OFFCURVE",
+"256 303 OFFCURVE",
+"308 303 CURVE",
 "311 320 LINE",
 "276 320 OFFCURVE",
 "261 333 OFFCURVE",
@@ -30750,14 +34424,7 @@ nodes = (
 "51 -67 OFFCURVE",
 "23 -105 OFFCURVE",
 "-48 -105 CURVE",
-"-53 -130 LINE",
-"120 -130 OFFCURVE",
-"157 -82 OFFCURVE",
-"186 52 CURVE SMOOTH",
-"214 181 LINE SMOOTH",
-"235 275 OFFCURVE",
-"256 303 OFFCURVE",
-"308 303 CURVE"
+"-53 -130 LINE"
 );
 }
 );
@@ -30769,6 +34436,13 @@ paths = (
 {
 closed = 1;
 nodes = (
+"152 -130 OFFCURVE",
+"182 -100 OFFCURVE",
+"215 52 CURVE SMOOTH",
+"243 181 LINE SMOOTH",
+"262 271 OFFCURVE",
+"282 298 OFFCURVE",
+"334 298 CURVE",
 "339 325 LINE",
 "299 325 OFFCURVE",
 "289 341 OFFCURVE",
@@ -30803,14 +34477,7 @@ nodes = (
 "56 -71 OFFCURVE",
 "31 -100 OFFCURVE",
 "-36 -100 CURVE",
-"-42 -130 LINE",
-"152 -130 OFFCURVE",
-"182 -100 OFFCURVE",
-"215 52 CURVE SMOOTH",
-"243 181 LINE SMOOTH",
-"262 271 OFFCURVE",
-"282 298 OFFCURVE",
-"334 298 CURVE"
+"-42 -130 LINE"
 );
 }
 );
@@ -30821,7 +34488,7 @@ unicode = 007D;
 },
 {
 glyphname = bracketleft;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -30829,29 +34496,29 @@ paths = (
 {
 closed = 1;
 nodes = (
-"-9 -115 LINE",
 "99 -115 LINE",
 "291 754 LINE",
-"182 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"-9 -130 LINE",
-"206 -130 LINE",
-"211 -105 LINE",
-"3 -105 LINE",
+"182 754 LINE",
 "-9 -115 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"177 729 LINE",
+"206 -130 LINE",
+"211 -105 LINE",
+"3 -105 LINE",
+"-9 -115 LINE",
+"-9 -130 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "396 729 LINE",
 "401 754 LINE",
-"182 754 LINE"
+"182 754 LINE",
+"177 729 LINE"
 );
 }
 );
@@ -30863,29 +34530,29 @@ paths = (
 {
 closed = 1;
 nodes = (
-"-4 -115 LINE",
 "129 -115 LINE",
 "313 754 LINE",
-"179 754 LINE"
+"179 754 LINE",
+"-4 -115 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"-4 -115 LINE",
-"-4 -130 LINE",
 "221 -130 LINE",
 "227 -100 LINE",
-"-1 -100 LINE"
+"-1 -100 LINE",
+"-4 -115 LINE",
+"-4 -130 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"173 724 LINE",
 "402 724 LINE",
 "408 754 LINE",
-"179 754 LINE"
+"179 754 LINE",
+"173 724 LINE"
 );
 }
 );
@@ -30896,7 +34563,7 @@ unicode = 005B;
 },
 {
 glyphname = bracketright;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:05:59 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -30904,29 +34571,28 @@ paths = (
 {
 closed = 1;
 nodes = (
-"368 739 LINE",
-"260 739 LINE",
-"68 -130 LINE",
-"177 -130 LINE"
+"177 -130 LINE",
+"372 754 LINE",
+"260 754 LINE",
+"68 -130 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"368 754 LINE",
-"153 754 LINE",
-"148 729 LINE",
-"356 729 LINE",
-"368 739 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"177 -130 LINE",
 "182 -105 LINE",
 "-37 -105 LINE",
-"-42 -130 LINE",
-"177 -130 LINE"
+"-42 -130 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"364 729 LINE",
+"372 754 LINE",
+"153 754 LINE",
+"148 729 LINE"
 );
 }
 );
@@ -30938,23 +34604,28 @@ paths = (
 {
 closed = 1;
 nodes = (
-"389 739 LINE",
-"256 739 LINE",
-"72 -130 LINE",
 "206 -130 LINE",
 "389 754 LINE",
-"164 754 LINE",
-"158 724 LINE",
-"386 724 LINE"
+"259 754 LINE",
+"72 -130 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
+"206 -130 LINE",
 "212 -100 LINE",
 "-17 -100 LINE",
-"-23 -130 LINE",
-"206 -130 LINE"
+"-23 -130 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"383 724 LINE",
+"389 754 LINE",
+"160 754 LINE",
+"154 724 LINE"
 );
 }
 );
@@ -31022,7 +34693,7 @@ unicode = 0028;
 },
 {
 glyphname = parenright;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -31030,6 +34701,12 @@ paths = (
 {
 closed = 1;
 nodes = (
+"225 60 OFFCURVE",
+"319 254 OFFCURVE",
+"319 431 CURVE SMOOTH",
+"319 546 OFFCURVE",
+"279 660 OFFCURVE",
+"178 784 CURVE",
 "150 771 LINE",
 "194 694 OFFCURVE",
 "212 611 OFFCURVE",
@@ -31037,13 +34714,7 @@ nodes = (
 "212 330 OFFCURVE",
 "136 50 OFFCURVE",
 "-54 -140 CURVE",
-"-33 -156 LINE",
-"225 60 OFFCURVE",
-"319 254 OFFCURVE",
-"319 431 CURVE SMOOTH",
-"319 546 OFFCURVE",
-"279 660 OFFCURVE",
-"178 784 CURVE"
+"-33 -156 LINE"
 );
 }
 );
@@ -31055,6 +34726,12 @@ paths = (
 {
 closed = 1;
 nodes = (
+"163 0 OFFCURVE",
+"324 190 OFFCURVE",
+"324 425 CURVE SMOOTH",
+"324 539 OFFCURVE",
+"286 654 OFFCURVE",
+"179 784 CURVE",
 "152 771 LINE",
 "183 699 OFFCURVE",
 "195 619 OFFCURVE",
@@ -31062,13 +34739,7 @@ nodes = (
 "195 302 OFFCURVE",
 "110 47 OFFCURVE",
 "-44 -140 CURVE",
-"-22 -156 LINE",
-"163 0 OFFCURVE",
-"324 190 OFFCURVE",
-"324 425 CURVE SMOOTH",
-"324 539 OFFCURVE",
-"286 654 OFFCURVE",
-"179 784 CURVE"
+"-22 -156 LINE"
 );
 }
 );
@@ -31079,7 +34750,7 @@ unicode = 0029;
 },
 {
 glyphname = emdash;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -31087,10 +34758,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"0 202 LINE",
 "828 202 LINE",
 "828 246 LINE",
-"0 246 LINE"
+"0 246 LINE",
+"0 202 LINE"
 );
 }
 );
@@ -31102,10 +34773,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"-17 192 LINE",
 "858 192 LINE",
 "858 246 LINE",
-"-17 246 LINE"
+"-17 246 LINE",
+"-17 192 LINE"
 );
 }
 );
@@ -31116,7 +34787,7 @@ unicode = 2014;
 },
 {
 glyphname = endash;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -31124,10 +34795,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"0 202 LINE",
 "538 202 LINE",
 "538 246 LINE",
-"0 246 LINE"
+"0 246 LINE",
+"0 202 LINE"
 );
 }
 );
@@ -31139,10 +34810,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"-14 192 LINE",
 "570 192 LINE",
 "570 246 LINE",
-"-14 246 LINE"
+"-14 246 LINE",
+"-14 192 LINE"
 );
 }
 );
@@ -31153,7 +34824,7 @@ unicode = 2013;
 },
 {
 glyphname = hyphen;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -31161,10 +34832,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"50 202 LINE",
 "345 202 LINE",
 "345 246 LINE",
-"50 246 LINE"
+"50 246 LINE",
+"50 202 LINE"
 );
 }
 );
@@ -31176,10 +34847,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"58 182 LINE",
 "353 182 LINE",
 "353 246 LINE",
-"58 246 LINE"
+"58 246 LINE",
+"58 182 LINE"
 );
 }
 );
@@ -31189,8 +34860,8 @@ width = 415;
 unicode = 002D;
 },
 {
-glyphname = uni00AD;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = softhyphen;
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -31198,10 +34869,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"50 202 LINE",
 "345 202 LINE",
 "345 246 LINE",
-"50 246 LINE"
+"50 246 LINE",
+"50 202 LINE"
 );
 }
 );
@@ -31213,10 +34884,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"60 182 LINE",
 "355 182 LINE",
 "355 246 LINE",
-"60 246 LINE"
+"60 246 LINE",
+"60 182 LINE"
 );
 }
 );
@@ -31226,97 +34897,12 @@ width = 415;
 unicode = 00AD;
 },
 {
-glyphname = apostrophe;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = guillemetleft;
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
 paths = (
-{
-closed = 1;
-nodes = (
-"129 504 LINE",
-"217 549 OFFCURVE",
-"276 613 OFFCURVE",
-"276 679 CURVE SMOOTH",
-"276 725 OFFCURVE",
-"247 763 OFFCURVE",
-"202 763 CURVE SMOOTH",
-"167 763 OFFCURVE",
-"134 740 OFFCURVE",
-"134 699 CURVE SMOOTH",
-"134 669 OFFCURVE",
-"152 649 OFFCURVE",
-"180 649 CURVE SMOOTH",
-"211 649 OFFCURVE",
-"219 675 OFFCURVE",
-"229 675 CURVE SMOOTH",
-"233 675 OFFCURVE",
-"240 670 OFFCURVE",
-"240 658 CURVE SMOOTH",
-"240 627 OFFCURVE",
-"200 579 OFFCURVE",
-"116 527 CURVE"
-);
-}
-);
-width = 180;
-},
-{
-layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
-paths = (
-{
-closed = 1;
-nodes = (
-"142 473 LINE",
-"252 514 OFFCURVE",
-"316 577 OFFCURVE",
-"316 653 CURVE SMOOTH",
-"316 702 OFFCURVE",
-"289 763 OFFCURVE",
-"221 763 CURVE SMOOTH",
-"175 763 OFFCURVE",
-"134 736 OFFCURVE",
-"134 686 CURVE SMOOTH",
-"134 654 OFFCURVE",
-"152 618 OFFCURVE",
-"194 618 CURVE SMOOTH",
-"238 618 OFFCURVE",
-"245 656 OFFCURVE",
-"257 656 CURVE SMOOTH",
-"262 656 OFFCURVE",
-"270 649 OFFCURVE",
-"270 633 CURVE SMOOTH",
-"270 588 OFFCURVE",
-"210 535 OFFCURVE",
-"123 502 CURVE"
-);
-}
-);
-width = 248;
-}
-);
-unicode = 02BC;
-},
-{
-glyphname = guillemotleft;
-lastChange = "2016-08-16 11:12:44 +0000";
-layers = (
-{
-layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
-paths = (
-{
-closed = 1;
-nodes = (
-"247 53 LINE",
-"174 220 LINE",
-"322 391 LINE",
-"310 402 LINE",
-"72 231 LINE",
-"67 209 LINE",
-"229 38 LINE"
-);
-},
 {
 closed = 1;
 nodes = (
@@ -31328,6 +34914,18 @@ nodes = (
 "230 209 LINE",
 "392 38 LINE"
 );
+},
+{
+closed = 1;
+nodes = (
+"247 53 LINE",
+"174 220 LINE",
+"322 391 LINE",
+"310 402 LINE",
+"72 231 LINE",
+"67 209 LINE",
+"229 38 LINE"
+);
 }
 );
 width = 508;
@@ -31335,18 +34933,6 @@ width = 508;
 {
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
 paths = (
-{
-closed = 1;
-nodes = (
-"257 43 LINE",
-"204 220 LINE",
-"333 401 LINE",
-"320 412 LINE",
-"62 231 LINE",
-"57 209 LINE",
-"239 28 LINE"
-);
-},
 {
 closed = 1;
 nodes = (
@@ -31358,6 +34944,18 @@ nodes = (
 "240 209 LINE",
 "422 28 LINE"
 );
+},
+{
+closed = 1;
+nodes = (
+"257 43 LINE",
+"204 220 LINE",
+"333 401 LINE",
+"320 412 LINE",
+"62 231 LINE",
+"57 209 LINE",
+"239 28 LINE"
+);
 }
 );
 width = 528;
@@ -31366,8 +34964,8 @@ width = 528;
 unicode = 00AB;
 },
 {
-glyphname = guillemotright;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = guillemetright;
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -31375,25 +34973,25 @@ paths = (
 {
 closed = 1;
 nodes = (
-"207 38 LINE",
 "445 209 LINE",
 "450 231 LINE",
 "288 402 LINE",
 "270 391 LINE",
 "344 220 LINE",
-"195 53 LINE"
+"195 53 LINE",
+"207 38 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"44 38 LINE",
 "282 209 LINE",
 "287 231 LINE",
 "125 402 LINE",
 "107 391 LINE",
 "181 220 LINE",
-"32 53 LINE"
+"32 53 LINE",
+"44 38 LINE"
 );
 }
 );
@@ -31405,25 +35003,25 @@ paths = (
 {
 closed = 1;
 nodes = (
-"217 28 LINE",
 "475 209 LINE",
 "480 231 LINE",
 "298 412 LINE",
 "281 401 LINE",
 "334 220 LINE",
-"205 43 LINE"
+"205 43 LINE",
+"217 28 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"34 28 LINE",
 "292 209 LINE",
 "297 231 LINE",
 "115 412 LINE",
 "98 401 LINE",
 "151 220 LINE",
-"22 43 LINE"
+"22 43 LINE",
+"34 28 LINE"
 );
 }
 );
@@ -31477,7 +35075,7 @@ unicode = 2039;
 },
 {
 glyphname = guilsinglright;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -31485,13 +35083,13 @@ paths = (
 {
 closed = 1;
 nodes = (
-"43 38 LINE",
 "281 209 LINE",
 "286 231 LINE",
 "124 402 LINE",
 "106 391 LINE",
 "180 220 LINE",
-"31 53 LINE"
+"31 53 LINE",
+"43 38 LINE"
 );
 }
 );
@@ -31503,13 +35101,13 @@ paths = (
 {
 closed = 1;
 nodes = (
-"44 28 LINE",
 "302 209 LINE",
 "307 231 LINE",
 "125 412 LINE",
 "108 401 LINE",
 "161 220 LINE",
-"32 43 LINE"
+"32 43 LINE",
+"44 28 LINE"
 );
 }
 );
@@ -31520,7 +35118,7 @@ unicode = 203A;
 },
 {
 glyphname = quotedblbase;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -31528,34 +35126,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"17 -142 LINE",
-"111 -94 OFFCURVE",
-"174 -25 OFFCURVE",
-"174 45 CURVE SMOOTH",
-"174 97 OFFCURVE",
-"140 139 OFFCURVE",
-"86 139 CURVE SMOOTH",
-"40 139 OFFCURVE",
-"12 109 OFFCURVE",
-"12 70 CURVE SMOOTH",
-"12 37 OFFCURVE",
-"33 15 OFFCURVE",
-"66 15 CURVE SMOOTH",
-"104 15 OFFCURVE",
-"107 46 OFFCURVE",
-"122 46 CURVE SMOOTH",
-"129 46 OFFCURVE",
-"138 38 OFFCURVE",
-"138 20 CURVE SMOOTH",
-"138 -19 OFFCURVE",
-"98 -72 OFFCURVE",
-"4 -119 CURVE"
-);
-},
-{
-closed = 1;
-nodes = (
-"223 -142 LINE",
 "317 -94 OFFCURVE",
 "380 -25 OFFCURVE",
 "380 45 CURVE SMOOTH",
@@ -31576,7 +35146,35 @@ nodes = (
 "344 20 CURVE SMOOTH",
 "344 -19 OFFCURVE",
 "304 -72 OFFCURVE",
-"210 -119 CURVE"
+"210 -119 CURVE",
+"223 -142 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"111 -94 OFFCURVE",
+"174 -25 OFFCURVE",
+"174 45 CURVE SMOOTH",
+"174 97 OFFCURVE",
+"140 139 OFFCURVE",
+"86 139 CURVE SMOOTH",
+"40 139 OFFCURVE",
+"12 109 OFFCURVE",
+"12 70 CURVE SMOOTH",
+"12 37 OFFCURVE",
+"33 15 OFFCURVE",
+"66 15 CURVE SMOOTH",
+"104 15 OFFCURVE",
+"107 46 OFFCURVE",
+"122 46 CURVE SMOOTH",
+"129 46 OFFCURVE",
+"138 38 OFFCURVE",
+"138 20 CURVE SMOOTH",
+"138 -19 OFFCURVE",
+"98 -72 OFFCURVE",
+"4 -119 CURVE",
+"17 -142 LINE"
 );
 }
 );
@@ -31588,34 +35186,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"-21 -152 LINE",
-"102 -101 OFFCURVE",
-"172 -24 OFFCURVE",
-"172 49 CURVE SMOOTH",
-"172 97 OFFCURVE",
-"142 170 OFFCURVE",
-"69 170 CURVE SMOOTH",
-"22 170 OFFCURVE",
-"-21 139 OFFCURVE",
-"-21 90 CURVE SMOOTH",
-"-21 56 OFFCURVE",
-"-1 15 OFFCURVE",
-"46 15 CURVE SMOOTH",
-"92 15 OFFCURVE",
-"94 55 OFFCURVE",
-"108 55 CURVE SMOOTH",
-"114 55 OFFCURVE",
-"123 47 OFFCURVE",
-"123 27 CURVE SMOOTH",
-"123 -24 OFFCURVE",
-"64 -79 OFFCURVE",
-"-34 -129 CURVE"
-);
-},
-{
-closed = 1;
-nodes = (
-"230 -152 LINE",
 "353 -101 OFFCURVE",
 "423 -24 OFFCURVE",
 "423 49 CURVE SMOOTH",
@@ -31636,7 +35206,35 @@ nodes = (
 "374 27 CURVE SMOOTH",
 "374 -24 OFFCURVE",
 "315 -79 OFFCURVE",
-"217 -129 CURVE"
+"217 -129 CURVE",
+"230 -152 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"102 -101 OFFCURVE",
+"172 -24 OFFCURVE",
+"172 49 CURVE SMOOTH",
+"172 97 OFFCURVE",
+"142 170 OFFCURVE",
+"69 170 CURVE SMOOTH",
+"22 170 OFFCURVE",
+"-21 139 OFFCURVE",
+"-21 90 CURVE SMOOTH",
+"-21 56 OFFCURVE",
+"-1 15 OFFCURVE",
+"46 15 CURVE SMOOTH",
+"92 15 OFFCURVE",
+"94 55 OFFCURVE",
+"108 55 CURVE SMOOTH",
+"114 55 OFFCURVE",
+"123 47 OFFCURVE",
+"123 27 CURVE SMOOTH",
+"123 -24 OFFCURVE",
+"64 -79 OFFCURVE",
+"-34 -129 CURVE",
+"-21 -152 LINE"
 );
 }
 );
@@ -31647,7 +35245,7 @@ unicode = 201E;
 },
 {
 glyphname = quotedblleft;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -31655,13 +35253,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"486 728 LINE",
-"392 680 OFFCURVE",
-"329 611 OFFCURVE",
-"329 541 CURVE SMOOTH",
-"329 489 OFFCURVE",
-"363 447 OFFCURVE",
-"417 447 CURVE SMOOTH",
 "463 447 OFFCURVE",
 "491 477 OFFCURVE",
 "491 516 CURVE SMOOTH",
@@ -31676,19 +35267,19 @@ nodes = (
 "365 566 CURVE SMOOTH",
 "365 605 OFFCURVE",
 "405 658 OFFCURVE",
-"499 705 CURVE"
+"499 705 CURVE",
+"486 728 LINE",
+"392 680 OFFCURVE",
+"329 611 OFFCURVE",
+"329 541 CURVE SMOOTH",
+"329 489 OFFCURVE",
+"363 447 OFFCURVE",
+"417 447 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"280 728 LINE",
-"186 680 OFFCURVE",
-"123 611 OFFCURVE",
-"123 541 CURVE SMOOTH",
-"123 489 OFFCURVE",
-"157 447 OFFCURVE",
-"211 447 CURVE SMOOTH",
 "257 447 OFFCURVE",
 "285 477 OFFCURVE",
 "285 516 CURVE SMOOTH",
@@ -31703,7 +35294,14 @@ nodes = (
 "159 566 CURVE SMOOTH",
 "159 605 OFFCURVE",
 "199 658 OFFCURVE",
-"293 705 CURVE"
+"293 705 CURVE",
+"280 728 LINE",
+"186 680 OFFCURVE",
+"123 611 OFFCURVE",
+"123 541 CURVE SMOOTH",
+"123 489 OFFCURVE",
+"157 447 OFFCURVE",
+"211 447 CURVE SMOOTH"
 );
 }
 );
@@ -31715,13 +35313,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"545 763 LINE",
-"422 712 OFFCURVE",
-"352 635 OFFCURVE",
-"352 562 CURVE SMOOTH",
-"352 514 OFFCURVE",
-"382 441 OFFCURVE",
-"455 441 CURVE SMOOTH",
 "502 441 OFFCURVE",
 "545 472 OFFCURVE",
 "545 521 CURVE SMOOTH",
@@ -31736,19 +35327,19 @@ nodes = (
 "401 584 CURVE SMOOTH",
 "401 635 OFFCURVE",
 "460 690 OFFCURVE",
-"558 740 CURVE"
+"558 740 CURVE",
+"545 763 LINE",
+"422 712 OFFCURVE",
+"352 635 OFFCURVE",
+"352 562 CURVE SMOOTH",
+"352 514 OFFCURVE",
+"382 441 OFFCURVE",
+"455 441 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"294 763 LINE",
-"171 712 OFFCURVE",
-"101 635 OFFCURVE",
-"101 562 CURVE SMOOTH",
-"101 514 OFFCURVE",
-"131 441 OFFCURVE",
-"204 441 CURVE SMOOTH",
 "251 441 OFFCURVE",
 "294 472 OFFCURVE",
 "294 521 CURVE SMOOTH",
@@ -31763,7 +35354,14 @@ nodes = (
 "150 584 CURVE SMOOTH",
 "150 635 OFFCURVE",
 "209 690 OFFCURVE",
-"307 740 CURVE"
+"307 740 CURVE",
+"294 763 LINE",
+"171 712 OFFCURVE",
+"101 635 OFFCURVE",
+"101 562 CURVE SMOOTH",
+"101 514 OFFCURVE",
+"131 441 OFFCURVE",
+"204 441 CURVE SMOOTH"
 );
 }
 );
@@ -31774,7 +35372,7 @@ unicode = 201C;
 },
 {
 glyphname = quotedblright;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -31782,34 +35380,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"152 447 LINE",
-"246 495 OFFCURVE",
-"309 564 OFFCURVE",
-"309 634 CURVE SMOOTH",
-"309 686 OFFCURVE",
-"275 728 OFFCURVE",
-"221 728 CURVE SMOOTH",
-"175 728 OFFCURVE",
-"147 698 OFFCURVE",
-"147 659 CURVE SMOOTH",
-"147 626 OFFCURVE",
-"168 604 OFFCURVE",
-"201 604 CURVE SMOOTH",
-"239 604 OFFCURVE",
-"242 635 OFFCURVE",
-"257 635 CURVE SMOOTH",
-"264 635 OFFCURVE",
-"273 627 OFFCURVE",
-"273 609 CURVE SMOOTH",
-"273 570 OFFCURVE",
-"233 517 OFFCURVE",
-"139 470 CURVE"
-);
-},
-{
-closed = 1;
-nodes = (
-"358 447 LINE",
 "452 495 OFFCURVE",
 "515 564 OFFCURVE",
 "515 634 CURVE SMOOTH",
@@ -31830,7 +35400,35 @@ nodes = (
 "479 609 CURVE SMOOTH",
 "479 570 OFFCURVE",
 "439 517 OFFCURVE",
-"345 470 CURVE"
+"345 470 CURVE",
+"358 447 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"246 495 OFFCURVE",
+"309 564 OFFCURVE",
+"309 634 CURVE SMOOTH",
+"309 686 OFFCURVE",
+"275 728 OFFCURVE",
+"221 728 CURVE SMOOTH",
+"175 728 OFFCURVE",
+"147 698 OFFCURVE",
+"147 659 CURVE SMOOTH",
+"147 626 OFFCURVE",
+"168 604 OFFCURVE",
+"201 604 CURVE SMOOTH",
+"239 604 OFFCURVE",
+"242 635 OFFCURVE",
+"257 635 CURVE SMOOTH",
+"264 635 OFFCURVE",
+"273 627 OFFCURVE",
+"273 609 CURVE SMOOTH",
+"273 570 OFFCURVE",
+"233 517 OFFCURVE",
+"139 470 CURVE",
+"152 447 LINE"
 );
 }
 );
@@ -31842,34 +35440,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"124 441 LINE",
-"247 492 OFFCURVE",
-"317 569 OFFCURVE",
-"317 642 CURVE SMOOTH",
-"317 690 OFFCURVE",
-"287 763 OFFCURVE",
-"214 763 CURVE SMOOTH",
-"167 763 OFFCURVE",
-"124 732 OFFCURVE",
-"124 683 CURVE SMOOTH",
-"124 649 OFFCURVE",
-"144 608 OFFCURVE",
-"191 608 CURVE SMOOTH",
-"237 608 OFFCURVE",
-"239 648 OFFCURVE",
-"253 648 CURVE SMOOTH",
-"259 648 OFFCURVE",
-"268 640 OFFCURVE",
-"268 620 CURVE SMOOTH",
-"268 569 OFFCURVE",
-"209 514 OFFCURVE",
-"111 464 CURVE"
-);
-},
-{
-closed = 1;
-nodes = (
-"375 441 LINE",
 "498 492 OFFCURVE",
 "568 569 OFFCURVE",
 "568 642 CURVE SMOOTH",
@@ -31890,7 +35460,35 @@ nodes = (
 "519 620 CURVE SMOOTH",
 "519 569 OFFCURVE",
 "460 514 OFFCURVE",
-"362 464 CURVE"
+"362 464 CURVE",
+"375 441 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"247 492 OFFCURVE",
+"317 569 OFFCURVE",
+"317 642 CURVE SMOOTH",
+"317 690 OFFCURVE",
+"287 763 OFFCURVE",
+"214 763 CURVE SMOOTH",
+"167 763 OFFCURVE",
+"124 732 OFFCURVE",
+"124 683 CURVE SMOOTH",
+"124 649 OFFCURVE",
+"144 608 OFFCURVE",
+"191 608 CURVE SMOOTH",
+"237 608 OFFCURVE",
+"239 648 OFFCURVE",
+"253 648 CURVE SMOOTH",
+"259 648 OFFCURVE",
+"268 640 OFFCURVE",
+"268 620 CURVE SMOOTH",
+"268 569 OFFCURVE",
+"209 514 OFFCURVE",
+"111 464 CURVE",
+"124 441 LINE"
 );
 }
 );
@@ -31901,7 +35499,7 @@ unicode = 201D;
 },
 {
 glyphname = quoteleft;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -31909,13 +35507,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"276 728 LINE",
-"182 680 OFFCURVE",
-"119 611 OFFCURVE",
-"119 541 CURVE SMOOTH",
-"119 489 OFFCURVE",
-"153 447 OFFCURVE",
-"207 447 CURVE SMOOTH",
 "253 447 OFFCURVE",
 "281 477 OFFCURVE",
 "281 516 CURVE SMOOTH",
@@ -31930,7 +35521,14 @@ nodes = (
 "155 566 CURVE SMOOTH",
 "155 605 OFFCURVE",
 "195 658 OFFCURVE",
-"289 705 CURVE"
+"289 705 CURVE",
+"276 728 LINE",
+"182 680 OFFCURVE",
+"119 611 OFFCURVE",
+"119 541 CURVE SMOOTH",
+"119 489 OFFCURVE",
+"153 447 OFFCURVE",
+"207 447 CURVE SMOOTH"
 );
 }
 );
@@ -31942,13 +35540,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"301 762 LINE",
-"178 711 OFFCURVE",
-"108 634 OFFCURVE",
-"108 561 CURVE SMOOTH",
-"108 513 OFFCURVE",
-"138 440 OFFCURVE",
-"211 440 CURVE SMOOTH",
 "258 440 OFFCURVE",
 "301 471 OFFCURVE",
 "301 520 CURVE SMOOTH",
@@ -31963,7 +35554,14 @@ nodes = (
 "157 583 CURVE SMOOTH",
 "157 634 OFFCURVE",
 "216 689 OFFCURVE",
-"314 739 CURVE"
+"314 739 CURVE",
+"301 762 LINE",
+"178 711 OFFCURVE",
+"108 634 OFFCURVE",
+"108 561 CURVE SMOOTH",
+"108 513 OFFCURVE",
+"138 440 OFFCURVE",
+"211 440 CURVE SMOOTH"
 );
 }
 );
@@ -31974,7 +35572,7 @@ unicode = 2018;
 },
 {
 glyphname = quoteright;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -31982,7 +35580,79 @@ paths = (
 {
 closed = 1;
 nodes = (
-"149 447 LINE",
+"217 549 OFFCURVE",
+"276 613 OFFCURVE",
+"276 679 CURVE SMOOTH",
+"276 725 OFFCURVE",
+"247 763 OFFCURVE",
+"202 763 CURVE SMOOTH",
+"167 763 OFFCURVE",
+"134 740 OFFCURVE",
+"134 699 CURVE SMOOTH",
+"134 669 OFFCURVE",
+"152 649 OFFCURVE",
+"180 649 CURVE SMOOTH",
+"211 649 OFFCURVE",
+"219 675 OFFCURVE",
+"229 675 CURVE SMOOTH",
+"233 675 OFFCURVE",
+"240 670 OFFCURVE",
+"240 658 CURVE SMOOTH",
+"240 627 OFFCURVE",
+"200 579 OFFCURVE",
+"116 527 CURVE",
+"129 504 LINE"
+);
+}
+);
+width = 180;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+paths = (
+{
+closed = 1;
+nodes = (
+"252 514 OFFCURVE",
+"316 577 OFFCURVE",
+"316 653 CURVE SMOOTH",
+"316 702 OFFCURVE",
+"289 763 OFFCURVE",
+"221 763 CURVE SMOOTH",
+"175 763 OFFCURVE",
+"134 736 OFFCURVE",
+"134 686 CURVE SMOOTH",
+"134 654 OFFCURVE",
+"152 618 OFFCURVE",
+"194 618 CURVE SMOOTH",
+"238 618 OFFCURVE",
+"245 656 OFFCURVE",
+"257 656 CURVE SMOOTH",
+"262 656 OFFCURVE",
+"270 649 OFFCURVE",
+"270 633 CURVE SMOOTH",
+"270 588 OFFCURVE",
+"210 535 OFFCURVE",
+"123 502 CURVE",
+"142 473 LINE"
+);
+}
+);
+width = 248;
+}
+);
+unicode = 2019;
+},
+{
+glyphname = quoteright;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+paths = (
+{
+closed = 1;
+nodes = (
 "243 495 OFFCURVE",
 "306 564 OFFCURVE",
 "306 634 CURVE SMOOTH",
@@ -32003,7 +35673,8 @@ nodes = (
 "270 609 CURVE SMOOTH",
 "270 570 OFFCURVE",
 "230 517 OFFCURVE",
-"136 470 CURVE"
+"136 470 CURVE",
+"149 447 LINE"
 );
 }
 );
@@ -32015,7 +35686,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"139 441 LINE",
 "262 492 OFFCURVE",
 "332 569 OFFCURVE",
 "332 642 CURVE SMOOTH",
@@ -32036,7 +35706,8 @@ nodes = (
 "283 620 CURVE SMOOTH",
 "283 569 OFFCURVE",
 "224 514 OFFCURVE",
-"126 464 CURVE"
+"126 464 CURVE",
+"139 441 LINE"
 );
 }
 );
@@ -32047,7 +35718,7 @@ unicode = 2019;
 },
 {
 glyphname = quotesinglbase;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -32055,7 +35726,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"11 -142 LINE",
 "105 -94 OFFCURVE",
 "168 -25 OFFCURVE",
 "168 45 CURVE SMOOTH",
@@ -32076,7 +35746,8 @@ nodes = (
 "132 20 CURVE SMOOTH",
 "132 -19 OFFCURVE",
 "92 -72 OFFCURVE",
-"-2 -119 CURVE"
+"-2 -119 CURVE",
+"11 -142 LINE"
 );
 }
 );
@@ -32088,7 +35759,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"1 -152 LINE",
 "124 -101 OFFCURVE",
 "194 -24 OFFCURVE",
 "194 49 CURVE SMOOTH",
@@ -32109,7 +35779,8 @@ nodes = (
 "145 27 CURVE SMOOTH",
 "145 -24 OFFCURVE",
 "86 -79 OFFCURVE",
-"-12 -129 CURVE"
+"-12 -129 CURVE",
+"1 -152 LINE"
 );
 }
 );
@@ -32134,8 +35805,8 @@ width = 206;
 unicode = 0020;
 },
 {
-glyphname = uni00A0;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = nbspace;
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -32165,7 +35836,7 @@ unicode = 000D;
 },
 {
 glyphname = .notdef;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -32173,55 +35844,55 @@ paths = (
 {
 closed = 1;
 nodes = (
-"127 -326 LINE",
-"221 -326 LINE",
+"201 899 LINE",
 "221 924 LINE",
-"127 924 LINE"
+"608 -301 LINE",
+"588 -326 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"127 -326 LINE",
 "682 -326 LINE",
 "682 -301 LINE",
-"127 -301 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"127 899 LINE",
-"682 899 LINE",
-"682 924 LINE",
-"127 924 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"588 -326 LINE",
-"682 -326 LINE",
-"682 924 LINE",
-"588 924 LINE"
+"127 -301 LINE",
+"127 -326 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
 "221 -326 LINE",
-"608 899 LINE",
-"588 924 LINE",
-"201 -301 LINE"
+"221 924 LINE",
+"127 924 LINE",
+"127 -326 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"201 899 LINE",
-"588 -326 LINE",
-"608 -301 LINE",
-"221 924 LINE"
+"608 899 LINE",
+"588 924 LINE",
+"201 -301 LINE",
+"221 -326 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"682 -326 LINE",
+"682 924 LINE",
+"588 924 LINE",
+"588 -326 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"682 899 LINE",
+"682 924 LINE",
+"127 924 LINE",
+"127 899 LINE"
 );
 }
 );
@@ -32233,55 +35904,55 @@ paths = (
 {
 closed = 1;
 nodes = (
-"137 -326 LINE",
-"231 -326 LINE",
+"211 899 LINE",
 "231 924 LINE",
-"137 924 LINE"
+"618 -301 LINE",
+"598 -326 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"137 -326 LINE",
 "692 -326 LINE",
 "692 -301 LINE",
-"137 -301 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"137 899 LINE",
-"692 899 LINE",
-"692 924 LINE",
-"137 924 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"598 -326 LINE",
-"692 -326 LINE",
-"692 924 LINE",
-"598 924 LINE"
+"137 -301 LINE",
+"137 -326 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
 "231 -326 LINE",
-"618 899 LINE",
-"598 924 LINE",
-"211 -301 LINE"
+"231 924 LINE",
+"137 924 LINE",
+"137 -326 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"211 899 LINE",
-"598 -326 LINE",
-"618 -301 LINE",
-"231 924 LINE"
+"618 899 LINE",
+"598 924 LINE",
+"211 -301 LINE",
+"231 -326 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"692 -326 LINE",
+"692 924 LINE",
+"598 924 LINE",
+"598 -326 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"692 899 LINE",
+"692 924 LINE",
+"137 924 LINE",
+"137 899 LINE"
 );
 }
 );
@@ -32290,8 +35961,8 @@ width = 829;
 );
 },
 {
-glyphname = Euro;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = cent;
+lastChange = "2016-08-22 13:06:34 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -32299,6 +35970,581 @@ paths = (
 {
 closed = 1;
 nodes = (
+"346 137 OFFCURVE",
+"409 187 OFFCURVE",
+"453 269 CURVE",
+"433 283 LINE",
+"382 194 OFFCURVE",
+"323 167 OFFCURVE",
+"264 167 CURVE SMOOTH",
+"194 167 OFFCURVE",
+"178 206 OFFCURVE",
+"178 270 CURVE SMOOTH",
+"178 383 OFFCURVE",
+"228 574 OFFCURVE",
+"356 574 CURVE SMOOTH",
+"377 574 OFFCURVE",
+"406 569 OFFCURVE",
+"406 554 CURVE SMOOTH",
+"406 540 OFFCURVE",
+"376 537 OFFCURVE",
+"376 501 CURVE SMOOTH",
+"376 470 OFFCURVE",
+"400 453 OFFCURVE",
+"431 453 CURVE SMOOTH",
+"465 453 OFFCURVE",
+"489 473 OFFCURVE",
+"489 511 CURVE SMOOTH",
+"489 567 OFFCURVE",
+"435 604 OFFCURVE",
+"355 604 CURVE SMOOTH",
+"202 604 OFFCURVE",
+"73 471 OFFCURVE",
+"73 331 CURVE SMOOTH",
+"73 233 OFFCURVE",
+"136 137 OFFCURVE",
+"258 137 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"237 5 LINE",
+"402 733 LINE",
+"372 733 LINE",
+"207 5 LINE"
+);
+}
+);
+width = 466;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+paths = (
+{
+closed = 1;
+nodes = (
+"365 135 OFFCURVE",
+"450 188 OFFCURVE",
+"503 275 CURVE",
+"478 294 LINE",
+"416 203 OFFCURVE",
+"344 175 OFFCURVE",
+"279 175 CURVE SMOOTH",
+"234 175 OFFCURVE",
+"206 189 OFFCURVE",
+"206 229 CURVE SMOOTH",
+"206 332 OFFCURVE",
+"261 570 OFFCURVE",
+"352 570 CURVE SMOOTH",
+"371 570 OFFCURVE",
+"386 564 OFFCURVE",
+"386 545 CURVE SMOOTH",
+"386 526 OFFCURVE",
+"370 504 OFFCURVE",
+"370 481 CURVE SMOOTH",
+"370 452 OFFCURVE",
+"394 425 OFFCURVE",
+"439 425 CURVE SMOOTH",
+"492 425 OFFCURVE",
+"514 461 OFFCURVE",
+"514 495 CURVE SMOOTH",
+"514 552 OFFCURVE",
+"449 600 OFFCURVE",
+"358 600 CURVE SMOOTH",
+"203 600 OFFCURVE",
+"63 460 OFFCURVE",
+"63 322 CURVE SMOOTH",
+"63 225 OFFCURVE",
+"132 135 OFFCURVE",
+"264 135 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"221 6 LINE",
+"411 734 LINE",
+"382 734 LINE",
+"192 6 LINE"
+);
+}
+);
+width = 486;
+}
+);
+unicode = 00A2;
+},
+{
+glyphname = colonsign;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+paths = (
+{
+closed = 1;
+nodes = (
+"193 23 LINE",
+"502 733 LINE",
+"470 733 LINE",
+"161 23 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"119 23 LINE",
+"428 733 LINE",
+"396 733 LINE",
+"87 23 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"343 137 OFFCURVE",
+"406 187 OFFCURVE",
+"450 269 CURVE",
+"430 283 LINE",
+"379 194 OFFCURVE",
+"320 167 OFFCURVE",
+"261 167 CURVE SMOOTH",
+"191 167 OFFCURVE",
+"175 206 OFFCURVE",
+"175 270 CURVE SMOOTH",
+"175 383 OFFCURVE",
+"224 574 OFFCURVE",
+"350 574 CURVE SMOOTH",
+"419 574 OFFCURVE",
+"449 516 OFFCURVE",
+"446 446 CURVE",
+"471 446 LINE",
+"504 604 LINE",
+"492 604 LINE",
+"458 572 LINE",
+"426 595 OFFCURVE",
+"400 604 OFFCURVE",
+"358 604 CURVE SMOOTH",
+"196 604 OFFCURVE",
+"70 471 OFFCURVE",
+"70 331 CURVE SMOOTH",
+"70 233 OFFCURVE",
+"133 137 OFFCURVE",
+"255 137 CURVE SMOOTH"
+);
+}
+);
+width = 478;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+paths = (
+{
+closed = 1;
+nodes = (
+"204 23 LINE",
+"513 733 LINE",
+"481 733 LINE",
+"172 23 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"130 23 LINE",
+"439 733 LINE",
+"407 733 LINE",
+"98 23 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"362 139 OFFCURVE",
+"447 192 OFFCURVE",
+"500 279 CURVE",
+"475 298 LINE",
+"413 207 OFFCURVE",
+"341 179 OFFCURVE",
+"276 179 CURVE SMOOTH",
+"231 179 OFFCURVE",
+"203 193 OFFCURVE",
+"203 233 CURVE SMOOTH",
+"203 336 OFFCURVE",
+"263 572 OFFCURVE",
+"362 572 CURVE SMOOTH",
+"437 572 OFFCURVE",
+"471 514 OFFCURVE",
+"456 440 CURVE",
+"492 440 LINE",
+"527 603 LINE",
+"510 603 LINE",
+"480 568 LINE",
+"453 591 OFFCURVE",
+"411 604 OFFCURVE",
+"362 604 CURVE SMOOTH",
+"207 604 OFFCURVE",
+"60 464 OFFCURVE",
+"60 326 CURVE SMOOTH",
+"60 229 OFFCURVE",
+"129 139 OFFCURVE",
+"261 139 CURVE SMOOTH"
+);
+}
+);
+width = 498;
+}
+);
+unicode = 20A1;
+},
+{
+glyphname = currency;
+lastChange = "2016-08-22 14:01:47 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+paths = (
+{
+closed = 1;
+nodes = (
+"494 135 OFFCURVE",
+"599 240 OFFCURVE",
+"599 368 CURVE SMOOTH",
+"599 496 OFFCURVE",
+"494 602 OFFCURVE",
+"364 602 CURVE SMOOTH",
+"234 602 OFFCURVE",
+"130 496 OFFCURVE",
+"130 368 CURVE SMOOTH",
+"130 240 OFFCURVE",
+"234 135 OFFCURVE",
+"364 135 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"241 235 LINE",
+"224 262 LINE",
+"130 152 LINE",
+"152 135 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"242 500 LINE",
+"152 601 LINE",
+"130 584 LINE",
+"224 474 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"270 200 OFFCURVE",
+"195 275 OFFCURVE",
+"195 368 CURVE",
+"195 461 OFFCURVE",
+"270 537 OFFCURVE",
+"364 537 CURVE SMOOTH",
+"458 537 OFFCURVE",
+"534 461 OFFCURVE",
+"534 368 CURVE SMOOTH",
+"534 275 OFFCURVE",
+"458 200 OFFCURVE",
+"364 200 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"599 152 LINE",
+"505 262 LINE",
+"488 235 LINE",
+"577 135 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"599 584 LINE",
+"577 601 LINE",
+"487 500 LINE",
+"505 474 LINE"
+);
+}
+);
+width = 669;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+paths = (
+{
+closed = 1;
+nodes = (
+"514 135 OFFCURVE",
+"619 240 OFFCURVE",
+"619 368 CURVE SMOOTH",
+"619 496 OFFCURVE",
+"514 602 OFFCURVE",
+"384 602 CURVE SMOOTH",
+"254 602 OFFCURVE",
+"150 496 OFFCURVE",
+"150 368 CURVE SMOOTH",
+"150 240 OFFCURVE",
+"254 135 OFFCURVE",
+"384 135 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"281 225 LINE",
+"234 282 LINE",
+"140 172 LINE",
+"192 125 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"282 510 LINE",
+"192 611 LINE",
+"140 564 LINE",
+"234 454 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"298 215 OFFCURVE",
+"230 283 OFFCURVE",
+"230 368 CURVE",
+"230 453 OFFCURVE",
+"298 522 OFFCURVE",
+"384 522 CURVE SMOOTH",
+"470 522 OFFCURVE",
+"539 453 OFFCURVE",
+"539 368 CURVE SMOOTH",
+"539 283 OFFCURVE",
+"470 215 OFFCURVE",
+"384 215 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"629 172 LINE",
+"535 282 LINE",
+"488 225 LINE",
+"577 125 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"629 564 LINE",
+"577 611 LINE",
+"487 510 LINE",
+"535 454 LINE"
+);
+}
+);
+width = 689;
+}
+);
+unicode = 00A4;
+},
+{
+glyphname = dollar;
+lastChange = "2016-08-22 14:01:54 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+paths = (
+{
+closed = 1;
+nodes = (
+"407 -13 OFFCURVE",
+"516 87 OFFCURVE",
+"516 219 CURVE SMOOTH",
+"516 445 OFFCURVE",
+"194 358 OFFCURVE",
+"194 517 CURVE SMOOTH",
+"194 607 OFFCURVE",
+"296 658 OFFCURVE",
+"384 658 CURVE SMOOTH",
+"459 658 OFFCURVE",
+"523 620 OFFCURVE",
+"523 592 CURVE SMOOTH",
+"523 564 OFFCURVE",
+"462 569 OFFCURVE",
+"462 522 CURVE SMOOTH",
+"462 491 OFFCURVE",
+"488 477 OFFCURVE",
+"512 477 CURVE SMOOTH",
+"549 477 OFFCURVE",
+"570 509 OFFCURVE",
+"570 551 CURVE SMOOTH",
+"570 639 OFFCURVE",
+"479 683 OFFCURVE",
+"383 683 CURVE SMOOTH",
+"239 683 OFFCURVE",
+"135 584 OFFCURVE",
+"135 469 CURVE SMOOTH",
+"135 267 OFFCURVE",
+"459 336 OFFCURVE",
+"459 166 CURVE SMOOTH",
+"459 92 OFFCURVE",
+"397 12 OFFCURVE",
+"257 12 CURVE SMOOTH",
+"148 12 OFFCURVE",
+"86 61 OFFCURVE",
+"86 94 CURVE SMOOTH",
+"86 132 OFFCURVE",
+"167 104 OFFCURVE",
+"167 166 CURVE SMOOTH",
+"167 195 OFFCURVE",
+"150 218 OFFCURVE",
+"113 218 CURVE SMOOTH",
+"76 218 OFFCURVE",
+"42 195 OFFCURVE",
+"42 139 CURVE SMOOTH",
+"42 51 OFFCURVE",
+"124 -13 OFFCURVE",
+"250 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"171 -115 LINE",
+"366 754 LINE",
+"336 754 LINE",
+"141 -115 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"287 -115 LINE",
+"482 754 LINE",
+"452 754 LINE",
+"257 -115 LINE"
+);
+}
+);
+width = 594;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+paths = (
+{
+closed = 1;
+nodes = (
+"433 -13 OFFCURVE",
+"535 91 OFFCURVE",
+"535 224 CURVE SMOOTH",
+"535 470 OFFCURVE",
+"190 374 OFFCURVE",
+"190 524 CURVE SMOOTH",
+"190 604 OFFCURVE",
+"290 653 OFFCURVE",
+"376 653 CURVE SMOOTH",
+"448 653 OFFCURVE",
+"507 618 OFFCURVE",
+"507 594 CURVE SMOOTH",
+"507 570 OFFCURVE",
+"449 573 OFFCURVE",
+"449 520 CURVE SMOOTH",
+"449 484 OFFCURVE",
+"477 460 OFFCURVE",
+"515 460 CURVE SMOOTH",
+"557 460 OFFCURVE",
+"579 490 OFFCURVE",
+"579 537 CURVE SMOOTH",
+"579 634 OFFCURVE",
+"483 683 OFFCURVE",
+"377 683 CURVE SMOOTH",
+"223 683 OFFCURVE",
+"111 581 OFFCURVE",
+"111 454 CURVE SMOOTH",
+"111 232 OFFCURVE",
+"456 320 OFFCURVE",
+"456 155 CURVE SMOOTH",
+"456 83 OFFCURVE",
+"389 22 OFFCURVE",
+"245 22 CURVE SMOOTH",
+"151 22 OFFCURVE",
+"103 48 OFFCURVE",
+"103 71 CURVE SMOOTH",
+"103 99 OFFCURVE",
+"175 83 OFFCURVE",
+"175 149 CURVE SMOOTH",
+"175 190 OFFCURVE",
+"148 218 OFFCURVE",
+"103 218 CURVE SMOOTH",
+"50 218 OFFCURVE",
+"24 180 OFFCURVE",
+"24 133 CURVE SMOOTH",
+"24 58 OFFCURVE",
+"91 -13 OFFCURVE",
+"246 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"175 -115 LINE",
+"370 754 LINE",
+"340 754 LINE",
+"145 -115 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"289 -115 LINE",
+"484 754 LINE",
+"454 754 LINE",
+"259 -115 LINE"
+);
+}
+);
+width = 598;
+}
+);
+unicode = 0024;
+},
+{
+glyphname = euro;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+paths = (
+{
+closed = 1;
+nodes = (
+"377 -13 OFFCURVE",
+"418 10 OFFCURVE",
+"444 32 CURVE",
+"460 0 LINE",
+"485 0 LINE",
+"533 179 LINE",
+"499 179 LINE",
+"468 83 OFFCURVE",
+"400 14 OFFCURVE",
+"323 14 CURVE SMOOTH",
+"262 14 OFFCURVE",
+"242 58 OFFCURVE",
+"242 134 CURVE SMOOTH",
+"242 180 OFFCURVE",
+"249 232 OFFCURVE",
+"259 279 CURVE",
+"513 279 LINE",
 "523 325 LINE",
 "269 325 LINE",
 "291 407 LINE",
@@ -32330,24 +36576,7 @@ nodes = (
 "136 279 LINE",
 "136 117 OFFCURVE",
 "185 -13 OFFCURVE",
-"320 -13 CURVE SMOOTH",
-"377 -13 OFFCURVE",
-"418 10 OFFCURVE",
-"444 32 CURVE",
-"460 0 LINE",
-"485 0 LINE",
-"533 179 LINE",
-"499 179 LINE",
-"468 83 OFFCURVE",
-"400 14 OFFCURVE",
-"323 14 CURVE SMOOTH",
-"262 14 OFFCURVE",
-"242 58 OFFCURVE",
-"242 134 CURVE SMOOTH",
-"242 180 OFFCURVE",
-"249 232 OFFCURVE",
-"259 279 CURVE",
-"513 279 LINE"
+"320 -13 CURVE SMOOTH"
 );
 }
 );
@@ -32359,6 +36588,23 @@ paths = (
 {
 closed = 1;
 nodes = (
+"410 -13 OFFCURVE",
+"448 8 OFFCURVE",
+"477 32 CURVE",
+"493 0 LINE",
+"518 0 LINE",
+"566 179 LINE",
+"522 179 LINE",
+"493 88 OFFCURVE",
+"430 19 OFFCURVE",
+"355 19 CURVE SMOOTH",
+"295 19 OFFCURVE",
+"275 63 OFFCURVE",
+"275 136 CURVE SMOOTH",
+"275 179 OFFCURVE",
+"282 232 OFFCURVE",
+"292 279 CURVE",
+"546 279 LINE",
 "556 325 LINE",
 "302 325 LINE",
 "324 407 LINE",
@@ -32390,24 +36636,7 @@ nodes = (
 "139 279 LINE",
 "139 117 OFFCURVE",
 "199 -13 OFFCURVE",
-"350 -13 CURVE SMOOTH",
-"410 -13 OFFCURVE",
-"448 8 OFFCURVE",
-"477 32 CURVE",
-"493 0 LINE",
-"518 0 LINE",
-"566 179 LINE",
-"522 179 LINE",
-"493 88 OFFCURVE",
-"430 19 OFFCURVE",
-"355 19 CURVE SMOOTH",
-"295 19 OFFCURVE",
-"275 63 OFFCURVE",
-"275 136 CURVE SMOOTH",
-"275 179 OFFCURVE",
-"282 232 OFFCURVE",
-"292 279 CURVE",
-"546 279 LINE"
+"350 -13 CURVE SMOOTH"
 );
 }
 );
@@ -32417,585 +36646,8 @@ width = 634;
 unicode = 20AC;
 },
 {
-glyphname = cent;
-lastChange = "2016-08-16 11:12:44 +0000";
-layers = (
-{
-layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
-paths = (
-{
-closed = 1;
-nodes = (
-"406 554 LINE SMOOTH",
-"406 540 OFFCURVE",
-"376 537 OFFCURVE",
-"376 501 CURVE SMOOTH",
-"376 470 OFFCURVE",
-"400 453 OFFCURVE",
-"431 453 CURVE SMOOTH",
-"465 453 OFFCURVE",
-"489 473 OFFCURVE",
-"489 511 CURVE SMOOTH",
-"489 567 OFFCURVE",
-"435 604 OFFCURVE",
-"355 604 CURVE SMOOTH",
-"202 604 OFFCURVE",
-"73 471 OFFCURVE",
-"73 331 CURVE SMOOTH",
-"73 233 OFFCURVE",
-"136 137 OFFCURVE",
-"258 137 CURVE SMOOTH",
-"346 137 OFFCURVE",
-"409 187 OFFCURVE",
-"453 269 CURVE",
-"433 283 LINE",
-"382 194 OFFCURVE",
-"323 167 OFFCURVE",
-"264 167 CURVE SMOOTH",
-"194 167 OFFCURVE",
-"178 206 OFFCURVE",
-"178 270 CURVE SMOOTH",
-"178 383 OFFCURVE",
-"228 574 OFFCURVE",
-"356 574 CURVE SMOOTH",
-"377 574 OFFCURVE",
-"406 569 OFFCURVE",
-"406 554 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"207 5 LINE",
-"237 5 LINE",
-"402 733 LINE",
-"372 733 LINE"
-);
-}
-);
-width = 466;
-},
-{
-layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
-paths = (
-{
-closed = 1;
-nodes = (
-"514 495 LINE SMOOTH",
-"514 552 OFFCURVE",
-"449 600 OFFCURVE",
-"358 600 CURVE SMOOTH",
-"203 600 OFFCURVE",
-"63 460 OFFCURVE",
-"63 322 CURVE SMOOTH",
-"63 225 OFFCURVE",
-"132 135 OFFCURVE",
-"264 135 CURVE SMOOTH",
-"365 135 OFFCURVE",
-"450 188 OFFCURVE",
-"503 275 CURVE",
-"478 294 LINE",
-"416 203 OFFCURVE",
-"344 175 OFFCURVE",
-"279 175 CURVE SMOOTH",
-"234 175 OFFCURVE",
-"206 189 OFFCURVE",
-"206 229 CURVE SMOOTH",
-"206 236 OFFCURVE",
-"207 245 OFFCURVE",
-"208 251 CURVE SMOOTH",
-"253 520 OFFCURVE",
-"297 570 OFFCURVE",
-"352 570 CURVE SMOOTH",
-"371 570 OFFCURVE",
-"386 564 OFFCURVE",
-"386 545 CURVE SMOOTH",
-"386 526 OFFCURVE",
-"370 504 OFFCURVE",
-"370 481 CURVE SMOOTH",
-"370 452 OFFCURVE",
-"394 425 OFFCURVE",
-"439 425 CURVE SMOOTH",
-"492 425 OFFCURVE",
-"514 461 OFFCURVE",
-"514 495 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"192 6 LINE",
-"221 6 LINE",
-"411 734 LINE",
-"382 734 LINE"
-);
-}
-);
-width = 486;
-}
-);
-unicode = 00A2;
-},
-{
-glyphname = colonmonetary;
-lastChange = "2016-08-16 11:12:44 +0000";
-layers = (
-{
-layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
-paths = (
-{
-closed = 1;
-nodes = (
-"350 574 LINE SMOOTH",
-"419 574 OFFCURVE",
-"449 516 OFFCURVE",
-"446 446 CURVE",
-"471 446 LINE",
-"504 604 LINE",
-"492 604 LINE",
-"458 572 LINE",
-"426 595 OFFCURVE",
-"400 604 OFFCURVE",
-"358 604 CURVE SMOOTH",
-"196 604 OFFCURVE",
-"70 471 OFFCURVE",
-"70 331 CURVE SMOOTH",
-"70 233 OFFCURVE",
-"133 137 OFFCURVE",
-"255 137 CURVE SMOOTH",
-"343 137 OFFCURVE",
-"406 187 OFFCURVE",
-"450 269 CURVE",
-"430 283 LINE",
-"379 194 OFFCURVE",
-"320 167 OFFCURVE",
-"261 167 CURVE SMOOTH",
-"191 167 OFFCURVE",
-"175 206 OFFCURVE",
-"175 270 CURVE SMOOTH",
-"175 383 OFFCURVE",
-"224 574 OFFCURVE",
-"350 574 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"193 23 LINE",
-"502 733 LINE",
-"470 733 LINE",
-"161 23 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"119 23 LINE",
-"428 733 LINE",
-"396 733 LINE",
-"87 23 LINE"
-);
-}
-);
-width = 478;
-},
-{
-layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
-paths = (
-{
-closed = 1;
-nodes = (
-"204 23 LINE",
-"513 733 LINE",
-"481 733 LINE",
-"172 23 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"130 23 LINE",
-"439 733 LINE",
-"407 733 LINE",
-"98 23 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"362 572 LINE SMOOTH",
-"437 572 OFFCURVE",
-"459 519 OFFCURVE",
-"459 472 CURVE SMOOTH",
-"459 461 OFFCURVE",
-"458 450 OFFCURVE",
-"456 440 CURVE",
-"492 440 LINE",
-"527 603 LINE",
-"510 603 LINE",
-"480 568 LINE",
-"453 591 OFFCURVE",
-"411 604 OFFCURVE",
-"362 604 CURVE SMOOTH",
-"207 604 OFFCURVE",
-"60 464 OFFCURVE",
-"60 326 CURVE SMOOTH",
-"60 229 OFFCURVE",
-"129 139 OFFCURVE",
-"261 139 CURVE SMOOTH",
-"362 139 OFFCURVE",
-"447 192 OFFCURVE",
-"500 279 CURVE",
-"475 298 LINE",
-"413 207 OFFCURVE",
-"341 179 OFFCURVE",
-"276 179 CURVE SMOOTH",
-"231 179 OFFCURVE",
-"203 193 OFFCURVE",
-"203 233 CURVE SMOOTH",
-"203 240 OFFCURVE",
-"204 249 OFFCURVE",
-"205 255 CURVE SMOOTH",
-"250 524 OFFCURVE",
-"307 572 OFFCURVE",
-"362 572 CURVE SMOOTH"
-);
-}
-);
-width = 498;
-}
-);
-unicode = 20A1;
-},
-{
-glyphname = currency;
-lastChange = "2016-08-16 11:12:44 +0000";
-layers = (
-{
-layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
-paths = (
-{
-closed = 1;
-nodes = (
-"130 368 LINE SMOOTH",
-"130 240 OFFCURVE",
-"234 135 OFFCURVE",
-"364 135 CURVE SMOOTH",
-"494 135 OFFCURVE",
-"599 240 OFFCURVE",
-"599 368 CURVE SMOOTH",
-"599 496 OFFCURVE",
-"494 602 OFFCURVE",
-"364 602 CURVE SMOOTH",
-"234 602 OFFCURVE",
-"130 496 OFFCURVE",
-"130 368 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"195 368 LINE",
-"195 461 OFFCURVE",
-"270 537 OFFCURVE",
-"364 537 CURVE SMOOTH",
-"458 537 OFFCURVE",
-"534 461 OFFCURVE",
-"534 368 CURVE SMOOTH",
-"534 275 OFFCURVE",
-"458 200 OFFCURVE",
-"364 200 CURVE SMOOTH",
-"270 200 OFFCURVE",
-"195 275 OFFCURVE",
-"195 368 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"152 135 LINE",
-"241 235 LINE",
-"224 262 LINE",
-"130 152 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"577 601 LINE",
-"487 500 LINE",
-"505 474 LINE",
-"599 584 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"599 152 LINE",
-"505 262 LINE",
-"488 235 LINE",
-"577 135 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"130 584 LINE",
-"224 474 LINE",
-"242 500 LINE",
-"152 601 LINE"
-);
-}
-);
-width = 669;
-},
-{
-layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
-paths = (
-{
-closed = 1;
-nodes = (
-"150 368 LINE SMOOTH",
-"150 240 OFFCURVE",
-"254 135 OFFCURVE",
-"384 135 CURVE SMOOTH",
-"514 135 OFFCURVE",
-"619 240 OFFCURVE",
-"619 368 CURVE SMOOTH",
-"619 496 OFFCURVE",
-"514 602 OFFCURVE",
-"384 602 CURVE SMOOTH",
-"254 602 OFFCURVE",
-"150 496 OFFCURVE",
-"150 368 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"230 368 LINE",
-"230 453 OFFCURVE",
-"298 522 OFFCURVE",
-"384 522 CURVE SMOOTH",
-"470 522 OFFCURVE",
-"539 453 OFFCURVE",
-"539 368 CURVE SMOOTH",
-"539 283 OFFCURVE",
-"470 215 OFFCURVE",
-"384 215 CURVE SMOOTH",
-"298 215 OFFCURVE",
-"230 283 OFFCURVE",
-"230 368 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"192 125 LINE",
-"281 225 LINE",
-"234 282 LINE",
-"140 172 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"577 611 LINE",
-"487 510 LINE",
-"535 454 LINE",
-"629 564 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"629 172 LINE",
-"535 282 LINE",
-"488 225 LINE",
-"577 125 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"140 564 LINE",
-"234 454 LINE",
-"282 510 LINE",
-"192 611 LINE"
-);
-}
-);
-width = 689;
-}
-);
-unicode = 00A4;
-},
-{
-glyphname = dollar;
-lastChange = "2016-08-16 11:12:44 +0000";
-layers = (
-{
-layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
-paths = (
-{
-closed = 1;
-nodes = (
-"257 12 LINE SMOOTH",
-"397 12 OFFCURVE",
-"459 92 OFFCURVE",
-"459 166 CURVE SMOOTH",
-"459 336 OFFCURVE",
-"135 267 OFFCURVE",
-"135 469 CURVE SMOOTH",
-"135 584 OFFCURVE",
-"239 683 OFFCURVE",
-"383 683 CURVE SMOOTH",
-"479 683 OFFCURVE",
-"570 639 OFFCURVE",
-"570 551 CURVE SMOOTH",
-"570 509 OFFCURVE",
-"549 477 OFFCURVE",
-"512 477 CURVE SMOOTH",
-"488 477 OFFCURVE",
-"462 491 OFFCURVE",
-"462 522 CURVE SMOOTH",
-"462 569 OFFCURVE",
-"523 564 OFFCURVE",
-"523 592 CURVE SMOOTH",
-"523 620 OFFCURVE",
-"459 658 OFFCURVE",
-"384 658 CURVE SMOOTH",
-"296 658 OFFCURVE",
-"194 607 OFFCURVE",
-"194 517 CURVE SMOOTH",
-"194 358 OFFCURVE",
-"516 445 OFFCURVE",
-"516 219 CURVE SMOOTH",
-"516 87 OFFCURVE",
-"407 -13 OFFCURVE",
-"250 -13 CURVE SMOOTH",
-"124 -13 OFFCURVE",
-"42 51 OFFCURVE",
-"42 139 CURVE SMOOTH",
-"42 195 OFFCURVE",
-"76 218 OFFCURVE",
-"113 218 CURVE SMOOTH",
-"150 218 OFFCURVE",
-"167 195 OFFCURVE",
-"167 166 CURVE SMOOTH",
-"167 104 OFFCURVE",
-"86 132 OFFCURVE",
-"86 94 CURVE SMOOTH",
-"86 61 OFFCURVE",
-"148 12 OFFCURVE",
-"257 12 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"452 754 LINE",
-"482 754 LINE",
-"287 -115 LINE",
-"257 -115 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"336 754 LINE",
-"366 754 LINE",
-"171 -115 LINE",
-"141 -115 LINE"
-);
-}
-);
-width = 594;
-},
-{
-layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
-paths = (
-{
-closed = 1;
-nodes = (
-"245 22 LINE SMOOTH",
-"389 22 OFFCURVE",
-"456 83 OFFCURVE",
-"456 155 CURVE SMOOTH",
-"456 320 OFFCURVE",
-"111 232 OFFCURVE",
-"111 454 CURVE SMOOTH",
-"111 581 OFFCURVE",
-"223 683 OFFCURVE",
-"377 683 CURVE SMOOTH",
-"483 683 OFFCURVE",
-"579 634 OFFCURVE",
-"579 537 CURVE SMOOTH",
-"579 490 OFFCURVE",
-"557 460 OFFCURVE",
-"515 460 CURVE SMOOTH",
-"477 460 OFFCURVE",
-"449 484 OFFCURVE",
-"449 520 CURVE SMOOTH",
-"449 573 OFFCURVE",
-"507 570 OFFCURVE",
-"507 594 CURVE SMOOTH",
-"507 618 OFFCURVE",
-"448 653 OFFCURVE",
-"376 653 CURVE SMOOTH",
-"290 653 OFFCURVE",
-"190 604 OFFCURVE",
-"190 524 CURVE SMOOTH",
-"190 374 OFFCURVE",
-"535 470 OFFCURVE",
-"535 224 CURVE SMOOTH",
-"535 91 OFFCURVE",
-"433 -13 OFFCURVE",
-"246 -13 CURVE SMOOTH",
-"91 -13 OFFCURVE",
-"24 58 OFFCURVE",
-"24 133 CURVE SMOOTH",
-"24 180 OFFCURVE",
-"50 218 OFFCURVE",
-"103 218 CURVE SMOOTH",
-"148 218 OFFCURVE",
-"175 190 OFFCURVE",
-"175 149 CURVE SMOOTH",
-"175 83 OFFCURVE",
-"103 99 OFFCURVE",
-"103 71 CURVE SMOOTH",
-"103 48 OFFCURVE",
-"151 22 OFFCURVE",
-"245 22 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"454 754 LINE",
-"484 754 LINE",
-"289 -115 LINE",
-"259 -115 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"340 754 LINE",
-"370 754 LINE",
-"175 -115 LINE",
-"145 -115 LINE"
-);
-}
-);
-width = 598;
-}
-);
-unicode = 0024;
-},
-{
 glyphname = florin;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -33003,6 +36655,9 @@ paths = (
 {
 closed = 1;
 nodes = (
+"52 -314 OFFCURVE",
+"164 -249 OFFCURVE",
+"214 45 CURVE SMOOTH",
 "291 501 LINE SMOOTH",
 "320 676 OFFCURVE",
 "355 724 OFFCURVE",
@@ -33043,19 +36698,16 @@ nodes = (
 "-139 -240 CURVE SMOOTH",
 "-139 -292 OFFCURVE",
 "-73 -314 OFFCURVE",
-"-27 -314 CURVE SMOOTH",
-"52 -314 OFFCURVE",
-"164 -249 OFFCURVE",
-"214 45 CURVE SMOOTH"
+"-27 -314 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"61 396 LINE",
 "382 396 LINE",
 "382 440 LINE",
-"61 440 LINE"
+"61 440 LINE",
+"61 396 LINE"
 );
 }
 );
@@ -33067,6 +36719,9 @@ paths = (
 {
 closed = 1;
 nodes = (
+"72 -314 OFFCURVE",
+"206 -250 OFFCURVE",
+"256 45 CURVE SMOOTH",
 "333 501 LINE SMOOTH",
 "362 673 OFFCURVE",
 "396 724 OFFCURVE",
@@ -33107,19 +36762,16 @@ nodes = (
 "-147 -230 CURVE SMOOTH",
 "-147 -289 OFFCURVE",
 "-70 -314 OFFCURVE",
-"-14 -314 CURVE SMOOTH",
-"72 -314 OFFCURVE",
-"206 -250 OFFCURVE",
-"256 45 CURVE SMOOTH"
+"-14 -314 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"83 391 LINE",
 "444 391 LINE",
 "444 440 LINE",
-"83 440 LINE"
+"83 440 LINE",
+"83 391 LINE"
 );
 }
 );
@@ -33130,7 +36782,7 @@ unicode = 0192;
 },
 {
 glyphname = franc;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -33138,58 +36790,58 @@ paths = (
 {
 closed = 1;
 nodes = (
-"-2 155 LINE",
-"360 155 LINE",
-"372 199 LINE",
-"10 199 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"199 0 LINE",
 "358 706 LINE",
 "241 706 LINE",
-"86 0 LINE",
-"199 0 LINE"
+"86 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"132 681 LINE",
-"462 681 LINE SMOOTH",
-"601 681 OFFCURVE",
-"630 644 OFFCURVE",
-"630 481 CURVE",
-"660 481 LINE",
-"691 706 LINE",
-"132 706 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"-10 0 LINE",
 "309 0 LINE",
 "309 25 LINE",
-"-10 25 LINE"
+"-10 25 LINE",
+"-10 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"223 376 LINE",
-"310 376 LINE SMOOTH",
-"393 376 OFFCURVE",
-"408 349 OFFCURVE",
-"408 224 CURVE",
+"360 155 LINE",
+"372 199 LINE",
+"10 199 LINE",
+"-2 155 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "438 224 LINE",
 "494 528 LINE",
 "469 528 LINE",
 "438 428 OFFCURVE",
 "403 401 OFFCURVE",
 "326 401 CURVE SMOOTH",
-"223 401 LINE"
+"223 401 LINE",
+"223 376 LINE",
+"310 376 LINE SMOOTH",
+"393 376 OFFCURVE",
+"408 349 OFFCURVE",
+"408 224 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"660 481 LINE",
+"691 706 LINE",
+"132 706 LINE",
+"132 681 LINE",
+"462 681 LINE SMOOTH",
+"601 681 OFFCURVE",
+"630 644 OFFCURVE",
+"630 481 CURVE"
 );
 }
 );
@@ -33201,58 +36853,58 @@ paths = (
 {
 closed = 1;
 nodes = (
+"236 0 LINE",
 "404 754 LINE",
 "253 754 LINE",
-"89 0 LINE",
-"236 0 LINE"
+"89 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"138 724 LINE",
-"498 724 LINE SMOOTH",
-"622 724 OFFCURVE",
-"659 687 OFFCURVE",
-"659 548 CURVE",
-"699 548 LINE",
-"735 754 LINE",
-"138 754 LINE"
+"371 0 LINE",
+"371 31 LINE",
+"2 31 LINE",
+"2 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"269 374 LINE",
-"356 374 LINE SMOOTH",
-"416 374 OFFCURVE",
-"454 348 OFFCURVE",
-"454 227 CURVE",
+"387 150 LINE",
+"399 199 LINE",
+"17 199 LINE",
+"5 150 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "488 227 LINE",
 "553 535 LINE",
 "518 535 LINE",
 "488 441 OFFCURVE",
 "439 404 OFFCURVE",
 "372 404 CURVE SMOOTH",
-"269 404 LINE"
+"269 404 LINE",
+"269 374 LINE",
+"356 374 LINE SMOOTH",
+"416 374 OFFCURVE",
+"454 348 OFFCURVE",
+"454 227 CURVE"
 );
 },
 {
 closed = 1;
 nodes = (
-"2 0 LINE",
-"371 0 LINE",
-"371 31 LINE",
-"2 31 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"5 150 LINE",
-"387 150 LINE",
-"399 199 LINE",
-"17 199 LINE"
+"699 548 LINE",
+"735 754 LINE",
+"138 754 LINE",
+"138 724 LINE",
+"498 724 LINE SMOOTH",
+"622 724 OFFCURVE",
+"659 687 OFFCURVE",
+"659 548 CURVE"
 );
 }
 );
@@ -33263,7 +36915,7 @@ unicode = 20A3;
 },
 {
 glyphname = lira;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:02:04 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -33271,55 +36923,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"76 396 LINE",
-"450 396 LINE",
-"462 440 LINE",
-"88 440 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"46 276 LINE",
-"420 276 LINE",
-"432 320 LINE",
-"58 320 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"90 110 LINE SMOOTH",
-"119 110 OFFCURVE",
-"153 96 OFFCURVE",
-"168 78 CURVE",
-"152 49 OFFCURVE",
-"120 10 OFFCURVE",
-"75 10 CURVE SMOOTH",
-"46 10 OFFCURVE",
-"26 26 OFFCURVE",
-"26 54 CURVE SMOOTH",
-"26 88 OFFCURVE",
-"54 110 OFFCURVE",
-"90 110 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"194 154 LINE SMOOTH",
-"193 146 OFFCURVE",
-"192 140 OFFCURVE",
-"187 126 CURVE",
-"161 135 OFFCURVE",
-"135 144 OFFCURVE",
-"104 144 CURVE SMOOTH",
-"36 144 OFFCURVE",
-"-12 101 OFFCURVE",
-"-12 50 CURVE SMOOTH",
-"-12 6 OFFCURVE",
-"24 -20 OFFCURVE",
-"72 -20 CURVE SMOOTH",
 "125 -20 OFFCURVE",
 "171 13 OFFCURVE",
 "198 54 CURVE",
@@ -33368,7 +36971,54 @@ nodes = (
 "199 202 CURVE SMOOTH",
 "199 183 OFFCURVE",
 "197 170 OFFCURVE",
-"194 154 CURVE SMOOTH"
+"194 154 CURVE SMOOTH",
+"193 146 OFFCURVE",
+"192 140 OFFCURVE",
+"187 126 CURVE",
+"161 135 OFFCURVE",
+"135 144 OFFCURVE",
+"104 144 CURVE SMOOTH",
+"36 144 OFFCURVE",
+"-12 101 OFFCURVE",
+"-12 50 CURVE SMOOTH",
+"-12 6 OFFCURVE",
+"24 -20 OFFCURVE",
+"72 -20 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"46 10 OFFCURVE",
+"26 26 OFFCURVE",
+"26 54 CURVE SMOOTH",
+"26 88 OFFCURVE",
+"54 110 OFFCURVE",
+"90 110 CURVE SMOOTH",
+"119 110 OFFCURVE",
+"153 96 OFFCURVE",
+"168 78 CURVE",
+"152 49 OFFCURVE",
+"120 10 OFFCURVE",
+"75 10 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"420 276 LINE",
+"432 320 LINE",
+"58 320 LINE",
+"46 276 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"450 396 LINE",
+"462 440 LINE",
+"88 440 LINE",
+"76 396 LINE"
 );
 }
 );
@@ -33380,37 +37030,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"91 105 LINE SMOOTH",
-"114 105 OFFCURVE",
-"142 94 OFFCURVE",
-"154 83 CURVE",
-"141 52 OFFCURVE",
-"114 15 OFFCURVE",
-"76 15 CURVE SMOOTH",
-"52 15 OFFCURVE",
-"32 31 OFFCURVE",
-"32 55 CURVE SMOOTH",
-"32 83 OFFCURVE",
-"60 105 OFFCURVE",
-"91 105 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"182 164 LINE SMOOTH",
-"178 141 OFFCURVE",
-"178 146 OFFCURVE",
-"175 136 CURVE",
-"155 140 OFFCURVE",
-"127 144 OFFCURVE",
-"106 144 CURVE SMOOTH",
-"36 144 OFFCURVE",
-"-11 101 OFFCURVE",
-"-11 50 CURVE SMOOTH",
-"-11 6 OFFCURVE",
-"24 -20 OFFCURVE",
-"75 -20 CURVE SMOOTH",
 "133 -20 OFFCURVE",
 "188 13 OFFCURVE",
 "219 54 CURVE",
@@ -33459,25 +37078,54 @@ nodes = (
 "187 212 CURVE SMOOTH",
 "187 195 OFFCURVE",
 "185 179 OFFCURVE",
-"182 164 CURVE SMOOTH"
+"182 164 CURVE SMOOTH",
+"178 141 OFFCURVE",
+"178 146 OFFCURVE",
+"175 136 CURVE",
+"155 140 OFFCURVE",
+"127 144 OFFCURVE",
+"106 144 CURVE SMOOTH",
+"36 144 OFFCURVE",
+"-11 101 OFFCURVE",
+"-11 50 CURVE SMOOTH",
+"-11 6 OFFCURVE",
+"24 -20 OFFCURVE",
+"75 -20 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"78 395 LINE",
-"472 395 LINE",
-"483 444 LINE",
-"89 444 LINE"
+"52 15 OFFCURVE",
+"32 31 OFFCURVE",
+"32 55 CURVE SMOOTH",
+"32 83 OFFCURVE",
+"60 105 OFFCURVE",
+"91 105 CURVE SMOOTH",
+"114 105 OFFCURVE",
+"142 94 OFFCURVE",
+"154 83 CURVE",
+"141 52 OFFCURVE",
+"114 15 OFFCURVE",
+"76 15 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"51 271 LINE",
 "445 271 LINE",
 "456 320 LINE",
-"62 320 LINE"
+"62 320 LINE",
+"51 271 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"472 395 LINE",
+"483 444 LINE",
+"89 444 LINE",
+"78 395 LINE"
 );
 }
 );
@@ -33487,8 +37135,8 @@ width = 579;
 unicode = 20A4;
 },
 {
-glyphname = sterling;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = liraTurkish;
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -33496,37 +37144,479 @@ paths = (
 {
 closed = 1;
 nodes = (
-"73 110 LINE SMOOTH",
-"102 110 OFFCURVE",
-"136 96 OFFCURVE",
-"151 78 CURVE",
-"135 49 OFFCURVE",
-"103 10 OFFCURVE",
-"58 10 CURVE SMOOTH",
-"29 10 OFFCURVE",
-"9 26 OFFCURVE",
-"9 54 CURVE SMOOTH",
-"9 88 OFFCURVE",
-"37 110 OFFCURVE",
-"73 110 CURVE SMOOTH"
+"179 0 LINE",
+"347 754 LINE",
+"230 754 LINE",
+"66 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"177 154 LINE",
-"176 145 OFFCURVE",
-"173 135 OFFCURVE",
-"170 126 CURVE",
-"144 135 OFFCURVE",
-"118 144 OFFCURVE",
-"87 144 CURVE SMOOTH",
-"19 144 OFFCURVE",
-"-29 101 OFFCURVE",
-"-29 50 CURVE SMOOTH",
-"-29 6 OFFCURVE",
-"7 -20 OFFCURVE",
-"55 -20 CURVE SMOOTH",
+"239 0 LINE SMOOTH",
+"435 0 OFFCURVE",
+"582 96 OFFCURVE",
+"582 257 CURVE SMOOTH",
+"582 322 OFFCURVE",
+"558 349 OFFCURVE",
+"518 349 CURVE SMOOTH",
+"483 349 OFFCURVE",
+"456 328 OFFCURVE",
+"456 295 CURVE SMOOTH",
+"456 274 OFFCURVE",
+"467 259 OFFCURVE",
+"491 259 CURVE SMOOTH",
+"523 259 OFFCURVE",
+"523 286 OFFCURVE",
+"539 286 CURVE SMOOTH",
+"550 286 OFFCURVE",
+"554 275 OFFCURVE",
+"554 251 CURVE SMOOTH",
+"554 114 OFFCURVE",
+"425 25 OFFCURVE",
+"248 25 CURVE",
+"0 25 LINE",
+"-6 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"450 427 LINE",
+"450 474 LINE",
+"15 318 LINE",
+"15 271 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"450 555 LINE",
+"450 602 LINE",
+"15 446 LINE",
+"15 399 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"430 729 LINE",
+"430 754 LINE",
+"141 754 LINE",
+"141 729 LINE"
+);
+}
+);
+width = 598;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+paths = (
+{
+closed = 1;
+nodes = (
+"229 0 LINE",
+"397 754 LINE",
+"246 754 LINE",
+"82 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"249 0 LINE SMOOTH",
+"445 0 OFFCURVE",
+"592 90 OFFCURVE",
+"592 233 CURVE SMOOTH",
+"592 296 OFFCURVE",
+"568 339 OFFCURVE",
+"512 339 CURVE SMOOTH",
+"467 339 OFFCURVE",
+"436 311 OFFCURVE",
+"436 272 CURVE SMOOTH",
+"436 245 OFFCURVE",
+"450 224 OFFCURVE",
+"481 224 CURVE SMOOTH",
+"519 224 OFFCURVE",
+"520 256 OFFCURVE",
+"539 256 CURVE SMOOTH",
+"550 256 OFFCURVE",
+"554 245 OFFCURVE",
+"554 222 CURVE SMOOTH",
+"554 107 OFFCURVE",
+"428 35 OFFCURVE",
+"258 35 CURVE",
+"10 35 LINE",
+"4 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"478 412 LINE",
+"478 464 LINE",
+"43 308 LINE",
+"43 256 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"478 545 LINE",
+"478 597 LINE",
+"43 441 LINE",
+"43 389 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"505 724 LINE",
+"505 754 LINE",
+"126 754 LINE",
+"126 724 LINE"
+);
+}
+);
+width = 618;
+}
+);
+unicode = 20BA;
+},
+{
+glyphname = naira;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+paths = (
+{
+closed = 1;
+nodes = (
+"565 -13 LINE",
+"598 228 LINE",
+"594 228 LINE",
+"378 706 LINE",
+"254 706 LINE",
+"254 657 LINE",
+"258 657 LINE",
+"545 -13 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"222 0 LINE",
+"222 25 LINE",
+"-20 25 LINE",
+"-20 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"107 0 LINE",
+"265 706 LINE",
+"235 706 LINE",
+"77 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"753 359 LINE",
+"765 403 LINE",
+"63 403 LINE",
+"51 359 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"378 681 LINE",
+"378 706 LINE",
+"126 706 LINE",
+"126 681 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"786 485 LINE",
+"798 529 LINE",
+"96 529 LINE",
+"84 485 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"575 -13 LINE",
+"736 706 LINE",
+"706 706 LINE",
+"545 -13 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"833 681 LINE",
+"833 706 LINE",
+"591 706 LINE",
+"591 681 LINE"
+);
+}
+);
+width = 743;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+paths = (
+{
+closed = 1;
+nodes = (
+"589 -13 LINE",
+"633 285 LINE",
+"621 285 LINE",
+"380 683 LINE",
+"266 683 LINE",
+"247 566 LINE",
+"251 566 LINE",
+"569 -13 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"236 0 LINE",
+"236 30 LINE",
+"-1 30 LINE",
+"-1 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"126 0 LINE",
+"272 683 LINE",
+"232 683 LINE",
+"86 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"772 336 LINE",
+"784 385 LINE",
+"32 385 LINE",
+"20 336 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"380 653 LINE",
+"380 683 LINE",
+"123 683 LINE",
+"123 653 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"804 467 LINE",
+"816 515 LINE",
+"64 515 LINE",
+"52 467 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"600 -13 LINE",
+"749 683 LINE",
+"709 683 LINE",
+"569 -13 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"826 653 LINE",
+"826 683 LINE",
+"608 683 LINE",
+"608 653 LINE"
+);
+}
+);
+width = 763;
+}
+);
+unicode = 20A6;
+},
+{
+glyphname = rupeeIndian;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+paths = (
+{
+closed = 1;
+nodes = (
+"212 371 LINE SMOOTH",
+"421 371 OFFCURVE",
+"541 437 OFFCURVE",
+"541 537 CURVE SMOOTH",
+"541 637 OFFCURVE",
+"451 706 OFFCURVE",
+"282 706 CURVE SMOOTH",
+"67 706 LINE",
+"67 681 LINE",
+"270 681 LINE SMOOTH",
+"383 681 OFFCURVE",
+"405 652 OFFCURVE",
+"405 572 CURVE SMOOTH",
+"405 456 OFFCURVE",
+"343 396 OFFCURVE",
+"233 396 CURVE SMOOTH",
+"70 396 LINE",
+"70 371 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"529 -10 OFFCURVE",
+"549 4 OFFCURVE",
+"568 25 CURVE",
+"552 39 LINE",
+"540 27 OFFCURVE",
+"527 23 OFFCURVE",
+"506 23 CURVE SMOOTH",
+"446 23 OFFCURVE",
+"444 56 OFFCURVE",
+"441 138 CURVE SMOOTH",
+"435 271 OFFCURVE",
+"417 319 OFFCURVE",
+"279 369 CURVE",
+"279 373 LINE",
+"156 370 LINE",
+"239 370 OFFCURVE",
+"292 331 OFFCURVE",
+"299 233 CURVE SMOOTH",
+"304 154 OFFCURVE",
+"287 -10 OFFCURVE",
+"474 -10 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"619 534 LINE",
+"619 578 LINE",
+"67 578 LINE",
+"67 534 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"619 662 LINE",
+"619 706 LINE",
+"67 706 LINE",
+"67 662 LINE"
+);
+}
+);
+width = 570;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+paths = (
+{
+closed = 1;
+nodes = (
+"183 371 LINE SMOOTH",
+"418 371 OFFCURVE",
+"557 435 OFFCURVE",
+"557 542 CURVE SMOOTH",
+"557 635 OFFCURVE",
+"451 706 OFFCURVE",
+"253 706 CURVE SMOOTH",
+"134 706 LINE",
+"134 671 LINE",
+"241 671 LINE SMOOTH",
+"348 671 OFFCURVE",
+"372 645 OFFCURVE",
+"372 574 CURVE SMOOTH",
+"372 461 OFFCURVE",
+"310 406 OFFCURVE",
+"204 406 CURVE SMOOTH",
+"87 406 LINE",
+"77 371 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"511 -10 OFFCURVE",
+"536 4 OFFCURVE",
+"559 25 CURVE",
+"543 49 LINE",
+"531 37 OFFCURVE",
+"516 33 OFFCURVE",
+"501 33 CURVE SMOOTH",
+"473 33 OFFCURVE",
+"458 49 OFFCURVE",
+"454 142 CURVE SMOOTH",
+"449 275 OFFCURVE",
+"442 317 OFFCURVE",
+"292 373 CURVE",
+"292 377 LINE",
+"127 370 LINE",
+"198 370 OFFCURVE",
+"244 331 OFFCURVE",
+"250 233 CURVE SMOOTH",
+"256 150 OFFCURVE",
+"235 -10 OFFCURVE",
+"448 -10 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"645 545 LINE",
+"656 594 LINE",
+"99 594 LINE",
+"88 545 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"672 671 LINE",
+"683 720 LINE",
+"126 720 LINE",
+"115 671 LINE"
+);
+}
+);
+width = 590;
+}
+);
+unicode = 20B9;
+},
+{
+glyphname = sterling;
+lastChange = "2016-08-22 14:02:17 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+paths = (
+{
+closed = 1;
+nodes = (
 "108 -20 OFFCURVE",
 "154 13 OFFCURVE",
 "181 54 CURVE",
@@ -33575,16 +37665,45 @@ nodes = (
 "182 202 CURVE SMOOTH",
 "182 184 OFFCURVE",
 "180 169 OFFCURVE",
-"177 154 CURVE"
+"177 154 CURVE",
+"176 145 OFFCURVE",
+"173 135 OFFCURVE",
+"170 126 CURVE",
+"144 135 OFFCURVE",
+"118 144 OFFCURVE",
+"87 144 CURVE SMOOTH",
+"19 144 OFFCURVE",
+"-29 101 OFFCURVE",
+"-29 50 CURVE SMOOTH",
+"-29 6 OFFCURVE",
+"7 -20 OFFCURVE",
+"55 -20 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"60 355 LINE",
+"29 10 OFFCURVE",
+"9 26 OFFCURVE",
+"9 54 CURVE SMOOTH",
+"9 88 OFFCURVE",
+"37 110 OFFCURVE",
+"73 110 CURVE SMOOTH",
+"102 110 OFFCURVE",
+"136 96 OFFCURVE",
+"151 78 CURVE",
+"135 49 OFFCURVE",
+"103 10 OFFCURVE",
+"58 10 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
 "434 355 LINE",
 "444 399 LINE",
-"70 399 LINE"
+"70 399 LINE",
+"60 355 LINE"
 );
 }
 );
@@ -33596,37 +37715,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"79 105 LINE SMOOTH",
-"102 105 OFFCURVE",
-"130 94 OFFCURVE",
-"142 83 CURVE",
-"129 52 OFFCURVE",
-"102 15 OFFCURVE",
-"64 15 CURVE SMOOTH",
-"40 15 OFFCURVE",
-"20 31 OFFCURVE",
-"20 55 CURVE SMOOTH",
-"20 83 OFFCURVE",
-"48 105 OFFCURVE",
-"79 105 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"170 164 LINE SMOOTH",
-"166 141 OFFCURVE",
-"166 146 OFFCURVE",
-"163 136 CURVE",
-"143 140 OFFCURVE",
-"115 144 OFFCURVE",
-"94 144 CURVE SMOOTH",
-"24 144 OFFCURVE",
-"-23 101 OFFCURVE",
-"-23 50 CURVE SMOOTH",
-"-23 6 OFFCURVE",
-"12 -20 OFFCURVE",
-"63 -20 CURVE SMOOTH",
 "121 -20 OFFCURVE",
 "176 13 OFFCURVE",
 "207 54 CURVE",
@@ -33675,16 +37763,45 @@ nodes = (
 "175 212 CURVE SMOOTH",
 "175 195 OFFCURVE",
 "173 179 OFFCURVE",
-"170 164 CURVE SMOOTH"
+"170 164 CURVE SMOOTH",
+"166 141 OFFCURVE",
+"166 146 OFFCURVE",
+"163 136 CURVE",
+"143 140 OFFCURVE",
+"115 144 OFFCURVE",
+"94 144 CURVE SMOOTH",
+"24 144 OFFCURVE",
+"-23 101 OFFCURVE",
+"-23 50 CURVE SMOOTH",
+"-23 6 OFFCURVE",
+"12 -20 OFFCURVE",
+"63 -20 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"66 355 LINE",
+"40 15 OFFCURVE",
+"20 31 OFFCURVE",
+"20 55 CURVE SMOOTH",
+"20 83 OFFCURVE",
+"48 105 OFFCURVE",
+"79 105 CURVE SMOOTH",
+"102 105 OFFCURVE",
+"130 94 OFFCURVE",
+"142 83 CURVE",
+"129 52 OFFCURVE",
+"102 15 OFFCURVE",
+"64 15 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
 "460 355 LINE",
 "471 404 LINE",
-"77 404 LINE"
+"77 404 LINE",
+"66 355 LINE"
 );
 }
 );
@@ -33694,8 +37811,8 @@ width = 591;
 unicode = 00A3;
 },
 {
-glyphname = uni20A6;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = won;
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -33703,258 +37820,86 @@ paths = (
 {
 closed = 1;
 nodes = (
-"84 485 LINE",
-"786 485 LINE",
-"798 529 LINE",
-"96 529 LINE"
+"1023 686 LINE",
+"990 686 LINE",
+"582 196 LINE",
+"472 -12 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"51 359 LINE",
-"753 359 LINE",
-"765 403 LINE",
-"63 403 LINE"
+"544 458 LINE",
+"511 458 LINE",
+"308 198 LINE",
+"194 -12 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"126 681 LINE",
-"378 681 LINE",
-"378 706 LINE",
-"126 706 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"-20 0 LINE",
-"222 0 LINE",
-"222 25 LINE",
-"-20 25 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"265 706 LINE",
-"235 706 LINE",
-"77 0 LINE",
-"107 0 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"378 706 LINE",
-"254 706 LINE",
-"254 657 LINE",
-"258 657 LINE",
-"545 -13 LINE",
-"565 -13 LINE",
-"598 228 LINE",
-"594 228 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"833 706 LINE",
-"591 706 LINE",
-"591 681 LINE",
-"833 681 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"545 -13 LINE",
-"575 -13 LINE",
-"736 706 LINE",
-"706 706 LINE"
-);
-}
-);
-width = 743;
-},
-{
-layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
-paths = (
-{
-closed = 1;
-nodes = (
-"52 467 LINE",
-"804 467 LINE",
-"816 515 LINE",
-"64 515 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"20 336 LINE",
-"772 336 LINE",
-"784 385 LINE",
-"32 385 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"123 653 LINE",
-"380 653 LINE",
-"380 683 LINE",
-"123 683 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"-1 0 LINE",
-"236 0 LINE",
-"236 30 LINE",
-"-1 30 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"272 683 LINE",
-"232 683 LINE",
-"86 0 LINE",
-"126 0 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"608 653 LINE",
-"826 653 LINE",
-"826 683 LINE",
-"608 683 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"749 683 LINE",
-"709 683 LINE",
-"563 0 LINE",
-"578 -13 LINE",
-"600 -13 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"380 683 LINE",
-"266 683 LINE",
-"247 566 LINE",
-"251 566 LINE",
-"569 -13 LINE",
-"589 -13 LINE",
-"625 285 LINE",
-"621 285 LINE"
-);
-}
-);
-width = 763;
-}
-);
-unicode = 20A6;
-},
-{
-glyphname = uni20A9;
-lastChange = "2016-08-16 11:12:44 +0000";
-layers = (
-{
-layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
-paths = (
-{
-closed = 1;
-nodes = (
-"72 502 LINE",
-"990 502 LINE",
-"1002 546 LINE",
-"84 546 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"36 376 LINE",
-"954 376 LINE",
-"966 420 LINE",
-"48 420 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"194 -12 LINE",
+"311 202 LINE",
+"307 202 LINE",
 "351 696 LINE",
 "228 696 LINE",
-"173 -10 LINE",
-"194 -10 LINE",
-"311 202 LINE",
-"307 202 LINE"
+"173 -12 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"149 681 LINE",
-"840 681 LINE",
-"840 706 LINE",
-"149 706 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"308 198 LINE",
-"194 -10 LINE",
-"544 458 LINE",
-"511 458 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"472 -12 LINE",
+"585 200 LINE",
+"581 200 LINE",
 "629 696 LINE",
 "506 696 LINE",
-"451 -10 LINE",
-"472 -10 LINE",
-"585 200 LINE",
-"581 200 LINE"
+"451 -12 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"882 681 LINE",
+"954 376 LINE",
+"966 420 LINE",
+"48 420 LINE",
+"36 376 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"990 502 LINE",
+"1002 546 LINE",
+"84 546 LINE",
+"72 502 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"840 681 LINE",
+"840 706 LINE",
+"149 706 LINE",
+"149 681 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"777 690 LINE",
+"744 690 LINE",
+"541 478 LINE",
+"575 467 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "1096 681 LINE",
 "1096 706 LINE",
-"882 706 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"582 196 LINE",
-"472 -10 LINE",
-"1023 686 LINE",
-"990 686 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"541 478 LINE",
-"575 467 LINE",
-"777 690 LINE",
-"744 690 LINE"
+"882 706 LINE",
+"882 681 LINE"
 );
 }
 );
@@ -33966,49 +37911,68 @@ paths = (
 {
 closed = 1;
 nodes = (
-"59 467 LINE",
-"1017 467 LINE",
-"1029 516 LINE",
-"71 516 LINE"
+"1065 663 LINE",
+"1026 663 LINE",
+"616 210 LINE",
+"488 -12 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"47 341 LINE",
-"1005 341 LINE",
-"1017 390 LINE",
-"59 390 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"351 673 LINE",
-"188 673 LINE",
-"153 -13 LINE",
-"184 -13 LINE",
-"320 210 LINE",
-"316 210 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"104 653 LINE",
-"862 653 LINE",
-"862 683 LINE",
-"104 683 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"514 388 LINE",
 "501 424 LINE",
 "317 206 LINE",
-"176 -13 LINE",
-"186 -13 LINE",
-"514 388 LINE"
+"186 -12 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"186 -12 LINE",
+"320 210 LINE",
+"316 210 LINE",
+"351 673 LINE",
+"188 673 LINE",
+"153 -12 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"488 -12 LINE",
+"616 210 LINE",
+"612 210 LINE",
+"647 673 LINE",
+"484 673 LINE",
+"449 -12 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"1005 341 LINE",
+"1017 390 LINE",
+"59 390 LINE",
+"47 341 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"1017 467 LINE",
+"1029 516 LINE",
+"71 516 LINE",
+"59 467 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"862 653 LINE",
+"862 683 LINE",
+"104 683 LINE",
+"104 653 LINE"
 );
 },
 {
@@ -34023,31 +37987,10 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"899 653 LINE",
 "1119 653 LINE",
 "1119 683 LINE",
-"899 683 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"616 210 LINE",
-"478 -13 LINE",
-"488 -13 LINE",
-"1065 663 LINE",
-"1026 663 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"647 673 LINE",
-"484 673 LINE",
-"449 -13 LINE",
-"480 -13 LINE",
-"616 210 LINE",
-"612 210 LINE"
+"899 683 LINE",
+"899 653 LINE"
 );
 }
 );
@@ -34057,312 +38000,8 @@ width = 986;
 unicode = 20A9;
 },
 {
-glyphname = uni20B9;
-lastChange = "2016-08-16 11:12:44 +0000";
-layers = (
-{
-layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
-paths = (
-{
-closed = 1;
-nodes = (
-"67 662 LINE",
-"619 662 LINE",
-"619 706 LINE",
-"67 706 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"67 534 LINE",
-"619 534 LINE",
-"619 578 LINE",
-"67 578 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"67 706 LINE",
-"67 681 LINE",
-"270 681 LINE SMOOTH",
-"383 681 OFFCURVE",
-"405 652 OFFCURVE",
-"405 572 CURVE SMOOTH",
-"405 456 OFFCURVE",
-"343 396 OFFCURVE",
-"233 396 CURVE SMOOTH",
-"70 396 LINE",
-"70 371 LINE",
-"212 371 LINE SMOOTH",
-"421 371 OFFCURVE",
-"541 437 OFFCURVE",
-"541 537 CURVE SMOOTH",
-"541 637 OFFCURVE",
-"451 706 OFFCURVE",
-"282 706 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"156 370 LINE",
-"239 370 OFFCURVE",
-"292 331 OFFCURVE",
-"299 233 CURVE SMOOTH",
-"304 154 OFFCURVE",
-"287 -10 OFFCURVE",
-"474 -10 CURVE SMOOTH",
-"529 -10 OFFCURVE",
-"549 4 OFFCURVE",
-"568 25 CURVE",
-"552 39 LINE",
-"540 27 OFFCURVE",
-"527 23 OFFCURVE",
-"506 23 CURVE SMOOTH",
-"446 23 OFFCURVE",
-"444 56 OFFCURVE",
-"441 138 CURVE SMOOTH",
-"435 271 OFFCURVE",
-"417 319 OFFCURVE",
-"279 369 CURVE",
-"279 373 LINE"
-);
-}
-);
-width = 570;
-},
-{
-layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
-paths = (
-{
-closed = 1;
-nodes = (
-"134 706 LINE",
-"134 671 LINE",
-"241 671 LINE SMOOTH",
-"348 671 OFFCURVE",
-"372 645 OFFCURVE",
-"372 574 CURVE SMOOTH",
-"372 461 OFFCURVE",
-"310 406 OFFCURVE",
-"204 406 CURVE SMOOTH",
-"87 406 LINE",
-"77 371 LINE",
-"183 371 LINE SMOOTH",
-"418 371 OFFCURVE",
-"557 435 OFFCURVE",
-"557 542 CURVE SMOOTH",
-"557 635 OFFCURVE",
-"451 706 OFFCURVE",
-"253 706 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"127 370 LINE",
-"198 370 OFFCURVE",
-"244 331 OFFCURVE",
-"250 233 CURVE SMOOTH",
-"256 150 OFFCURVE",
-"235 -10 OFFCURVE",
-"448 -10 CURVE SMOOTH",
-"511 -10 OFFCURVE",
-"536 4 OFFCURVE",
-"559 25 CURVE",
-"543 49 LINE",
-"531 37 OFFCURVE",
-"516 33 OFFCURVE",
-"501 33 CURVE SMOOTH",
-"473 33 OFFCURVE",
-"458 49 OFFCURVE",
-"454 142 CURVE SMOOTH",
-"449 275 OFFCURVE",
-"442 317 OFFCURVE",
-"292 373 CURVE",
-"292 377 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"115 671 LINE",
-"672 671 LINE",
-"683 720 LINE",
-"126 720 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"88 545 LINE",
-"645 545 LINE",
-"656 594 LINE",
-"99 594 LINE"
-);
-}
-);
-width = 590;
-}
-);
-unicode = 20B9;
-},
-{
-glyphname = uni20BA;
-lastChange = "2016-08-16 11:12:44 +0000";
-layers = (
-{
-layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
-paths = (
-{
-closed = 1;
-nodes = (
-"347 754 LINE",
-"230 754 LINE",
-"66 0 LINE",
-"179 0 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"141 729 LINE",
-"430 729 LINE",
-"430 754 LINE",
-"141 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"15 399 LINE",
-"450 555 LINE",
-"450 602 LINE",
-"15 446 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"15 271 LINE",
-"450 427 LINE",
-"450 474 LINE",
-"15 318 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"248 25 LINE",
-"0 25 LINE",
-"-6 0 LINE",
-"239 0 LINE SMOOTH",
-"435 0 OFFCURVE",
-"582 96 OFFCURVE",
-"582 257 CURVE SMOOTH",
-"582 322 OFFCURVE",
-"558 349 OFFCURVE",
-"518 349 CURVE SMOOTH",
-"483 349 OFFCURVE",
-"456 328 OFFCURVE",
-"456 295 CURVE SMOOTH",
-"456 274 OFFCURVE",
-"467 259 OFFCURVE",
-"491 259 CURVE SMOOTH",
-"523 259 OFFCURVE",
-"523 286 OFFCURVE",
-"539 286 CURVE SMOOTH",
-"550 286 OFFCURVE",
-"554 275 OFFCURVE",
-"554 251 CURVE SMOOTH",
-"554 114 OFFCURVE",
-"425 25 OFFCURVE",
-"248 25 CURVE SMOOTH"
-);
-}
-);
-width = 598;
-},
-{
-layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
-paths = (
-{
-closed = 1;
-nodes = (
-"397 754 LINE",
-"246 754 LINE",
-"82 0 LINE",
-"229 0 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"126 724 LINE",
-"505 724 LINE",
-"505 754 LINE",
-"126 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"43 389 LINE",
-"478 545 LINE",
-"478 597 LINE",
-"43 441 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"43 256 LINE",
-"478 412 LINE",
-"478 464 LINE",
-"43 308 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"258 35 LINE",
-"10 35 LINE",
-"4 0 LINE",
-"249 0 LINE SMOOTH",
-"445 0 OFFCURVE",
-"592 90 OFFCURVE",
-"592 233 CURVE SMOOTH",
-"592 296 OFFCURVE",
-"568 339 OFFCURVE",
-"512 339 CURVE SMOOTH",
-"467 339 OFFCURVE",
-"436 311 OFFCURVE",
-"436 272 CURVE SMOOTH",
-"436 245 OFFCURVE",
-"450 224 OFFCURVE",
-"481 224 CURVE SMOOTH",
-"519 224 OFFCURVE",
-"520 256 OFFCURVE",
-"539 256 CURVE SMOOTH",
-"550 256 OFFCURVE",
-"554 245 OFFCURVE",
-"554 222 CURVE SMOOTH",
-"554 107 OFFCURVE",
-"428 35 OFFCURVE",
-"258 35 CURVE"
-);
-}
-);
-width = 618;
-}
-);
-unicode = 20BA;
-},
-{
 glyphname = yen;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:13:54 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -34370,75 +38009,75 @@ paths = (
 {
 closed = 1;
 nodes = (
-"110 334 LINE",
-"602 334 LINE",
-"613 378 LINE",
-"121 378 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"78 208 LINE",
-"570 208 LINE",
-"582 252 LINE",
-"90 252 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"410 329 LINE",
-"293 329 LINE",
-"222 0 LINE",
-"335 0 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"113 0 LINE",
-"465 0 LINE",
-"465 25 LINE",
-"113 25 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"402 318 LINE",
 "258 707 LINE",
 "133 707 LINE",
-"293 287 LINE",
-"402 318 LINE"
+"293 287 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"51 682 LINE",
+"465 0 LINE",
+"465 25 LINE",
+"113 25 LINE",
+"113 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"335 0 LINE",
+"410 329 LINE",
+"293 329 LINE",
+"222 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"570 208 LINE",
+"582 252 LINE",
+"90 252 LINE",
+"78 208 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"602 334 LINE",
+"613 378 LINE",
+"121 378 LINE",
+"110 334 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "385 682 LINE",
 "385 707 LINE",
-"51 707 LINE"
+"51 707 LINE",
+"51 682 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"397 343 LINE",
-"393 343 LINE",
-"346 270 LINE",
 "381 270 LINE",
 "673 687 LINE",
-"638 687 LINE"
+"638 687 LINE",
+"397 343 LINE",
+"393 343 LINE",
+"346 270 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"519 682 LINE",
 "764 682 LINE",
 "764 707 LINE",
-"519 707 LINE"
+"519 707 LINE",
+"519 682 LINE"
 );
 }
 );
@@ -34450,75 +38089,75 @@ paths = (
 {
 closed = 1;
 nodes = (
-"91 279 LINE",
-"583 279 LINE",
-"595 328 LINE",
-"103 328 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"65 153 LINE",
-"557 153 LINE",
-"569 202 LINE",
-"77 202 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"418 307 LINE",
-"267 307 LINE",
-"192 0 LINE",
-"339 0 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"85 0 LINE",
-"464 0 LINE",
-"464 31 LINE",
-"85 31 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"418 308 LINE",
 "267 683 LINE",
 "112 683 LINE",
-"272 254 LINE",
-"418 308 LINE"
+"272 254 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"40 653 LINE",
+"464 0 LINE",
+"464 31 LINE",
+"85 31 LINE",
+"85 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"339 0 LINE",
+"418 307 LINE",
+"267 307 LINE",
+"192 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"557 153 LINE",
+"569 202 LINE",
+"77 202 LINE",
+"65 153 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"583 279 LINE",
+"595 328 LINE",
+"103 328 LINE",
+"91 279 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "394 653 LINE",
 "394 683 LINE",
-"40 683 LINE"
+"40 683 LINE",
+"40 653 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"412 334 LINE",
-"408 334 LINE",
-"357 260 LINE",
 "403 260 LINE",
 "674 663 LINE",
-"639 663 LINE"
+"639 663 LINE",
+"412 334 LINE",
+"408 334 LINE",
+"357 260 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"520 653 LINE",
 "745 653 LINE",
 "745 683 LINE",
-"520 683 LINE"
+"520 683 LINE",
+"520 653 LINE"
 );
 }
 );
@@ -34528,8 +38167,8 @@ width = 627;
 unicode = 00A5;
 },
 {
-glyphname = plus;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = colonsign.001;
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -34537,12 +38176,217 @@ paths = (
 {
 closed = 1;
 nodes = (
-"61 321 LINE",
-"559 321 LINE",
-"559 365 LINE",
-"61 365 LINE"
+"193 23 LINE",
+"502 733 LINE",
+"470 733 LINE",
+"161 23 LINE"
 );
 },
+{
+closed = 1;
+nodes = (
+"119 23 LINE",
+"428 733 LINE",
+"396 733 LINE",
+"87 23 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"343 137 OFFCURVE",
+"406 187 OFFCURVE",
+"450 269 CURVE",
+"430 283 LINE",
+"379 194 OFFCURVE",
+"320 167 OFFCURVE",
+"261 167 CURVE SMOOTH",
+"191 167 OFFCURVE",
+"175 206 OFFCURVE",
+"175 270 CURVE SMOOTH",
+"175 383 OFFCURVE",
+"224 574 OFFCURVE",
+"350 574 CURVE SMOOTH",
+"419 574 OFFCURVE",
+"449 516 OFFCURVE",
+"446 446 CURVE",
+"471 446 LINE",
+"504 604 LINE",
+"492 604 LINE",
+"458 572 LINE",
+"426 595 OFFCURVE",
+"400 604 OFFCURVE",
+"358 604 CURVE SMOOTH",
+"196 604 OFFCURVE",
+"70 471 OFFCURVE",
+"70 331 CURVE SMOOTH",
+"70 233 OFFCURVE",
+"133 137 OFFCURVE",
+"255 137 CURVE SMOOTH"
+);
+}
+);
+width = 478;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+paths = (
+{
+closed = 1;
+nodes = (
+"204 23 LINE",
+"513 733 LINE",
+"481 733 LINE",
+"172 23 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"130 23 LINE",
+"439 733 LINE",
+"407 733 LINE",
+"98 23 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"362 139 OFFCURVE",
+"447 192 OFFCURVE",
+"500 279 CURVE",
+"475 298 LINE",
+"413 207 OFFCURVE",
+"341 179 OFFCURVE",
+"276 179 CURVE SMOOTH",
+"231 179 OFFCURVE",
+"203 193 OFFCURVE",
+"203 233 CURVE SMOOTH",
+"203 336 OFFCURVE",
+"263 572 OFFCURVE",
+"362 572 CURVE SMOOTH",
+"437 572 OFFCURVE",
+"471 514 OFFCURVE",
+"456 440 CURVE",
+"492 440 LINE",
+"527 603 LINE",
+"510 603 LINE",
+"480 568 LINE",
+"453 591 OFFCURVE",
+"411 604 OFFCURVE",
+"362 604 CURVE SMOOTH",
+"207 604 OFFCURVE",
+"60 464 OFFCURVE",
+"60 326 CURVE SMOOTH",
+"60 229 OFFCURVE",
+"129 139 OFFCURVE",
+"261 139 CURVE SMOOTH"
+);
+}
+);
+width = 498;
+}
+);
+},
+{
+glyphname = bulletoperator;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+paths = (
+{
+closed = 1;
+nodes = (
+"135 184 OFFCURVE",
+"165 213 OFFCURVE",
+"165 251 CURVE SMOOTH",
+"165 289 OFFCURVE",
+"135 319 OFFCURVE",
+"97 319 CURVE SMOOTH",
+"59 319 OFFCURVE",
+"30 289 OFFCURVE",
+"30 251 CURVE SMOOTH",
+"30 251 LINE SMOOTH",
+"30 213 OFFCURVE",
+"59 184 OFFCURVE",
+"97 184 CURVE SMOOTH"
+);
+}
+);
+width = 166;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+paths = (
+{
+closed = 1;
+nodes = (
+"161 167 OFFCURVE",
+"200 206 OFFCURVE",
+"200 254 CURVE SMOOTH",
+"200 302 OFFCURVE",
+"161 341 OFFCURVE",
+"113 341 CURVE SMOOTH",
+"65 341 OFFCURVE",
+"26 302 OFFCURVE",
+"26 254 CURVE SMOOTH",
+"26 254 LINE SMOOTH",
+"26 206 OFFCURVE",
+"65 167 OFFCURVE",
+"113 167 CURVE SMOOTH"
+);
+}
+);
+width = 214;
+}
+);
+unicode = 2219;
+},
+{
+glyphname = divisionslash;
+lastChange = "2016-08-22 14:11:03 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+paths = (
+{
+closed = 1;
+nodes = (
+"-85 0 LINE",
+"505 753 LINE",
+"446 753 LINE",
+"-144 0 LINE"
+);
+}
+);
+width = 254;
+},
+{
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+paths = (
+{
+closed = 1;
+nodes = (
+"-85 0 LINE",
+"505 753 LINE",
+"446 753 LINE",
+"-144 0 LINE"
+);
+}
+);
+width = 274;
+}
+);
+unicode = 2215;
+},
+{
+glyphname = plus;
+lastChange = "2016-08-22 10:35:49 +0000";
+layers = (
+{
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+paths = (
 {
 closed = 1;
 nodes = (
@@ -34550,6 +38394,15 @@ nodes = (
 "332 612 LINE",
 "288 612 LINE",
 "288 74 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"559 321 LINE",
+"559 365 LINE",
+"61 365 LINE",
+"61 321 LINE"
 );
 }
 );
@@ -34561,19 +38414,19 @@ paths = (
 {
 closed = 1;
 nodes = (
-"71 316 LINE",
-"569 316 LINE",
-"569 370 LINE",
-"71 370 LINE"
+"347 74 LINE",
+"347 612 LINE",
+"293 612 LINE",
+"293 74 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"347 74 LINE",
-"347 612 LINE",
-"293 612 LINE",
-"293 74 LINE"
+"569 316 LINE",
+"569 370 LINE",
+"71 370 LINE",
+"71 316 LINE"
 );
 }
 );
@@ -34584,7 +38437,7 @@ unicode = 002B;
 },
 {
 glyphname = minus;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -34592,10 +38445,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"61 321 LINE",
 "559 321 LINE",
 "559 365 LINE",
-"61 365 LINE"
+"61 365 LINE",
+"61 321 LINE"
 );
 }
 );
@@ -34607,10 +38460,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"71 316 LINE",
 "569 316 LINE",
 "569 370 LINE",
-"71 370 LINE"
+"71 370 LINE",
+"71 316 LINE"
 );
 }
 );
@@ -34621,7 +38474,7 @@ unicode = 2212;
 },
 {
 glyphname = multiply;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -34629,19 +38482,19 @@ paths = (
 {
 closed = 1;
 nodes = (
-"96 532 LINE",
-"506 122 LINE",
 "538 154 LINE",
-"128 564 LINE"
+"128 564 LINE",
+"96 532 LINE",
+"506 122 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"126 124 LINE",
 "536 534 LINE",
 "506 564 LINE",
-"98 156 LINE"
+"98 156 LINE",
+"126 124 LINE"
 );
 }
 );
@@ -34653,19 +38506,19 @@ paths = (
 {
 closed = 1;
 nodes = (
-"96 527 LINE",
-"506 117 LINE",
-"546 164 LINE",
-"136 574 LINE"
+"556 532 LINE",
+"512 575 LINE",
+"102 165 LINE",
+"146 122 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"146 122 LINE",
-"556 532 LINE",
-"512 575 LINE",
-"102 165 LINE"
+"546 164 LINE",
+"136 574 LINE",
+"96 527 LINE",
+"506 117 LINE"
 );
 }
 );
@@ -34676,7 +38529,7 @@ unicode = 00D7;
 },
 {
 glyphname = divide;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -34684,19 +38537,15 @@ paths = (
 {
 closed = 1;
 nodes = (
-"70 321 LINE",
 "568 321 LINE",
 "568 365 LINE",
-"70 365 LINE"
+"70 365 LINE",
+"70 321 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"265 156 LINE SMOOTH",
-"265 124 OFFCURVE",
-"292 97 OFFCURVE",
-"324 97 CURVE SMOOTH",
 "356 97 OFFCURVE",
 "383 124 OFFCURVE",
 "383 156 CURVE SMOOTH",
@@ -34705,16 +38554,16 @@ nodes = (
 "324 215 CURVE SMOOTH",
 "292 215 OFFCURVE",
 "265 188 OFFCURVE",
-"265 156 CURVE SMOOTH"
+"265 156 CURVE SMOOTH",
+"265 156 LINE SMOOTH",
+"265 124 OFFCURVE",
+"292 97 OFFCURVE",
+"324 97 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"265 530 LINE SMOOTH",
-"265 498 OFFCURVE",
-"292 471 OFFCURVE",
-"324 471 CURVE SMOOTH",
 "356 471 OFFCURVE",
 "383 498 OFFCURVE",
 "383 530 CURVE SMOOTH",
@@ -34723,7 +38572,11 @@ nodes = (
 "324 589 CURVE SMOOTH",
 "292 589 OFFCURVE",
 "265 563 OFFCURVE",
-"265 530 CURVE SMOOTH"
+"265 530 CURVE SMOOTH",
+"265 530 LINE SMOOTH",
+"265 498 OFFCURVE",
+"292 471 OFFCURVE",
+"324 471 CURVE SMOOTH"
 );
 }
 );
@@ -34735,19 +38588,15 @@ paths = (
 {
 closed = 1;
 nodes = (
-"80 316 LINE",
 "578 316 LINE",
 "578 370 LINE",
-"80 370 LINE"
+"80 370 LINE",
+"80 316 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"257 142 LINE SMOOTH",
-"257 100 OFFCURVE",
-"292 65 OFFCURVE",
-"334 65 CURVE SMOOTH",
 "376 65 OFFCURVE",
 "411 100 OFFCURVE",
 "411 142 CURVE SMOOTH",
@@ -34756,16 +38605,16 @@ nodes = (
 "334 219 CURVE SMOOTH",
 "292 219 OFFCURVE",
 "257 184 OFFCURVE",
-"257 142 CURVE SMOOTH"
+"257 142 CURVE SMOOTH",
+"257 142 LINE SMOOTH",
+"257 100 OFFCURVE",
+"292 65 OFFCURVE",
+"334 65 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"257 544 LINE SMOOTH",
-"257 502 OFFCURVE",
-"292 467 OFFCURVE",
-"334 467 CURVE SMOOTH",
 "376 467 OFFCURVE",
 "411 502 OFFCURVE",
 "411 544 CURVE SMOOTH",
@@ -34774,7 +38623,11 @@ nodes = (
 "334 621 CURVE SMOOTH",
 "292 621 OFFCURVE",
 "257 586 OFFCURVE",
-"257 544 CURVE SMOOTH"
+"257 544 CURVE SMOOTH",
+"257 544 LINE SMOOTH",
+"257 502 OFFCURVE",
+"292 467 OFFCURVE",
+"334 467 CURVE SMOOTH"
 );
 }
 );
@@ -34785,7 +38638,7 @@ unicode = 00F7;
 },
 {
 glyphname = equal;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -34793,19 +38646,19 @@ paths = (
 {
 closed = 1;
 nodes = (
-"95 402 LINE",
 "593 402 LINE",
 "593 450 LINE",
-"95 450 LINE"
+"95 450 LINE",
+"95 402 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"46 235 LINE",
 "544 235 LINE",
 "544 283 LINE",
-"46 283 LINE"
+"46 283 LINE",
+"46 235 LINE"
 );
 }
 );
@@ -34817,19 +38670,19 @@ paths = (
 {
 closed = 1;
 nodes = (
-"63 224 LINE",
-"561 224 LINE",
-"561 278 LINE",
-"63 278 LINE"
+"611 420 LINE",
+"611 474 LINE",
+"113 474 LINE",
+"113 420 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"113 420 LINE",
-"611 420 LINE",
-"611 474 LINE",
-"113 474 LINE"
+"561 224 LINE",
+"561 278 LINE",
+"63 278 LINE",
+"63 224 LINE"
 );
 }
 );
@@ -34840,7 +38693,7 @@ unicode = 003D;
 },
 {
 glyphname = notequal;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -34848,28 +38701,28 @@ paths = (
 {
 closed = 1;
 nodes = (
-"443 604 LINE",
-"130 72 LINE",
 "182 72 LINE",
-"495 604 LINE"
+"495 604 LINE",
+"443 604 LINE",
+"130 72 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"105 402 LINE",
-"603 402 LINE",
-"603 450 LINE",
-"105 450 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"56 235 LINE",
 "554 235 LINE",
 "554 283 LINE",
-"56 283 LINE"
+"56 283 LINE",
+"56 235 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"603 402 LINE",
+"603 450 LINE",
+"105 450 LINE",
+"105 402 LINE"
 );
 }
 );
@@ -34881,28 +38734,28 @@ paths = (
 {
 closed = 1;
 nodes = (
-"87 400 LINE",
-"585 400 LINE",
-"585 454 LINE",
-"87 454 LINE"
+"289 72 LINE",
+"438 604 LINE",
+"392 604 LINE",
+"243 72 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"87 234 LINE",
 "585 234 LINE",
 "585 288 LINE",
-"87 288 LINE"
+"87 288 LINE",
+"87 234 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"392 604 LINE",
-"243 72 LINE",
-"289 72 LINE",
-"438 604 LINE"
+"585 400 LINE",
+"585 454 LINE",
+"87 454 LINE",
+"87 400 LINE"
 );
 }
 );
@@ -34913,7 +38766,7 @@ unicode = 2260;
 },
 {
 glyphname = greater;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -34921,19 +38774,19 @@ paths = (
 {
 closed = 1;
 nodes = (
+"595 316 LINE",
 "595 373 LINE",
-"127 607 LINE",
-"127 553 LINE",
-"595 319 LINE"
+"127 139 LINE",
+"127 82 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
 "595 373 LINE",
-"127 139 LINE",
-"127 82 LINE",
-"595 316 LINE"
+"127 607 LINE",
+"127 553 LINE",
+"595 319 LINE"
 );
 }
 );
@@ -34945,19 +38798,19 @@ paths = (
 {
 closed = 1;
 nodes = (
+"593 311 LINE",
 "593 378 LINE",
-"125 612 LINE",
-"125 548 LINE",
-"593 314 LINE"
+"125 144 LINE",
+"125 77 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
 "593 378 LINE",
-"125 144 LINE",
-"125 77 LINE",
-"593 311 LINE"
+"125 612 LINE",
+"125 548 LINE",
+"593 314 LINE"
 );
 }
 );
@@ -34968,7 +38821,7 @@ unicode = 003E;
 },
 {
 glyphname = less;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -34976,19 +38829,19 @@ paths = (
 {
 closed = 1;
 nodes = (
-"70 319 LINE",
-"538 553 LINE",
-"538 607 LINE",
-"70 373 LINE"
+"538 139 LINE",
+"70 373 LINE",
+"70 316 LINE",
+"538 82 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"70 316 LINE",
-"538 82 LINE",
-"538 139 LINE",
-"70 373 LINE"
+"538 553 LINE",
+"538 607 LINE",
+"70 373 LINE",
+"70 319 LINE"
 );
 }
 );
@@ -35000,19 +38853,19 @@ paths = (
 {
 closed = 1;
 nodes = (
-"70 314 LINE",
-"538 548 LINE",
-"538 612 LINE",
-"70 378 LINE"
+"538 144 LINE",
+"70 378 LINE",
+"70 311 LINE",
+"538 77 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"70 311 LINE",
-"538 77 LINE",
-"538 144 LINE",
-"70 378 LINE"
+"538 548 LINE",
+"538 612 LINE",
+"70 378 LINE",
+"70 314 LINE"
 );
 }
 );
@@ -35023,7 +38876,7 @@ unicode = 003C;
 },
 {
 glyphname = greaterequal;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -35031,28 +38884,28 @@ paths = (
 {
 closed = 1;
 nodes = (
+"576 408 LINE",
+"576 465 LINE",
+"108 231 LINE",
+"108 174 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"516 43 LINE",
+"516 87 LINE",
+"18 87 LINE",
+"18 43 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "576 465 LINE",
 "108 699 LINE",
 "108 645 LINE",
 "576 411 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"576 465 LINE",
-"108 231 LINE",
-"108 174 LINE",
-"576 408 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"516 87 LINE",
-"18 87 LINE",
-"18 43 LINE",
-"516 43 LINE"
 );
 }
 );
@@ -35064,10 +38917,19 @@ paths = (
 {
 closed = 1;
 nodes = (
+"516 402 LINE",
+"516 469 LINE",
+"48 235 LINE",
+"48 168 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"536 38 LINE",
 "536 92 LINE",
 "38 92 LINE",
-"38 38 LINE",
-"536 38 LINE"
+"38 38 LINE"
 );
 },
 {
@@ -35078,15 +38940,6 @@ nodes = (
 "48 639 LINE",
 "516 405 LINE"
 );
-},
-{
-closed = 1;
-nodes = (
-"516 469 LINE",
-"48 235 LINE",
-"48 168 LINE",
-"516 402 LINE"
-);
 }
 );
 width = 598;
@@ -35096,7 +38949,7 @@ unicode = 2265;
 },
 {
 glyphname = lessequal;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -35104,28 +38957,28 @@ paths = (
 {
 closed = 1;
 nodes = (
-"80 411 LINE",
-"548 645 LINE",
-"548 699 LINE",
-"80 465 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"80 408 LINE",
-"548 174 LINE",
 "548 231 LINE",
-"80 465 LINE"
+"80 465 LINE",
+"80 408 LINE",
+"548 174 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"20 43 LINE",
 "518 43 LINE",
 "518 87 LINE",
-"20 87 LINE"
+"20 87 LINE",
+"20 43 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"548 645 LINE",
+"548 699 LINE",
+"80 465 LINE",
+"80 411 LINE"
 );
 }
 );
@@ -35137,28 +38990,28 @@ paths = (
 {
 closed = 1;
 nodes = (
-"39 38 LINE",
+"527 235 LINE",
+"59 469 LINE",
+"59 402 LINE",
+"527 168 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "537 38 LINE",
 "537 92 LINE",
-"39 92 LINE"
+"39 92 LINE",
+"39 38 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"59 405 LINE",
 "527 639 LINE",
 "527 703 LINE",
-"59 469 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"59 402 LINE",
-"527 168 LINE",
-"527 235 LINE",
-"59 469 LINE"
+"59 469 LINE",
+"59 405 LINE"
 );
 }
 );
@@ -35169,20 +39022,11 @@ unicode = 2264;
 },
 {
 glyphname = plusminus;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
 paths = (
-{
-closed = 1;
-nodes = (
-"99 411 LINE",
-"597 411 LINE",
-"597 455 LINE",
-"99 455 LINE"
-);
-},
 {
 closed = 1;
 nodes = (
@@ -35195,10 +39039,19 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"59 43 LINE",
 "557 43 LINE",
 "557 87 LINE",
-"59 87 LINE"
+"59 87 LINE",
+"59 43 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"597 411 LINE",
+"597 455 LINE",
+"99 455 LINE",
+"99 411 LINE"
 );
 }
 );
@@ -35207,15 +39060,6 @@ width = 578;
 {
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
 paths = (
-{
-closed = 1;
-nodes = (
-"69 406 LINE",
-"567 406 LINE",
-"567 460 LINE",
-"69 460 LINE"
-);
-},
 {
 closed = 1;
 nodes = (
@@ -35228,10 +39072,19 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"69 38 LINE",
 "567 38 LINE",
 "567 92 LINE",
-"69 92 LINE"
+"69 92 LINE",
+"69 38 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"567 406 LINE",
+"567 460 LINE",
+"69 460 LINE",
+"69 406 LINE"
 );
 }
 );
@@ -35242,7 +39095,7 @@ unicode = 00B1;
 },
 {
 glyphname = approxequal;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -35250,6 +39103,15 @@ paths = (
 {
 closed = 1;
 nodes = (
+"153 400 OFFCURVE",
+"179 436 OFFCURVE",
+"224 436 CURVE SMOOTH",
+"294 436 OFFCURVE",
+"360 375 OFFCURVE",
+"435 375 CURVE SMOOTH",
+"507 375 OFFCURVE",
+"541 412 OFFCURVE",
+"576 458 CURVE",
 "538 487 LINE",
 "511 455 OFFCURVE",
 "481 423 OFFCURVE",
@@ -35260,21 +39122,21 @@ nodes = (
 "155 484 OFFCURVE",
 "123 445 OFFCURVE",
 "92 397 CURVE",
-"131 366 LINE",
-"153 400 OFFCURVE",
-"179 436 OFFCURVE",
-"224 436 CURVE SMOOTH",
-"294 436 OFFCURVE",
-"360 375 OFFCURVE",
-"435 375 CURVE SMOOTH",
-"507 375 OFFCURVE",
-"541 412 OFFCURVE",
-"576 458 CURVE"
+"131 366 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
+"153 233 OFFCURVE",
+"179 269 OFFCURVE",
+"224 269 CURVE SMOOTH",
+"294 269 OFFCURVE",
+"360 208 OFFCURVE",
+"435 208 CURVE SMOOTH",
+"507 208 OFFCURVE",
+"541 245 OFFCURVE",
+"576 291 CURVE",
 "538 320 LINE",
 "511 288 OFFCURVE",
 "481 256 OFFCURVE",
@@ -35285,16 +39147,7 @@ nodes = (
 "155 317 OFFCURVE",
 "123 278 OFFCURVE",
 "92 230 CURVE",
-"131 199 LINE",
-"153 233 OFFCURVE",
-"179 269 OFFCURVE",
-"224 269 CURVE SMOOTH",
-"294 269 OFFCURVE",
-"360 208 OFFCURVE",
-"435 208 CURVE SMOOTH",
-"507 208 OFFCURVE",
-"541 245 OFFCURVE",
-"576 291 CURVE"
+"131 199 LINE"
 );
 }
 );
@@ -35306,6 +39159,15 @@ paths = (
 {
 closed = 1;
 nodes = (
+"159 399 OFFCURVE",
+"184 436 OFFCURVE",
+"229 436 CURVE SMOOTH",
+"299 436 OFFCURVE",
+"365 375 OFFCURVE",
+"440 375 CURVE SMOOTH",
+"514 375 OFFCURVE",
+"556 419 OFFCURVE",
+"586 458 CURVE",
 "542 503 LINE",
 "509 464 OFFCURVE",
 "486 438 OFFCURVE",
@@ -35316,21 +39178,21 @@ nodes = (
 "158 499 OFFCURVE",
 "119 452 OFFCURVE",
 "91 410 CURVE",
-"137 365 LINE",
-"159 399 OFFCURVE",
-"184 436 OFFCURVE",
-"229 436 CURVE SMOOTH",
-"299 436 OFFCURVE",
-"365 375 OFFCURVE",
-"440 375 CURVE SMOOTH",
-"514 375 OFFCURVE",
-"556 419 OFFCURVE",
-"586 458 CURVE"
+"137 365 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
+"159 219 OFFCURVE",
+"184 256 OFFCURVE",
+"229 256 CURVE SMOOTH",
+"299 256 OFFCURVE",
+"365 195 OFFCURVE",
+"440 195 CURVE SMOOTH",
+"514 195 OFFCURVE",
+"556 239 OFFCURVE",
+"586 278 CURVE",
 "542 323 LINE",
 "509 284 OFFCURVE",
 "486 258 OFFCURVE",
@@ -35341,16 +39203,7 @@ nodes = (
 "158 319 OFFCURVE",
 "119 272 OFFCURVE",
 "91 230 CURVE",
-"137 185 LINE",
-"159 219 OFFCURVE",
-"184 256 OFFCURVE",
-"229 256 CURVE SMOOTH",
-"299 256 OFFCURVE",
-"365 195 OFFCURVE",
-"440 195 CURVE SMOOTH",
-"514 195 OFFCURVE",
-"556 239 OFFCURVE",
-"586 278 CURVE"
+"137 185 LINE"
 );
 }
 );
@@ -35361,7 +39214,7 @@ unicode = 2248;
 },
 {
 glyphname = asciitilde;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -35369,6 +39222,15 @@ paths = (
 {
 closed = 1;
 nodes = (
+"95 260 OFFCURVE",
+"117 291 OFFCURVE",
+"167 291 CURVE SMOOTH",
+"231 291 OFFCURVE",
+"291 230 OFFCURVE",
+"358 230 CURVE SMOOTH",
+"420 230 OFFCURVE",
+"453 274 OFFCURVE",
+"485 320 CURVE",
 "444 345 LINE",
 "420 309 OFFCURVE",
 "399 282 OFFCURVE",
@@ -35379,16 +39241,7 @@ nodes = (
 "98 343 OFFCURVE",
 "61 296 OFFCURVE",
 "30 248 CURVE",
-"70 221 LINE",
-"95 260 OFFCURVE",
-"117 291 OFFCURVE",
-"167 291 CURVE SMOOTH",
-"231 291 OFFCURVE",
-"291 230 OFFCURVE",
-"358 230 CURVE SMOOTH",
-"420 230 OFFCURVE",
-"453 274 OFFCURVE",
-"485 320 CURVE"
+"70 221 LINE"
 );
 }
 );
@@ -35400,6 +39253,15 @@ paths = (
 {
 closed = 1;
 nodes = (
+"102 250 OFFCURVE",
+"124 281 OFFCURVE",
+"174 281 CURVE SMOOTH",
+"238 281 OFFCURVE",
+"298 220 OFFCURVE",
+"365 220 CURVE SMOOTH",
+"432 220 OFFCURVE",
+"467 264 OFFCURVE",
+"502 310 CURVE",
 "451 355 LINE",
 "427 319 OFFCURVE",
 "406 292 OFFCURVE",
@@ -35410,16 +39272,7 @@ nodes = (
 "100 353 OFFCURVE",
 "60 306 OFFCURVE",
 "27 258 CURVE",
-"77 211 LINE",
-"102 250 OFFCURVE",
-"124 281 OFFCURVE",
-"174 281 CURVE SMOOTH",
-"238 281 OFFCURVE",
-"298 220 OFFCURVE",
-"365 220 CURVE SMOOTH",
-"432 220 OFFCURVE",
-"467 264 OFFCURVE",
-"502 310 CURVE"
+"77 211 LINE"
 );
 }
 );
@@ -35430,7 +39283,7 @@ unicode = 007E;
 },
 {
 glyphname = logicalnot;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -35438,19 +39291,19 @@ paths = (
 {
 closed = 1;
 nodes = (
-"20 282 LINE",
 "518 282 LINE",
 "518 326 LINE",
-"20 326 LINE"
+"20 326 LINE",
+"20 282 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"441 307 LINE",
-"441 72 LINE",
 "518 72 LINE",
-"518 307 LINE"
+"518 307 LINE",
+"441 307 LINE",
+"441 72 LINE"
 );
 }
 );
@@ -35462,19 +39315,19 @@ paths = (
 {
 closed = 1;
 nodes = (
-"30 277 LINE",
 "528 277 LINE",
 "528 326 LINE",
-"30 326 LINE"
+"30 326 LINE",
+"30 277 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"435 307 LINE",
-"435 55 LINE",
 "528 55 LINE",
-"528 307 LINE"
+"528 307 LINE",
+"435 307 LINE",
+"435 55 LINE"
 );
 }
 );
@@ -35485,7 +39338,7 @@ unicode = 00AC;
 },
 {
 glyphname = infinity;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:02:58 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -35493,7 +39346,15 @@ paths = (
 {
 closed = 1;
 nodes = (
-"761 296 LINE SMOOTH",
+"309 117 OFFCURVE",
+"365 168 OFFCURVE",
+"415 231 CURVE",
+"481 141 OFFCURVE",
+"539 117 OFFCURVE",
+"592 117 CURVE SMOOTH",
+"680 117 OFFCURVE",
+"761 183 OFFCURVE",
+"761 296 CURVE SMOOTH",
 "761 401 OFFCURVE",
 "691 468 OFFCURVE",
 "600 468 CURVE SMOOTH",
@@ -35508,22 +39369,12 @@ nodes = (
 "66 291 CURVE SMOOTH",
 "66 186 OFFCURVE",
 "141 117 OFFCURVE",
-"231 117 CURVE SMOOTH",
-"309 117 OFFCURVE",
-"365 168 OFFCURVE",
-"415 231 CURVE",
-"481 141 OFFCURVE",
-"539 117 OFFCURVE",
-"592 117 CURVE SMOOTH",
-"680 117 OFFCURVE",
-"761 183 OFFCURVE",
-"761 296 CURVE SMOOTH"
+"231 117 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"238 172 LINE SMOOTH",
 "173 172 OFFCURVE",
 "123 223 OFFCURVE",
 "123 293 CURVE SMOOTH",
@@ -35541,19 +39392,18 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"592 414 LINE SMOOTH",
-"660 414 OFFCURVE",
-"703 358 OFFCURVE",
-"703 294 CURVE SMOOTH",
-"703 238 OFFCURVE",
-"670 172 OFFCURVE",
-"596 172 CURVE SMOOTH",
 "540 172 OFFCURVE",
 "500 210 OFFCURVE",
 "437 294 CURVE",
 "493 374 OFFCURVE",
 "536 414 OFFCURVE",
-"592 414 CURVE SMOOTH"
+"592 414 CURVE SMOOTH",
+"660 414 OFFCURVE",
+"703 358 OFFCURVE",
+"703 294 CURVE SMOOTH",
+"703 238 OFFCURVE",
+"670 172 OFFCURVE",
+"596 172 CURVE SMOOTH"
 );
 }
 );
@@ -35565,7 +39415,15 @@ paths = (
 {
 closed = 1;
 nodes = (
-"783 297 LINE SMOOTH",
+"317 106 OFFCURVE",
+"371 153 OFFCURVE",
+"424 221 CURVE",
+"492 125 OFFCURVE",
+"553 106 OFFCURVE",
+"609 106 CURVE SMOOTH",
+"697 106 OFFCURVE",
+"783 175 OFFCURVE",
+"783 297 CURVE SMOOTH",
 "783 406 OFFCURVE",
 "706 477 OFFCURVE",
 "614 477 CURVE SMOOTH",
@@ -35580,22 +39438,12 @@ nodes = (
 "64 290 CURVE SMOOTH",
 "64 178 OFFCURVE",
 "146 106 OFFCURVE",
-"234 106 CURVE SMOOTH",
-"317 106 OFFCURVE",
-"371 153 OFFCURVE",
-"424 221 CURVE",
-"492 125 OFFCURVE",
-"553 106 OFFCURVE",
-"609 106 CURVE SMOOTH",
-"697 106 OFFCURVE",
-"783 175 OFFCURVE",
-"783 297 CURVE SMOOTH"
+"234 106 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"246 183 LINE SMOOTH",
 "187 183 OFFCURVE",
 "143 232 OFFCURVE",
 "143 289 CURVE SMOOTH",
@@ -35613,19 +39461,18 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"605 401 LINE SMOOTH",
-"666 401 OFFCURVE",
-"704 352 OFFCURVE",
-"704 289 CURVE SMOOTH",
-"704 244 OFFCURVE",
-"670 183 OFFCURVE",
-"611 183 CURVE SMOOTH",
 "558 183 OFFCURVE",
 "526 207 OFFCURVE",
 "463 294 CURVE",
 "528 376 OFFCURVE",
 "561 401 OFFCURVE",
-"605 401 CURVE SMOOTH"
+"605 401 CURVE SMOOTH",
+"666 401 OFFCURVE",
+"704 352 OFFCURVE",
+"704 289 CURVE SMOOTH",
+"704 244 OFFCURVE",
+"670 183 OFFCURVE",
+"611 183 CURVE SMOOTH"
 );
 }
 );
@@ -35636,7 +39483,7 @@ unicode = 221E;
 },
 {
 glyphname = integral;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:03:04 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -35644,7 +39491,9 @@ paths = (
 {
 closed = 1;
 nodes = (
-"313 159 LINE SMOOTH",
+"210 -202 OFFCURVE",
+"313 -138 OFFCURVE",
+"313 159 CURVE SMOOTH",
 "313 261 OFFCURVE",
 "301 560 OFFCURVE",
 "301 658 CURVE SMOOTH",
@@ -35686,10 +39535,7 @@ nodes = (
 "17 -120 CURVE SMOOTH",
 "17 -176 OFFCURVE",
 "79 -202 OFFCURVE",
-"130 -202 CURVE SMOOTH",
-"210 -202 OFFCURVE",
-"313 -138 OFFCURVE",
-"313 159 CURVE SMOOTH"
+"130 -202 CURVE SMOOTH"
 );
 }
 );
@@ -35701,7 +39547,9 @@ paths = (
 {
 closed = 1;
 nodes = (
-"340 161 LINE SMOOTH",
+"228 -202 OFFCURVE",
+"340 -140 OFFCURVE",
+"340 161 CURVE SMOOTH",
 "340 259 OFFCURVE",
 "328 560 OFFCURVE",
 "328 659 CURVE SMOOTH",
@@ -35743,10 +39591,7 @@ nodes = (
 "19 -118 CURVE SMOOTH",
 "19 -177 OFFCURVE",
 "86 -202 OFFCURVE",
-"141 -202 CURVE SMOOTH",
-"228 -202 OFFCURVE",
-"340 -140 OFFCURVE",
-"340 161 CURVE SMOOTH"
+"141 -202 CURVE SMOOTH"
 );
 }
 );
@@ -35756,8 +39601,8 @@ width = 466;
 unicode = 222B;
 },
 {
-glyphname = Omega;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = Ohm;
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -35765,32 +39610,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"730 174 LINE",
-"707 174 LINE",
-"686 109 OFFCURVE",
-"672 95 OFFCURVE",
-"630 95 CURVE SMOOTH",
-"508 95 LINE",
-"508 99 LINE",
-"607 187 OFFCURVE",
-"694 269 OFFCURVE",
-"694 421 CURVE SMOOTH",
-"694 607 OFFCURVE",
-"565 733 OFFCURVE",
-"387 733 CURVE SMOOTH",
-"208 733 OFFCURVE",
-"72 606 OFFCURVE",
-"72 412 CURVE SMOOTH",
-"72 249 OFFCURVE",
-"168 165 OFFCURVE",
-"251 100 CURVE",
-"251 96 LINE",
-"144 96 LINE SMOOTH",
-"100 96 OFFCURVE",
-"84 112 OFFCURVE",
-"62 174 CURVE",
-"38 174 LINE",
-"63 0 LINE",
 "335 0 LINE",
 "345 23 LINE",
 "257 156 OFFCURVE",
@@ -35806,7 +39625,31 @@ nodes = (
 "514 160 OFFCURVE",
 "421 23 CURVE",
 "430 0 LINE",
-"701 0 LINE"
+"701 0 LINE",
+"730 174 LINE",
+"707 174 LINE",
+"686 109 OFFCURVE",
+"672 95 OFFCURVE",
+"630 95 CURVE SMOOTH",
+"508 99 LINE",
+"607 187 OFFCURVE",
+"694 269 OFFCURVE",
+"694 421 CURVE SMOOTH",
+"694 607 OFFCURVE",
+"565 733 OFFCURVE",
+"387 733 CURVE SMOOTH",
+"208 733 OFFCURVE",
+"72 606 OFFCURVE",
+"72 412 CURVE SMOOTH",
+"72 249 OFFCURVE",
+"168 165 OFFCURVE",
+"251 100 CURVE",
+"144 96 LINE SMOOTH",
+"100 96 OFFCURVE",
+"84 112 OFFCURVE",
+"62 174 CURVE",
+"38 174 LINE",
+"63 0 LINE"
 );
 }
 );
@@ -35818,6 +39661,22 @@ paths = (
 {
 closed = 1;
 nodes = (
+"365 0 LINE",
+"375 26 LINE",
+"326 132 OFFCURVE",
+"263 268 OFFCURVE",
+"263 399 CURVE SMOOTH",
+"263 626 OFFCURVE",
+"323 694 OFFCURVE",
+"415 694 CURVE SMOOTH",
+"506 694 OFFCURVE",
+"572 615 OFFCURVE",
+"572 402 CURVE SMOOTH",
+"572 267 OFFCURVE",
+"500 123 OFFCURVE",
+"458 26 CURVE",
+"468 0 LINE",
+"756 0 LINE",
 "788 189 LINE",
 "747 189 LINE",
 "724 127 OFFCURVE",
@@ -35841,23 +39700,7 @@ nodes = (
 "111 128 OFFCURVE",
 "87 189 CURVE",
 "48 189 LINE",
-"75 0 LINE",
-"365 0 LINE",
-"375 26 LINE",
-"326 132 OFFCURVE",
-"263 268 OFFCURVE",
-"263 399 CURVE SMOOTH",
-"263 626 OFFCURVE",
-"323 694 OFFCURVE",
-"415 694 CURVE SMOOTH",
-"506 694 OFFCURVE",
-"572 615 OFFCURVE",
-"572 402 CURVE SMOOTH",
-"572 267 OFFCURVE",
-"500 123 OFFCURVE",
-"458 26 CURVE",
-"468 0 LINE",
-"756 0 LINE"
+"75 0 LINE"
 );
 }
 );
@@ -35867,8 +39710,8 @@ width = 782;
 unicode = 2126;
 },
 {
-glyphname = Delta;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = increment;
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -35887,9 +39730,9 @@ nodes = (
 {
 closed = 1;
 nodes = (
+"279 570 LINE",
 "478 37 LINE",
-"67 37 LINE",
-"279 570 LINE"
+"67 37 LINE"
 );
 }
 );
@@ -35912,9 +39755,9 @@ nodes = (
 {
 closed = 1;
 nodes = (
+"268 527 LINE",
 "459 73 LINE",
-"83 73 LINE",
-"268 527 LINE"
+"83 73 LINE"
 );
 }
 );
@@ -35925,7 +39768,7 @@ unicode = 2206;
 },
 {
 glyphname = product;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:15:33 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -35933,55 +39776,46 @@ paths = (
 {
 closed = 1;
 nodes = (
-"107 -64 LINE",
-"241 -64 LINE",
-"241 734 LINE",
-"107 734 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"17 -79 LINE",
-"321 -79 LINE",
-"321 -54 LINE",
-"17 -54 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"17 709 LINE",
-"351 709 LINE",
-"351 734 LINE",
-"17 734 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"470 -64 LINE",
 "604 -64 LINE",
 "604 734 LINE",
-"470 734 LINE"
+"470 734 LINE",
+"470 -64 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"390 -79 LINE",
+"321 -79 LINE",
+"321 -54 LINE",
+"17 -54 LINE",
+"17 -79 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "694 -79 LINE",
 "694 -54 LINE",
-"390 -54 LINE"
+"390 -54 LINE",
+"390 -79 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"340 709 LINE",
+"241 -64 LINE",
+"241 734 LINE",
+"107 734 LINE",
+"107 -64 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "694 709 LINE",
 "694 734 LINE",
-"340 734 LINE"
+"17 734 LINE",
+"17 709 LINE"
 );
 }
 );
@@ -35993,46 +39827,46 @@ paths = (
 {
 closed = 1;
 nodes = (
-"126 -71 LINE",
-"284 -71 LINE",
-"284 733 LINE",
-"126 733 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"27 -86 LINE",
-"357 -86 LINE",
-"357 -56 LINE",
-"27 -56 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"666 -71 LINE",
 "666 733 LINE",
 "508 733 LINE",
-"508 -71 LINE",
-"666 -71 LINE"
+"508 -71 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
+"357 -86 LINE",
+"357 -56 LINE",
+"27 -56 LINE",
+"27 -86 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"765 -86 LINE",
 "765 -56 LINE",
 "435 -56 LINE",
-"435 -86 LINE",
-"765 -86 LINE"
+"435 -86 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"27 703 LINE",
+"284 -71 LINE",
+"284 733 LINE",
+"126 733 LINE",
+"126 -71 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "765 703 LINE",
 "765 733 LINE",
-"27 733 LINE"
+"27 733 LINE",
+"27 703 LINE"
 );
 }
 );
@@ -36043,7 +39877,7 @@ unicode = 220F;
 },
 {
 glyphname = summation;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -36051,6 +39885,7 @@ paths = (
 {
 closed = 1;
 nodes = (
+"571 -87 LINE",
 "618 141 LINE",
 "592 148 LINE",
 "547 31 OFFCURVE",
@@ -36069,8 +39904,7 @@ nodes = (
 "92 709 LINE",
 "315 278 LINE",
 "88 -53 LINE",
-"88 -87 LINE",
-"571 -87 LINE"
+"88 -87 LINE"
 );
 }
 );
@@ -36082,6 +39916,7 @@ paths = (
 {
 closed = 1;
 nodes = (
+"622 -96 LINE",
 "676 149 LINE",
 "630 149 LINE",
 "585 43 OFFCURVE",
@@ -36100,8 +39935,7 @@ nodes = (
 "103 690 LINE",
 "331 264 LINE",
 "98 -56 LINE",
-"98 -96 LINE",
-"622 -96 LINE"
+"98 -96 LINE"
 );
 }
 );
@@ -36112,7 +39946,7 @@ unicode = 2211;
 },
 {
 glyphname = radical;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -36120,6 +39954,7 @@ paths = (
 {
 closed = 1;
 nodes = (
+"307 -172 LINE",
 "668 915 LINE",
 "639 915 LINE",
 "350 50 LINE",
@@ -36128,8 +39963,7 @@ nodes = (
 "54 440 LINE",
 "54 415 LINE",
 "148 415 LINE",
-"293 -175 LINE",
-"307 -172 LINE"
+"293 -175 LINE"
 );
 }
 );
@@ -36141,6 +39975,7 @@ paths = (
 {
 closed = 1;
 nodes = (
+"440 -175 LINE",
 "637 914 LINE",
 "576 914 LINE",
 "430 81 LINE",
@@ -36149,8 +39984,7 @@ nodes = (
 "64 440 LINE",
 "64 405 LINE",
 "162 405 LINE",
-"401 -183 LINE",
-"440 -175 LINE"
+"401 -183 LINE"
 );
 }
 );
@@ -36160,8 +39994,8 @@ width = 622;
 unicode = 221A;
 },
 {
-glyphname = mu;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = micro;
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -36169,33 +40003,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"514 450 LINE",
-"412 450 LINE",
-"341 154 LINE SMOOTH",
-"334 125 OFFCURVE",
-"331 101 OFFCURVE",
-"331 82 CURVE SMOOTH",
-"331 9 OFFCURVE",
-"373 -12 OFFCURVE",
-"412 -12 CURVE SMOOTH",
-"477 -12 OFFCURVE",
-"523 45 OFFCURVE",
-"564 142 CURVE",
-"544 151 LINE",
-"507 73 OFFCURVE",
-"472 30 OFFCURVE",
-"444 30 CURVE SMOOTH",
-"430 30 OFFCURVE",
-"424 41 OFFCURVE",
-"424 60 CURVE SMOOTH",
-"424 77 OFFCURVE",
-"429 106 OFFCURVE",
-"439 147 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
+"226 -12 OFFCURVE",
+"285 41 OFFCURVE",
+"327 96 CURVE",
+"334 96 LINE",
 "356 216 LINE",
 "327 113 OFFCURVE",
 "257 32 OFFCURVE",
@@ -36214,32 +40025,12 @@ nodes = (
 "56 70 CURVE SMOOTH",
 "56 12 OFFCURVE",
 "99 -12 OFFCURVE",
-"150 -12 CURVE SMOOTH",
-"226 -12 OFFCURVE",
-"285 41 OFFCURVE",
-"327 96 CURVE",
-"334 96 LINE"
+"150 -12 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"65 425 LINE",
-"224 425 LINE",
-"224 450 LINE",
-"65 450 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"65 126 LINE",
-"29 -59 OFFCURVE",
-"-41 -153 OFFCURVE",
-"-41 -217 CURVE SMOOTH",
-"-41 -248 OFFCURVE",
-"-24 -261 OFFCURVE",
-"1 -261 CURVE SMOOTH",
 "37 -261 OFFCURVE",
 "68 -236 OFFCURVE",
 "68 -174 CURVE SMOOTH",
@@ -36249,7 +40040,50 @@ nodes = (
 "60 -45 OFFCURVE",
 "62 -16 OFFCURVE",
 "68 21 CURVE",
-"72 21 LINE"
+"72 21 LINE",
+"65 126 LINE",
+"29 -59 OFFCURVE",
+"-41 -153 OFFCURVE",
+"-41 -217 CURVE SMOOTH",
+"-41 -248 OFFCURVE",
+"-24 -261 OFFCURVE",
+"1 -261 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"224 425 LINE",
+"224 450 LINE",
+"65 450 LINE",
+"65 425 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"477 -12 OFFCURVE",
+"523 45 OFFCURVE",
+"564 142 CURVE",
+"544 151 LINE",
+"507 73 OFFCURVE",
+"472 30 OFFCURVE",
+"444 30 CURVE SMOOTH",
+"430 30 OFFCURVE",
+"424 41 OFFCURVE",
+"424 60 CURVE SMOOTH",
+"424 77 OFFCURVE",
+"429 106 OFFCURVE",
+"439 147 CURVE SMOOTH",
+"514 450 LINE",
+"412 450 LINE",
+"341 154 LINE SMOOTH",
+"334 125 OFFCURVE",
+"331 101 OFFCURVE",
+"331 82 CURVE SMOOTH",
+"331 9 OFFCURVE",
+"373 -12 OFFCURVE",
+"412 -12 CURVE SMOOTH"
 );
 }
 );
@@ -36329,42 +40163,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"41 420 LINE",
-"215 420 LINE",
-"215 450 LINE",
-"41 450 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"559 450 LINE",
-"425 450 LINE",
-"351 153 LINE SMOOTH",
-"338 100 OFFCURVE",
-"335 86 OFFCURVE",
-"335 70 CURVE SMOOTH",
-"335 15 OFFCURVE",
-"370 -11 OFFCURVE",
-"422 -11 CURVE SMOOTH",
-"513 -11 OFFCURVE",
-"576 69 OFFCURVE",
-"602 152 CURVE",
-"577 161 LINE",
-"540 69 OFFCURVE",
-"499 41 OFFCURVE",
-"479 41 CURVE SMOOTH",
-"472 41 OFFCURVE",
-"467 45 OFFCURVE",
-"467 54 CURVE SMOOTH",
-"467 58 OFFCURVE",
-"468 70 OFFCURVE",
-"472 87 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
+"232 -11 OFFCURVE",
+"292 43 OFFCURVE",
+"332 98 CURVE",
+"339 98 LINE",
 "370 220 LINE",
 "339 108 OFFCURVE",
 "239 35 OFFCURVE",
@@ -36383,23 +40185,12 @@ nodes = (
 "50 69 CURVE SMOOTH",
 "50 13 OFFCURVE",
 "99 -11 OFFCURVE",
-"152 -11 CURVE SMOOTH",
-"232 -11 OFFCURVE",
-"292 43 OFFCURVE",
-"332 98 CURVE",
-"339 98 LINE"
+"152 -11 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"54 104 LINE",
-"13 -90 OFFCURVE",
-"-49 -153 OFFCURVE",
-"-49 -220 CURVE SMOOTH",
-"-49 -252 OFFCURVE",
-"-34 -277 OFFCURVE",
-"5 -277 CURVE SMOOTH",
 "48 -277 OFFCURVE",
 "81 -246 OFFCURVE",
 "81 -174 CURVE SMOOTH",
@@ -36409,7 +40200,50 @@ nodes = (
 "76 -38 OFFCURVE",
 "76 -17 OFFCURVE",
 "78 8 CURVE",
-"82 8 LINE"
+"82 8 LINE",
+"54 104 LINE",
+"13 -90 OFFCURVE",
+"-49 -153 OFFCURVE",
+"-49 -220 CURVE SMOOTH",
+"-49 -252 OFFCURVE",
+"-34 -277 OFFCURVE",
+"5 -277 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"215 420 LINE",
+"215 450 LINE",
+"41 450 LINE",
+"41 420 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"513 -11 OFFCURVE",
+"576 69 OFFCURVE",
+"602 152 CURVE",
+"577 161 LINE",
+"540 69 OFFCURVE",
+"499 41 OFFCURVE",
+"479 41 CURVE SMOOTH",
+"472 41 OFFCURVE",
+"467 45 OFFCURVE",
+"467 54 CURVE SMOOTH",
+"467 58 OFFCURVE",
+"468 70 OFFCURVE",
+"472 87 CURVE SMOOTH",
+"559 450 LINE",
+"425 450 LINE",
+"351 153 LINE SMOOTH",
+"338 100 OFFCURVE",
+"335 86 OFFCURVE",
+"335 70 CURVE SMOOTH",
+"335 15 OFFCURVE",
+"370 -11 OFFCURVE",
+"422 -11 CURVE SMOOTH"
 );
 }
 );
@@ -36420,7 +40254,7 @@ unicode = 00B5;
 },
 {
 glyphname = partialdiff;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:16:12 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -36428,16 +40262,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"286 451 LINE SMOOTH",
-"218 451 OFFCURVE",
-"154 420 OFFCURVE",
-"113 374 CURVE SMOOTH",
-"77 333 OFFCURVE",
-"49 267 OFFCURVE",
-"49 193 CURVE SMOOTH",
-"49 67 OFFCURVE",
-"129 -11 OFFCURVE",
-"249 -11 CURVE SMOOTH",
 "410 -11 OFFCURVE",
 "530 129 OFFCURVE",
 "530 391 CURVE SMOOTH",
@@ -36459,13 +40283,24 @@ nodes = (
 "413 390 CURVE",
 "385 429 OFFCURVE",
 "343 451 OFFCURVE",
-"286 451 CURVE SMOOTH"
+"286 451 CURVE SMOOTH",
+"151 451 OFFCURVE",
+"49 341 OFFCURVE",
+"49 193 CURVE SMOOTH",
+"49 67 OFFCURVE",
+"129 -11 OFFCURVE",
+"249 -11 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"314 411 LINE",
+"199 19 OFFCURVE",
+"176 58 OFFCURVE",
+"176 138 CURVE SMOOTH",
+"176 224 OFFCURVE",
+"202 411 OFFCURVE",
+"314 411 CURVE",
 "365 411 OFFCURVE",
 "392 372 OFFCURVE",
 "403 350 CURVE",
@@ -36474,13 +40309,7 @@ nodes = (
 "352 136 CURVE SMOOTH",
 "320 52 OFFCURVE",
 "295 19 OFFCURVE",
-"249 19 CURVE SMOOTH",
-"199 19 OFFCURVE",
-"176 58 OFFCURVE",
-"176 138 CURVE SMOOTH",
-"176 224 OFFCURVE",
-"202 411 OFFCURVE",
-"314 411 CURVE SMOOTH"
+"249 19 CURVE SMOOTH"
 );
 }
 );
@@ -36492,13 +40321,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"306 455 LINE",
-"164 455 OFFCURVE",
-"59 339 OFFCURVE",
-"59 197 CURVE SMOOTH",
-"59 69 OFFCURVE",
-"144 -12 OFFCURVE",
-"274 -12 CURVE SMOOTH",
 "465 -12 OFFCURVE",
 "580 162 OFFCURVE",
 "580 384 CURVE SMOOTH",
@@ -36520,13 +40342,24 @@ nodes = (
 "439 397 CURVE",
 "408 437 OFFCURVE",
 "362 455 OFFCURVE",
-"306 455 CURVE SMOOTH"
+"306 455 CURVE",
+"164 455 OFFCURVE",
+"59 339 OFFCURVE",
+"59 197 CURVE SMOOTH",
+"59 69 OFFCURVE",
+"144 -12 OFFCURVE",
+"274 -12 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"345 399 LINE SMOOTH",
+"233 31 OFFCURVE",
+"211 63 OFFCURVE",
+"211 136 CURVE SMOOTH",
+"211 210 OFFCURVE",
+"234 399 OFFCURVE",
+"345 399 CURVE SMOOTH",
 "391 399 OFFCURVE",
 "416 366 OFFCURVE",
 "428 343 CURVE",
@@ -36535,13 +40368,7 @@ nodes = (
 "375 138 CURVE SMOOTH",
 "350 79 OFFCURVE",
 "319 31 OFFCURVE",
-"272 31 CURVE SMOOTH",
-"233 31 OFFCURVE",
-"211 63 OFFCURVE",
-"211 136 CURVE SMOOTH",
-"211 210 OFFCURVE",
-"234 399 OFFCURVE",
-"345 399 CURVE SMOOTH"
+"272 31 CURVE SMOOTH"
 );
 }
 );
@@ -36552,13 +40379,14 @@ unicode = 2202;
 },
 {
 glyphname = percent;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:03:19 +0000";
 layers = (
 {
 components = (
 {
+alignment = -1;
 name = fraction;
-transform = "{1, 0, 0, 1, 311, -1}";
+transform = "{1, 0, 0, 1, 323, 0}";
 },
 {
 name = zero.numerator;
@@ -36575,8 +40403,9 @@ width = 913;
 {
 components = (
 {
+alignment = -1;
 name = fraction;
-transform = "{1, 0, 0, 1, 311, -1}";
+transform = "{1, 0, 0, 1, 317, 0}";
 },
 {
 name = zero.numerator;
@@ -36595,13 +40424,14 @@ unicode = 0025;
 },
 {
 glyphname = perthousand;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:03:34 +0000";
 layers = (
 {
 components = (
 {
+alignment = -1;
 name = fraction;
-transform = "{1, 0, 0, 1, 311, 0}";
+transform = "{1, 0, 0, 1, 312, 0}";
 },
 {
 name = zero.numerator;
@@ -36622,8 +40452,9 @@ width = 1289;
 {
 components = (
 {
+alignment = -1;
 name = fraction;
-transform = "{1, 0, 0, 1, 311, 0}";
+transform = "{1, 0, 0, 1, 322, 0}";
 },
 {
 name = zero.numerator;
@@ -36645,100 +40476,8 @@ width = 1309;
 unicode = 2030;
 },
 {
-glyphname = uni2215;
-lastChange = "2016-08-16 11:12:44 +0000";
-layers = (
-{
-layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
-paths = (
-{
-closed = 1;
-nodes = (
-"446 753 LINE",
-"-144 0 LINE",
-"-85 0 LINE",
-"505 753 LINE"
-);
-}
-);
-width = 254;
-},
-{
-layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
-paths = (
-{
-closed = 1;
-nodes = (
-"446 753 LINE",
-"-144 0 LINE",
-"-85 0 LINE",
-"505 753 LINE"
-);
-}
-);
-width = 274;
-}
-);
-unicode = 2215;
-},
-{
-glyphname = uni2219;
-lastChange = "2016-08-16 11:12:44 +0000";
-layers = (
-{
-layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
-paths = (
-{
-closed = 1;
-nodes = (
-"30 251 LINE SMOOTH",
-"30 213 OFFCURVE",
-"59 184 OFFCURVE",
-"97 184 CURVE SMOOTH",
-"135 184 OFFCURVE",
-"165 213 OFFCURVE",
-"165 251 CURVE SMOOTH",
-"165 289 OFFCURVE",
-"135 319 OFFCURVE",
-"97 319 CURVE SMOOTH",
-"59 319 OFFCURVE",
-"30 289 OFFCURVE",
-"30 251 CURVE SMOOTH"
-);
-}
-);
-width = 166;
-},
-{
-layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
-paths = (
-{
-closed = 1;
-nodes = (
-"26 254 LINE SMOOTH",
-"26 206 OFFCURVE",
-"65 167 OFFCURVE",
-"113 167 CURVE SMOOTH",
-"161 167 OFFCURVE",
-"200 206 OFFCURVE",
-"200 254 CURVE SMOOTH",
-"200 302 OFFCURVE",
-"161 341 OFFCURVE",
-"113 341 CURVE SMOOTH",
-"65 341 OFFCURVE",
-"26 302 OFFCURVE",
-"26 254 CURVE SMOOTH"
-);
-}
-);
-width = 214;
-}
-);
-unicode = 2219;
-},
-{
 glyphname = lozenge;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -36746,23 +40485,23 @@ paths = (
 {
 closed = 1;
 nodes = (
+"375 -74 LINE",
 "575 347 LINE",
 "375 771 LINE",
 "279 771 LINE",
 "76 347 LINE",
-"276 -74 LINE",
-"375 -74 LINE"
+"276 -74 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"504 347 LINE",
-"329 -24 LINE",
-"325 -24 LINE",
 "147 348 LINE",
 "325 717 LINE",
-"329 717 LINE"
+"329 717 LINE",
+"504 347 LINE",
+"329 -24 LINE",
+"325 -24 LINE"
 );
 }
 );
@@ -36774,23 +40513,23 @@ paths = (
 {
 closed = 1;
 nodes = (
+"401 -77 LINE",
 "612 347 LINE",
 "402 774 LINE",
 "289 774 LINE",
 "76 347 LINE",
-"286 -77 LINE",
-"401 -77 LINE"
+"286 -77 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"516 347 LINE",
-"347 -7 LINE",
-"343 -7 LINE",
 "172 348 LINE",
 "343 700 LINE",
-"347 700 LINE"
+"347 700 LINE",
+"516 347 LINE",
+"347 -7 LINE",
+"343 -7 LINE"
 );
 }
 );
@@ -36801,7 +40540,7 @@ unicode = 25CA;
 },
 {
 glyphname = at;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:03:43 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -36809,19 +40548,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"546 44 LINE SMOOTH",
-"675 44 OFFCURVE",
-"779 175 OFFCURVE",
-"779 335 CURVE SMOOTH",
-"779 501 OFFCURVE",
-"668 630 OFFCURVE",
-"471 630 CURVE SMOOTH",
-"255 630 OFFCURVE",
-"64 474 OFFCURVE",
-"64 199 CURVE SMOOTH",
-"64 -40 OFFCURVE",
-"208 -152 OFFCURVE",
-"389 -152 CURVE SMOOTH",
 "487 -152 OFFCURVE",
 "569 -119 OFFCURVE",
 "654 -32 CURVE",
@@ -36855,22 +40581,24 @@ nodes = (
 "465 112 CURVE SMOOTH",
 "465 65 OFFCURVE",
 "494 44 OFFCURVE",
-"546 44 CURVE SMOOTH"
+"546 44 CURVE SMOOTH",
+"675 44 OFFCURVE",
+"779 175 OFFCURVE",
+"779 335 CURVE SMOOTH",
+"779 501 OFFCURVE",
+"668 630 OFFCURVE",
+"471 630 CURVE SMOOTH",
+"255 630 OFFCURVE",
+"64 474 OFFCURVE",
+"64 199 CURVE SMOOTH",
+"64 -40 OFFCURVE",
+"208 -152 OFFCURVE",
+"389 -152 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"524 390 LINE",
-"506 435 OFFCURVE",
-"485 454 OFFCURVE",
-"443 454 CURVE SMOOTH",
-"338 454 OFFCURVE",
-"219 336 OFFCURVE",
-"219 194 CURVE SMOOTH",
-"219 90 OFFCURVE",
-"282 44 OFFCURVE",
-"345 44 CURVE SMOOTH",
 "402 44 OFFCURVE",
 "439 82 OFFCURVE",
 "458 115 CURVE",
@@ -36891,7 +40619,17 @@ nodes = (
 "512 329 OFFCURVE",
 "510 322 OFFCURVE",
 "510 309 CURVE",
-"530 390 LINE"
+"530 390 LINE",
+"524 390 LINE",
+"506 435 OFFCURVE",
+"485 454 OFFCURVE",
+"443 454 CURVE SMOOTH",
+"338 454 OFFCURVE",
+"219 336 OFFCURVE",
+"219 194 CURVE SMOOTH",
+"219 90 OFFCURVE",
+"282 44 OFFCURVE",
+"345 44 CURVE SMOOTH"
 );
 }
 );
@@ -36903,19 +40641,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"563 44 LINE SMOOTH",
-"697 44 OFFCURVE",
-"799 176 OFFCURVE",
-"799 335 CURVE SMOOTH",
-"799 501 OFFCURVE",
-"688 630 OFFCURVE",
-"491 630 CURVE SMOOTH",
-"275 630 OFFCURVE",
-"84 474 OFFCURVE",
-"84 199 CURVE SMOOTH",
-"84 -40 OFFCURVE",
-"228 -152 OFFCURVE",
-"409 -152 CURVE SMOOTH",
 "507 -152 OFFCURVE",
 "589 -119 OFFCURVE",
 "674 -32 CURVE",
@@ -36949,22 +40674,24 @@ nodes = (
 "475 113 CURVE SMOOTH",
 "475 65 OFFCURVE",
 "509 44 OFFCURVE",
-"563 44 CURVE SMOOTH"
+"563 44 CURVE SMOOTH",
+"697 44 OFFCURVE",
+"799 176 OFFCURVE",
+"799 335 CURVE SMOOTH",
+"799 501 OFFCURVE",
+"688 630 OFFCURVE",
+"491 630 CURVE SMOOTH",
+"275 630 OFFCURVE",
+"84 474 OFFCURVE",
+"84 199 CURVE SMOOTH",
+"84 -40 OFFCURVE",
+"228 -152 OFFCURVE",
+"409 -152 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"535 395 LINE",
-"517 436 OFFCURVE",
-"496 454 OFFCURVE",
-"453 454 CURVE SMOOTH",
-"345 454 OFFCURVE",
-"224 335 OFFCURVE",
-"224 195 CURVE SMOOTH",
-"224 90 OFFCURVE",
-"292 44 OFFCURVE",
-"356 44 CURVE SMOOTH",
 "412 44 OFFCURVE",
 "451 79 OFFCURVE",
 "468 110 CURVE",
@@ -36985,7 +40712,17 @@ nodes = (
 "522 329 OFFCURVE",
 "520 322 OFFCURVE",
 "520 309 CURVE",
-"541 395 LINE"
+"541 395 LINE",
+"535 395 LINE",
+"517 436 OFFCURVE",
+"496 454 OFFCURVE",
+"453 454 CURVE SMOOTH",
+"345 454 OFFCURVE",
+"224 335 OFFCURVE",
+"224 195 CURVE SMOOTH",
+"224 90 OFFCURVE",
+"292 44 OFFCURVE",
+"356 44 CURVE SMOOTH"
 );
 }
 );
@@ -36996,7 +40733,7 @@ unicode = 0040;
 },
 {
 glyphname = ampersand;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:16:30 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -37004,22 +40741,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"406 457 LINE",
-"536 494 OFFCURVE",
-"646 568 OFFCURVE",
-"646 654 CURVE SMOOTH",
-"646 717 OFFCURVE",
-"585 763 OFFCURVE",
-"482 763 CURVE SMOOTH",
-"332 763 OFFCURVE",
-"276 665 OFFCURVE",
-"276 581 CURVE SMOOTH",
-"276 516 OFFCURVE",
-"310 401 OFFCURVE",
-"363 277 CURVE SMOOTH",
-"455 61 OFFCURVE",
-"528 0 OFFCURVE",
-"632 0 CURVE SMOOTH",
 "719 0 OFFCURVE",
 "798 42 OFFCURVE",
 "841 124 CURVE",
@@ -37041,19 +40762,28 @@ nodes = (
 "555 662 CURVE SMOOTH",
 "555 577 OFFCURVE",
 "490 504 OFFCURVE",
-"397 482 CURVE"
+"397 482 CURVE",
+"406 457 LINE",
+"536 494 OFFCURVE",
+"646 568 OFFCURVE",
+"646 654 CURVE SMOOTH",
+"646 717 OFFCURVE",
+"585 763 OFFCURVE",
+"482 763 CURVE SMOOTH",
+"332 763 OFFCURVE",
+"276 665 OFFCURVE",
+"276 581 CURVE SMOOTH",
+"276 516 OFFCURVE",
+"310 401 OFFCURVE",
+"363 277 CURVE SMOOTH",
+"455 61 OFFCURVE",
+"528 0 OFFCURVE",
+"632 0 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"319 441 LINE",
-"145 395 OFFCURVE",
-"53 297 OFFCURVE",
-"53 178 CURVE SMOOTH",
-"53 61 OFFCURVE",
-"142 -11 OFFCURVE",
-"268 -11 CURVE SMOOTH",
 "383 -11 OFFCURVE",
 "443 48 OFFCURVE",
 "494 101 CURVE",
@@ -37066,21 +40796,24 @@ nodes = (
 "183 230 CURVE SMOOTH",
 "183 318 OFFCURVE",
 "215 384 OFFCURVE",
-"325 416 CURVE"
+"325 416 CURVE",
+"319 441 LINE",
+"145 395 OFFCURVE",
+"53 297 OFFCURVE",
+"53 178 CURVE SMOOTH",
+"53 61 OFFCURVE",
+"142 -11 OFFCURVE",
+"268 -11 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"550 172 LINE",
 "629 283 OFFCURVE",
 "678 430 OFFCURVE",
 "726 430 CURVE SMOOTH",
-"737 430 OFFCURVE",
-"743 423 OFFCURVE",
-"743 410 CURVE SMOOTH",
-"743 400 OFFCURVE",
-"740 392 OFFCURVE",
+"750 430 OFFCURVE",
+"740 413 OFFCURVE",
 "740 383 CURVE SMOOTH",
 "740 359 OFFCURVE",
 "760 340 OFFCURVE",
@@ -37093,7 +40826,8 @@ nodes = (
 "759 470 CURVE SMOOTH",
 "641 470 OFFCURVE",
 "609 302 OFFCURVE",
-"529 193 CURVE"
+"529 193 CURVE",
+"550 172 LINE"
 );
 }
 );
@@ -37105,22 +40839,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"394 447 LINE",
-"560 489 OFFCURVE",
-"680 549 OFFCURVE",
-"680 643 CURVE SMOOTH",
-"680 717 OFFCURVE",
-"606 768 OFFCURVE",
-"494 768 CURVE SMOOTH",
-"335 768 OFFCURVE",
-"256 664 OFFCURVE",
-"256 570 CURVE SMOOTH",
-"256 508 OFFCURVE",
-"290 399 OFFCURVE",
-"340 277 CURVE SMOOTH",
-"439 36 OFFCURVE",
-"504 -10 OFFCURVE",
-"616 -10 CURVE SMOOTH",
 "735 -10 OFFCURVE",
 "808 42 OFFCURVE",
 "853 129 CURVE",
@@ -37142,19 +40860,28 @@ nodes = (
 "556 659 CURVE SMOOTH",
 "556 578 OFFCURVE",
 "499 501 OFFCURVE",
-"385 477 CURVE"
+"385 477 CURVE",
+"394 447 LINE",
+"560 489 OFFCURVE",
+"680 549 OFFCURVE",
+"680 643 CURVE SMOOTH",
+"680 717 OFFCURVE",
+"606 768 OFFCURVE",
+"494 768 CURVE SMOOTH",
+"335 768 OFFCURVE",
+"256 664 OFFCURVE",
+"256 570 CURVE SMOOTH",
+"256 508 OFFCURVE",
+"290 399 OFFCURVE",
+"340 277 CURVE SMOOTH",
+"439 36 OFFCURVE",
+"504 -10 OFFCURVE",
+"616 -10 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"291 438 LINE",
-"133 393 OFFCURVE",
-"27 300 OFFCURVE",
-"27 175 CURVE SMOOTH",
-"27 62 OFFCURVE",
-"115 -11 OFFCURVE",
-"245 -11 CURVE SMOOTH",
 "354 -11 OFFCURVE",
 "432 41 OFFCURVE",
 "476 91 CURVE",
@@ -37167,13 +40894,19 @@ nodes = (
 "205 269 CURVE SMOOTH",
 "205 343 OFFCURVE",
 "232 383 OFFCURVE",
-"302 408 CURVE"
+"302 408 CURVE",
+"291 438 LINE",
+"133 393 OFFCURVE",
+"27 300 OFFCURVE",
+"27 175 CURVE SMOOTH",
+"27 62 OFFCURVE",
+"115 -11 OFFCURVE",
+"245 -11 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"554 178 LINE",
 "633 280 OFFCURVE",
 "673 413 OFFCURVE",
 "711 413 CURVE SMOOTH",
@@ -37191,7 +40924,8 @@ nodes = (
 "762 476 CURVE SMOOTH",
 "635 476 OFFCURVE",
 "605 305 OFFCURVE",
-"527 199 CURVE"
+"527 199 CURVE",
+"554 178 LINE"
 );
 }
 );
@@ -37202,7 +40936,7 @@ unicode = 0026;
 },
 {
 glyphname = paragraph;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -37210,14 +40944,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"372 754 LINE SMOOTH",
-"193 754 OFFCURVE",
-"86 632 OFFCURVE",
-"86 496 CURVE SMOOTH",
-"86 392 OFFCURVE",
-"148 317 OFFCURVE",
-"274 309 CURVE",
-"171 -157 LINE",
 "243 -157 LINE",
 "429 685 LINE",
 "521 685 LINE",
@@ -37225,7 +40951,15 @@ nodes = (
 "407 -157 LINE",
 "593 685 LINE",
 "688 685 LINE",
-"703 754 LINE"
+"703 754 LINE",
+"372 754 LINE SMOOTH",
+"193 754 OFFCURVE",
+"86 632 OFFCURVE",
+"86 496 CURVE SMOOTH",
+"86 392 OFFCURVE",
+"148 317 OFFCURVE",
+"274 309 CURVE",
+"171 -157 LINE"
 );
 }
 );
@@ -37237,14 +40971,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"379 754 LINE SMOOTH",
-"230 754 OFFCURVE",
-"96 654 OFFCURVE",
-"96 498 CURVE SMOOTH",
-"96 391 OFFCURVE",
-"158 318 OFFCURVE",
-"285 309 CURVE",
-"186 -157 LINE",
 "268 -157 LINE",
 "446 680 LINE",
 "543 680 LINE",
@@ -37252,7 +40978,15 @@ nodes = (
 "447 -157 LINE",
 "625 680 LINE",
 "720 680 LINE",
-"735 754 LINE"
+"735 754 LINE",
+"379 754 LINE SMOOTH",
+"230 754 OFFCURVE",
+"96 654 OFFCURVE",
+"96 498 CURVE SMOOTH",
+"96 391 OFFCURVE",
+"158 318 OFFCURVE",
+"285 309 CURVE",
+"186 -157 LINE"
 );
 }
 );
@@ -37263,7 +40997,7 @@ unicode = 00B6;
 },
 {
 glyphname = section;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:16:52 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -37271,8 +41005,45 @@ paths = (
 {
 closed = 1;
 nodes = (
-"290 131 LINE",
-"282 118 LINE",
+"295 -156 OFFCURVE",
+"359 -61 OFFCURVE",
+"359 37 CURVE SMOOTH",
+"359 218 OFFCURVE",
+"140 270 OFFCURVE",
+"140 376 CURVE SMOOTH",
+"140 442 OFFCURVE",
+"223 439 OFFCURVE",
+"240 467 CURVE",
+"248 480 LINE",
+"140 475 OFFCURVE",
+"61 412 OFFCURVE",
+"61 314 CURVE SMOOTH",
+"61 147 OFFCURVE",
+"292 62 OFFCURVE",
+"292 -45 CURVE SMOOTH",
+"292 -96 OFFCURVE",
+"241 -126 OFFCURVE",
+"163 -126 CURVE SMOOTH",
+"106 -126 OFFCURVE",
+"80 -110 OFFCURVE",
+"80 -91 CURVE SMOOTH",
+"80 -65 OFFCURVE",
+"133 -62 OFFCURVE",
+"133 -13 CURVE SMOOTH",
+"133 8 OFFCURVE",
+"123 32 OFFCURVE",
+"86 32 CURVE SMOOTH",
+"46 32 OFFCURVE",
+"17 3 OFFCURVE",
+"17 -48 CURVE SMOOTH",
+"17 -113 OFFCURVE",
+"64 -156 OFFCURVE",
+"157 -156 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
 "398 122 OFFCURVE",
 "468 193 OFFCURVE",
 "468 287 CURVE SMOOTH",
@@ -37305,47 +41076,8 @@ nodes = (
 "390 217 CURVE SMOOTH",
 "390 153 OFFCURVE",
 "313 168 OFFCURVE",
-"290 131 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"240 467 LINE",
-"248 480 LINE",
-"140 475 OFFCURVE",
-"61 412 OFFCURVE",
-"61 314 CURVE SMOOTH",
-"61 147 OFFCURVE",
-"292 62 OFFCURVE",
-"292 -45 CURVE SMOOTH",
-"292 -96 OFFCURVE",
-"241 -126 OFFCURVE",
-"163 -126 CURVE SMOOTH",
-"106 -126 OFFCURVE",
-"80 -110 OFFCURVE",
-"80 -91 CURVE SMOOTH",
-"80 -65 OFFCURVE",
-"133 -62 OFFCURVE",
-"133 -13 CURVE SMOOTH",
-"133 8 OFFCURVE",
-"123 32 OFFCURVE",
-"86 32 CURVE SMOOTH",
-"46 32 OFFCURVE",
-"17 3 OFFCURVE",
-"17 -48 CURVE SMOOTH",
-"17 -113 OFFCURVE",
-"64 -156 OFFCURVE",
-"157 -156 CURVE SMOOTH",
-"295 -156 OFFCURVE",
-"359 -61 OFFCURVE",
-"359 37 CURVE SMOOTH",
-"359 218 OFFCURVE",
-"140 270 OFFCURVE",
-"140 376 CURVE SMOOTH",
-"140 442 OFFCURVE",
-"223 439 OFFCURVE",
-"240 467 CURVE SMOOTH"
+"290 131 CURVE",
+"282 118 LINE"
 );
 }
 );
@@ -37357,7 +41089,54 @@ paths = (
 {
 closed = 1;
 nodes = (
-"387 719 LINE SMOOTH",
+"298 -161 OFFCURVE",
+"396 -76 OFFCURVE",
+"396 36 CURVE SMOOTH",
+"396 203 OFFCURVE",
+"175 267 OFFCURVE",
+"175 379 CURVE SMOOTH",
+"175 437 OFFCURVE",
+"235 438 OFFCURVE",
+"253 466 CURVE SMOOTH",
+"262 480 LINE",
+"149 475 OFFCURVE",
+"64 402 OFFCURVE",
+"64 293 CURVE SMOOTH",
+"64 116 OFFCURVE",
+"291 58 OFFCURVE",
+"291 -48 CURVE SMOOTH",
+"291 -111 OFFCURVE",
+"211 -126 OFFCURVE",
+"168 -126 CURVE SMOOTH",
+"140 -126 OFFCURVE",
+"113 -120 OFFCURVE",
+"113 -98 CURVE SMOOTH",
+"113 -69 OFFCURVE",
+"159 -70 OFFCURVE",
+"159 -24 CURVE SMOOTH",
+"159 4 OFFCURVE",
+"142 24 OFFCURVE",
+"108 24 CURVE SMOOTH",
+"63 24 OFFCURVE",
+"35 -12 OFFCURVE",
+"35 -56 CURVE SMOOTH",
+"35 -109 OFFCURVE",
+"75 -161 OFFCURVE",
+"173 -161 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"414 123 OFFCURVE",
+"497 200 OFFCURVE",
+"497 303 CURVE SMOOTH",
+"497 474 OFFCURVE",
+"267 518 OFFCURVE",
+"267 634 CURVE SMOOTH",
+"267 691 OFFCURVE",
+"323 719 OFFCURVE",
+"387 719 CURVE SMOOTH",
 "417 719 OFFCURVE",
 "443 713 OFFCURVE",
 "443 691 CURVE SMOOTH",
@@ -37382,56 +41161,7 @@ nodes = (
 "386 177 OFFCURVE",
 "343 143 OFFCURVE",
 "301 143 CURVE",
-"300 118 LINE",
-"414 123 OFFCURVE",
-"497 200 OFFCURVE",
-"497 303 CURVE SMOOTH",
-"497 474 OFFCURVE",
-"267 518 OFFCURVE",
-"267 634 CURVE SMOOTH",
-"267 691 OFFCURVE",
-"323 719 OFFCURVE",
-"387 719 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"168 -126 LINE SMOOTH",
-"140 -126 OFFCURVE",
-"113 -120 OFFCURVE",
-"113 -98 CURVE SMOOTH",
-"113 -69 OFFCURVE",
-"159 -70 OFFCURVE",
-"159 -24 CURVE SMOOTH",
-"159 4 OFFCURVE",
-"142 24 OFFCURVE",
-"108 24 CURVE SMOOTH",
-"63 24 OFFCURVE",
-"35 -12 OFFCURVE",
-"35 -56 CURVE SMOOTH",
-"35 -109 OFFCURVE",
-"75 -161 OFFCURVE",
-"173 -161 CURVE SMOOTH",
-"298 -161 OFFCURVE",
-"396 -76 OFFCURVE",
-"396 36 CURVE SMOOTH",
-"396 203 OFFCURVE",
-"175 267 OFFCURVE",
-"175 379 CURVE SMOOTH",
-"175 437 OFFCURVE",
-"235 438 OFFCURVE",
-"253 466 CURVE SMOOTH",
-"262 480 LINE",
-"149 475 OFFCURVE",
-"64 402 OFFCURVE",
-"64 293 CURVE SMOOTH",
-"64 116 OFFCURVE",
-"291 58 OFFCURVE",
-"291 -48 CURVE SMOOTH",
-"291 -111 OFFCURVE",
-"211 -126 OFFCURVE",
-"168 -126 CURVE SMOOTH"
+"300 118 LINE"
 );
 }
 );
@@ -37442,7 +41172,7 @@ unicode = 00A7;
 },
 {
 glyphname = copyright;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:03:58 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -37450,7 +41180,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"386 -10 LINE SMOOTH",
 "636 -10 OFFCURVE",
 "849 201 OFFCURVE",
 "849 442 CURVE SMOOTH",
@@ -37468,25 +41197,6 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"537 715 LINE SMOOTH",
-"697 715 OFFCURVE",
-"809 601 OFFCURVE",
-"809 441 CURVE SMOOTH",
-"809 228 OFFCURVE",
-"609 29 OFFCURVE",
-"391 29 CURVE SMOOTH",
-"224 29 OFFCURVE",
-"118 145 OFFCURVE",
-"118 299 CURVE SMOOTH",
-"118 515 OFFCURVE",
-"325 715 OFFCURVE",
-"537 715 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"421 152 LINE SMOOTH",
 "465 152 OFFCURVE",
 "511 164 OFFCURVE",
 "551 187 CURVE",
@@ -37520,6 +41230,23 @@ nodes = (
 "307 152 OFFCURVE",
 "421 152 CURVE SMOOTH"
 );
+},
+{
+closed = 1;
+nodes = (
+"224 29 OFFCURVE",
+"118 145 OFFCURVE",
+"118 299 CURVE SMOOTH",
+"118 515 OFFCURVE",
+"325 715 OFFCURVE",
+"537 715 CURVE SMOOTH",
+"697 715 OFFCURVE",
+"809 601 OFFCURVE",
+"809 441 CURVE SMOOTH",
+"809 228 OFFCURVE",
+"609 29 OFFCURVE",
+"391 29 CURVE SMOOTH"
+);
 }
 );
 width = 833;
@@ -37530,7 +41257,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"392 -10 LINE SMOOTH",
 "642 -10 OFFCURVE",
 "855 201 OFFCURVE",
 "855 442 CURVE SMOOTH",
@@ -37548,25 +41274,6 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"543 705 LINE SMOOTH",
-"697 705 OFFCURVE",
-"805 595 OFFCURVE",
-"805 441 CURVE SMOOTH",
-"805 233 OFFCURVE",
-"610 39 OFFCURVE",
-"397 39 CURVE SMOOTH",
-"236 39 OFFCURVE",
-"134 151 OFFCURVE",
-"134 300 CURVE SMOOTH",
-"134 509 OFFCURVE",
-"336 705 OFFCURVE",
-"543 705 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"427 152 LINE SMOOTH",
 "471 152 OFFCURVE",
 "517 164 OFFCURVE",
 "557 187 CURVE",
@@ -37600,6 +41307,23 @@ nodes = (
 "313 152 OFFCURVE",
 "427 152 CURVE SMOOTH"
 );
+},
+{
+closed = 1;
+nodes = (
+"236 39 OFFCURVE",
+"134 151 OFFCURVE",
+"134 300 CURVE SMOOTH",
+"134 509 OFFCURVE",
+"336 705 OFFCURVE",
+"543 705 CURVE SMOOTH",
+"697 705 OFFCURVE",
+"805 595 OFFCURVE",
+"805 441 CURVE SMOOTH",
+"805 233 OFFCURVE",
+"610 39 OFFCURVE",
+"397 39 CURVE SMOOTH"
+);
 }
 );
 width = 853;
@@ -37609,7 +41333,7 @@ unicode = 00A9;
 },
 {
 glyphname = registered;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:04:06 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -37617,7 +41341,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"370 -10 LINE SMOOTH",
 "620 -10 OFFCURVE",
 "833 201 OFFCURVE",
 "833 442 CURVE SMOOTH",
@@ -37635,56 +41358,6 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"521 715 LINE SMOOTH",
-"681 715 OFFCURVE",
-"793 601 OFFCURVE",
-"793 441 CURVE SMOOTH",
-"793 228 OFFCURVE",
-"593 29 OFFCURVE",
-"375 29 CURVE SMOOTH",
-"208 29 OFFCURVE",
-"102 145 OFFCURVE",
-"102 299 CURVE SMOOTH",
-"102 515 OFFCURVE",
-"309 715 OFFCURVE",
-"521 715 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"442 602 LINE",
-"349 602 LINE",
-"255 167 LINE",
-"345 167 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"297 602 LINE",
-"294 580 LINE",
-"478 580 LINE SMOOTH",
-"536 580 OFFCURVE",
-"546 557 OFFCURVE",
-"546 519 CURVE SMOOTH",
-"546 451 OFFCURVE",
-"514 407 OFFCURVE",
-"457 407 CURVE SMOOTH",
-"350 407 LINE",
-"350 393 LINE",
-"445 393 LINE SMOOTH",
-"571 393 OFFCURVE",
-"645 438 OFFCURVE",
-"645 505 CURVE SMOOTH",
-"645 562 OFFCURVE",
-"590 602 OFFCURVE",
-"485 602 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
 "424 161 LINE",
 "428 183 LINE",
 "211 183 LINE",
@@ -37694,13 +41367,15 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"412 394 LINE SMOOTH",
-"459 394 OFFCURVE",
-"468 345 OFFCURVE",
-"470 301 CURVE SMOOTH",
-"474 228 OFFCURVE",
-"478 161 OFFCURVE",
-"591 161 CURVE SMOOTH",
+"345 167 LINE",
+"442 602 LINE",
+"349 602 LINE",
+"255 167 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "630 161 OFFCURVE",
 "639 169 OFFCURVE",
 "650 181 CURVE",
@@ -37714,7 +41389,54 @@ nodes = (
 "573 328 OFFCURVE",
 "563 358 OFFCURVE",
 "483 390 CURVE",
-"483 394 LINE"
+"483 394 LINE",
+"412 394 LINE SMOOTH",
+"459 394 OFFCURVE",
+"468 345 OFFCURVE",
+"470 301 CURVE SMOOTH",
+"474 228 OFFCURVE",
+"478 161 OFFCURVE",
+"591 161 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"208 29 OFFCURVE",
+"102 145 OFFCURVE",
+"102 299 CURVE SMOOTH",
+"102 515 OFFCURVE",
+"309 715 OFFCURVE",
+"521 715 CURVE SMOOTH",
+"681 715 OFFCURVE",
+"793 601 OFFCURVE",
+"793 441 CURVE SMOOTH",
+"793 228 OFFCURVE",
+"593 29 OFFCURVE",
+"375 29 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"445 393 LINE SMOOTH",
+"571 393 OFFCURVE",
+"645 438 OFFCURVE",
+"645 505 CURVE SMOOTH",
+"645 562 OFFCURVE",
+"590 602 OFFCURVE",
+"485 602 CURVE SMOOTH",
+"297 602 LINE",
+"294 580 LINE",
+"478 580 LINE SMOOTH",
+"536 580 OFFCURVE",
+"546 557 OFFCURVE",
+"546 519 CURVE SMOOTH",
+"546 451 OFFCURVE",
+"514 407 OFFCURVE",
+"457 407 CURVE SMOOTH",
+"350 407 LINE",
+"350 393 LINE"
 );
 }
 );
@@ -37726,7 +41448,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"381 -10 LINE SMOOTH",
 "631 -10 OFFCURVE",
 "844 201 OFFCURVE",
 "844 442 CURVE SMOOTH",
@@ -37744,56 +41465,6 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"532 705 LINE SMOOTH",
-"686 705 OFFCURVE",
-"794 595 OFFCURVE",
-"794 441 CURVE SMOOTH",
-"794 233 OFFCURVE",
-"599 39 OFFCURVE",
-"386 39 CURVE SMOOTH",
-"225 39 OFFCURVE",
-"123 151 OFFCURVE",
-"123 300 CURVE SMOOTH",
-"123 509 OFFCURVE",
-"325 705 OFFCURVE",
-"532 705 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"463 602 LINE",
-"350 602 LINE",
-"256 167 LINE",
-"366 167 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"308 602 LINE",
-"305 570 LINE",
-"489 570 LINE SMOOTH",
-"537 570 OFFCURVE",
-"547 547 OFFCURVE",
-"547 510 CURVE SMOOTH",
-"547 449 OFFCURVE",
-"519 412 OFFCURVE",
-"468 412 CURVE SMOOTH",
-"361 412 LINE",
-"361 383 LINE",
-"456 383 LINE SMOOTH",
-"585 383 OFFCURVE",
-"661 433 OFFCURVE",
-"661 503 CURVE SMOOTH",
-"661 563 OFFCURVE",
-"604 602 OFFCURVE",
-"496 602 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
 "435 161 LINE",
 "439 193 LINE",
 "222 193 LINE",
@@ -37803,13 +41474,15 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"423 384 LINE SMOOTH",
-"462 384 OFFCURVE",
-"468 344 OFFCURVE",
-"471 301 CURVE SMOOTH",
-"476 226 OFFCURVE",
-"481 161 OFFCURVE",
-"600 161 CURVE SMOOTH",
+"366 167 LINE",
+"463 602 LINE",
+"350 602 LINE",
+"256 167 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "642 161 OFFCURVE",
 "650 169 OFFCURVE",
 "661 181 CURVE",
@@ -37823,7 +41496,54 @@ nodes = (
 "594 324 OFFCURVE",
 "591 346 OFFCURVE",
 "494 380 CURVE",
-"494 384 LINE"
+"494 384 LINE",
+"423 384 LINE SMOOTH",
+"462 384 OFFCURVE",
+"468 344 OFFCURVE",
+"471 301 CURVE SMOOTH",
+"476 226 OFFCURVE",
+"481 161 OFFCURVE",
+"600 161 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"225 39 OFFCURVE",
+"123 151 OFFCURVE",
+"123 300 CURVE SMOOTH",
+"123 509 OFFCURVE",
+"325 705 OFFCURVE",
+"532 705 CURVE SMOOTH",
+"686 705 OFFCURVE",
+"794 595 OFFCURVE",
+"794 441 CURVE SMOOTH",
+"794 233 OFFCURVE",
+"599 39 OFFCURVE",
+"386 39 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"456 383 LINE SMOOTH",
+"585 383 OFFCURVE",
+"661 433 OFFCURVE",
+"661 503 CURVE SMOOTH",
+"661 563 OFFCURVE",
+"604 602 OFFCURVE",
+"496 602 CURVE SMOOTH",
+"308 602 LINE",
+"305 570 LINE",
+"489 570 LINE SMOOTH",
+"537 570 OFFCURVE",
+"547 547 OFFCURVE",
+"547 510 CURVE SMOOTH",
+"547 449 OFFCURVE",
+"519 412 OFFCURVE",
+"468 412 CURVE SMOOTH",
+"361 412 LINE",
+"361 383 LINE"
 );
 }
 );
@@ -37834,7 +41554,7 @@ unicode = 00AE;
 },
 {
 glyphname = trademark;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -37842,45 +41562,77 @@ paths = (
 {
 closed = 1;
 nodes = (
-"187 388 LINE",
-"274 388 LINE",
-"352 754 LINE",
-"265 754 LINE"
+"629 376 LINE",
+"802 710 LINE",
+"806 710 LINE",
+"825 749 LINE",
+"818 754 LINE",
+"807 754 LINE",
+"652 459 LINE",
+"612 376 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"121 380 LINE",
 "336 380 LINE",
 "341 403 LINE",
-"126 403 LINE"
+"126 403 LINE",
+"121 380 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"141 732 LINE",
-"462 732 LINE",
-"467 754 LINE",
-"146 754 LINE"
+"274 388 LINE",
+"352 754 LINE",
+"265 754 LINE",
+"187 388 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"120 633 LINE",
+"539 380 LINE",
+"544 403 LINE",
+"416 403 LINE",
+"411 380 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "147 633 LINE",
 "160 691 OFFCURVE",
 "198 732 OFFCURVE",
 "247 732 CURVE",
 "242 754 LINE",
-"146 754 LINE"
+"146 754 LINE",
+"120 633 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
+"462 732 LINE",
+"467 754 LINE",
+"146 754 LINE",
+"141 732 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"486 388 LINE",
+"564 754 LINE",
+"535 754 LINE",
+"457 388 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"441 633 LINE",
 "467 754 LINE",
 "372 754 LINE",
 "357 732 LINE",
@@ -37889,89 +41641,57 @@ nodes = (
 "417 663 CURVE SMOOTH",
 "417 654 OFFCURVE",
 "416 644 OFFCURVE",
-"414 633 CURVE",
-"441 633 LINE"
+"414 633 CURVE"
 );
 },
 {
 closed = 1;
 nodes = (
-"738 388 LINE",
-"824 388 LINE",
-"902 754 LINE",
-"816 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"681 380 LINE",
 "857 380 LINE",
 "862 403 LINE",
-"686 403 LINE"
+"686 403 LINE",
+"681 380 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"818 732 LINE",
-"932 732 LINE",
-"937 754 LINE",
-"823 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"457 388 LINE",
-"486 388 LINE",
-"564 754 LINE",
-"535 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"411 380 LINE",
-"539 380 LINE",
-"544 403 LINE",
-"416 403 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"486 732 LINE",
-"614 732 LINE",
-"619 754 LINE",
-"491 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"626 376 LINE",
+"668 459 LINE",
+"670 494 LINE",
+"666 494 LINE",
 "645 754 LINE",
 "559 754 LINE",
 "554 710 LINE",
 "558 710 LINE",
-"592 376 LINE",
-"626 376 LINE",
-"668 459 LINE",
-"670 494 LINE",
-"666 494 LINE"
+"592 376 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"652 459 LINE",
-"612 376 LINE",
-"629 376 LINE",
-"802 710 LINE",
-"806 710 LINE",
-"825 749 LINE",
-"818 754 LINE",
-"807 754 LINE"
+"614 732 LINE",
+"619 754 LINE",
+"491 754 LINE",
+"486 732 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"824 388 LINE",
+"902 754 LINE",
+"816 754 LINE",
+"738 388 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"932 732 LINE",
+"937 754 LINE",
+"823 754 LINE",
+"818 732 LINE"
 );
 }
 );
@@ -37983,45 +41703,77 @@ paths = (
 {
 closed = 1;
 nodes = (
-"190 388 LINE",
-"277 388 LINE",
-"355 754 LINE",
-"268 754 LINE"
+"632 376 LINE",
+"805 710 LINE",
+"809 710 LINE",
+"828 749 LINE",
+"821 754 LINE",
+"810 754 LINE",
+"655 459 LINE",
+"615 376 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"124 380 LINE",
 "339 380 LINE",
 "344 403 LINE",
-"129 403 LINE"
+"129 403 LINE",
+"124 380 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"144 732 LINE",
-"465 732 LINE",
-"470 754 LINE",
-"149 754 LINE"
+"277 388 LINE",
+"355 754 LINE",
+"268 754 LINE",
+"190 388 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"123 633 LINE",
+"542 380 LINE",
+"547 403 LINE",
+"419 403 LINE",
+"414 380 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "150 633 LINE",
 "163 691 OFFCURVE",
 "201 732 OFFCURVE",
 "250 732 CURVE",
 "245 754 LINE",
-"149 754 LINE"
+"149 754 LINE",
+"123 633 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
+"465 732 LINE",
+"470 754 LINE",
+"149 754 LINE",
+"144 732 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"489 388 LINE",
+"567 754 LINE",
+"538 754 LINE",
+"460 388 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"444 633 LINE",
 "470 754 LINE",
 "375 754 LINE",
 "360 732 LINE",
@@ -38030,89 +41782,57 @@ nodes = (
 "420 663 CURVE SMOOTH",
 "420 654 OFFCURVE",
 "419 644 OFFCURVE",
-"417 633 CURVE",
-"444 633 LINE"
+"417 633 CURVE"
 );
 },
 {
 closed = 1;
 nodes = (
-"741 388 LINE",
-"827 388 LINE",
-"905 754 LINE",
-"819 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"684 380 LINE",
 "860 380 LINE",
 "865 403 LINE",
-"689 403 LINE"
+"689 403 LINE",
+"684 380 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"821 732 LINE",
-"935 732 LINE",
-"940 754 LINE",
-"826 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"460 388 LINE",
-"489 388 LINE",
-"567 754 LINE",
-"538 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"414 380 LINE",
-"542 380 LINE",
-"547 403 LINE",
-"419 403 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"489 732 LINE",
-"617 732 LINE",
-"622 754 LINE",
-"494 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"629 376 LINE",
+"671 459 LINE",
+"673 494 LINE",
+"669 494 LINE",
 "648 754 LINE",
 "562 754 LINE",
 "557 710 LINE",
 "561 710 LINE",
-"595 376 LINE",
-"629 376 LINE",
-"671 459 LINE",
-"673 494 LINE",
-"669 494 LINE"
+"595 376 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"655 459 LINE",
-"615 376 LINE",
-"632 376 LINE",
-"805 710 LINE",
-"809 710 LINE",
-"828 749 LINE",
-"821 754 LINE",
-"810 754 LINE"
+"617 732 LINE",
+"622 754 LINE",
+"494 754 LINE",
+"489 732 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"827 388 LINE",
+"905 754 LINE",
+"819 754 LINE",
+"741 388 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"935 732 LINE",
+"940 754 LINE",
+"826 754 LINE",
+"821 732 LINE"
 );
 }
 );
@@ -38123,7 +41843,7 @@ unicode = 2122;
 },
 {
 glyphname = degree;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:04:14 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -38131,37 +41851,35 @@ paths = (
 {
 closed = 1;
 nodes = (
-"279 763 LINE SMOOTH",
-"197 763 OFFCURVE",
-"129 705 OFFCURVE",
-"129 610 CURVE SMOOTH",
-"129 515 OFFCURVE",
-"197 459 OFFCURVE",
-"278 459 CURVE SMOOTH",
 "359 459 OFFCURVE",
 "427 515 OFFCURVE",
 "427 608 CURVE SMOOTH",
 "427 693 OFFCURVE",
 "369 763 OFFCURVE",
-"279 763 CURVE SMOOTH"
+"279 763 CURVE SMOOTH",
+"197 763 OFFCURVE",
+"129 705 OFFCURVE",
+"129 610 CURVE SMOOTH",
+"129 515 OFFCURVE",
+"197 459 OFFCURVE",
+"278 459 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"280 718 LINE SMOOTH",
-"343 718 OFFCURVE",
-"375 671 OFFCURVE",
-"375 611 CURVE SMOOTH",
-"375 547 OFFCURVE",
-"339 503 OFFCURVE",
-"280 503 CURVE SMOOTH",
 "220 503 OFFCURVE",
 "182 549 OFFCURVE",
 "182 612 CURVE SMOOTH",
 "182 675 OFFCURVE",
 "219 718 OFFCURVE",
-"280 718 CURVE SMOOTH"
+"280 718 CURVE SMOOTH",
+"343 718 OFFCURVE",
+"375 671 OFFCURVE",
+"375 611 CURVE SMOOTH",
+"375 547 OFFCURVE",
+"339 503 OFFCURVE",
+"280 503 CURVE SMOOTH"
 );
 }
 );
@@ -38173,37 +41891,35 @@ paths = (
 {
 closed = 1;
 nodes = (
-"287 763 LINE SMOOTH",
-"205 763 OFFCURVE",
-"137 705 OFFCURVE",
-"137 610 CURVE SMOOTH",
-"137 515 OFFCURVE",
-"205 459 OFFCURVE",
-"286 459 CURVE SMOOTH",
 "367 459 OFFCURVE",
 "435 515 OFFCURVE",
 "435 608 CURVE SMOOTH",
 "435 693 OFFCURVE",
 "377 763 OFFCURVE",
-"287 763 CURVE SMOOTH"
+"287 763 CURVE SMOOTH",
+"205 763 OFFCURVE",
+"137 705 OFFCURVE",
+"137 610 CURVE SMOOTH",
+"137 515 OFFCURVE",
+"205 459 OFFCURVE",
+"286 459 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"288 708 LINE SMOOTH",
-"344 708 OFFCURVE",
-"373 665 OFFCURVE",
-"373 611 CURVE SMOOTH",
-"373 553 OFFCURVE",
-"341 513 OFFCURVE",
-"288 513 CURVE SMOOTH",
 "234 513 OFFCURVE",
 "200 555 OFFCURVE",
 "200 612 CURVE SMOOTH",
 "200 669 OFFCURVE",
 "233 708 OFFCURVE",
-"288 708 CURVE SMOOTH"
+"288 708 CURVE SMOOTH",
+"344 708 OFFCURVE",
+"373 665 OFFCURVE",
+"373 611 CURVE SMOOTH",
+"373 553 OFFCURVE",
+"341 513 OFFCURVE",
+"288 513 CURVE SMOOTH"
 );
 }
 );
@@ -38214,7 +41930,7 @@ unicode = 00B0;
 },
 {
 glyphname = bar;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -38222,10 +41938,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"174 763 LINE",
-"174 -157 LINE",
 "233 -157 LINE",
-"233 763 LINE"
+"233 763 LINE",
+"174 763 LINE",
+"174 -157 LINE"
 );
 }
 );
@@ -38237,10 +41953,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"184 763 LINE",
-"184 -157 LINE",
 "263 -157 LINE",
-"263 763 LINE"
+"263 763 LINE",
+"184 763 LINE",
+"184 -157 LINE"
 );
 }
 );
@@ -38251,7 +41967,7 @@ unicode = 007C;
 },
 {
 glyphname = brokenbar;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -38259,19 +41975,19 @@ paths = (
 {
 closed = 1;
 nodes = (
-"183 763 LINE",
-"183 347 LINE",
 "242 347 LINE",
-"242 763 LINE"
+"242 763 LINE",
+"183 763 LINE",
+"183 347 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"183 249 LINE",
-"183 -157 LINE",
 "242 -157 LINE",
-"242 249 LINE"
+"242 249 LINE",
+"183 249 LINE",
+"183 -157 LINE"
 );
 }
 );
@@ -38283,19 +41999,19 @@ paths = (
 {
 closed = 1;
 nodes = (
-"193 763 LINE",
-"193 347 LINE",
 "272 347 LINE",
-"272 763 LINE"
+"272 763 LINE",
+"193 763 LINE",
+"193 347 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"193 249 LINE",
-"193 -157 LINE",
 "272 -157 LINE",
-"272 249 LINE"
+"272 249 LINE",
+"193 249 LINE",
+"193 -157 LINE"
 );
 }
 );
@@ -38306,7 +42022,7 @@ unicode = 00A6;
 },
 {
 glyphname = dagger;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:17:14 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -38411,11 +42127,8 @@ nodes = (
 "343 763 OFFCURVE",
 "316 716 OFFCURVE",
 "316 667 CURVE SMOOTH",
-"316 638 OFFCURVE",
-"325 596 OFFCURVE",
-"325 551 CURVE SMOOTH",
-"325 536 OFFCURVE",
-"324 518 OFFCURVE",
+"316 602 OFFCURVE",
+"333 576 OFFCURVE",
 "321 498 CURVE",
 "246 506 OFFCURVE",
 "221 544 OFFCURVE",
@@ -38447,8 +42160,8 @@ width = 561;
 unicode = 2020;
 },
 {
-glyphname = uni2113;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = literSign;
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -38456,6 +42169,9 @@ paths = (
 {
 closed = 1;
 nodes = (
+"350 -11 OFFCURVE",
+"412 41 OFFCURVE",
+"455 123 CURVE",
 "435 136 LINE",
 "403 84 OFFCURVE",
 "369 38 OFFCURVE",
@@ -38480,10 +42196,7 @@ nodes = (
 "104 186 LINE SMOOTH",
 "104 65 OFFCURVE",
 "150 -11 OFFCURVE",
-"259 -11 CURVE SMOOTH",
-"350 -11 OFFCURVE",
-"412 41 OFFCURVE",
-"455 123 CURVE"
+"259 -11 CURVE SMOOTH"
 );
 },
 {
@@ -38510,6 +42223,9 @@ paths = (
 {
 closed = 1;
 nodes = (
+"387 -12 OFFCURVE",
+"450 34 OFFCURVE",
+"507 135 CURVE",
 "479 161 LINE",
 "441 106 OFFCURVE",
 "408 78 OFFCURVE",
@@ -38534,10 +42250,7 @@ nodes = (
 "119 193 LINE SMOOTH",
 "119 67 OFFCURVE",
 "178 -12 OFFCURVE",
-"297 -12 CURVE SMOOTH",
-"387 -12 OFFCURVE",
-"450 34 OFFCURVE",
-"507 135 CURVE"
+"297 -12 CURVE SMOOTH"
 );
 },
 {
@@ -38563,7 +42276,7 @@ unicode = 2113;
 },
 {
 glyphname = daggerdbl;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:17:36 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -38571,31 +42284,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"209 237 LINE",
-"220 204 OFFCURVE",
-"225 171 OFFCURVE",
-"225 136 CURVE SMOOTH",
-"225 94 OFFCURVE",
-"218 50 OFFCURVE",
-"208 4 CURVE",
-"105 4 OFFCURVE",
-"78 38 OFFCURVE",
-"29 38 CURVE SMOOTH",
-"-9 38 OFFCURVE",
-"-33 17 OFFCURVE",
-"-33 -13 CURVE SMOOTH",
-"-33 -42 OFFCURVE",
-"-12 -56 OFFCURVE",
-"16 -56 CURVE SMOOTH",
-"62 -56 OFFCURVE",
-"100 -20 OFFCURVE",
-"203 -20 CURVE",
-"172 -158 OFFCURVE",
-"119 -184 OFFCURVE",
-"119 -242 CURVE SMOOTH",
-"119 -276 OFFCURVE",
-"137 -290 OFFCURVE",
-"163 -290 CURVE SMOOTH",
 "197 -290 OFFCURVE",
 "220 -265 OFFCURVE",
 "220 -195 CURVE SMOOTH",
@@ -38664,7 +42352,31 @@ nodes = (
 "311 469 CURVE",
 "292 384 OFFCURVE",
 "266 309 OFFCURVE",
-"209 237 CURVE"
+"209 237 CURVE",
+"220 204 OFFCURVE",
+"225 171 OFFCURVE",
+"225 136 CURVE SMOOTH",
+"225 94 OFFCURVE",
+"218 50 OFFCURVE",
+"208 4 CURVE",
+"105 4 OFFCURVE",
+"78 38 OFFCURVE",
+"29 38 CURVE SMOOTH",
+"-9 38 OFFCURVE",
+"-33 17 OFFCURVE",
+"-33 -13 CURVE SMOOTH",
+"-33 -42 OFFCURVE",
+"-12 -56 OFFCURVE",
+"16 -56 CURVE SMOOTH",
+"62 -56 OFFCURVE",
+"100 -20 OFFCURVE",
+"203 -20 CURVE",
+"172 -158 OFFCURVE",
+"119 -184 OFFCURVE",
+"119 -242 CURVE SMOOTH",
+"119 -276 OFFCURVE",
+"137 -290 OFFCURVE",
+"163 -290 CURVE SMOOTH"
 );
 }
 );
@@ -38676,31 +42388,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"208 237 LINE",
-"219 202 OFFCURVE",
-"224 154 OFFCURVE",
-"224 116 CURVE SMOOTH",
-"224 82 OFFCURVE",
-"219 46 OFFCURVE",
-"211 9 CURVE",
-"135 14 OFFCURVE",
-"108 53 OFFCURVE",
-"54 53 CURVE SMOOTH",
-"7 53 OFFCURVE",
-"-23 23 OFFCURVE",
-"-23 -18 CURVE SMOOTH",
-"-23 -54 OFFCURVE",
-"1 -71 OFFCURVE",
-"33 -71 CURVE SMOOTH",
-"82 -71 OFFCURVE",
-"126 -33 OFFCURVE",
-"204 -25 CURVE",
-"180 -100 OFFCURVE",
-"117 -178 OFFCURVE",
-"117 -234 CURVE SMOOTH",
-"117 -263 OFFCURVE",
-"134 -290 OFFCURVE",
-"175 -290 CURVE SMOOTH",
 "228 -290 OFFCURVE",
 "255 -243 OFFCURVE",
 "255 -194 CURVE SMOOTH",
@@ -38752,11 +42439,8 @@ nodes = (
 "337 763 OFFCURVE",
 "310 716 OFFCURVE",
 "310 667 CURVE SMOOTH",
-"310 638 OFFCURVE",
-"319 596 OFFCURVE",
-"319 551 CURVE SMOOTH",
-"319 536 OFFCURVE",
-"318 518 OFFCURVE",
+"310 602 OFFCURVE",
+"327 576 OFFCURVE",
 "315 498 CURVE",
 "240 506 OFFCURVE",
 "215 544 OFFCURVE",
@@ -38772,7 +42456,31 @@ nodes = (
 "308 464 CURVE",
 "292 381 OFFCURVE",
 "267 307 OFFCURVE",
-"208 237 CURVE"
+"208 237 CURVE",
+"219 202 OFFCURVE",
+"224 154 OFFCURVE",
+"224 116 CURVE SMOOTH",
+"224 82 OFFCURVE",
+"219 46 OFFCURVE",
+"211 9 CURVE",
+"135 14 OFFCURVE",
+"108 53 OFFCURVE",
+"54 53 CURVE SMOOTH",
+"7 53 OFFCURVE",
+"-23 23 OFFCURVE",
+"-23 -18 CURVE SMOOTH",
+"-23 -54 OFFCURVE",
+"1 -71 OFFCURVE",
+"33 -71 CURVE SMOOTH",
+"82 -71 OFFCURVE",
+"126 -33 OFFCURVE",
+"204 -25 CURVE",
+"180 -100 OFFCURVE",
+"117 -178 OFFCURVE",
+"117 -234 CURVE SMOOTH",
+"117 -263 OFFCURVE",
+"134 -290 OFFCURVE",
+"175 -290 CURVE SMOOTH"
 );
 }
 );
@@ -38782,8 +42490,8 @@ width = 561;
 unicode = 2021;
 },
 {
-glyphname = uni2116;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = numero;
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 components = (
@@ -38792,11 +42500,11 @@ name = N;
 },
 {
 name = ordmasculine;
-transform = "{1, 0, 0, 1, 689, 0}";
+transform = "{1, 0, 0, 1, 769, 0}";
 }
 );
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
-width = 1065;
+width = 1115;
 },
 {
 components = (
@@ -38805,18 +42513,18 @@ name = N;
 },
 {
 name = ordmasculine;
-transform = "{1, 0, 0, 1, 712, 0}";
+transform = "{1, 0, 0, 1, 749, 0}";
 }
 );
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
-width = 1086;
+width = 1123;
 }
 );
 unicode = 2116;
 },
 {
 glyphname = estimated;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -38824,16 +42532,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"895 349 LINE",
-"895 559 OFFCURVE",
-"718 731 OFFCURVE",
-"481 731 CURVE SMOOTH",
-"253 731 OFFCURVE",
-"68 565 OFFCURVE",
-"68 359 CURVE SMOOTH",
-"68 154 OFFCURVE",
-"253 -12 OFFCURVE",
-"481 -12 CURVE SMOOTH",
 "614 -12 OFFCURVE",
 "734 45 OFFCURVE",
 "808 132 CURVE",
@@ -38850,17 +42548,22 @@ nodes = (
 "220 345 LINE SMOOTH",
 "220 348 OFFCURVE",
 "222 349 OFFCURVE",
-"225 349 CURVE SMOOTH"
+"225 349 CURVE SMOOTH",
+"895 349 LINE",
+"895 559 OFFCURVE",
+"718 731 OFFCURVE",
+"481 731 CURVE SMOOTH",
+"253 731 OFFCURVE",
+"68 565 OFFCURVE",
+"68 359 CURVE SMOOTH",
+"68 154 OFFCURVE",
+"253 -12 OFFCURVE",
+"481 -12 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"743 375 LINE SMOOTH",
-"743 373 OFFCURVE",
-"742 369 OFFCURVE",
-"739 369 CURVE SMOOTH",
-"225 369 LINE SMOOTH",
 "222 369 OFFCURVE",
 "220 373 OFFCURVE",
 "220 375 CURVE SMOOTH",
@@ -38876,7 +42579,12 @@ nodes = (
 "733 604 CURVE SMOOTH",
 "740 597 OFFCURVE",
 "743 588 OFFCURVE",
-"743 579 CURVE SMOOTH"
+"743 579 CURVE SMOOTH",
+"743 375 LINE SMOOTH",
+"743 373 OFFCURVE",
+"742 369 OFFCURVE",
+"739 369 CURVE SMOOTH",
+"225 369 LINE SMOOTH"
 );
 }
 );
@@ -38888,16 +42596,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"905 349 LINE",
-"905 559 OFFCURVE",
-"728 731 OFFCURVE",
-"491 731 CURVE SMOOTH",
-"263 731 OFFCURVE",
-"78 565 OFFCURVE",
-"78 359 CURVE SMOOTH",
-"78 154 OFFCURVE",
-"263 -12 OFFCURVE",
-"491 -12 CURVE SMOOTH",
 "624 -12 OFFCURVE",
 "744 45 OFFCURVE",
 "818 132 CURVE",
@@ -38914,17 +42612,22 @@ nodes = (
 "230 345 LINE SMOOTH",
 "230 348 OFFCURVE",
 "232 349 OFFCURVE",
-"235 349 CURVE SMOOTH"
+"235 349 CURVE SMOOTH",
+"905 349 LINE",
+"905 559 OFFCURVE",
+"728 731 OFFCURVE",
+"491 731 CURVE SMOOTH",
+"263 731 OFFCURVE",
+"78 565 OFFCURVE",
+"78 359 CURVE SMOOTH",
+"78 154 OFFCURVE",
+"263 -12 OFFCURVE",
+"491 -12 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"753 375 LINE SMOOTH",
-"753 373 OFFCURVE",
-"752 369 OFFCURVE",
-"749 369 CURVE SMOOTH",
-"235 369 LINE SMOOTH",
 "232 369 OFFCURVE",
 "230 373 OFFCURVE",
 "230 375 CURVE SMOOTH",
@@ -38940,7 +42643,12 @@ nodes = (
 "743 604 CURVE SMOOTH",
 "750 597 OFFCURVE",
 "753 588 OFFCURVE",
-"753 579 CURVE SMOOTH"
+"753 579 CURVE SMOOTH",
+"753 375 LINE SMOOTH",
+"753 373 OFFCURVE",
+"752 369 OFFCURVE",
+"749 369 CURVE SMOOTH",
+"235 369 LINE SMOOTH"
 );
 }
 );
@@ -38994,7 +42702,7 @@ unicode = 005E;
 },
 {
 glyphname = servicemark;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -39002,87 +42710,21 @@ paths = (
 {
 closed = 1;
 nodes = (
-"667 388 LINE",
-"753 388 LINE",
-"831 754 LINE",
-"745 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"611 380 LINE",
-"787 380 LINE",
-"792 403 LINE",
-"616 403 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"748 732 LINE",
-"862 732 LINE",
-"866 754 LINE",
-"752 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"386 388 LINE",
-"415 388 LINE",
-"493 754 LINE",
-"464 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"341 380 LINE",
-"469 380 LINE",
-"474 403 LINE",
-"346 403 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"416 732 LINE",
-"544 732 LINE",
-"548 754 LINE",
-"420 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"574 754 LINE",
-"488 754 LINE",
-"484 710 LINE",
-"488 710 LINE",
-"522 376 LINE",
-"556 376 LINE",
-"598 459 LINE",
-"600 494 LINE",
-"596 494 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"582 459 LINE",
-"542 376 LINE",
-"559 376 LINE",
-"732 710 LINE",
-"736 710 LINE",
-"754 749 LINE",
-"747 754 LINE",
-"736 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"277 372 OFFCURVE",
+"346 412 OFFCURVE",
+"346 506 CURVE SMOOTH",
+"346 648 OFFCURVE",
+"186 625 OFFCURVE",
+"186 691 CURVE SMOOTH",
+"186 723 OFFCURVE",
+"224 741 OFFCURVE",
+"258 741 CURVE SMOOTH",
+"303 741 OFFCURVE",
+"337 708 OFFCURVE",
+"337 659 CURVE",
+"360 659 LINE",
+"377 759 LINE",
+"354 759 LINE",
 "334 736 LINE",
 "318 752 OFFCURVE",
 "293 763 OFFCURVE",
@@ -39105,22 +42747,88 @@ nodes = (
 "119 406 LINE",
 "139 386 OFFCURVE",
 "166 372 OFFCURVE",
-"207 372 CURVE SMOOTH",
-"277 372 OFFCURVE",
-"346 412 OFFCURVE",
-"346 506 CURVE SMOOTH",
-"346 648 OFFCURVE",
-"186 625 OFFCURVE",
-"186 691 CURVE SMOOTH",
-"186 723 OFFCURVE",
-"224 741 OFFCURVE",
-"258 741 CURVE SMOOTH",
-"303 741 OFFCURVE",
-"337 708 OFFCURVE",
-"337 659 CURVE",
-"360 659 LINE",
-"377 759 LINE",
-"354 759 LINE"
+"207 372 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"469 380 LINE",
+"474 403 LINE",
+"346 403 LINE",
+"341 380 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"415 388 LINE",
+"493 754 LINE",
+"464 754 LINE",
+"386 388 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"787 380 LINE",
+"792 403 LINE",
+"616 403 LINE",
+"611 380 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"556 376 LINE",
+"598 459 LINE",
+"600 494 LINE",
+"596 494 LINE",
+"574 754 LINE",
+"488 754 LINE",
+"484 710 LINE",
+"488 710 LINE",
+"522 376 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"559 376 LINE",
+"732 710 LINE",
+"736 710 LINE",
+"754 749 LINE",
+"747 754 LINE",
+"736 754 LINE",
+"582 459 LINE",
+"542 376 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"544 732 LINE",
+"548 754 LINE",
+"420 754 LINE",
+"416 732 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"753 388 LINE",
+"831 754 LINE",
+"745 754 LINE",
+"667 388 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"862 732 LINE",
+"866 754 LINE",
+"752 754 LINE",
+"748 732 LINE"
 );
 }
 );
@@ -39132,87 +42840,21 @@ paths = (
 {
 closed = 1;
 nodes = (
-"677 388 LINE",
-"763 388 LINE",
-"841 754 LINE",
-"755 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"621 380 LINE",
-"797 380 LINE",
-"802 403 LINE",
-"626 403 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"758 732 LINE",
-"872 732 LINE",
-"876 754 LINE",
-"762 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"396 388 LINE",
-"425 388 LINE",
-"503 754 LINE",
-"474 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"351 380 LINE",
-"479 380 LINE",
-"484 403 LINE",
-"356 403 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"426 732 LINE",
-"554 732 LINE",
-"558 754 LINE",
-"430 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"584 754 LINE",
-"498 754 LINE",
-"494 710 LINE",
-"498 710 LINE",
-"532 376 LINE",
-"566 376 LINE",
-"608 459 LINE",
-"610 494 LINE",
-"606 494 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"592 459 LINE",
-"552 376 LINE",
-"569 376 LINE",
-"742 710 LINE",
-"746 710 LINE",
-"764 749 LINE",
-"757 754 LINE",
-"746 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"287 372 OFFCURVE",
+"356 412 OFFCURVE",
+"356 506 CURVE SMOOTH",
+"356 648 OFFCURVE",
+"196 625 OFFCURVE",
+"196 691 CURVE SMOOTH",
+"196 723 OFFCURVE",
+"234 741 OFFCURVE",
+"268 741 CURVE SMOOTH",
+"313 741 OFFCURVE",
+"347 708 OFFCURVE",
+"347 659 CURVE",
+"370 659 LINE",
+"387 759 LINE",
+"364 759 LINE",
 "344 736 LINE",
 "328 752 OFFCURVE",
 "303 763 OFFCURVE",
@@ -39235,22 +42877,88 @@ nodes = (
 "129 406 LINE",
 "149 386 OFFCURVE",
 "176 372 OFFCURVE",
-"217 372 CURVE SMOOTH",
-"287 372 OFFCURVE",
-"356 412 OFFCURVE",
-"356 506 CURVE SMOOTH",
-"356 648 OFFCURVE",
-"196 625 OFFCURVE",
-"196 691 CURVE SMOOTH",
-"196 723 OFFCURVE",
-"234 741 OFFCURVE",
-"268 741 CURVE SMOOTH",
-"313 741 OFFCURVE",
-"347 708 OFFCURVE",
-"347 659 CURVE",
-"370 659 LINE",
-"387 759 LINE",
-"364 759 LINE"
+"217 372 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"479 380 LINE",
+"484 403 LINE",
+"356 403 LINE",
+"351 380 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"425 388 LINE",
+"503 754 LINE",
+"474 754 LINE",
+"396 388 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"797 380 LINE",
+"802 403 LINE",
+"626 403 LINE",
+"621 380 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"566 376 LINE",
+"608 459 LINE",
+"610 494 LINE",
+"606 494 LINE",
+"584 754 LINE",
+"498 754 LINE",
+"494 710 LINE",
+"498 710 LINE",
+"532 376 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"569 376 LINE",
+"742 710 LINE",
+"746 710 LINE",
+"764 749 LINE",
+"757 754 LINE",
+"746 754 LINE",
+"592 459 LINE",
+"552 376 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"554 732 LINE",
+"558 754 LINE",
+"430 754 LINE",
+"426 732 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"763 388 LINE",
+"841 754 LINE",
+"755 754 LINE",
+"677 388 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"872 732 LINE",
+"876 754 LINE",
+"762 754 LINE",
+"758 732 LINE"
 );
 }
 );
@@ -39260,8 +42968,488 @@ width = 805;
 unicode = 2120;
 },
 {
-glyphname = uni030F;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = gravecomb;
+lastChange = "2016-08-22 13:36:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{348, 450}";
+},
+{
+name = top;
+position = "{403, 688}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+paths = (
+{
+closed = 1;
+nodes = (
+"467 548 LINE",
+"328 652 LINE SMOOTH",
+"291 680 OFFCURVE",
+"279 688 OFFCURVE",
+"262 688 CURVE SMOOTH",
+"230 688 OFFCURVE",
+"208 663 OFFCURVE",
+"208 635 CURVE SMOOTH",
+"208 614 OFFCURVE",
+"221 599 OFFCURVE",
+"248 592 CURVE SMOOTH",
+"414 548 LINE"
+);
+}
+);
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{316, 450}";
+},
+{
+name = top;
+position = "{371, 691}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+paths = (
+{
+closed = 1;
+nodes = (
+"515 550 LINE",
+"339 659 LINE SMOOTH",
+"301 682 OFFCURVE",
+"281 691 OFFCURVE",
+"253 691 CURVE SMOOTH",
+"216 691 OFFCURVE",
+"195 667 OFFCURVE",
+"195 642 CURVE SMOOTH",
+"195 620 OFFCURVE",
+"211 596 OFFCURVE",
+"248 589 CURVE SMOOTH",
+"446 550 LINE"
+);
+}
+);
+width = 600;
+}
+);
+unicode = 0300;
+},
+{
+glyphname = acutecomb;
+lastChange = "2016-08-22 13:36:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{359, 450}";
+},
+{
+name = top;
+position = "{419, 707}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+paths = (
+{
+closed = 1;
+nodes = (
+"359 567 LINE",
+"533 606 LINE SMOOTH",
+"581 617 OFFCURVE",
+"602 639 OFFCURVE",
+"602 668 CURVE SMOOTH",
+"602 693 OFFCURVE",
+"587 707 OFFCURVE",
+"564 707 CURVE SMOOTH",
+"544 707 OFFCURVE",
+"522 697 OFFCURVE",
+"479 671 CURVE SMOOTH",
+"307 567 LINE"
+);
+}
+);
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{405, 450}";
+},
+{
+name = top;
+position = "{458, 682}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+paths = (
+{
+closed = 1;
+nodes = (
+"351 541 LINE",
+"549 580 LINE SMOOTH",
+"586 587 OFFCURVE",
+"602 611 OFFCURVE",
+"602 633 CURVE SMOOTH",
+"602 658 OFFCURVE",
+"581 682 OFFCURVE",
+"544 682 CURVE SMOOTH",
+"516 682 OFFCURVE",
+"496 673 OFFCURVE",
+"458 650 CURVE SMOOTH",
+"282 541 LINE"
+);
+}
+);
+width = 600;
+}
+);
+unicode = 0301;
+},
+{
+glyphname = circumflexcomb;
+lastChange = "2016-08-22 13:40:39 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{372, 450}";
+},
+{
+name = top;
+position = "{388, 569}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+paths = (
+{
+closed = 1;
+nodes = (
+"278 539 LINE",
+"390 580 LINE",
+"476 539 LINE",
+"519 539 LINE",
+"427 639 LINE",
+"365 639 LINE",
+"236 539 LINE"
+);
+}
+);
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{345, 450}";
+},
+{
+name = top;
+position = "{390, 646}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+paths = (
+{
+closed = 1;
+nodes = (
+"255 534 LINE",
+"387 579 LINE",
+"499 534 LINE",
+"546 534 LINE",
+"423 646 LINE",
+"367 646 LINE",
+"209 534 LINE"
+);
+}
+);
+width = 600;
+}
+);
+unicode = 0302;
+},
+{
+glyphname = brevecomb;
+lastChange = "2016-08-22 13:40:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{374, 450}";
+},
+{
+name = top;
+position = "{410, 586}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+paths = (
+{
+closed = 1;
+nodes = (
+"480 543 OFFCURVE",
+"530 587 OFFCURVE",
+"544 658 CURVE",
+"514 658 LINE",
+"502 618 OFFCURVE",
+"465 609 OFFCURVE",
+"393 609 CURVE SMOOTH",
+"334 609 OFFCURVE",
+"309 612 OFFCURVE",
+"309 658 CURVE",
+"278 658 LINE",
+"260 584 OFFCURVE",
+"299 543 OFFCURVE",
+"386 543 CURVE SMOOTH"
+);
+}
+);
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{381, 450}";
+},
+{
+name = top;
+position = "{425, 680}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+paths = (
+{
+closed = 1;
+nodes = (
+"466 546 OFFCURVE",
+"541 589 OFFCURVE",
+"559 680 CURVE",
+"520 680 LINE",
+"509 632 OFFCURVE",
+"450 621 OFFCURVE",
+"397 621 CURVE SMOOTH",
+"348 621 OFFCURVE",
+"292 632 OFFCURVE",
+"304 680 CURVE",
+"265 680 LINE",
+"243 586 OFFCURVE",
+"295 546 OFFCURVE",
+"382 546 CURVE SMOOTH"
+);
+}
+);
+width = 600;
+}
+);
+unicode = 0306;
+},
+{
+glyphname = tildecomb;
+lastChange = "2016-08-22 13:36:02 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{359, 450}";
+},
+{
+name = top;
+position = "{411, 675}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+paths = (
+{
+closed = 1;
+nodes = (
+"244 547 LINE",
+"257 575 OFFCURVE",
+"284 596 OFFCURVE",
+"317 596 CURVE SMOOTH",
+"365 596 OFFCURVE",
+"385 548 OFFCURVE",
+"447 548 CURVE SMOOTH",
+"503 548 OFFCURVE",
+"554 588 OFFCURVE",
+"580 675 CURVE",
+"546 675 LINE",
+"533 652 OFFCURVE",
+"508 624 OFFCURVE",
+"472 624 CURVE SMOOTH",
+"425 624 OFFCURVE",
+"401 672 OFFCURVE",
+"344 672 CURVE SMOOTH",
+"284 672 OFFCURVE",
+"232 619 OFFCURVE",
+"212 547 CURVE"
+);
+}
+);
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{365, 450}";
+},
+{
+name = top;
+position = "{418, 680}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+paths = (
+{
+closed = 1;
+nodes = (
+"242 546 LINE",
+"254 571 OFFCURVE",
+"285 591 OFFCURVE",
+"321 591 CURVE SMOOTH",
+"374 591 OFFCURVE",
+"390 547 OFFCURVE",
+"453 547 CURVE SMOOTH",
+"523 547 OFFCURVE",
+"570 600 OFFCURVE",
+"598 680 CURVE",
+"562 680 LINE",
+"552 662 OFFCURVE",
+"522 635 OFFCURVE",
+"481 635 CURVE SMOOTH",
+"430 635 OFFCURVE",
+"414 679 OFFCURVE",
+"351 679 CURVE SMOOTH",
+"276 679 OFFCURVE",
+"229 615 OFFCURVE",
+"208 546 CURVE"
+);
+}
+);
+width = 600;
+}
+);
+unicode = 0303;
+},
+{
+glyphname = hookabovecomb;
+lastChange = "2016-08-22 14:06:04 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{323, 450}";
+},
+{
+name = top;
+position = "{377, 683}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+paths = (
+{
+closed = 1;
+nodes = (
+"370 524 LINE",
+"387 550 OFFCURVE",
+"447 560 OFFCURVE",
+"454 600 CURVE SMOOTH",
+"465 657 OFFCURVE",
+"430 683 OFFCURVE",
+"370 683 CURVE SMOOTH",
+"326 683 OFFCURVE",
+"273 662 OFFCURVE",
+"262 603 CURVE SMOOTH",
+"258 583 OFFCURVE",
+"271 568 OFFCURVE",
+"294 568 CURVE SMOOTH",
+"315 568 OFFCURVE",
+"328 576 OFFCURVE",
+"330 590 CURVE SMOOTH",
+"334 608 OFFCURVE",
+"320 606 OFFCURVE",
+"323 618 CURVE SMOOTH",
+"326 633 OFFCURVE",
+"344 643 OFFCURVE",
+"364 643 CURVE SMOOTH",
+"385 643 OFFCURVE",
+"402 636 OFFCURVE",
+"395 598 CURVE SMOOTH",
+"390 574 OFFCURVE",
+"350 560 OFFCURVE",
+"343 524 CURVE"
+);
+}
+);
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{332, 450}";
+},
+{
+name = top;
+position = "{390, 700}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+paths = (
+{
+closed = 1;
+nodes = (
+"381 507 LINE",
+"391 557 OFFCURVE",
+"461 538 OFFCURVE",
+"473 600 CURVE SMOOTH",
+"487 671 OFFCURVE",
+"458 700 OFFCURVE",
+"385 700 CURVE SMOOTH",
+"325 700 OFFCURVE",
+"273 673 OFFCURVE",
+"260 608 CURVE SMOOTH",
+"254 578 OFFCURVE",
+"270 559 OFFCURVE",
+"294 559 CURVE SMOOTH",
+"311 559 OFFCURVE",
+"335 566 OFFCURVE",
+"338 585 CURVE SMOOTH",
+"342 613 OFFCURVE",
+"322 601 OFFCURVE",
+"325 625 CURVE SMOOTH",
+"327 639 OFFCURVE",
+"348 657 OFFCURVE",
+"376 657 CURVE SMOOTH",
+"405 657 OFFCURVE",
+"420 641 OFFCURVE",
+"413 609 CURVE SMOOTH",
+"408 585 OFFCURVE",
+"356 577 OFFCURVE",
+"342 507 CURVE"
+);
+}
+);
+width = 600;
+}
+);
+unicode = 0309;
+},
+{
+glyphname = dblgravecomb;
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -39309,23 +43497,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"360 554 LINE",
-"243 718 LINE SMOOTH",
-"220 750 OFFCURVE",
-"202 760 OFFCURVE",
-"177 760 CURVE SMOOTH",
-"143 760 OFFCURVE",
-"115 742 OFFCURVE",
-"115 704 CURVE SMOOTH",
-"115 692 OFFCURVE",
-"118 669 OFFCURVE",
-"150 649 CURVE SMOOTH",
-"297 554 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
 "560 554 LINE",
 "443 718 LINE SMOOTH",
 "420 750 OFFCURVE",
@@ -39339,6 +43510,23 @@ nodes = (
 "350 649 CURVE SMOOTH",
 "497 554 LINE"
 );
+},
+{
+closed = 1;
+nodes = (
+"360 554 LINE",
+"243 718 LINE SMOOTH",
+"220 750 OFFCURVE",
+"202 760 OFFCURVE",
+"177 760 CURVE SMOOTH",
+"143 760 OFFCURVE",
+"115 742 OFFCURVE",
+"115 704 CURVE SMOOTH",
+"115 692 OFFCURVE",
+"118 669 OFFCURVE",
+"150 649 CURVE SMOOTH",
+"297 554 LINE"
+);
 }
 );
 width = 476;
@@ -39347,8 +43535,8 @@ width = 476;
 unicode = 030F;
 },
 {
-glyphname = uni0311;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = breveinvertedcomb;
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -39356,16 +43544,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"413 576 LINE",
-"416 589 OFFCURVE",
-"417 603 OFFCURVE",
-"417 614 CURVE SMOOTH",
-"417 687 OFFCURVE",
-"371 733 OFFCURVE",
-"287 733 CURVE SMOOTH",
-"181 733 OFFCURVE",
-"127 660 OFFCURVE",
-"100 576 CURVE",
 "134 576 LINE",
 "158 630 OFFCURVE",
 "205 655 OFFCURVE",
@@ -39375,7 +43553,17 @@ nodes = (
 "380 588 CURVE SMOOTH",
 "380 584 OFFCURVE",
 "380 580 OFFCURVE",
-"379 576 CURVE"
+"379 576 CURVE",
+"413 576 LINE",
+"416 589 OFFCURVE",
+"417 603 OFFCURVE",
+"417 614 CURVE SMOOTH",
+"417 687 OFFCURVE",
+"371 733 OFFCURVE",
+"287 733 CURVE SMOOTH",
+"181 733 OFFCURVE",
+"127 660 OFFCURVE",
+"100 576 CURVE"
 );
 }
 );
@@ -39387,16 +43575,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"426 556 LINE",
-"430 574 OFFCURVE",
-"432 591 OFFCURVE",
-"432 606 CURVE SMOOTH",
-"432 684 OFFCURVE",
-"379 733 OFFCURVE",
-"293 733 CURVE SMOOTH",
-"187 733 OFFCURVE",
-"114 659 OFFCURVE",
-"93 556 CURVE",
 "141 556 LINE",
 "156 614 OFFCURVE",
 "213 635 OFFCURVE",
@@ -39406,7 +43584,17 @@ nodes = (
 "383 570 CURVE SMOOTH",
 "383 566 OFFCURVE",
 "383 561 OFFCURVE",
-"382 556 CURVE"
+"382 556 CURVE",
+"426 556 LINE",
+"430 574 OFFCURVE",
+"432 591 OFFCURVE",
+"432 606 CURVE SMOOTH",
+"432 684 OFFCURVE",
+"379 733 OFFCURVE",
+"293 733 CURVE SMOOTH",
+"187 733 OFFCURVE",
+"114 659 OFFCURVE",
+"93 556 CURVE"
 );
 }
 );
@@ -39416,8 +43604,146 @@ width = 357;
 unicode = 0311;
 },
 {
-glyphname = commaaccent;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = horncomb;
+lastChange = "2016-08-22 14:06:04 +0000";
+layers = (
+{
+anchors = (
+{
+name = _topright;
+position = "{305, 450}";
+},
+{
+name = topright;
+position = "{305, 450}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+paths = (
+{
+closed = 1;
+nodes = (
+"334 476 OFFCURVE",
+"372 499 OFFCURVE",
+"388 582 CURVE",
+"324 582 LINE",
+"311 527 OFFCURVE",
+"295 503 OFFCURVE",
+"224 503 CURVE",
+"221 476 LINE"
+);
+}
+);
+width = 600;
+},
+{
+anchors = (
+{
+name = _topright;
+position = "{313, 450}";
+},
+{
+name = topright;
+position = "{313, 450}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+paths = (
+{
+closed = 1;
+nodes = (
+"333 465 OFFCURVE",
+"386 481 OFFCURVE",
+"405 582 CURVE",
+"329 582 LINE",
+"316 527 OFFCURVE",
+"296 503 OFFCURVE",
+"225 503 CURVE",
+"220 465 LINE"
+);
+}
+);
+width = 600;
+}
+);
+unicode = 031B;
+},
+{
+glyphname = dotbelowcomb;
+lastChange = "2016-08-22 13:47:05 +0000";
+layers = (
+{
+anchors = (
+{
+name = _bottom;
+position = "{241, 0}";
+},
+{
+name = bottom;
+position = "{194, -203}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+paths = (
+{
+closed = 1;
+nodes = (
+"247 -203 OFFCURVE",
+"277 -174 OFFCURVE",
+"277 -136 CURVE SMOOTH",
+"277 -98 OFFCURVE",
+"247 -68 OFFCURVE",
+"209 -68 CURVE SMOOTH",
+"171 -68 OFFCURVE",
+"142 -98 OFFCURVE",
+"142 -136 CURVE SMOOTH",
+"142 -174 OFFCURVE",
+"171 -203 OFFCURVE",
+"209 -203 CURVE SMOOTH"
+);
+}
+);
+width = 600;
+},
+{
+anchors = (
+{
+name = _bottom;
+position = "{250, 0}";
+},
+{
+name = bottom;
+position = "{196, -233}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+paths = (
+{
+closed = 1;
+nodes = (
+"258 -233 OFFCURVE",
+"295 -196 OFFCURVE",
+"295 -153 CURVE SMOOTH",
+"295 -109 OFFCURVE",
+"258 -72 OFFCURVE",
+"214 -72 CURVE SMOOTH",
+"171 -72 OFFCURVE",
+"134 -109 OFFCURVE",
+"134 -153 CURVE SMOOTH",
+"134 -196 OFFCURVE",
+"171 -233 OFFCURVE",
+"214 -233 CURVE SMOOTH"
+);
+}
+);
+width = 600;
+}
+);
+unicode = 0323;
+},
+{
+glyphname = commaaccentcomb;
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -39425,7 +43751,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"-77 -310 LINE",
 "24 -274 OFFCURVE",
 "70 -220 OFFCURVE",
 "70 -164 CURVE SMOOTH",
@@ -39446,7 +43771,8 @@ nodes = (
 "34 -186 CURVE SMOOTH",
 "34 -211 OFFCURVE",
 "4 -247 OFFCURVE",
-"-90 -287 CURVE"
+"-90 -287 CURVE",
+"-77 -310 LINE"
 );
 }
 );
@@ -39458,7 +43784,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"-76 -315 LINE",
 "32 -280 OFFCURVE",
 "93 -235 OFFCURVE",
 "93 -167 CURVE SMOOTH",
@@ -39479,18 +43804,68 @@ nodes = (
 "47 -188 CURVE SMOOTH",
 "47 -226 OFFCURVE",
 "-9 -260 OFFCURVE",
-"-90 -286 CURVE"
+"-90 -286 CURVE",
+"-76 -315 LINE"
 );
 }
 );
 width = 200;
 }
 );
-unicode = F6C3;
+unicode = 0326;
 },
 {
-glyphname = uni030F.cap;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = strokeshortcomb;
+lastChange = "2016-08-22 13:44:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = _center;
+position = "{92, 262}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+paths = (
+{
+closed = 1;
+nodes = (
+"274 244 LINE",
+"274 279 LINE",
+"-91 279 LINE",
+"-91 244 LINE"
+);
+}
+);
+width = 600;
+},
+{
+anchors = (
+{
+name = _center;
+position = "{304, 221}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+paths = (
+{
+closed = 1;
+nodes = (
+"486 201 LINE",
+"486 241 LINE",
+"121 241 LINE",
+"121 201 LINE"
+);
+}
+);
+width = 600;
+}
+);
+unicode = 0335;
+},
+{
+glyphname = dblgravecomb.cap;
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -39498,24 +43873,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"369 784 LINE",
-"422 784 LINE",
-"283 888 LINE SMOOTH",
-"246 916 OFFCURVE",
-"234 924 OFFCURVE",
-"217 924 CURVE SMOOTH",
-"185 924 OFFCURVE",
-"163 899 OFFCURVE",
-"163 871 CURVE SMOOTH",
-"163 850 OFFCURVE",
-"176 835 OFFCURVE",
-"203 828 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"573 784 LINE",
 "626 784 LINE",
 "487 888 LINE SMOOTH",
 "450 916 OFFCURVE",
@@ -39526,7 +43883,25 @@ nodes = (
 "367 871 CURVE SMOOTH",
 "367 850 OFFCURVE",
 "380 835 OFFCURVE",
-"407 828 CURVE SMOOTH"
+"407 828 CURVE SMOOTH",
+"573 784 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"422 784 LINE",
+"283 888 LINE SMOOTH",
+"246 916 OFFCURVE",
+"234 924 OFFCURVE",
+"217 924 CURVE SMOOTH",
+"185 924 OFFCURVE",
+"163 899 OFFCURVE",
+"163 871 CURVE SMOOTH",
+"163 850 OFFCURVE",
+"176 835 OFFCURVE",
+"203 828 CURVE SMOOTH",
+"369 784 LINE"
 );
 }
 );
@@ -39575,8 +43950,8 @@ width = 540;
 );
 },
 {
-glyphname = uni0311.cap;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = breveinvertedcomb.cap;
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -39584,6 +43959,13 @@ paths = (
 {
 closed = 1;
 nodes = (
+"190 787 LINE",
+"203 831 OFFCURVE",
+"253 851 OFFCURVE",
+"333 851 CURVE SMOOTH",
+"398 851 OFFCURVE",
+"435 838 OFFCURVE",
+"435 787 CURVE",
 "469 787 LINE",
 "472 799 OFFCURVE",
 "473 809 OFFCURVE",
@@ -39593,14 +43975,7 @@ nodes = (
 "336 924 CURVE SMOOTH",
 "239 924 OFFCURVE",
 "171 864 OFFCURVE",
-"156 787 CURVE",
-"190 787 LINE",
-"203 831 OFFCURVE",
-"253 851 OFFCURVE",
-"333 851 CURVE SMOOTH",
-"398 851 OFFCURVE",
-"435 838 OFFCURVE",
-"435 787 CURVE"
+"156 787 CURVE"
 );
 }
 );
@@ -39612,6 +43987,13 @@ paths = (
 {
 closed = 1;
 nodes = (
+"212 780 LINE",
+"223 828 OFFCURVE",
+"272 849 OFFCURVE",
+"335 849 CURVE SMOOTH",
+"394 849 OFFCURVE",
+"440 828 OFFCURVE",
+"428 780 CURVE",
 "467 780 LINE",
 "471 797 OFFCURVE",
 "473 811 OFFCURVE",
@@ -39621,17 +44003,7 @@ nodes = (
 "350 924 CURVE SMOOTH",
 "256 924 OFFCURVE",
 "191 871 OFFCURVE",
-"173 780 CURVE",
-"212 780 LINE",
-"223 828 OFFCURVE",
-"272 849 OFFCURVE",
-"335 849 CURVE SMOOTH",
-"392 849 OFFCURVE",
-"429 833 OFFCURVE",
-"429 793 CURVE SMOOTH",
-"429 789 OFFCURVE",
-"429 784 OFFCURVE",
-"428 780 CURVE"
+"173 780 CURVE"
 );
 }
 );
@@ -39640,8 +44012,8 @@ width = 357;
 );
 },
 {
-glyphname = uni02C9;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = firsttonechinese;
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -39649,10 +44021,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"125 637 LINE",
 "445 637 LINE",
 "460 703 LINE",
-"140 703 LINE"
+"140 703 LINE",
+"125 637 LINE"
 );
 }
 );
@@ -39664,10 +44036,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"116 627 LINE",
 "456 627 LINE",
 "475 713 LINE",
-"135 713 LINE"
+"135 713 LINE",
+"116 627 LINE"
 );
 }
 );
@@ -39678,7 +44050,7 @@ unicode = 02C9;
 },
 {
 glyphname = acute;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:44 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -39686,6 +44058,7 @@ paths = (
 {
 closed = 1;
 nodes = (
+"152 554 LINE",
 "329 661 LINE SMOOTH",
 "357 678 OFFCURVE",
 "369 698 OFFCURVE",
@@ -39696,8 +44069,7 @@ nodes = (
 "298 754 OFFCURVE",
 "276 744 OFFCURVE",
 "241 704 CURVE SMOOTH",
-"110 554 LINE",
-"152 554 LINE"
+"110 554 LINE"
 );
 }
 );
@@ -39731,7 +44103,7 @@ unicode = 00B4;
 },
 {
 glyphname = breve;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -39739,13 +44111,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"132 733 LINE",
-"129 720 OFFCURVE",
-"128 706 OFFCURVE",
-"128 695 CURVE SMOOTH",
-"128 622 OFFCURVE",
-"174 576 OFFCURVE",
-"258 576 CURVE SMOOTH",
 "364 576 OFFCURVE",
 "418 649 OFFCURVE",
 "445 733 CURVE",
@@ -39758,7 +44123,14 @@ nodes = (
 "165 721 CURVE SMOOTH",
 "165 725 OFFCURVE",
 "165 729 OFFCURVE",
-"166 733 CURVE"
+"166 733 CURVE",
+"132 733 LINE",
+"129 720 OFFCURVE",
+"128 706 OFFCURVE",
+"128 695 CURVE SMOOTH",
+"128 622 OFFCURVE",
+"174 576 OFFCURVE",
+"258 576 CURVE SMOOTH"
 );
 }
 );
@@ -39770,13 +44142,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"134 733 LINE",
-"130 715 OFFCURVE",
-"128 698 OFFCURVE",
-"128 683 CURVE SMOOTH",
-"128 605 OFFCURVE",
-"181 556 OFFCURVE",
-"267 556 CURVE SMOOTH",
 "373 556 OFFCURVE",
 "446 630 OFFCURVE",
 "467 733 CURVE",
@@ -39789,7 +44154,14 @@ nodes = (
 "177 719 CURVE SMOOTH",
 "177 723 OFFCURVE",
 "177 728 OFFCURVE",
-"178 733 CURVE"
+"178 733 CURVE",
+"134 733 LINE",
+"130 715 OFFCURVE",
+"128 698 OFFCURVE",
+"128 683 CURVE SMOOTH",
+"128 605 OFFCURVE",
+"181 556 OFFCURVE",
+"267 556 CURVE SMOOTH"
 );
 }
 );
@@ -39800,7 +44172,7 @@ unicode = 02D8;
 },
 {
 glyphname = caron;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -39808,13 +44180,13 @@ paths = (
 {
 closed = 1;
 nodes = (
+"280 554 LINE",
+"454 754 LINE",
 "411 754 LINE",
 "269 648 LINE",
 "173 754 LINE",
 "130 754 LINE",
-"218 554 LINE",
-"280 554 LINE",
-"454 754 LINE"
+"218 554 LINE"
 );
 }
 );
@@ -39826,13 +44198,13 @@ paths = (
 {
 closed = 1;
 nodes = (
+"300 554 LINE",
+"494 754 LINE",
 "451 754 LINE",
 "293 668 LINE",
 "173 754 LINE",
 "130 754 LINE",
-"238 554 LINE",
-"300 554 LINE",
-"494 754 LINE"
+"238 554 LINE"
 );
 }
 );
@@ -39843,7 +44215,7 @@ unicode = 02C7;
 },
 {
 glyphname = cedilla;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -39851,6 +44223,14 @@ paths = (
 {
 closed = 1;
 nodes = (
+"75 -226 OFFCURVE",
+"163 -196 OFFCURVE",
+"163 -130 CURVE SMOOTH",
+"163 -91 OFFCURVE",
+"133 -66 OFFCURVE",
+"81 -66 CURVE SMOOTH",
+"62 -66 LINE",
+"105 10 LINE",
 "75 10 LINE",
 "16 -90 LINE",
 "60 -91 OFFCURVE",
@@ -39865,15 +44245,7 @@ nodes = (
 "-65 -209 LINE",
 "-55 -216 OFFCURVE",
 "-29 -226 OFFCURVE",
-"9 -226 CURVE SMOOTH",
-"75 -226 OFFCURVE",
-"163 -196 OFFCURVE",
-"163 -130 CURVE SMOOTH",
-"163 -91 OFFCURVE",
-"133 -66 OFFCURVE",
-"81 -66 CURVE SMOOTH",
-"62 -66 LINE",
-"105 10 LINE"
+"9 -226 CURVE SMOOTH"
 );
 }
 );
@@ -39885,6 +44257,14 @@ paths = (
 {
 closed = 1;
 nodes = (
+"67 -235 OFFCURVE",
+"160 -202 OFFCURVE",
+"160 -131 CURVE SMOOTH",
+"160 -91 OFFCURVE",
+"131 -66 OFFCURVE",
+"78 -66 CURVE SMOOTH",
+"59 -66 LINE",
+"102 10 LINE",
 "55 10 LINE",
 "-11 -100 LINE",
 "44 -101 OFFCURVE",
@@ -39899,15 +44279,7 @@ nodes = (
 "-85 -218 LINE",
 "-75 -225 OFFCURVE",
 "-50 -235 OFFCURVE",
-"-8 -235 CURVE SMOOTH",
-"67 -235 OFFCURVE",
-"160 -202 OFFCURVE",
-"160 -131 CURVE SMOOTH",
-"160 -91 OFFCURVE",
-"131 -66 OFFCURVE",
-"78 -66 CURVE SMOOTH",
-"59 -66 LINE",
-"102 10 LINE"
+"-8 -235 CURVE SMOOTH"
 );
 }
 );
@@ -39918,7 +44290,7 @@ unicode = 00B8;
 },
 {
 glyphname = circumflex;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -39926,13 +44298,13 @@ paths = (
 {
 closed = 1;
 nodes = (
+"127 554 LINE",
+"269 660 LINE",
+"365 554 LINE",
 "408 554 LINE",
 "320 754 LINE",
 "258 754 LINE",
-"85 554 LINE",
-"127 554 LINE",
-"269 660 LINE",
-"365 554 LINE"
+"85 554 LINE"
 );
 }
 );
@@ -39944,13 +44316,13 @@ paths = (
 {
 closed = 1;
 nodes = (
+"122 554 LINE",
+"280 640 LINE",
+"400 554 LINE",
 "443 554 LINE",
 "335 754 LINE",
 "273 754 LINE",
-"80 554 LINE",
-"122 554 LINE",
-"280 640 LINE",
-"400 554 LINE"
+"80 554 LINE"
 );
 }
 );
@@ -39961,7 +44333,7 @@ unicode = 02C6;
 },
 {
 glyphname = dieresis;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:04:36 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -39969,28 +44341,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"122 667 LINE SMOOTH",
-"122 636 OFFCURVE",
-"146 612 OFFCURVE",
-"177 612 CURVE SMOOTH",
-"207 612 OFFCURVE",
-"232 636 OFFCURVE",
-"232 667 CURVE SMOOTH",
-"232 697 OFFCURVE",
-"207 722 OFFCURVE",
-"177 722 CURVE SMOOTH",
-"146 722 OFFCURVE",
-"122 697 OFFCURVE",
-"122 667 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"312 667 LINE SMOOTH",
-"312 636 OFFCURVE",
-"336 612 OFFCURVE",
-"367 612 CURVE SMOOTH",
 "397 612 OFFCURVE",
 "422 636 OFFCURVE",
 "422 667 CURVE SMOOTH",
@@ -39999,7 +44349,27 @@ nodes = (
 "367 722 CURVE SMOOTH",
 "336 722 OFFCURVE",
 "312 697 OFFCURVE",
-"312 667 CURVE SMOOTH"
+"312 667 CURVE SMOOTH",
+"312 636 OFFCURVE",
+"336 612 OFFCURVE",
+"367 612 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"207 612 OFFCURVE",
+"232 636 OFFCURVE",
+"232 667 CURVE SMOOTH",
+"232 697 OFFCURVE",
+"207 722 OFFCURVE",
+"177 722 CURVE SMOOTH",
+"146 722 OFFCURVE",
+"122 697 OFFCURVE",
+"122 667 CURVE SMOOTH",
+"122 636 OFFCURVE",
+"146 612 OFFCURVE",
+"177 612 CURVE SMOOTH"
 );
 }
 );
@@ -40011,28 +44381,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"118 667 LINE SMOOTH",
-"118 631 OFFCURVE",
-"148 601 OFFCURVE",
-"184 601 CURVE SMOOTH",
-"220 601 OFFCURVE",
-"250 631 OFFCURVE",
-"250 667 CURVE SMOOTH",
-"250 703 OFFCURVE",
-"220 733 OFFCURVE",
-"184 733 CURVE SMOOTH",
-"148 733 OFFCURVE",
-"118 703 OFFCURVE",
-"118 667 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"308 667 LINE SMOOTH",
-"308 631 OFFCURVE",
-"338 601 OFFCURVE",
-"374 601 CURVE SMOOTH",
 "410 601 OFFCURVE",
 "440 631 OFFCURVE",
 "440 667 CURVE SMOOTH",
@@ -40041,7 +44389,27 @@ nodes = (
 "374 733 CURVE SMOOTH",
 "338 733 OFFCURVE",
 "308 703 OFFCURVE",
-"308 667 CURVE SMOOTH"
+"308 667 CURVE SMOOTH",
+"308 631 OFFCURVE",
+"338 601 OFFCURVE",
+"374 601 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"220 601 OFFCURVE",
+"250 631 OFFCURVE",
+"250 667 CURVE SMOOTH",
+"250 703 OFFCURVE",
+"220 733 OFFCURVE",
+"184 733 CURVE SMOOTH",
+"148 733 OFFCURVE",
+"118 703 OFFCURVE",
+"118 667 CURVE SMOOTH",
+"118 631 OFFCURVE",
+"148 601 OFFCURVE",
+"184 601 CURVE SMOOTH"
 );
 }
 );
@@ -40052,7 +44420,7 @@ unicode = 00A8;
 },
 {
 glyphname = dotaccent;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 13:46:54 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -40060,10 +44428,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"118 665 LINE SMOOTH",
-"118 627 OFFCURVE",
-"147 598 OFFCURVE",
-"185 598 CURVE SMOOTH",
 "223 598 OFFCURVE",
 "253 627 OFFCURVE",
 "253 665 CURVE SMOOTH",
@@ -40072,7 +44436,10 @@ nodes = (
 "185 733 CURVE SMOOTH",
 "147 733 OFFCURVE",
 "118 703 OFFCURVE",
-"118 665 CURVE SMOOTH"
+"118 665 CURVE SMOOTH",
+"118 627 OFFCURVE",
+"147 598 OFFCURVE",
+"185 598 CURVE SMOOTH"
 );
 }
 );
@@ -40084,10 +44451,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"110 653 LINE SMOOTH",
-"110 610 OFFCURVE",
-"147 573 OFFCURVE",
-"190 573 CURVE SMOOTH",
 "234 573 OFFCURVE",
 "271 610 OFFCURVE",
 "271 653 CURVE SMOOTH",
@@ -40096,7 +44459,10 @@ nodes = (
 "190 734 CURVE SMOOTH",
 "147 734 OFFCURVE",
 "110 697 OFFCURVE",
-"110 653 CURVE SMOOTH"
+"110 653 CURVE SMOOTH",
+"110 610 OFFCURVE",
+"147 573 OFFCURVE",
+"190 573 CURVE SMOOTH"
 );
 }
 );
@@ -40160,7 +44526,7 @@ unicode = 0060;
 },
 {
 glyphname = hungarumlaut;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:44 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -40168,23 +44534,7 @@ paths = (
 {
 closed = 1;
 nodes = (
-"336 661 LINE SMOOTH",
-"364 678 OFFCURVE",
-"376 698 OFFCURVE",
-"376 716 CURVE SMOOTH",
-"376 735 OFFCURVE",
-"364 754 OFFCURVE",
-"330 754 CURVE SMOOTH",
-"305 754 OFFCURVE",
-"283 744 OFFCURVE",
-"248 704 CURVE SMOOTH",
-"117 554 LINE",
-"159 554 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"336 554 LINE",
 "513 661 LINE SMOOTH",
 "541 678 OFFCURVE",
 "553 698 OFFCURVE",
@@ -40195,8 +44545,24 @@ nodes = (
 "482 754 OFFCURVE",
 "460 744 OFFCURVE",
 "425 704 CURVE SMOOTH",
-"294 554 LINE",
-"336 554 LINE"
+"294 554 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"159 554 LINE",
+"336 661 LINE SMOOTH",
+"364 678 OFFCURVE",
+"376 698 OFFCURVE",
+"376 716 CURVE SMOOTH",
+"376 735 OFFCURVE",
+"364 754 OFFCURVE",
+"330 754 CURVE SMOOTH",
+"305 754 OFFCURVE",
+"283 744 OFFCURVE",
+"248 704 CURVE SMOOTH",
+"117 554 LINE"
 );
 }
 );
@@ -40205,23 +44571,6 @@ width = 456;
 {
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
 paths = (
-{
-closed = 1;
-nodes = (
-"139 554 LINE",
-"314 643 LINE SMOOTH",
-"352 662 OFFCURVE",
-"365 676 OFFCURVE",
-"365 702 CURVE SMOOTH",
-"365 734 OFFCURVE",
-"345 760 OFFCURVE",
-"306 760 CURVE SMOOTH",
-"287 760 OFFCURVE",
-"265 754 OFFCURVE",
-"231 718 CURVE SMOOTH",
-"77 554 LINE"
-);
-},
 {
 closed = 1;
 nodes = (
@@ -40238,6 +44587,23 @@ nodes = (
 "437 718 CURVE SMOOTH",
 "283 554 LINE"
 );
+},
+{
+closed = 1;
+nodes = (
+"139 554 LINE",
+"314 643 LINE SMOOTH",
+"352 662 OFFCURVE",
+"365 676 OFFCURVE",
+"365 702 CURVE SMOOTH",
+"365 734 OFFCURVE",
+"345 760 OFFCURVE",
+"306 760 CURVE SMOOTH",
+"287 760 OFFCURVE",
+"265 754 OFFCURVE",
+"231 718 CURVE SMOOTH",
+"77 554 LINE"
+);
 }
 );
 width = 476;
@@ -40247,7 +44613,7 @@ unicode = 02DD;
 },
 {
 glyphname = macron;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -40255,10 +44621,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"120 637 LINE",
 "440 637 LINE",
 "455 703 LINE",
-"135 703 LINE"
+"135 703 LINE",
+"120 637 LINE"
 );
 }
 );
@@ -40270,10 +44636,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"115 627 LINE",
 "455 627 LINE",
 "474 713 LINE",
-"134 713 LINE"
+"134 713 LINE",
+"115 627 LINE"
 );
 }
 );
@@ -40284,7 +44650,7 @@ unicode = 00AF;
 },
 {
 glyphname = ogonek;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 background = {
@@ -40321,7 +44687,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"-32 -232 LINE SMOOTH",
 "9 -232 OFFCURVE",
 "54 -213 OFFCURVE",
 "81 -186 CURVE",
@@ -40341,7 +44706,8 @@ nodes = (
 "-109 -172 CURVE SMOOTH",
 "-109 -208 OFFCURVE",
 "-78 -232 OFFCURVE",
-"-32 -232 CURVE SMOOTH"
+"-32 -232 CURVE SMOOTH",
+"-32 -232 LINE SMOOTH"
 );
 }
 );
@@ -40353,7 +44719,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"-2 -237 LINE SMOOTH",
 "50 -237 OFFCURVE",
 "114 -214 OFFCURVE",
 "142 -186 CURVE",
@@ -40373,7 +44738,8 @@ nodes = (
 "-91 -168 CURVE SMOOTH",
 "-91 -211 OFFCURVE",
 "-58 -237 OFFCURVE",
-"-2 -237 CURVE SMOOTH"
+"-2 -237 CURVE SMOOTH",
+"-2 -237 LINE SMOOTH"
 );
 }
 );
@@ -40384,7 +44750,7 @@ unicode = 02DB;
 },
 {
 glyphname = ring;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 11:15:51 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -40392,10 +44758,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"118 660 LINE SMOOTH",
-"118 603 OFFCURVE",
-"161 560 OFFCURVE",
-"218 560 CURVE SMOOTH",
 "275 560 OFFCURVE",
 "320 603 OFFCURVE",
 "320 660 CURVE SMOOTH",
@@ -40404,13 +44766,18 @@ nodes = (
 "218 762 CURVE SMOOTH",
 "161 762 OFFCURVE",
 "118 717 OFFCURVE",
-"118 660 CURVE SMOOTH"
+"118 660 CURVE SMOOTH",
+"118 603 OFFCURVE",
+"161 560 OFFCURVE",
+"218 560 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"161 660 LINE",
+"187 603 OFFCURVE",
+"161 629 OFFCURVE",
+"161 660 CURVE",
 "161 692 OFFCURVE",
 "187 717 OFFCURVE",
 "218 717 CURVE SMOOTH",
@@ -40419,10 +44786,7 @@ nodes = (
 "275 660 CURVE SMOOTH",
 "275 629 OFFCURVE",
 "250 603 OFFCURVE",
-"218 603 CURVE SMOOTH",
-"187 603 OFFCURVE",
-"161 629 OFFCURVE",
-"161 660 CURVE SMOOTH"
+"218 603 CURVE SMOOTH"
 );
 }
 );
@@ -40434,7 +44798,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"228 560 LINE SMOOTH",
 "284 560 OFFCURVE",
 "330 606 OFFCURVE",
 "330 662 CURVE SMOOTH",
@@ -40452,19 +44815,18 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"228 706 LINE SMOOTH",
-"252 706 OFFCURVE",
-"273 686 OFFCURVE",
-"273 662 CURVE SMOOTH",
-"273 637 OFFCURVE",
-"253 616 OFFCURVE",
-"228 616 CURVE SMOOTH",
 "203 616 OFFCURVE",
 "183 638 OFFCURVE",
 "183 662 CURVE SMOOTH",
 "183 686 OFFCURVE",
 "204 706 OFFCURVE",
-"228 706 CURVE SMOOTH"
+"228 706 CURVE SMOOTH",
+"252 706 OFFCURVE",
+"273 686 OFFCURVE",
+"273 662 CURVE SMOOTH",
+"273 637 OFFCURVE",
+"253 616 OFFCURVE",
+"228 616 CURVE SMOOTH"
 );
 }
 );
@@ -40475,7 +44837,7 @@ unicode = 02DA;
 },
 {
 glyphname = tilde;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 10:35:49 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -40483,16 +44845,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"458 731 LINE",
-"445 708 OFFCURVE",
-"420 680 OFFCURVE",
-"384 680 CURVE SMOOTH",
-"337 680 OFFCURVE",
-"313 728 OFFCURVE",
-"256 728 CURVE SMOOTH",
-"196 728 OFFCURVE",
-"144 675 OFFCURVE",
-"124 603 CURVE",
 "156 603 LINE",
 "169 631 OFFCURVE",
 "196 652 OFFCURVE",
@@ -40502,7 +44854,17 @@ nodes = (
 "359 604 CURVE SMOOTH",
 "415 604 OFFCURVE",
 "466 644 OFFCURVE",
-"492 731 CURVE"
+"492 731 CURVE",
+"458 731 LINE",
+"445 708 OFFCURVE",
+"420 680 OFFCURVE",
+"384 680 CURVE SMOOTH",
+"337 680 OFFCURVE",
+"313 728 OFFCURVE",
+"256 728 CURVE SMOOTH",
+"196 728 OFFCURVE",
+"144 675 OFFCURVE",
+"124 603 CURVE"
 );
 }
 );
@@ -40514,16 +44876,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"479 731 LINE",
-"467 711 OFFCURVE",
-"435 680 OFFCURVE",
-"390 680 CURVE SMOOTH",
-"335 680 OFFCURVE",
-"317 728 OFFCURVE",
-"250 728 CURVE SMOOTH",
-"168 728 OFFCURVE",
-"117 658 OFFCURVE",
-"95 583 CURVE",
 "131 583 LINE",
 "145 610 OFFCURVE",
 "178 632 OFFCURVE",
@@ -40533,7 +44885,17 @@ nodes = (
 "360 584 CURVE SMOOTH",
 "436 584 OFFCURVE",
 "487 643 OFFCURVE",
-"517 731 CURVE"
+"517 731 CURVE",
+"479 731 LINE",
+"467 711 OFFCURVE",
+"435 680 OFFCURVE",
+"390 680 CURVE SMOOTH",
+"335 680 OFFCURVE",
+"317 728 OFFCURVE",
+"250 728 CURVE SMOOTH",
+"168 728 OFFCURVE",
+"117 658 OFFCURVE",
+"95 583 CURVE"
 );
 }
 );
@@ -40544,7 +44906,7 @@ unicode = 02DC;
 },
 {
 glyphname = caron.alt;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -40552,7 +44914,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"123 504 LINE",
 "211 549 OFFCURVE",
 "270 613 OFFCURVE",
 "270 679 CURVE SMOOTH",
@@ -40573,7 +44934,8 @@ nodes = (
 "234 658 CURVE SMOOTH",
 "234 627 OFFCURVE",
 "194 579 OFFCURVE",
-"110 527 CURVE"
+"110 527 CURVE",
+"123 504 LINE"
 );
 }
 );
@@ -40585,7 +44947,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"142 473 LINE",
 "252 514 OFFCURVE",
 "316 577 OFFCURVE",
 "316 653 CURVE SMOOTH",
@@ -40606,7 +44967,8 @@ nodes = (
 "270 633 CURVE SMOOTH",
 "270 588 OFFCURVE",
 "210 535 OFFCURVE",
-"123 502 CURVE"
+"123 502 CURVE",
+"142 473 LINE"
 );
 }
 );
@@ -40615,8 +44977,8 @@ width = 248;
 );
 },
 {
-glyphname = acute.cap;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = acute.case;
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -40624,6 +44986,7 @@ paths = (
 {
 closed = 1;
 nodes = (
+"221 784 LINE",
 "395 823 LINE SMOOTH",
 "443 834 OFFCURVE",
 "464 856 OFFCURVE",
@@ -40634,8 +44997,7 @@ nodes = (
 "406 924 OFFCURVE",
 "384 914 OFFCURVE",
 "341 888 CURVE SMOOTH",
-"169 784 LINE",
-"221 784 LINE"
+"169 784 LINE"
 );
 }
 );
@@ -40667,8 +45029,8 @@ width = 335;
 );
 },
 {
-glyphname = breve.cap;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = breve.case;
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -40676,13 +45038,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"190 924 LINE",
-"187 912 OFFCURVE",
-"186 902 OFFCURVE",
-"186 893 CURVE SMOOTH",
-"186 828 OFFCURVE",
-"234 787 OFFCURVE",
-"319 787 CURVE SMOOTH",
 "422 787 OFFCURVE",
 "487 846 OFFCURVE",
 "503 924 CURVE",
@@ -40692,7 +45047,11 @@ nodes = (
 "326 860 CURVE SMOOTH",
 "261 860 OFFCURVE",
 "224 873 OFFCURVE",
-"224 924 CURVE"
+"224 924 CURVE",
+"190 924 LINE",
+"170 842 OFFCURVE",
+"223 787 OFFCURVE",
+"319 787 CURVE SMOOTH"
 );
 }
 );
@@ -40704,13 +45063,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"202 924 LINE",
-"198 907 OFFCURVE",
-"196 893 OFFCURVE",
-"196 880 CURVE SMOOTH",
-"196 810 OFFCURVE",
-"243 780 OFFCURVE",
-"319 780 CURVE SMOOTH",
 "413 780 OFFCURVE",
 "478 833 OFFCURVE",
 "496 924 CURVE",
@@ -40718,12 +45070,13 @@ nodes = (
 "446 876 OFFCURVE",
 "397 855 OFFCURVE",
 "334 855 CURVE SMOOTH",
-"277 855 OFFCURVE",
-"240 871 OFFCURVE",
-"240 911 CURVE SMOOTH",
-"240 915 OFFCURVE",
-"240 920 OFFCURVE",
-"241 924 CURVE"
+"275 855 OFFCURVE",
+"229 876 OFFCURVE",
+"241 924 CURVE",
+"202 924 LINE",
+"180 830 OFFCURVE",
+"222 780 OFFCURVE",
+"319 780 CURVE SMOOTH"
 );
 }
 );
@@ -40732,8 +45085,8 @@ width = 357;
 );
 },
 {
-glyphname = caron.cap;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = caron.case;
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -40741,13 +45094,13 @@ paths = (
 {
 closed = 1;
 nodes = (
+"353 784 LINE",
+"513 924 LINE",
 "470 924 LINE",
 "338 863 LINE",
 "232 924 LINE",
 "189 924 LINE",
-"291 784 LINE",
-"353 784 LINE",
-"513 924 LINE"
+"291 784 LINE"
 );
 }
 );
@@ -40759,13 +45112,13 @@ paths = (
 {
 closed = 1;
 nodes = (
-"173 923 LINE",
-"296 791 LINE",
 "352 791 LINE",
 "530 923 LINE",
 "484 923 LINE",
 "342 878 LINE",
-"220 923 LINE"
+"220 923 LINE",
+"173 923 LINE",
+"296 791 LINE"
 );
 }
 );
@@ -40774,8 +45127,8 @@ width = 364;
 );
 },
 {
-glyphname = circumflex.cap;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = circumflex.case;
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -40783,13 +45136,13 @@ paths = (
 {
 closed = 1;
 nodes = (
+"196 784 LINE",
+"328 845 LINE",
+"434 784 LINE",
 "477 784 LINE",
 "375 924 LINE",
 "313 924 LINE",
-"154 784 LINE",
-"196 784 LINE",
-"328 845 LINE",
-"434 784 LINE"
+"154 784 LINE"
 );
 }
 );
@@ -40801,13 +45154,13 @@ paths = (
 {
 closed = 1;
 nodes = (
+"183 791 LINE",
+"325 836 LINE",
+"447 791 LINE",
 "494 791 LINE",
 "371 923 LINE",
 "315 923 LINE",
-"137 791 LINE",
-"183 791 LINE",
-"325 836 LINE",
-"447 791 LINE"
+"137 791 LINE"
 );
 }
 );
@@ -40816,8 +45169,8 @@ width = 363;
 );
 },
 {
-glyphname = dieresis.cap;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = dieresis.case;
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -40825,28 +45178,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"175 869 LINE SMOOTH",
-"175 838 OFFCURVE",
-"199 814 OFFCURVE",
-"230 814 CURVE SMOOTH",
-"260 814 OFFCURVE",
-"285 838 OFFCURVE",
-"285 869 CURVE SMOOTH",
-"285 899 OFFCURVE",
-"260 924 OFFCURVE",
-"230 924 CURVE SMOOTH",
-"199 924 OFFCURVE",
-"175 899 OFFCURVE",
-"175 869 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"365 869 LINE SMOOTH",
-"365 838 OFFCURVE",
-"389 814 OFFCURVE",
-"420 814 CURVE SMOOTH",
 "450 814 OFFCURVE",
 "475 838 OFFCURVE",
 "475 869 CURVE SMOOTH",
@@ -40855,7 +45186,27 @@ nodes = (
 "420 924 CURVE SMOOTH",
 "389 924 OFFCURVE",
 "365 899 OFFCURVE",
-"365 869 CURVE SMOOTH"
+"365 869 CURVE SMOOTH",
+"365 838 OFFCURVE",
+"389 814 OFFCURVE",
+"420 814 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"260 814 OFFCURVE",
+"285 838 OFFCURVE",
+"285 869 CURVE SMOOTH",
+"285 899 OFFCURVE",
+"260 924 OFFCURVE",
+"230 924 CURVE SMOOTH",
+"199 924 OFFCURVE",
+"175 899 OFFCURVE",
+"175 869 CURVE SMOOTH",
+"175 838 OFFCURVE",
+"199 814 OFFCURVE",
+"230 814 CURVE SMOOTH"
 );
 }
 );
@@ -40867,28 +45218,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"169 860 LINE SMOOTH",
-"169 825 OFFCURVE",
-"198 797 OFFCURVE",
-"233 797 CURVE SMOOTH",
-"267 797 OFFCURVE",
-"296 825 OFFCURVE",
-"296 860 CURVE SMOOTH",
-"296 895 OFFCURVE",
-"267 923 OFFCURVE",
-"233 923 CURVE SMOOTH",
-"198 923 OFFCURVE",
-"169 895 OFFCURVE",
-"169 860 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"352 860 LINE SMOOTH",
-"352 825 OFFCURVE",
-"381 797 OFFCURVE",
-"415 797 CURVE SMOOTH",
 "450 797 OFFCURVE",
 "479 825 OFFCURVE",
 "479 860 CURVE SMOOTH",
@@ -40897,7 +45226,27 @@ nodes = (
 "415 923 CURVE SMOOTH",
 "381 923 OFFCURVE",
 "352 895 OFFCURVE",
-"352 860 CURVE SMOOTH"
+"352 860 CURVE SMOOTH",
+"352 825 OFFCURVE",
+"381 797 OFFCURVE",
+"415 797 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"267 797 OFFCURVE",
+"296 825 OFFCURVE",
+"296 860 CURVE SMOOTH",
+"296 895 OFFCURVE",
+"267 923 OFFCURVE",
+"233 923 CURVE SMOOTH",
+"198 923 OFFCURVE",
+"169 895 OFFCURVE",
+"169 860 CURVE SMOOTH",
+"169 825 OFFCURVE",
+"198 797 OFFCURVE",
+"233 797 CURVE SMOOTH"
 );
 }
 );
@@ -40906,8 +45255,8 @@ width = 340;
 );
 },
 {
-glyphname = dotaccent.cap;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = dotaccent.case;
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -40915,10 +45264,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"171 856 LINE SMOOTH",
-"171 818 OFFCURVE",
-"200 789 OFFCURVE",
-"238 789 CURVE SMOOTH",
 "276 789 OFFCURVE",
 "306 818 OFFCURVE",
 "306 856 CURVE SMOOTH",
@@ -40927,7 +45272,10 @@ nodes = (
 "238 924 CURVE SMOOTH",
 "200 924 OFFCURVE",
 "171 894 OFFCURVE",
-"171 856 CURVE SMOOTH"
+"171 856 CURVE SMOOTH",
+"171 818 OFFCURVE",
+"200 789 OFFCURVE",
+"238 789 CURVE SMOOTH"
 );
 }
 );
@@ -40939,10 +45287,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"178 858 LINE SMOOTH",
-"178 823 OFFCURVE",
-"208 793 OFFCURVE",
-"243 793 CURVE SMOOTH",
 "278 793 OFFCURVE",
 "309 823 OFFCURVE",
 "309 858 CURVE SMOOTH",
@@ -40951,7 +45295,10 @@ nodes = (
 "243 924 CURVE SMOOTH",
 "208 924 OFFCURVE",
 "178 893 OFFCURVE",
-"178 858 CURVE SMOOTH"
+"178 858 CURVE SMOOTH",
+"178 823 OFFCURVE",
+"208 793 OFFCURVE",
+"243 793 CURVE SMOOTH"
 );
 }
 );
@@ -40960,8 +45307,8 @@ width = 175;
 );
 },
 {
-glyphname = grave.cap;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = grave.case;
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -40969,7 +45316,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"370 784 LINE",
 "423 784 LINE",
 "284 888 LINE SMOOTH",
 "247 916 OFFCURVE",
@@ -40980,7 +45326,8 @@ nodes = (
 "164 871 CURVE SMOOTH",
 "164 850 OFFCURVE",
 "177 835 OFFCURVE",
-"204 828 CURVE SMOOTH"
+"204 828 CURVE SMOOTH",
+"370 784 LINE"
 );
 }
 );
@@ -41012,8 +45359,8 @@ width = 335;
 );
 },
 {
-glyphname = hungarumlaut.cap;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = hungarumlaut.case;
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -41021,23 +45368,7 @@ paths = (
 {
 closed = 1;
 nodes = (
-"391 823 LINE SMOOTH",
-"438 836 OFFCURVE",
-"460 856 OFFCURVE",
-"460 885 CURVE SMOOTH",
-"460 911 OFFCURVE",
-"445 924 OFFCURVE",
-"422 924 CURVE SMOOTH",
-"402 924 OFFCURVE",
-"379 916 OFFCURVE",
-"346 894 CURVE SMOOTH",
-"165 774 LINE",
-"217 774 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"423 774 LINE",
 "597 823 LINE SMOOTH",
 "644 836 OFFCURVE",
 "666 856 OFFCURVE",
@@ -41048,8 +45379,24 @@ nodes = (
 "608 924 OFFCURVE",
 "585 916 OFFCURVE",
 "552 894 CURVE SMOOTH",
-"371 774 LINE",
-"423 774 LINE"
+"371 774 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"217 774 LINE",
+"391 823 LINE SMOOTH",
+"438 836 OFFCURVE",
+"460 856 OFFCURVE",
+"460 885 CURVE SMOOTH",
+"460 911 OFFCURVE",
+"445 924 OFFCURVE",
+"422 924 CURVE SMOOTH",
+"402 924 OFFCURVE",
+"379 916 OFFCURVE",
+"346 894 CURVE SMOOTH",
+"165 774 LINE"
 );
 }
 );
@@ -41058,23 +45405,6 @@ width = 521;
 {
 layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
 paths = (
-{
-closed = 1;
-nodes = (
-"228 794 LINE",
-"379 830 LINE SMOOTH",
-"413 838 OFFCURVE",
-"428 859 OFFCURVE",
-"428 879 CURVE SMOOTH",
-"428 902 OFFCURVE",
-"409 924 OFFCURVE",
-"376 924 CURVE SMOOTH",
-"350 924 OFFCURVE",
-"328 919 OFFCURVE",
-"296 895 CURVE SMOOTH",
-"165 794 LINE"
-);
-},
 {
 closed = 1;
 nodes = (
@@ -41091,6 +45421,23 @@ nodes = (
 "527 895 CURVE SMOOTH",
 "396 794 LINE"
 );
+},
+{
+closed = 1;
+nodes = (
+"228 794 LINE",
+"379 830 LINE SMOOTH",
+"413 838 OFFCURVE",
+"428 859 OFFCURVE",
+"428 879 CURVE SMOOTH",
+"428 902 OFFCURVE",
+"409 924 OFFCURVE",
+"376 924 CURVE SMOOTH",
+"350 924 OFFCURVE",
+"328 919 OFFCURVE",
+"296 895 CURVE SMOOTH",
+"165 794 LINE"
+);
 }
 );
 width = 540;
@@ -41098,8 +45445,8 @@ width = 540;
 );
 },
 {
-glyphname = macron.cap;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = macron.case;
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -41107,10 +45454,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"179 858 LINE",
 "499 858 LINE",
 "514 924 LINE",
-"194 924 LINE"
+"194 924 LINE",
+"179 858 LINE"
 );
 }
 );
@@ -41122,10 +45469,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"167 837 LINE",
 "507 837 LINE",
 "526 923 LINE",
-"186 923 LINE"
+"186 923 LINE",
+"167 837 LINE"
 );
 }
 );
@@ -41134,8 +45481,8 @@ width = 375;
 );
 },
 {
-glyphname = ring.cap;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = ring.case;
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -41143,7 +45490,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"261 777 LINE SMOOTH",
 "302 777 OFFCURVE",
 "334 811 OFFCURVE",
 "334 852 CURVE SMOOTH",
@@ -41161,19 +45507,18 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"261 891 LINE SMOOTH",
-"282 891 OFFCURVE",
-"301 873 OFFCURVE",
-"301 852 CURVE SMOOTH",
-"301 830 OFFCURVE",
-"283 810 OFFCURVE",
-"261 810 CURVE SMOOTH",
 "239 810 OFFCURVE",
 "220 830 OFFCURVE",
 "220 852 CURVE SMOOTH",
 "220 873 OFFCURVE",
 "240 891 OFFCURVE",
-"261 891 CURVE SMOOTH"
+"261 891 CURVE SMOOTH",
+"282 891 OFFCURVE",
+"301 873 OFFCURVE",
+"301 852 CURVE SMOOTH",
+"301 830 OFFCURVE",
+"283 810 OFFCURVE",
+"261 810 CURVE SMOOTH"
 );
 }
 );
@@ -41185,7 +45530,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"258 783 LINE SMOOTH",
 "302 783 OFFCURVE",
 "329 810 OFFCURVE",
 "329 854 CURVE SMOOTH",
@@ -41203,19 +45547,18 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"258 893 LINE SMOOTH",
-"282 893 OFFCURVE",
-"294 878 OFFCURVE",
-"294 854 CURVE SMOOTH",
-"294 830 OFFCURVE",
-"282 813 OFFCURVE",
-"258 813 CURVE SMOOTH",
 "234 813 OFFCURVE",
 "222 830 OFFCURVE",
 "222 854 CURVE SMOOTH",
 "222 878 OFFCURVE",
 "234 893 OFFCURVE",
-"258 893 CURVE SMOOTH"
+"258 893 CURVE SMOOTH",
+"282 893 OFFCURVE",
+"294 878 OFFCURVE",
+"294 854 CURVE SMOOTH",
+"294 830 OFFCURVE",
+"282 813 OFFCURVE",
+"258 813 CURVE SMOOTH"
 );
 }
 );
@@ -41224,8 +45567,8 @@ width = 220;
 );
 },
 {
-glyphname = tilde.cap;
-lastChange = "2016-08-16 11:12:44 +0000";
+glyphname = tilde.case;
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -41233,16 +45576,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"507 924 LINE",
-"494 901 OFFCURVE",
-"469 873 OFFCURVE",
-"433 873 CURVE SMOOTH",
-"386 873 OFFCURVE",
-"362 921 OFFCURVE",
-"305 921 CURVE SMOOTH",
-"245 921 OFFCURVE",
-"193 868 OFFCURVE",
-"173 796 CURVE",
 "205 796 LINE",
 "218 824 OFFCURVE",
 "245 845 OFFCURVE",
@@ -41252,7 +45585,17 @@ nodes = (
 "408 797 CURVE SMOOTH",
 "464 797 OFFCURVE",
 "515 837 OFFCURVE",
-"541 924 CURVE"
+"541 924 CURVE",
+"507 924 LINE",
+"494 901 OFFCURVE",
+"469 873 OFFCURVE",
+"433 873 CURVE SMOOTH",
+"386 873 OFFCURVE",
+"362 921 OFFCURVE",
+"305 921 CURVE SMOOTH",
+"245 921 OFFCURVE",
+"193 868 OFFCURVE",
+"173 796 CURVE"
 );
 }
 );
@@ -41264,16 +45607,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"514 923 LINE",
-"504 905 OFFCURVE",
-"474 878 OFFCURVE",
-"433 878 CURVE SMOOTH",
-"382 878 OFFCURVE",
-"366 922 OFFCURVE",
-"303 922 CURVE SMOOTH",
-"228 922 OFFCURVE",
-"181 858 OFFCURVE",
-"160 789 CURVE",
 "194 789 LINE",
 "206 814 OFFCURVE",
 "237 834 OFFCURVE",
@@ -41283,7 +45616,17 @@ nodes = (
 "405 790 CURVE SMOOTH",
 "475 790 OFFCURVE",
 "522 843 OFFCURVE",
-"550 923 CURVE"
+"550 923 CURVE",
+"514 923 LINE",
+"504 905 OFFCURVE",
+"474 878 OFFCURVE",
+"433 878 CURVE SMOOTH",
+"382 878 OFFCURVE",
+"366 922 OFFCURVE",
+"303 922 CURVE SMOOTH",
+"228 922 OFFCURVE",
+"181 858 OFFCURVE",
+"160 789 CURVE"
 );
 }
 );
@@ -41292,8 +45635,439 @@ width = 408;
 );
 },
 {
+glyphname = brevecomb_acutecomb;
+lastChange = "2016-08-22 14:12:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{359, 450}";
+},
+{
+name = top;
+position = "{402, 713}";
+}
+);
+components = (
+{
+name = brevecomb;
+},
+{
+alignment = -1;
+name = acutecomb;
+transform = "{1, 0, 0, 1, 63, 108}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{357, 450}";
+},
+{
+name = top;
+position = "{497, 863}";
+}
+);
+components = (
+{
+name = brevecomb;
+},
+{
+alignment = -1;
+name = acutecomb;
+transform = "{1, 0, 0, 1, 58, 181}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 600;
+}
+);
+},
+{
+glyphname = brevecomb_gravecomb;
+lastChange = "2016-08-22 14:12:29 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{373, 450}";
+},
+{
+name = top;
+position = "{403, 824}";
+}
+);
+components = (
+{
+name = brevecomb;
+},
+{
+alignment = -1;
+name = gravecomb;
+transform = "{1, 0, 0, 1, -11, 136}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{370, 450}";
+},
+{
+name = top;
+position = "{416, 860}";
+}
+);
+components = (
+{
+name = brevecomb;
+},
+{
+alignment = -1;
+name = gravecomb;
+transform = "{1, 0, 0, 1, 5, 169}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 600;
+}
+);
+},
+{
+glyphname = brevecomb_hookabovecomb;
+lastChange = "2016-08-22 14:12:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{377, 450}";
+},
+{
+name = top;
+position = "{441, 821}";
+}
+);
+components = (
+{
+name = brevecomb;
+},
+{
+alignment = -1;
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 51, 136}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{350, 450}";
+},
+{
+name = top;
+position = "{447, 867}";
+}
+);
+components = (
+{
+name = brevecomb;
+},
+{
+alignment = -1;
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 51, 180}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 600;
+}
+);
+},
+{
+glyphname = brevecomb_tildecomb;
+lastChange = "2016-08-22 14:12:44 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{374, 450}";
+},
+{
+name = top;
+position = "{478, 811}";
+}
+);
+components = (
+{
+name = brevecomb;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, 51, 136}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{380, 450}";
+},
+{
+name = top;
+position = "{474, 854}";
+}
+);
+components = (
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, 19, 0}";
+},
+{
+alignment = -1;
+name = tildecomb;
+transform = "{1, 0, 0, 1, 63, 174}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 600;
+}
+);
+},
+{
+glyphname = circumflexcomb_acutecomb;
+lastChange = "2016-08-22 14:12:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{368, 450}";
+},
+{
+name = top;
+position = "{426, 813}";
+}
+);
+components = (
+{
+name = circumflexcomb;
+},
+{
+alignment = -1;
+name = acutecomb;
+transform = "{1, 0, 0, 1, -49, 106}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{367, 450}";
+},
+{
+name = top;
+position = "{422, 820}";
+}
+);
+components = (
+{
+name = circumflexcomb;
+},
+{
+alignment = -1;
+name = acutecomb;
+transform = "{1, 0, 0, 1, -34, 138}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 600;
+}
+);
+},
+{
+glyphname = circumflexcomb_gravecomb;
+lastChange = "2016-08-22 14:12:55 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{364, 450}";
+},
+{
+name = top;
+position = "{425, 825}";
+}
+);
+components = (
+{
+name = circumflexcomb;
+},
+{
+alignment = -1;
+name = gravecomb;
+transform = "{1, 0, 0, 1, 80, 137}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{363, 450}";
+},
+{
+name = top;
+position = "{431, 814}";
+}
+);
+components = (
+{
+name = circumflexcomb;
+},
+{
+alignment = -1;
+name = gravecomb;
+transform = "{1, 0, 0, 1, 74, 123}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 600;
+}
+);
+},
+{
+glyphname = circumflexcomb_hookabovecomb;
+lastChange = "2016-08-22 14:13:04 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{370, 450}";
+},
+{
+name = top;
+position = "{459, 785}";
+}
+);
+components = (
+{
+name = circumflexcomb;
+},
+{
+alignment = -1;
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 140, 97}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{366, 450}";
+},
+{
+name = top;
+position = "{465, 806}";
+}
+);
+components = (
+{
+name = circumflexcomb;
+},
+{
+alignment = -1;
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 167, 123}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 600;
+}
+);
+},
+{
+glyphname = circumflexcomb_tildecomb;
+lastChange = "2016-08-22 14:13:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{368, 450}";
+},
+{
+name = top;
+position = "{452, 794}";
+}
+);
+components = (
+{
+name = circumflexcomb;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, 29, 119}";
+}
+);
+layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{369, 450}";
+},
+{
+name = top;
+position = "{463, 800}";
+}
+);
+components = (
+{
+name = circumflexcomb;
+},
+{
+alignment = -1;
+name = tildecomb;
+transform = "{1, 0, 0, 1, 31, 120}";
+}
+);
+layerId = "DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC";
+width = 600;
+}
+);
+},
+{
 glyphname = NULL;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -41307,7 +46081,7 @@ width = 0;
 },
 {
 glyphname = espaciador;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 background = {
@@ -41328,10 +46102,10 @@ paths = (
 {
 closed = 1;
 nodes = (
+"-25 -326 LINE",
 "275 924 LINE",
 "168 924 LINE",
-"-132 -326 LINE",
-"-25 -326 LINE"
+"-132 -326 LINE"
 );
 }
 );
@@ -41343,10 +46117,10 @@ paths = (
 {
 closed = 1;
 nodes = (
+"11 -326 LINE",
 "311 924 LINE",
 "168 924 LINE",
-"-132 -326 LINE",
-"11 -326 LINE"
+"-132 -326 LINE"
 );
 }
 );
@@ -41356,7 +46130,7 @@ width = 143;
 },
 {
 glyphname = dotbelow;
-lastChange = "2016-08-16 11:12:44 +0000";
+lastChange = "2016-08-22 14:11:03 +0000";
 layers = (
 {
 layerId = "426C3F01-D24D-4224-A47E-56DA036E4742";
@@ -41364,10 +46138,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"-76 -166 LINE SMOOTH",
-"-76 -204 OFFCURVE",
-"-47 -233 OFFCURVE",
-"-9 -233 CURVE SMOOTH",
 "29 -233 OFFCURVE",
 "59 -204 OFFCURVE",
 "59 -166 CURVE SMOOTH",
@@ -41376,7 +46146,11 @@ nodes = (
 "-9 -98 CURVE SMOOTH",
 "-47 -98 OFFCURVE",
 "-76 -128 OFFCURVE",
-"-76 -166 CURVE SMOOTH"
+"-76 -166 CURVE SMOOTH",
+"-76 -166 LINE SMOOTH",
+"-76 -204 OFFCURVE",
+"-47 -233 OFFCURVE",
+"-9 -233 CURVE SMOOTH"
 );
 }
 );
@@ -41388,10 +46162,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"-91 -180 LINE SMOOTH",
-"-91 -223 OFFCURVE",
-"-54 -260 OFFCURVE",
-"-11 -260 CURVE SMOOTH",
 "33 -260 OFFCURVE",
 "70 -223 OFFCURVE",
 "70 -180 CURVE SMOOTH",
@@ -41400,7 +46170,11 @@ nodes = (
 "-11 -99 CURVE SMOOTH",
 "-54 -99 OFFCURVE",
 "-91 -136 OFFCURVE",
-"-91 -180 CURVE SMOOTH"
+"-91 -180 CURVE SMOOTH",
+"-91 -180 LINE SMOOTH",
+"-91 -223 OFFCURVE",
+"-54 -260 OFFCURVE",
+"-11 -260 CURVE SMOOTH"
 );
 }
 );
@@ -41409,7 +46183,6 @@ width = 175;
 );
 }
 );
-disablesAutomaticAlignment = 1;
 instances = (
 {
 interpolationWeight = 400;
@@ -41418,6 +46191,15 @@ instanceInterpolations = {
 };
 isItalic = 1;
 name = Italic;
+},
+{
+interpolationWeight = 500;
+instanceInterpolations = {
+"426C3F01-D24D-4224-A47E-56DA036E4742" = 0.666667;
+"DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC" = 0.333333;
+};
+name = Medium;
+weightClass = Medium;
 },
 {
 interpolationWeight = 700;
@@ -41455,7 +46237,7 @@ kerning = {
 Q = -24;
 V = -40;
 b = -12;
-guillemotleft = -32;
+guillemetleft = -32;
 guilsinglleft = -32;
 hyphen = 8;
 q = -16;
@@ -41499,7 +46281,7 @@ v = -16;
 "@MMK_R_comma" = 36;
 AE = -8;
 V = -16;
-guillemotleft = 4;
+guillemetleft = 4;
 };
 "@MMK_L_H" = {
 "@MMK_R_comma" = 24;
@@ -41524,7 +46306,7 @@ AE = 8;
 "@MMK_R_o" = 4;
 "@MMK_R_u" = 16;
 "@MMK_R_y" = -72;
-guillemotleft = -64;
+guillemetleft = -64;
 hyphen = -24;
 oslash = 20;
 v = -4;
@@ -41583,7 +46365,7 @@ X = -36;
 "@MMK_R_u" = 12;
 "@MMK_R_y" = -44;
 V = -28;
-guillemotleft = -40;
+guillemetleft = -40;
 hyphen = 8;
 };
 "@MMK_L_S" = {
@@ -41619,8 +46401,8 @@ V = -24;
 "@MMK_R_y" = -112;
 AE = -16;
 V = -24;
-guillemotleft = -120;
-guillemotright = -112;
+guillemetleft = -120;
+guillemetright = -112;
 guilsinglleft = -120;
 hyphen = -76;
 m = -88;
@@ -41657,8 +46439,8 @@ p = -16;
 "@MMK_R_y" = -68;
 AE = -84;
 Oslash = -60;
-guillemotleft = -112;
-guillemotright = -96;
+guillemetleft = -112;
+guillemetright = -96;
 guilsinglleft = -112;
 hyphen = -68;
 oslash = -88;
@@ -41683,8 +46465,8 @@ oslash = -88;
 "@MMK_R_u" = -60;
 AE = 20;
 Oslash = -44;
-guillemotleft = -88;
-guillemotright = -80;
+guillemetleft = -88;
+guillemetright = -80;
 guilsinglleft = -88;
 hyphen = -44;
 m = -52;
@@ -41871,7 +46653,7 @@ P = {
 "@MMK_R_u" = -12;
 "@MMK_R_y" = -28;
 AE = -76;
-guillemotleft = -108;
+guillemetleft = -108;
 hyphen = -72;
 oslash = -76;
 };
@@ -41895,8 +46677,8 @@ V = {
 "@MMK_R_y" = -64;
 AE = -80;
 Oslash = -52;
-guillemotleft = -100;
-guillemotright = -88;
+guillemetleft = -100;
+guillemetright = -88;
 guilsinglleft = -100;
 hyphen = -60;
 oslash = -76;
@@ -41911,8 +46693,8 @@ X = {
 "@MMK_R_u" = 20;
 "@MMK_R_y" = -56;
 Q = -32;
-guillemotleft = -44;
-guillemotright = -20;
+guillemetleft = -44;
+guillemetright = -20;
 };
 eight = {
 one = -20;
@@ -41927,13 +46709,13 @@ four = 20;
 one = -12;
 seven = -28;
 };
-guillemotleft = {
+guillemetleft = {
 "@MMK_R_T" = -108;
 "@MMK_R_W" = -36;
 "@MMK_R_Y" = -88;
 V = -40;
 };
-guillemotright = {
+guillemetright = {
 "@MMK_R_A" = -36;
 "@MMK_R_J" = -44;
 "@MMK_R_T" = -120;
@@ -42104,7 +46886,7 @@ seven = -28;
 Q = -32;
 V = -44;
 b = -8;
-guillemotleft = -40;
+guillemetleft = -40;
 guilsinglleft = -44;
 hyphen = -4;
 q = -20;
@@ -42176,7 +46958,7 @@ AE = -12;
 "@MMK_R_w" = -24;
 "@MMK_R_y" = -84;
 Oslash = -24;
-guillemotleft = -64;
+guillemetleft = -64;
 hyphen = -20;
 oslash = 16;
 v = -20;
@@ -42234,7 +47016,7 @@ X = -36;
 "@MMK_R_e" = -12;
 "@MMK_R_y" = -56;
 V = -28;
-guillemotleft = -36;
+guillemetleft = -36;
 quotedblleft = 12;
 quotedblright = 8;
 quoteleft = 8;
@@ -42272,8 +47054,8 @@ V = -24;
 "@MMK_R_y" = -116;
 AE = -16;
 V = -24;
-guillemotleft = -120;
-guillemotright = -104;
+guillemetleft = -120;
+guillemetright = -104;
 guilsinglleft = -124;
 hyphen = -84;
 m = -88;
@@ -42310,8 +47092,8 @@ p = -16;
 "@MMK_R_y" = -84;
 AE = -104;
 Oslash = -56;
-guillemotleft = -124;
-guillemotright = -92;
+guillemetleft = -124;
+guillemetright = -92;
 guilsinglleft = -128;
 hyphen = -88;
 oslash = -96;
@@ -42334,8 +47116,8 @@ oslash = -96;
 "@MMK_R_s" = -60;
 "@MMK_R_u" = -60;
 Oslash = -48;
-guillemotleft = -92;
-guillemotright = -76;
+guillemetleft = -92;
+guillemetright = -76;
 guilsinglleft = -96;
 hyphen = -64;
 m = -56;
@@ -42529,7 +47311,7 @@ P = {
 "@MMK_R_u" = -4;
 "@MMK_R_y" = -44;
 AE = -96;
-guillemotleft = -116;
+guillemetleft = -116;
 hyphen = -88;
 oslash = -84;
 };
@@ -42553,8 +47335,8 @@ V = {
 "@MMK_R_y" = -76;
 AE = -92;
 Oslash = -52;
-guillemotleft = -112;
-guillemotright = -84;
+guillemetleft = -112;
+guillemetright = -84;
 guilsinglleft = -116;
 hyphen = -76;
 oslash = -88;
@@ -42570,7 +47352,7 @@ X = {
 "@MMK_R_y" = -72;
 Oslash = -20;
 Q = -48;
-guillemotleft = -48;
+guillemetleft = -48;
 hyphen = -12;
 };
 b = {
@@ -42593,13 +47375,13 @@ four = 16;
 one = -16;
 seven = -24;
 };
-guillemotleft = {
+guillemetleft = {
 "@MMK_R_T" = -100;
 "@MMK_R_W" = -24;
 "@MMK_R_Y" = -92;
 V = -36;
 };
-guillemotright = {
+guillemetright = {
 "@MMK_R_A" = -32;
 "@MMK_R_J" = -36;
 "@MMK_R_T" = -116;

--- a/source/v2000 - initial glyphs migration/LibreBodoni Romans version 2.glyphs
+++ b/source/v2000 - initial glyphs migration/LibreBodoni Romans version 2.glyphs
@@ -1,0 +1,58886 @@
+{
+.appVersion = "913";
+copyright = "Copyright (c) 2014, Impallari Type (www.impallari.com)";
+customParameters = (
+{
+name = licenseURL;
+value = "http://scripts.sil.org/OFL";
+},
+{
+name = description;
+value = "Libre Bodoni is a webfont family optimized for body text. Based on 1923 ATF Specimens.";
+},
+{
+name = trademark;
+value = "Libre Bodoni is a trademark of Impallari Type.";
+},
+{
+name = license;
+value = "This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ at: http://scripts.sil.org/OFL";
+},
+{
+name = panose;
+value = (
+2,
+7,
+5,
+3,
+7,
+6,
+0,
+0,
+0,
+3
+);
+}
+);
+date = "2016-08-16 10:50:52 +0000";
+designer = "Pablo Impallari, Rodrigo Fuenzalida";
+designerURL = www.impallari.com;
+familyName = "Libre Bodoni";
+features = (
+{
+code = "sub f f i by f_f_i;\012	sub f f l by f_f_l;\012  sub f f by f_f;\012  sub f i by f_i;\012  sub f l by f_l;\012";
+name = liga;
+},
+{
+code = "sub [zero one two three four five six seven eight nine] [A a]' by [ordfeminine ordfeminine];\012	sub [zero one two three four five six seven eight nine] [O o]' by [ordmasculine ordmasculine];\012	sub [zero one two three four five six seven eight nine] period [A a]' by [ordfeminine ordfeminine];\012	sub [zero one two three four five six seven eight nine] period [O o]' by [ordmasculine ordmasculine];\012";
+name = ordn;
+},
+{
+code = "sub one [slash fraction] two by onehalf;\012	sub one [slash fraction] three by onethird;\012	sub one [slash fraction] four by onequarter;\012	sub one [slash fraction] eight by oneeighth;\012	sub two [slash fraction] three by twothirds;\012	sub three [slash fraction] four by threequarters;\012	sub three [slash fraction] eight by threeeighths;\012	sub five [slash fraction] eight by fiveeighths;\012	sub seven [slash fraction] eight by seveneighths;\012";
+name = frac;
+},
+{
+code = "sub zero by zerosuperior;\012	sub one by onesuperior;\012	sub two by twosuperior;\012	sub three by threesuperior;\012	sub four by foursuperior;\012	sub five by fivesuperior;\012	sub six by sixsuperior;\012	sub seven by sevensuperior;\012	sub eight by eightsuperior;\012	sub nine by ninesuperior;\012";
+name = sups;
+},
+{
+code = "sub zero by zeroinferior;\012	sub one by oneinferior;\012	sub two by twoinferior;\012	sub three by threeinferior;\012	sub four by fourinferior;\012	sub five by fiveinferior;\012	sub six by sixinferior;\012	sub seven by seveninferior;\012	sub eight by eightinferior;\012	sub nine by nineinferior;\012";
+name = sinf;
+},
+{
+code = "sub zero by zero.numerator;\012	sub one by one.numerator;\012	sub two by two.numerator;\012	sub three by three.numerator;\012	sub four by four.numerator;\012	sub five by five.numerator;\012	sub six by six.numerator;\012	sub seven by seven.numerator;\012	sub eight by eight.numerator;\012	sub nine by nine.numerator;\012";
+name = numr;
+},
+{
+code = "sub zero by zero.denominator;\012	sub one by one.denominator;\012	sub two by two.denominator;\012	sub three by three.denominator;\012	sub four by four.denominator;\012	sub five by five.denominator;\012	sub six by six.denominator;\012	sub seven by seven.denominator;\012	sub eight by eight.denominator;\012	sub nine by nine.denominator;\012";
+name = dnom;
+}
+);
+fontMaster = (
+{
+alignmentZones = (
+"{754, 12}",
+"{450, 12}",
+"{0, -12}",
+"{-314, -12}"
+);
+ascender = 754;
+capHeight = 754;
+customParameters = (
+{
+name = typoDescender;
+value = -326;
+},
+{
+name = typoLineGap;
+value = 0;
+},
+{
+name = hheaLineGap;
+value = 0;
+},
+{
+name = hheaAscender;
+value = 924;
+},
+{
+name = typoAscender;
+value = 924;
+},
+{
+name = hheaDescender;
+value = -326;
+},
+{
+name = winDescent;
+value = 326;
+},
+{
+name = winAscent;
+value = 924;
+}
+);
+descender = -314;
+horizontalStems = (
+30
+);
+id = UUID0;
+verticalStems = (
+110
+);
+weightValue = 400;
+xHeight = 450;
+},
+{
+alignmentZones = (
+"{754, 12}",
+"{450, 12}",
+"{0, -12}",
+"{-314, -12}"
+);
+ascender = 754;
+capHeight = 754;
+customParameters = (
+{
+name = typoDescender;
+value = -326;
+},
+{
+name = typoLineGap;
+value = 0;
+},
+{
+name = hheaLineGap;
+value = 0;
+},
+{
+name = hheaAscender;
+value = 924;
+},
+{
+name = typoAscender;
+value = 924;
+},
+{
+name = hheaDescender;
+value = -326;
+},
+{
+name = winDescent;
+value = 326;
+},
+{
+name = winAscent;
+value = 924;
+}
+);
+descender = -314;
+horizontalStems = (
+35
+);
+id = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+verticalStems = (
+138
+);
+weight = Bold;
+weightValue = 700;
+xHeight = 450;
+}
+);
+glyphs = (
+{
+glyphname = A;
+lastChange = "2016-08-22 11:54:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{343, 0}";
+},
+{
+name = ogonek;
+position = "{590, 44}";
+},
+{
+name = top;
+position = "{343, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"508 15 LINE",
+"642 15 LINE",
+"391 763 LINE",
+"361 763 LINE",
+"313 594 LINE",
+"320 565 LINE",
+"324 565 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"388 0 LINE",
+"735 0 LINE",
+"735 25 LINE",
+"388 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"209 236 LINE",
+"533 236 LINE",
+"533 261 LINE",
+"209 261 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"10 0 LINE",
+"254 0 LINE",
+"254 25 LINE",
+"10 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"330 594 LINE",
+"391 763 LINE",
+"361 763 LINE",
+"100 15 LINE",
+"133 15 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"612 15 LINE",
+"361 766 LINE",
+"331 766 LINE",
+"283 594 LINE",
+"290 565 LINE",
+"294 565 LINE",
+"478 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"224 0 LINE",
+"224 25 LINE",
+"-16 25 LINE",
+"-16 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"503 236 LINE",
+"503 261 LINE",
+"179 261 LINE",
+"179 236 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"701 0 LINE",
+"701 25 LINE",
+"358 25 LINE",
+"358 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"103 15 LINE",
+"300 594 LINE",
+"361 766 LINE",
+"331 766 LINE",
+"70 15 LINE"
+);
+}
+);
+width = 686;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{358, 0}";
+},
+{
+name = ogonek;
+position = "{643, 10}";
+},
+{
+name = top;
+position = "{383, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"349 752 OFFCURVE",
+"346 744 OFFCURVE",
+"332 696 CURVE",
+"329 689 OFFCURVE",
+"326 682 OFFCURVE",
+"324 680 CURVE",
+"324 679 OFFCURVE",
+"323 675 OFFCURVE",
+"321 671 CURVE SMOOTH",
+"320 667 OFFCURVE",
+"316 655 OFFCURVE",
+"313 646 CURVE",
+"308 638 OFFCURVE",
+"301 616 OFFCURVE",
+"296 600 CURVE SMOOTH",
+"278 547 OFFCURVE",
+"271 529 OFFCURVE",
+"266 520 CURVE SMOOTH",
+"260 508 OFFCURVE",
+"254 490 OFFCURVE",
+"246 466 CURVE",
+"245 457 OFFCURVE",
+"241 446 OFFCURVE",
+"240 446 CURVE",
+"240 445 OFFCURVE",
+"238 441 OFFCURVE",
+"237 437 CURVE SMOOTH",
+"235 433 OFFCURVE",
+"231 426 OFFCURVE",
+"229 421 CURVE SMOOTH",
+"228 418 OFFCURVE",
+"224 412 OFFCURVE",
+"223 404 CURVE SMOOTH",
+"220 391 OFFCURVE",
+"212 368 OFFCURVE",
+"203 353 CURVE SMOOTH",
+"199 346 OFFCURVE",
+"195 331 OFFCURVE",
+"190 318 CURVE SMOOTH",
+"184 306 OFFCURVE",
+"178 291 OFFCURVE",
+"176 286 CURVE SMOOTH",
+"173 281 OFFCURVE",
+"171 276 OFFCURVE",
+"171 274 CURVE SMOOTH",
+"171 273 OFFCURVE",
+"162 248 OFFCURVE",
+"148 203 CURVE",
+"145 190 OFFCURVE",
+"137 178 OFFCURVE",
+"136 170 CURVE",
+"132 164 OFFCURVE",
+"128 153 OFFCURVE",
+"126 145 CURVE SMOOTH",
+"121 132 OFFCURVE",
+"109 98 OFFCURVE",
+"99 77 CURVE",
+"96 65 OFFCURVE",
+"76 47 OFFCURVE",
+"65 42 CURVE SMOOTH",
+"62 40 OFFCURVE",
+"49 39 OFFCURVE",
+"32 39 CURVE",
+"3 37 OFFCURVE",
+"-3 36 OFFCURVE",
+"-6 27 CURVE SMOOTH",
+"-10 19 OFFCURVE",
+"-8 11 OFFCURVE",
+"-3 5 CURVE",
+"0 0 LINE",
+"62 0 LINE SMOOTH",
+"94 0 OFFCURVE",
+"128 0 OFFCURVE",
+"132 2 CURVE",
+"135 2 OFFCURVE",
+"161 2 OFFCURVE",
+"186 0 CURVE",
+"231 -2 LINE",
+"238 5 LINE",
+"243 8 OFFCURVE",
+"243 12 OFFCURVE",
+"243 19 CURVE SMOOTH",
+"243 36 OFFCURVE",
+"232 42 OFFCURVE",
+"207 44 CURVE",
+"198 44 OFFCURVE",
+"186 44 OFFCURVE",
+"179 42 CURVE",
+"157 39 OFFCURVE",
+"145 45 OFFCURVE",
+"140 64 CURVE",
+"140 69 OFFCURVE",
+"162 111 OFFCURVE",
+"162 132 CURVE",
+"165 139 OFFCURVE",
+"170 148 OFFCURVE",
+"171 156 CURVE",
+"177 173 OFFCURVE",
+"191 194 OFFCURVE",
+"191 198 CURVE",
+"207 206 OFFCURVE",
+"223 207 OFFCURVE",
+"316 207 CURVE SMOOTH",
+"342 207 OFFCURVE",
+"373 209 OFFCURVE",
+"385 209 CURVE",
+"398 211 OFFCURVE",
+"410 211 OFFCURVE",
+"410 209 CURVE",
+"414 206 OFFCURVE",
+"428 181 OFFCURVE",
+"440 140 CURVE SMOOTH",
+"444 132 OFFCURVE",
+"450 114 OFFCURVE",
+"454 100 CURVE SMOOTH",
+"463 72 OFFCURVE",
+"465 59 OFFCURVE",
+"458 50 CURVE SMOOTH",
+"455 45 OFFCURVE",
+"454 45 OFFCURVE",
+"432 45 CURVE SMOOTH",
+"408 44 OFFCURVE",
+"407 44 OFFCURVE",
+"396 37 CURVE SMOOTH",
+"391 34 OFFCURVE",
+"385 28 OFFCURVE",
+"385 25 CURVE",
+"382 19 OFFCURVE",
+"385 8 OFFCURVE",
+"391 3 CURVE SMOOTH",
+"396 0 OFFCURVE",
+"400 0 OFFCURVE",
+"429 0 CURVE",
+"487 2 OFFCURVE",
+"567 0 OFFCURVE",
+"649 0 CURVE",
+"695 -2 OFFCURVE",
+"733 -2 OFFCURVE",
+"736 -2 CURVE SMOOTH",
+"746 -2 OFFCURVE",
+"750 2 OFFCURVE",
+"755 11 CURVE",
+"758 19 OFFCURVE",
+"756 27 OFFCURVE",
+"748 36 CURVE SMOOTH",
+"742 40 LINE",
+"709 40 LINE SMOOTH",
+"689 40 OFFCURVE",
+"675 40 OFFCURVE",
+"674 42 CURVE SMOOTH",
+"674 44 OFFCURVE",
+"671 50 OFFCURVE",
+"667 59 CURVE",
+"666 67 OFFCURVE",
+"661 78 OFFCURVE",
+"659 84 CURVE SMOOTH",
+"658 89 OFFCURVE",
+"653 100 OFFCURVE",
+"649 109 CURVE SMOOTH",
+"647 117 OFFCURVE",
+"641 132 OFFCURVE",
+"636 144 CURVE",
+"633 156 OFFCURVE",
+"624 174 OFFCURVE",
+"619 187 CURVE",
+"616 201 OFFCURVE",
+"609 214 OFFCURVE",
+"608 217 CURVE SMOOTH",
+"605 223 OFFCURVE",
+"602 231 OFFCURVE",
+"600 237 CURVE SMOOTH",
+"597 246 OFFCURVE",
+"594 256 OFFCURVE",
+"591 262 CURVE",
+"589 270 OFFCURVE",
+"582 282 OFFCURVE",
+"579 295 CURVE",
+"575 306 OFFCURVE",
+"571 318 OFFCURVE",
+"567 323 CURVE",
+"558 345 OFFCURVE",
+"550 365 OFFCURVE",
+"546 379 CURVE",
+"535 407 OFFCURVE",
+"521 448 OFFCURVE",
+"516 463 CURVE SMOOTH",
+"512 470 OFFCURVE",
+"505 488 OFFCURVE",
+"500 502 CURVE",
+"474 582 OFFCURVE",
+"463 607 OFFCURVE",
+"457 622 CURVE",
+"450 635 OFFCURVE",
+"447 646 OFFCURVE",
+"432 683 CURVE SMOOTH",
+"429 691 OFFCURVE",
+"425 702 OFFCURVE",
+"424 711 CURVE",
+"416 731 OFFCURVE",
+"405 755 OFFCURVE",
+"399 759 CURVE",
+"395 763 OFFCURVE",
+"391 764 OFFCURVE",
+"377 764 CURVE SMOOTH",
+"362 764 OFFCURVE",
+"360 763 OFFCURVE",
+"357 759 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"312 487 OFFCURVE",
+"333 435 OFFCURVE",
+"345 398 CURVE SMOOTH",
+"349 387 OFFCURVE",
+"356 368 OFFCURVE",
+"358 356 CURVE",
+"363 343 OFFCURVE",
+"368 329 OFFCURVE",
+"370 324 CURVE",
+"373 320 OFFCURVE",
+"377 311 OFFCURVE",
+"379 304 CURVE SMOOTH",
+"380 299 OFFCURVE",
+"382 291 OFFCURVE",
+"383 290 CURVE SMOOTH",
+"387 284 OFFCURVE",
+"393 262 OFFCURVE",
+"393 257 CURVE SMOOTH",
+"393 254 OFFCURVE",
+"393 253 OFFCURVE",
+"391 251 CURVE SMOOTH",
+"388 249 OFFCURVE",
+"355 248 OFFCURVE",
+"337 249 CURVE SMOOTH",
+"313 251 OFFCURVE",
+"265 251 OFFCURVE",
+"254 249 CURVE SMOOTH",
+"251 249 OFFCURVE",
+"241 249 OFFCURVE",
+"232 251 CURVE",
+"209 253 OFFCURVE",
+"206 259 OFFCURVE",
+"216 281 CURVE",
+"220 286 OFFCURVE",
+"226 299 OFFCURVE",
+"229 309 CURVE SMOOTH",
+"232 320 OFFCURVE",
+"238 332 OFFCURVE",
+"240 340 CURVE SMOOTH",
+"243 348 OFFCURVE",
+"248 366 OFFCURVE",
+"256 383 CURVE",
+"279 448 OFFCURVE",
+"297 495 OFFCURVE",
+"299 499 CURVE SMOOTH",
+"301 502 OFFCURVE",
+"305 502 OFFCURVE",
+"307 496 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"666 15 LINE",
+"394 763 LINE",
+"368 763 LINE",
+"300 553 LINE",
+"306 516 LINE",
+"310 516 LINE",
+"493 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"229 0 LINE",
+"229 30 LINE",
+"-15 30 LINE",
+"-15 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"508 204 LINE",
+"508 233 LINE",
+"164 233 LINE",
+"164 204 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"730 0 LINE",
+"730 30 LINE",
+"383 30 LINE",
+"383 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"106 15 LINE",
+"342 604 LINE",
+"394 763 LINE",
+"368 763 LINE",
+"73 15 LINE"
+);
+}
+);
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 0041;
+},
+{
+glyphname = Aacute;
+lastChange = "2016-08-22 11:54:32 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 18, 304}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -7, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 00C1;
+},
+{
+glyphname = Abreve;
+lastChange = "2016-08-22 11:54:32 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, 48, 304}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, 85, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 0102;
+},
+{
+glyphname = Abreveacute;
+lastChange = "2016-08-22 11:54:32 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = brevecomb_acutecomb;
+transform = "{1, 0, 0, 1, 48, 304}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = brevecomb_acutecomb;
+transform = "{1, 0, 0, 1, 85, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 1EAE;
+},
+{
+glyphname = Abrevedotbelow;
+lastChange = "2016-08-22 11:54:32 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 59, 0}";
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, 48, 304}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 65, 0}";
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, 85, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 1EB6;
+},
+{
+glyphname = Abrevegrave;
+lastChange = "2016-08-22 11:54:32 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = brevecomb_gravecomb;
+transform = "{1, 0, 0, 1, 48, 304}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = brevecomb_gravecomb;
+transform = "{1, 0, 0, 1, 85, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 1EB0;
+},
+{
+glyphname = Abrevehookabove;
+lastChange = "2016-08-22 11:54:32 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = brevecomb_hookabovecomb;
+transform = "{1, 0, 0, 1, 48, 304}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = brevecomb_hookabovecomb;
+transform = "{1, 0, 0, 1, 85, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 1EB2;
+},
+{
+glyphname = Abrevetilde;
+lastChange = "2016-08-22 11:54:32 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = brevecomb_tildecomb;
+transform = "{1, 0, 0, 1, 48, 304}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = brevecomb_tildecomb;
+transform = "{1, 0, 0, 1, 85, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 1EB4;
+},
+{
+glyphname = Acircumflex;
+lastChange = "2016-08-22 11:54:32 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 53, 304}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 87, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 00C2;
+},
+{
+glyphname = Acircumflexacute;
+lastChange = "2016-08-22 11:54:32 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = circumflexcomb_acutecomb;
+transform = "{1, 0, 0, 1, 53, 304}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = circumflexcomb_acutecomb;
+transform = "{1, 0, 0, 1, 87, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 1EA4;
+},
+{
+glyphname = Acircumflexdotbelow;
+lastChange = "2016-08-22 11:54:32 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 59, 0}";
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 53, 304}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 65, 0}";
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 87, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 1EAC;
+},
+{
+glyphname = Acircumflexgrave;
+lastChange = "2016-08-22 11:54:32 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = circumflexcomb_gravecomb;
+transform = "{1, 0, 0, 1, 53, 304}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = circumflexcomb_gravecomb;
+transform = "{1, 0, 0, 1, 87, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 1EA6;
+},
+{
+glyphname = Acircumflexhookabove;
+lastChange = "2016-08-22 11:54:32 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = circumflexcomb_hookabovecomb;
+transform = "{1, 0, 0, 1, 53, 304}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = circumflexcomb_hookabovecomb;
+transform = "{1, 0, 0, 1, 87, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 1EA8;
+},
+{
+glyphname = Acircumflextilde;
+lastChange = "2016-08-22 11:54:32 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = circumflexcomb_tildecomb;
+transform = "{1, 0, 0, 1, 53, 304}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = circumflexcomb_tildecomb;
+transform = "{1, 0, 0, 1, 87, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 1EAA;
+},
+{
+glyphname = Adblgrave;
+lastChange = "2016-08-22 12:07:50 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = dblgravecomb.cap;
+transform = "{1, 0, 0, 1, 130, 0}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = dblgravecomb.cap;
+transform = "{1, 0, 0, 1, 115, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 0200;
+},
+{
+glyphname = Adieresis;
+lastChange = "2016-08-22 11:57:59 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = dieresis.case;
+transform = "{1, 0, 0, 1, 179, 0}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = dieresis.case;
+transform = "{1, 0, 0, 1, 213, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 00C4;
+},
+{
+glyphname = Adotbelow;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 59, 0}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 65, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 1EA0;
+},
+{
+glyphname = Agrave;
+lastChange = "2016-08-22 11:54:32 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 56, 304}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 134, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 00C0;
+},
+{
+glyphname = Ahookabove;
+lastChange = "2016-08-22 11:54:32 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 58, 304}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 99, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 1EA2;
+},
+{
+glyphname = Ainvertedbreve;
+lastChange = "2016-08-22 12:07:50 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = breveinvertedcomb.cap;
+transform = "{1, 0, 0, 1, 176, 0}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = breveinvertedcomb.cap;
+transform = "{1, 0, 0, 1, 206, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 0202;
+},
+{
+glyphname = Amacron;
+lastChange = "2016-08-22 11:58:49 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = macron.case;
+transform = "{1, 0, 0, 1, 175, 0}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = macron.case;
+transform = "{1, 0, 0, 1, 211, -1}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 0100;
+},
+{
+glyphname = Aogonek;
+lastChange = "2016-08-22 12:13:03 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = ogonek;
+transform = "{1, 0, 0, 1, 373, -6}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = ogonek;
+transform = "{1, 0, 0, 1, 397, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 0104;
+},
+{
+glyphname = Aring;
+lastChange = "2016-08-22 11:57:38 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = ring.case;
+transform = "{1, 0, 0, 1, 242, 40}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = ring.case;
+transform = "{1, 0, 0, 1, 275, 80}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 00C5;
+},
+{
+glyphname = Aringacute;
+lastChange = "2016-08-22 12:07:50 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = ring.case;
+transform = "{1, 0, 0, 1, 242, 40}";
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 18, 514}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = ring.case;
+transform = "{1, 0, 0, 1, 275, 80}";
+},
+{
+alignment = -1;
+name = acutecomb;
+transform = "{1, 0, 0, 1, 81, 434}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 01FA;
+},
+{
+glyphname = Atilde;
+lastChange = "2016-08-22 11:54:32 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, 52, 304}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, 70, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 00C3;
+},
+{
+glyphname = AE;
+lastChange = "2016-08-22 11:59:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{524, 0}";
+},
+{
+name = top;
+position = "{524, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"379 0 LINE",
+"1010 0 LINE",
+"1010 235 LINE",
+"975 235 LINE",
+"973 123 OFFCURVE",
+"916 25 OFFCURVE",
+"817 25 CURVE SMOOTH",
+"631 25 LINE",
+"631 363 LINE",
+"752 362 OFFCURVE",
+"783 327 OFFCURVE",
+"786 216 CURVE",
+"821 216 LINE",
+"821 526 LINE",
+"786 526 LINE",
+"786 419 OFFCURVE",
+"752 388 OFFCURVE",
+"631 388 CURVE",
+"631 729 LINE",
+"787 729 LINE SMOOTH",
+"886 729 OFFCURVE",
+"943 646 OFFCURVE",
+"945 549 CURVE",
+"980 549 LINE",
+"980 754 LINE",
+"339 754 LINE",
+"339 729 LINE",
+"442 729 LINE",
+"108 25 LINE",
+"10 25 LINE",
+"10 0 LINE",
+"254 0 LINE",
+"254 25 LINE",
+"138 25 LINE",
+"238 236 LINE",
+"497 236 LINE",
+"497 25 LINE",
+"379 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"473 729 LINE",
+"497 729 LINE",
+"497 261 LINE",
+"250 261 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"254 0 LINE",
+"254 25 LINE",
+"138 25 LINE",
+"238 236 LINE",
+"497 236 LINE",
+"497 25 LINE",
+"379 25 LINE",
+"379 0 LINE",
+"1010 0 LINE",
+"1010 235 LINE",
+"975 235 LINE",
+"973 123 OFFCURVE",
+"916 25 OFFCURVE",
+"817 25 CURVE SMOOTH",
+"631 25 LINE",
+"631 363 LINE",
+"752 362 OFFCURVE",
+"783 327 OFFCURVE",
+"786 216 CURVE",
+"821 216 LINE",
+"821 526 LINE",
+"786 526 LINE",
+"786 419 OFFCURVE",
+"752 388 OFFCURVE",
+"631 388 CURVE",
+"631 729 LINE",
+"787 729 LINE SMOOTH",
+"886 729 OFFCURVE",
+"943 646 OFFCURVE",
+"945 549 CURVE",
+"980 549 LINE",
+"980 754 LINE",
+"339 754 LINE",
+"339 729 LINE",
+"442 729 LINE",
+"108 25 LINE",
+"10 25 LINE",
+"10 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"473 729 LINE",
+"497 729 LINE",
+"497 261 LINE",
+"250 261 LINE"
+);
+}
+);
+width = 1047;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{566, 0}";
+},
+{
+name = top;
+position = "{566, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"455 0 LINE",
+"1096 0 LINE",
+"1096 245 LINE",
+"1056 245 LINE",
+"1054 131 OFFCURVE",
+"989 30 OFFCURVE",
+"878 30 CURVE SMOOTH",
+"708 30 LINE",
+"708 356 LINE",
+"837 355 OFFCURVE",
+"885 311 OFFCURVE",
+"887 216 CURVE",
+"927 216 LINE",
+"927 516 LINE",
+"887 516 LINE",
+"885 428 OFFCURVE",
+"837 387 OFFCURVE",
+"708 386 CURVE",
+"708 724 LINE",
+"878 724 LINE SMOOTH",
+"980 724 OFFCURVE",
+"1039 646 OFFCURVE",
+"1041 554 CURVE",
+"1081 554 LINE",
+"1081 754 LINE",
+"385 754 LINE",
+"385 724 LINE",
+"470 724 LINE",
+"102 30 LINE",
+"10 30 LINE",
+"10 0 LINE",
+"254 0 LINE",
+"254 30 LINE",
+"150 30 LINE",
+"257 231 LINE",
+"550 231 LINE",
+"550 30 LINE",
+"455 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"520 724 LINE",
+"550 724 LINE",
+"550 263 LINE",
+"274 263 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"254 0 LINE",
+"254 30 LINE",
+"150 30 LINE",
+"257 231 LINE",
+"550 231 LINE",
+"550 30 LINE",
+"455 30 LINE",
+"455 0 LINE",
+"1096 0 LINE",
+"1096 245 LINE",
+"1056 245 LINE",
+"1054 131 OFFCURVE",
+"989 30 OFFCURVE",
+"878 30 CURVE SMOOTH",
+"708 30 LINE",
+"708 356 LINE",
+"837 355 OFFCURVE",
+"885 311 OFFCURVE",
+"887 216 CURVE",
+"927 216 LINE",
+"927 516 LINE",
+"887 516 LINE",
+"885 428 OFFCURVE",
+"837 387 OFFCURVE",
+"708 386 CURVE",
+"708 724 LINE",
+"878 724 LINE SMOOTH",
+"980 724 OFFCURVE",
+"1039 646 OFFCURVE",
+"1041 554 CURVE",
+"1081 554 LINE",
+"1081 754 LINE",
+"385 754 LINE",
+"385 724 LINE",
+"470 724 LINE",
+"102 30 LINE",
+"10 30 LINE",
+"10 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"520 724 LINE",
+"550 724 LINE",
+"550 263 LINE",
+"274 263 LINE"
+);
+}
+);
+width = 1131;
+}
+);
+leftKerningGroup = AE;
+rightKerningGroup = E;
+unicode = 00C6;
+},
+{
+glyphname = AEacute;
+lastChange = "2016-08-22 11:59:17 +0000";
+layers = (
+{
+components = (
+{
+name = AE;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 199, 304}";
+}
+);
+layerId = UUID0;
+width = 1047;
+},
+{
+components = (
+{
+name = AE;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 176, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 1131;
+}
+);
+leftKerningGroup = AE;
+rightKerningGroup = E;
+unicode = 01FC;
+},
+{
+glyphname = B;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{352, 0}";
+},
+{
+name = top;
+position = "{352, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"127 15 LINE",
+"261 15 LINE",
+"261 754 LINE",
+"127 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"363 382 LINE SMOOTH",
+"516 382 OFFCURVE",
+"638 459 OFFCURVE",
+"638 572 CURVE SMOOTH",
+"638 677 OFFCURVE",
+"534 754 OFFCURVE",
+"403 754 CURVE SMOOTH",
+"17 754 LINE",
+"17 729 LINE",
+"363 729 LINE SMOOTH",
+"451 729 OFFCURVE",
+"493 703 OFFCURVE",
+"493 568 CURVE SMOOTH",
+"493 440 OFFCURVE",
+"455 412 OFFCURVE",
+"363 412 CURVE SMOOTH",
+"230 412 LINE",
+"230 382 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"333 382 LINE",
+"468 382 OFFCURVE",
+"513 344 OFFCURVE",
+"513 209 CURVE SMOOTH",
+"513 59 OFFCURVE",
+"457 25 OFFCURVE",
+"363 25 CURVE SMOOTH",
+"17 25 LINE",
+"17 0 LINE",
+"403 0 LINE SMOOTH",
+"552 0 OFFCURVE",
+"666 83 OFFCURVE",
+"666 204 CURVE SMOOTH",
+"666 345 OFFCURVE",
+"510 412 OFFCURVE",
+"303 412 CURVE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"380 0 LINE SMOOTH",
+"529 0 OFFCURVE",
+"643 83 OFFCURVE",
+"643 204 CURVE SMOOTH",
+"643 345 OFFCURVE",
+"487 412 OFFCURVE",
+"280 412 CURVE",
+"310 382 LINE",
+"445 382 OFFCURVE",
+"490 344 OFFCURVE",
+"490 209 CURVE SMOOTH",
+"490 59 OFFCURVE",
+"434 25 OFFCURVE",
+"340 25 CURVE SMOOTH",
+"-6 25 LINE",
+"-6 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"238 15 LINE",
+"238 754 LINE",
+"104 754 LINE",
+"104 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"340 382 LINE SMOOTH",
+"493 382 OFFCURVE",
+"615 459 OFFCURVE",
+"615 572 CURVE SMOOTH",
+"615 677 OFFCURVE",
+"511 754 OFFCURVE",
+"380 754 CURVE SMOOTH",
+"-6 754 LINE",
+"-6 729 LINE",
+"340 729 LINE SMOOTH",
+"428 729 OFFCURVE",
+"470 703 OFFCURVE",
+"470 568 CURVE SMOOTH",
+"470 440 OFFCURVE",
+"432 412 OFFCURVE",
+"340 412 CURVE SMOOTH",
+"207 412 LINE",
+"207 382 LINE"
+);
+}
+);
+width = 703;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{376, 0}";
+},
+{
+name = top;
+position = "{376, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"30 751 OFFCURVE",
+"25 747 OFFCURVE",
+"24 735 CURVE",
+"22 731 OFFCURVE",
+"24 727 OFFCURVE",
+"29 723 CURVE",
+"33 715 LINE",
+"75 715 LINE SMOOTH",
+"95 715 OFFCURVE",
+"116 715 OFFCURVE",
+"116 715 CURVE",
+"123 714 OFFCURVE",
+"124 702 OFFCURVE",
+"124 658 CURVE SMOOTH",
+"124 635 OFFCURVE",
+"126 609 OFFCURVE",
+"126 604 CURVE SMOOTH",
+"124 499 OFFCURVE",
+"123 394 OFFCURVE",
+"123 362 CURVE SMOOTH",
+"123 341 OFFCURVE",
+"123 307 OFFCURVE",
+"123 285 CURVE SMOOTH",
+"123 264 OFFCURVE",
+"123 225 OFFCURVE",
+"123 197 CURVE SMOOTH",
+"123 170 OFFCURVE",
+"123 127 OFFCURVE",
+"123 105 CURVE SMOOTH",
+"123 62 OFFCURVE",
+"121 41 OFFCURVE",
+"118 37 CURVE SMOOTH",
+"116 34 OFFCURVE",
+"95 34 OFFCURVE",
+"63 36 CURVE SMOOTH",
+"38 37 OFFCURVE",
+"38 37 OFFCURVE",
+"30 33 CURVE",
+"14 21 OFFCURVE",
+"21 -2 OFFCURVE",
+"44 -4 CURVE SMOOTH",
+"47 -4 OFFCURVE",
+"83 -2 OFFCURVE",
+"123 -2 CURVE",
+"162 0 OFFCURVE",
+"252 0 OFFCURVE",
+"321 0 CURVE SMOOTH",
+"418 0 OFFCURVE",
+"456 0 OFFCURVE",
+"481 3 CURVE",
+"515 4 OFFCURVE",
+"539 9 OFFCURVE",
+"558 17 CURVE SMOOTH",
+"561 18 OFFCURVE",
+"572 21 OFFCURVE",
+"575 23 CURVE",
+"594 29 OFFCURVE",
+"627 47 OFFCURVE",
+"641 59 CURVE SMOOTH",
+"685 91 OFFCURVE",
+"717 156 OFFCURVE",
+"714 206 CURVE SMOOTH",
+"712 233 OFFCURVE",
+"707 249 OFFCURVE",
+"699 271 CURVE",
+"687 292 OFFCURVE",
+"674 312 OFFCURVE",
+"660 321 CURVE SMOOTH",
+"653 326 OFFCURVE",
+"643 333 OFFCURVE",
+"640 337 CURVE",
+"629 346 OFFCURVE",
+"600 361 OFFCURVE",
+"577 370 CURVE SMOOTH",
+"559 376 OFFCURVE",
+"523 386 OFFCURVE",
+"504 389 CURVE SMOOTH",
+"497 390 OFFCURVE",
+"490 390 OFFCURVE",
+"490 392 CURVE",
+"485 394 OFFCURVE",
+"494 398 OFFCURVE",
+"509 400 CURVE",
+"530 405 OFFCURVE",
+"575 422 OFFCURVE",
+"592 430 CURVE SMOOTH",
+"615 443 OFFCURVE",
+"653 479 OFFCURVE",
+"663 499 CURVE",
+"671 512 OFFCURVE",
+"679 535 OFFCURVE",
+"679 546 CURVE",
+"682 561 OFFCURVE",
+"681 594 OFFCURVE",
+"678 608 CURVE SMOOTH",
+"671 635 OFFCURVE",
+"656 661 OFFCURVE",
+"633 683 CURVE",
+"621 696 OFFCURVE",
+"592 715 OFFCURVE",
+"588 715 CURVE SMOOTH",
+"588 715 OFFCURVE",
+"583 717 OFFCURVE",
+"575 721 CURVE SMOOTH",
+"542 735 OFFCURVE",
+"504 745 OFFCURVE",
+"471 748 CURVE",
+"462 748 OFFCURVE",
+"395 748 OFFCURVE",
+"321 750 CURVE",
+"249 750 OFFCURVE",
+"177 750 OFFCURVE",
+"161 751 CURVE SMOOTH",
+"107 753 OFFCURVE",
+"58 753 OFFCURVE",
+"46 751 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"445 707 OFFCURVE",
+"450 704 OFFCURVE",
+"462 694 CURVE SMOOTH",
+"488 674 OFFCURVE",
+"496 632 OFFCURVE",
+"492 540 CURVE SMOOTH",
+"489 486 OFFCURVE",
+"484 461 OFFCURVE",
+"469 441 CURVE",
+"465 433 OFFCURVE",
+"448 420 OFFCURVE",
+"440 415 CURVE",
+"428 411 OFFCURVE",
+"411 409 OFFCURVE",
+"356 409 CURVE SMOOTH",
+"304 409 OFFCURVE",
+"298 409 OFFCURVE",
+"295 412 CURVE SMOOTH",
+"293 415 OFFCURVE",
+"292 425 OFFCURVE",
+"292 527 CURVE SMOOTH",
+"292 587 OFFCURVE",
+"292 653 OFFCURVE",
+"293 673 CURVE",
+"293 707 OFFCURVE",
+"293 709 OFFCURVE",
+"298 712 CURVE SMOOTH",
+"301 715 OFFCURVE",
+"306 715 OFFCURVE",
+"362 715 CURVE SMOOTH",
+"414 715 OFFCURVE",
+"423 714 OFFCURVE",
+"433 710 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"427 370 OFFCURVE",
+"433 370 OFFCURVE",
+"440 365 CURVE SMOOTH",
+"443 364 OFFCURVE",
+"450 362 OFFCURVE",
+"454 359 CURVE SMOOTH",
+"457 357 OFFCURVE",
+"462 354 OFFCURVE",
+"466 353 CURVE SMOOTH",
+"472 349 OFFCURVE",
+"485 337 OFFCURVE",
+"492 329 CURVE",
+"514 308 OFFCURVE",
+"514 280 OFFCURVE",
+"514 217 CURVE",
+"515 198 OFFCURVE",
+"512 148 OFFCURVE",
+"507 116 CURVE",
+"504 90 OFFCURVE",
+"497 75 OFFCURVE",
+"481 59 CURVE SMOOTH",
+"469 45 OFFCURVE",
+"462 42 OFFCURVE",
+"440 37 CURVE",
+"430 36 OFFCURVE",
+"411 36 OFFCURVE",
+"362 36 CURVE SMOOTH",
+"300 36 OFFCURVE",
+"300 36 OFFCURVE",
+"295 39 CURVE SMOOTH",
+"292 42 OFFCURVE",
+"292 47 OFFCURVE",
+"292 116 CURVE SMOOTH",
+"292 157 OFFCURVE",
+"292 228 OFFCURVE",
+"292 275 CURVE",
+"290 333 OFFCURVE",
+"292 361 OFFCURVE",
+"293 364 CURVE SMOOTH",
+"296 376 OFFCURVE",
+"301 376 OFFCURVE",
+"354 376 CURVE",
+"380 374 OFFCURVE",
+"407 373 OFFCURVE",
+"413 373 CURVE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"428 0 LINE SMOOTH",
+"586 0 OFFCURVE",
+"706 60 OFFCURVE",
+"706 194 CURVE SMOOTH",
+"706 345 OFFCURVE",
+"558 402 OFFCURVE",
+"341 402 CURVE",
+"371 367 LINE",
+"489 367 OFFCURVE",
+"528 332 OFFCURVE",
+"528 206 CURVE SMOOTH",
+"528 63 OFFCURVE",
+"475 30 OFFCURVE",
+"388 30 CURVE SMOOTH",
+"25 30 LINE",
+"25 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"283 15 LINE",
+"283 754 LINE",
+"125 754 LINE",
+"125 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"388 367 LINE SMOOTH",
+"559 367 OFFCURVE",
+"678 434 OFFCURVE",
+"678 565 CURVE SMOOTH",
+"678 691 OFFCURVE",
+"568 754 OFFCURVE",
+"428 754 CURVE SMOOTH",
+"25 754 LINE",
+"25 724 LINE",
+"388 724 LINE SMOOTH",
+"471 724 OFFCURVE",
+"508 698 OFFCURVE",
+"508 564 CURVE SMOOTH",
+"508 432 OFFCURVE",
+"472 402 OFFCURVE",
+"388 402 CURVE SMOOTH",
+"228 402 LINE",
+"228 367 LINE"
+);
+}
+);
+width = 751;
+}
+);
+unicode = 0042;
+},
+{
+glyphname = C;
+lastChange = "2016-08-22 12:01:59 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{393, 0}";
+},
+{
+name = top;
+position = "{397, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"458 -12 OFFCURVE",
+"525 6 OFFCURVE",
+"578 46 CURVE",
+"612 0 LINE",
+"637 0 LINE",
+"637 212 LINE",
+"612 212 LINE",
+"588 103 OFFCURVE",
+"531 18 OFFCURVE",
+"393 18 CURVE SMOOTH",
+"279 18 OFFCURVE",
+"206 87 OFFCURVE",
+"206 377 CURVE SMOOTH",
+"206 667 OFFCURVE",
+"281 736 OFFCURVE",
+"395 736 CURVE SMOOTH",
+"526 736 OFFCURVE",
+"581 640 OFFCURVE",
+"603 528 CURVE",
+"628 528 LINE",
+"628 754 LINE",
+"603 754 LINE",
+"564 704 LINE",
+"513 747 OFFCURVE",
+"459 766 OFFCURVE",
+"396 766 CURVE SMOOTH",
+"200 766 OFFCURVE",
+"46 583 OFFCURVE",
+"46 377 CURVE SMOOTH",
+"46 171 OFFCURVE",
+"197 -12 OFFCURVE",
+"393 -12 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"458 -12 OFFCURVE",
+"525 6 OFFCURVE",
+"578 46 CURVE",
+"612 0 LINE",
+"637 0 LINE",
+"637 212 LINE",
+"612 212 LINE",
+"588 103 OFFCURVE",
+"531 18 OFFCURVE",
+"393 18 CURVE SMOOTH",
+"279 18 OFFCURVE",
+"206 87 OFFCURVE",
+"206 377 CURVE SMOOTH",
+"206 667 OFFCURVE",
+"281 736 OFFCURVE",
+"395 736 CURVE SMOOTH",
+"526 736 OFFCURVE",
+"581 640 OFFCURVE",
+"603 528 CURVE",
+"628 528 LINE",
+"628 754 LINE",
+"603 754 LINE",
+"564 704 LINE",
+"513 747 OFFCURVE",
+"459 766 OFFCURVE",
+"396 766 CURVE SMOOTH",
+"200 766 OFFCURVE",
+"46 583 OFFCURVE",
+"46 377 CURVE SMOOTH",
+"46 171 OFFCURVE",
+"197 -12 OFFCURVE",
+"393 -12 CURVE SMOOTH"
+);
+}
+);
+width = 687;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{412, -3}";
+},
+{
+name = top;
+position = "{410, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"476 -13 OFFCURVE",
+"534 4 OFFCURVE",
+"592 46 CURVE",
+"636 0 LINE",
+"666 0 LINE",
+"666 217 LINE",
+"636 217 LINE",
+"613 112 OFFCURVE",
+"549 22 OFFCURVE",
+"413 22 CURVE SMOOTH",
+"297 22 OFFCURVE",
+"240 86 OFFCURVE",
+"240 361 CURVE SMOOTH",
+"240 672 OFFCURVE",
+"313 728 OFFCURVE",
+"412 728 CURVE SMOOTH",
+"537 728 OFFCURVE",
+"600 639 OFFCURVE",
+"622 523 CURVE",
+"652 523 LINE",
+"652 754 LINE",
+"627 754 LINE",
+"583 704 LINE",
+"530 744 OFFCURVE",
+"485 763 OFFCURVE",
+"416 763 CURVE SMOOTH",
+"201 763 OFFCURVE",
+"50 577 OFFCURVE",
+"50 372 CURVE SMOOTH",
+"50 167 OFFCURVE",
+"202 -13 OFFCURVE",
+"412 -13 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"476 -13 OFFCURVE",
+"534 4 OFFCURVE",
+"592 46 CURVE",
+"636 0 LINE",
+"666 0 LINE",
+"666 217 LINE",
+"636 217 LINE",
+"613 112 OFFCURVE",
+"549 22 OFFCURVE",
+"413 22 CURVE SMOOTH",
+"297 22 OFFCURVE",
+"240 86 OFFCURVE",
+"240 361 CURVE SMOOTH",
+"240 672 OFFCURVE",
+"313 728 OFFCURVE",
+"412 728 CURVE SMOOTH",
+"537 728 OFFCURVE",
+"600 639 OFFCURVE",
+"622 523 CURVE",
+"652 523 LINE",
+"652 754 LINE",
+"627 754 LINE",
+"583 704 LINE",
+"530 744 OFFCURVE",
+"485 763 OFFCURVE",
+"416 763 CURVE SMOOTH",
+"201 763 OFFCURVE",
+"50 577 OFFCURVE",
+"50 372 CURVE SMOOTH",
+"50 167 OFFCURVE",
+"202 -13 OFFCURVE",
+"412 -13 CURVE SMOOTH"
+);
+}
+);
+width = 711;
+}
+);
+leftKerningGroup = C;
+rightKerningGroup = C;
+unicode = 0043;
+},
+{
+glyphname = Cacute;
+lastChange = "2016-08-22 12:00:34 +0000";
+layers = (
+{
+components = (
+{
+name = C;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 72, 304}";
+}
+);
+layerId = UUID0;
+width = 687;
+},
+{
+components = (
+{
+name = C;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 20, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 711;
+}
+);
+leftKerningGroup = C;
+rightKerningGroup = C;
+unicode = 0106;
+},
+{
+glyphname = Ccaron;
+lastChange = "2016-08-22 12:07:50 +0000";
+layers = (
+{
+components = (
+{
+name = C;
+},
+{
+name = caron.case;
+transform = "{1, 0, 0, 1, 227, 1}";
+}
+);
+layerId = UUID0;
+width = 687;
+},
+{
+components = (
+{
+name = C;
+},
+{
+name = caron.case;
+transform = "{1, 0, 0, 1, 196, 2}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 711;
+}
+);
+leftKerningGroup = C;
+rightKerningGroup = C;
+unicode = 010C;
+},
+{
+glyphname = Ccedilla;
+lastChange = "2016-08-22 12:01:59 +0000";
+layers = (
+{
+components = (
+{
+name = C;
+},
+{
+name = cedilla;
+transform = "{1, 0, 0, 1, 288, 6}";
+}
+);
+layerId = UUID0;
+width = 687;
+},
+{
+components = (
+{
+name = C;
+},
+{
+name = cedilla;
+transform = "{1, 0, 0, 1, 295, 10}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 711;
+}
+);
+leftKerningGroup = C;
+rightKerningGroup = C;
+unicode = 00C7;
+},
+{
+glyphname = Ccircumflex;
+lastChange = "2016-08-22 12:07:50 +0000";
+layers = (
+{
+components = (
+{
+name = C;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 107, 304}";
+}
+);
+layerId = UUID0;
+width = 687;
+},
+{
+components = (
+{
+name = C;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 114, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 711;
+}
+);
+leftKerningGroup = C;
+rightKerningGroup = C;
+unicode = 0108;
+},
+{
+glyphname = Cdotaccent;
+lastChange = "2016-08-22 12:08:11 +0000";
+layers = (
+{
+components = (
+{
+name = C;
+},
+{
+name = dotaccent.case;
+transform = "{1, 0, 0, 1, 322, 5}";
+}
+);
+layerId = UUID0;
+width = 687;
+},
+{
+components = (
+{
+name = C;
+},
+{
+name = dotaccent.case;
+transform = "{1, 0, 0, 1, 331, 2}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 711;
+}
+);
+leftKerningGroup = C;
+rightKerningGroup = C;
+unicode = 010A;
+},
+{
+glyphname = D;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{389, 0}";
+},
+{
+name = center;
+position = "{389, 377}";
+},
+{
+name = top;
+position = "{389, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"127 15 LINE",
+"261 15 LINE",
+"261 754 LINE",
+"127 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"361 729 LINE SMOOTH",
+"519 729 OFFCURVE",
+"579 662 OFFCURVE",
+"579 379 CURVE SMOOTH",
+"579 91 OFFCURVE",
+"517 25 OFFCURVE",
+"352 25 CURVE SMOOTH",
+"17 25 LINE",
+"17 0 LINE",
+"382 0 LINE SMOOTH",
+"582 0 OFFCURVE",
+"739 180 OFFCURVE",
+"739 380 CURVE SMOOTH",
+"739 578 OFFCURVE",
+"586 754 OFFCURVE",
+"392 754 CURVE SMOOTH",
+"17 754 LINE",
+"17 729 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"376 0 LINE SMOOTH",
+"576 0 OFFCURVE",
+"733 179 OFFCURVE",
+"733 377 CURVE SMOOTH",
+"733 575 OFFCURVE",
+"577 754 OFFCURVE",
+"377 754 CURVE SMOOTH",
+"11 754 LINE",
+"11 729 LINE",
+"345 729 LINE SMOOTH",
+"509 729 OFFCURVE",
+"573 663 OFFCURVE",
+"573 377 CURVE SMOOTH",
+"573 91 OFFCURVE",
+"510 25 OFFCURVE",
+"346 25 CURVE SMOOTH",
+"11 25 LINE",
+"11 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"255 15 LINE",
+"255 754 LINE",
+"121 754 LINE",
+"121 15 LINE"
+);
+}
+);
+width = 777;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{399, 0}";
+},
+{
+name = center;
+position = "{399, 377}";
+},
+{
+name = top;
+position = "{399, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"9 752 OFFCURVE",
+"4 740 OFFCURVE",
+"7 731 CURVE SMOOTH",
+"12 719 OFFCURVE",
+"16 719 OFFCURVE",
+"60 721 CURVE",
+"90 721 OFFCURVE",
+"101 721 OFFCURVE",
+"103 719 CURVE SMOOTH",
+"104 717 OFFCURVE",
+"106 710 OFFCURVE",
+"108 693 CURVE",
+"108 677 OFFCURVE",
+"108 666 OFFCURVE",
+"108 663 CURVE SMOOTH",
+"108 661 OFFCURVE",
+"106 651 OFFCURVE",
+"106 641 CURVE SMOOTH",
+"106 619 OFFCURVE",
+"106 603 OFFCURVE",
+"106 590 CURVE SMOOTH",
+"106 572 OFFCURVE",
+"106 241 OFFCURVE",
+"108 205 CURVE SMOOTH",
+"108 202 OFFCURVE",
+"108 188 OFFCURVE",
+"106 175 CURVE",
+"106 163 OFFCURVE",
+"106 127 OFFCURVE",
+"106 95 CURVE SMOOTH",
+"106 65 OFFCURVE",
+"104 37 OFFCURVE",
+"103 36 CURVE",
+"103 34 OFFCURVE",
+"100 32 OFFCURVE",
+"88 32 CURVE SMOOTH",
+"82 32 OFFCURVE",
+"70 34 OFFCURVE",
+"65 34 CURVE",
+"59 36 OFFCURVE",
+"45 37 OFFCURVE",
+"35 37 CURVE",
+"15 39 LINE",
+"9 32 LINE",
+"2 26 OFFCURVE",
+"2 24 OFFCURVE",
+"2 16 CURVE SMOOTH",
+"2 3 OFFCURVE",
+"14 -4 OFFCURVE",
+"32 -5 CURVE SMOOTH",
+"39 -5 OFFCURVE",
+"92 -2 OFFCURVE",
+"100 -1 CURVE",
+"106 1 OFFCURVE",
+"132 1 OFFCURVE",
+"225 -1 CURVE",
+"373 -2 OFFCURVE",
+"432 -2 OFFCURVE",
+"454 1 CURVE SMOOTH",
+"485 4 OFFCURVE",
+"542 20 OFFCURVE",
+"556 26 CURVE",
+"556 29 OFFCURVE",
+"568 34 OFFCURVE",
+"581 39 CURVE",
+"609 54 OFFCURVE",
+"635 73 OFFCURVE",
+"658 97 CURVE",
+"673 109 OFFCURVE",
+"682 122 OFFCURVE",
+"687 125 CURVE",
+"699 139 OFFCURVE",
+"720 177 OFFCURVE",
+"730 194 CURVE",
+"741 219 OFFCURVE",
+"758 258 OFFCURVE",
+"758 276 CURVE",
+"760 282 OFFCURVE",
+"762 291 OFFCURVE",
+"763 294 CURVE SMOOTH",
+"768 312 OFFCURVE",
+"771 401 OFFCURVE",
+"766 428 CURVE SMOOTH",
+"765 434 OFFCURVE",
+"763 448 OFFCURVE",
+"763 456 CURVE",
+"758 479 OFFCURVE",
+"748 519 OFFCURVE",
+"743 524 CURVE SMOOTH",
+"741 525 OFFCURVE",
+"741 527 OFFCURVE",
+"741 528 CURVE SMOOTH",
+"741 534 OFFCURVE",
+"710 594 OFFCURVE",
+"700 608 CURVE SMOOTH",
+"690 623 OFFCURVE",
+"662 654 OFFCURVE",
+"654 661 CURVE",
+"650 663 OFFCURVE",
+"642 671 OFFCURVE",
+"636 677 CURVE SMOOTH",
+"627 684 OFFCURVE",
+"617 693 OFFCURVE",
+"613 694 CURVE",
+"609 698 OFFCURVE",
+"600 701 OFFCURVE",
+"596 704 CURVE SMOOTH",
+"566 723 OFFCURVE",
+"523 739 OFFCURVE",
+"493 742 CURVE",
+"443 751 OFFCURVE",
+"424 752 OFFCURVE",
+"245 752 CURVE SMOOTH",
+"150 752 OFFCURVE",
+"60 754 OFFCURVE",
+"46 754 CURVE SMOOTH",
+"34 754 OFFCURVE",
+"21 754 OFFCURVE",
+"19 754 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"440 717 LINE",
+"464 710 LINE SMOOTH",
+"481 706 OFFCURVE",
+"492 701 OFFCURVE",
+"492 698 CURVE",
+"495 696 OFFCURVE",
+"498 693 OFFCURVE",
+"501 693 CURVE",
+"501 691 OFFCURVE",
+"511 684 OFFCURVE",
+"520 676 CURVE",
+"542 663 OFFCURVE",
+"542 661 OFFCURVE",
+"542 643 CURVE",
+"545 633 OFFCURVE",
+"548 621 OFFCURVE",
+"550 618 CURVE",
+"550 615 OFFCURVE",
+"551 611 OFFCURVE",
+"553 610 CURVE",
+"553 607 OFFCURVE",
+"556 597 OFFCURVE",
+"556 585 CURVE",
+"558 575 OFFCURVE",
+"559 558 OFFCURVE",
+"561 550 CURVE",
+"564 520 OFFCURVE",
+"566 499 OFFCURVE",
+"566 429 CURVE SMOOTH",
+"567 312 OFFCURVE",
+"566 251 OFFCURVE",
+"561 208 CURVE",
+"559 200 OFFCURVE",
+"558 186 OFFCURVE",
+"556 180 CURVE",
+"553 147 OFFCURVE",
+"545 120 OFFCURVE",
+"536 106 CURVE SMOOTH",
+"518 76 OFFCURVE",
+"500 57 OFFCURVE",
+"482 49 CURVE",
+"460 37 OFFCURVE",
+"432 34 OFFCURVE",
+"357 34 CURVE SMOOTH",
+"336 34 OFFCURVE",
+"319 34 OFFCURVE",
+"318 34 CURVE SMOOTH",
+"288 34 OFFCURVE",
+"286 36 OFFCURVE",
+"286 56 CURVE SMOOTH",
+"286 67 OFFCURVE",
+"286 266 OFFCURVE",
+"286 284 CURVE SMOOTH",
+"286 337 OFFCURVE",
+"286 643 OFFCURVE",
+"286 685 CURVE SMOOTH",
+"286 710 LINE",
+"293 715 LINE",
+"297 721 OFFCURVE",
+"300 721 OFFCURVE",
+"303 721 CURVE SMOOTH",
+"307 721 OFFCURVE",
+"338 719 OFFCURVE",
+"374 719 CURVE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"411 0 LINE SMOOTH",
+"611 0 OFFCURVE",
+"768 180 OFFCURVE",
+"768 380 CURVE SMOOTH",
+"768 578 OFFCURVE",
+"615 754 OFFCURVE",
+"421 754 CURVE SMOOTH",
+"20 754 LINE",
+"20 724 LINE",
+"390 724 LINE SMOOTH",
+"527 724 OFFCURVE",
+"578 657 OFFCURVE",
+"578 379 CURVE SMOOTH",
+"578 95 OFFCURVE",
+"525 30 OFFCURVE",
+"381 30 CURVE SMOOTH",
+"20 30 LINE",
+"20 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"273 15 LINE",
+"273 754 LINE",
+"115 754 LINE",
+"115 15 LINE"
+);
+}
+);
+width = 798;
+}
+);
+leftKerningGroup = D;
+rightKerningGroup = D;
+unicode = 0044;
+},
+{
+glyphname = DZ;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = D;
+},
+{
+name = Z;
+transform = "{1, 0, 0, 1, 777, 0}";
+}
+);
+layerId = UUID0;
+width = 1428;
+},
+{
+components = (
+{
+name = D;
+},
+{
+name = Z;
+transform = "{1, 0, 0, 1, 798, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 1419;
+}
+);
+leftKerningGroup = D;
+rightKerningGroup = Z;
+unicode = 01F1;
+},
+{
+glyphname = DZcaron;
+lastChange = "2016-08-22 12:07:50 +0000";
+layers = (
+{
+components = (
+{
+name = DZ;
+},
+{
+name = caron.case;
+transform = "{1, 0, 0, 1, 933, 1}";
+}
+);
+layerId = UUID0;
+width = 1428;
+},
+{
+components = (
+{
+name = DZ;
+},
+{
+name = caron.case;
+transform = "{1, 0, 0, 1, 895, 2}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 1419;
+}
+);
+leftKerningGroup = D;
+rightKerningGroup = Z;
+unicode = 01C4;
+},
+{
+glyphname = Eth;
+lastChange = "2016-08-22 12:09:32 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"127 15 LINE",
+"261 15 LINE",
+"261 754 LINE",
+"127 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"361 729 LINE SMOOTH",
+"519 729 OFFCURVE",
+"579 662 OFFCURVE",
+"579 379 CURVE SMOOTH",
+"579 91 OFFCURVE",
+"517 25 OFFCURVE",
+"352 25 CURVE SMOOTH",
+"17 25 LINE",
+"17 0 LINE",
+"382 0 LINE SMOOTH",
+"582 0 OFFCURVE",
+"739 180 OFFCURVE",
+"739 380 CURVE SMOOTH",
+"739 578 OFFCURVE",
+"586 754 OFFCURVE",
+"392 754 CURVE SMOOTH",
+"17 754 LINE",
+"17 729 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"16 367 LINE",
+"381 367 LINE",
+"381 402 LINE",
+"16 402 LINE"
+);
+}
+);
+};
+components = (
+{
+name = D;
+},
+{
+name = strokeshortcomb;
+transform = "{1, 0, 0, 1, 389, 377}";
+}
+);
+layerId = UUID0;
+width = 777;
+},
+{
+components = (
+{
+name = D;
+},
+{
+alignment = 1;
+name = strokeshortcomb;
+transform = "{1, 0, 0, 1, -65, 377}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 798;
+}
+);
+rightKerningGroup = D;
+unicode = 00D0;
+},
+{
+glyphname = Dcaron;
+lastChange = "2016-08-22 12:07:50 +0000";
+layers = (
+{
+components = (
+{
+name = D;
+},
+{
+name = caron.case;
+transform = "{1, 0, 0, 1, 219, 1}";
+}
+);
+layerId = UUID0;
+width = 777;
+},
+{
+components = (
+{
+name = D;
+},
+{
+name = caron.case;
+transform = "{1, 0, 0, 1, 185, 2}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 798;
+}
+);
+leftKerningGroup = D;
+rightKerningGroup = D;
+unicode = 010E;
+},
+{
+glyphname = Dcroat;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+components = (
+{
+name = D;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"381 367 LINE",
+"381 402 LINE",
+"16 402 LINE",
+"16 367 LINE"
+);
+}
+);
+width = 777;
+},
+{
+components = (
+{
+name = D;
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"411 361 LINE",
+"411 408 LINE",
+"16 408 LINE",
+"16 361 LINE"
+);
+}
+);
+width = 798;
+}
+);
+rightKerningGroup = D;
+unicode = 0110;
+},
+{
+glyphname = Ddotbelow;
+lastChange = "2016-08-22 11:53:09 +0000";
+layers = (
+{
+components = (
+{
+name = D;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 105, 0}";
+}
+);
+layerId = UUID0;
+width = 777;
+},
+{
+components = (
+{
+name = D;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 106, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 798;
+}
+);
+leftKerningGroup = D;
+rightKerningGroup = D;
+unicode = 1E0C;
+},
+{
+glyphname = Dz;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = D;
+},
+{
+name = z;
+transform = "{1, 0, 0, 1, 777, 0}";
+}
+);
+layerId = UUID0;
+width = 1257;
+},
+{
+components = (
+{
+name = D;
+},
+{
+name = z;
+transform = "{1, 0, 0, 1, 798, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 1274;
+}
+);
+leftKerningGroup = D;
+rightKerningGroup = z;
+unicode = 01F2;
+},
+{
+glyphname = Dzcaron;
+lastChange = "2016-08-22 12:07:50 +0000";
+layers = (
+{
+components = (
+{
+name = Dz;
+},
+{
+name = caron.case;
+transform = "{1, 0, 0, 1, 847, -303}";
+}
+);
+layerId = UUID0;
+width = 1257;
+},
+{
+components = (
+{
+name = Dz;
+},
+{
+name = caron.case;
+transform = "{1, 0, 0, 1, 822, -302}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 1274;
+}
+);
+leftKerningGroup = D;
+rightKerningGroup = z;
+unicode = 01C5;
+},
+{
+glyphname = E;
+lastChange = "2016-08-22 09:54:01 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{346, 0}";
+},
+{
+name = ogonek;
+position = "{622, 10}";
+},
+{
+name = top;
+position = "{346, 754}";
+},
+{
+name = topleft;
+position = "{20, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"126 15 LINE",
+"260 15 LINE",
+"260 744 LINE",
+"126 744 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"450 526 LINE",
+"415 526 LINE",
+"415 418 OFFCURVE",
+"381 388 OFFCURVE",
+"257 388 CURVE",
+"257 363 LINE",
+"381 363 OFFCURVE",
+"412 328 OFFCURVE",
+"415 216 CURVE",
+"450 216 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"8 729 LINE",
+"416 729 LINE SMOOTH",
+"515 729 OFFCURVE",
+"572 646 OFFCURVE",
+"574 549 CURVE",
+"609 549 LINE",
+"609 754 LINE",
+"8 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"8 0 LINE",
+"639 0 LINE",
+"639 235 LINE",
+"604 235 LINE",
+"602 123 OFFCURVE",
+"545 25 OFFCURVE",
+"446 25 CURVE SMOOTH",
+"8 25 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"639 0 LINE",
+"639 235 LINE",
+"604 235 LINE",
+"602 123 OFFCURVE",
+"545 25 OFFCURVE",
+"446 25 CURVE SMOOTH",
+"8 25 LINE",
+"8 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"260 15 LINE",
+"260 744 LINE",
+"126 744 LINE",
+"126 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"450 216 LINE",
+"450 526 LINE",
+"415 526 LINE",
+"415 418 OFFCURVE",
+"381 388 OFFCURVE",
+"257 388 CURVE",
+"257 363 LINE",
+"381 363 OFFCURVE",
+"412 328 OFFCURVE",
+"415 216 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"609 549 LINE",
+"609 754 LINE",
+"8 754 LINE",
+"8 729 LINE",
+"416 729 LINE SMOOTH",
+"515 729 OFFCURVE",
+"572 646 OFFCURVE",
+"574 549 CURVE"
+);
+}
+);
+width = 691;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{348, 0}";
+},
+{
+name = ogonek;
+position = "{626, 10}";
+},
+{
+name = top;
+position = "{348, 754}";
+},
+{
+name = topleft;
+position = "{20, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"115 15 LINE",
+"273 15 LINE",
+"273 754 LINE",
+"115 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 0 LINE",
+"661 0 LINE",
+"661 245 LINE",
+"621 245 LINE",
+"619 131 OFFCURVE",
+"554 30 OFFCURVE",
+"443 30 CURVE SMOOTH",
+"20 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 724 LINE",
+"443 724 LINE SMOOTH",
+"545 724 OFFCURVE",
+"604 646 OFFCURVE",
+"606 554 CURVE",
+"646 554 LINE",
+"646 754 LINE",
+"20 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"269 356 LINE",
+"401 356 OFFCURVE",
+"450 312 OFFCURVE",
+"452 216 CURVE",
+"492 216 LINE",
+"492 516 LINE",
+"452 516 LINE",
+"450 427 OFFCURVE",
+"401 386 OFFCURVE",
+"269 386 CURVE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"661 0 LINE",
+"661 245 LINE",
+"621 245 LINE",
+"619 131 OFFCURVE",
+"554 30 OFFCURVE",
+"443 30 CURVE SMOOTH",
+"20 30 LINE",
+"20 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"273 15 LINE",
+"273 754 LINE",
+"115 754 LINE",
+"115 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"492 216 LINE",
+"492 516 LINE",
+"452 516 LINE",
+"450 427 OFFCURVE",
+"401 386 OFFCURVE",
+"269 386 CURVE",
+"269 356 LINE",
+"401 356 OFFCURVE",
+"450 312 OFFCURVE",
+"452 216 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"646 554 LINE",
+"646 754 LINE",
+"20 754 LINE",
+"20 724 LINE",
+"443 724 LINE SMOOTH",
+"545 724 OFFCURVE",
+"604 646 OFFCURVE",
+"606 554 CURVE"
+);
+}
+);
+width = 696;
+}
+);
+leftKerningGroup = E;
+rightKerningGroup = E;
+unicode = 0045;
+},
+{
+glyphname = Eacute;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = E;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 21, 304}";
+}
+);
+layerId = UUID0;
+width = 691;
+},
+{
+components = (
+{
+name = E;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -42, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 696;
+}
+);
+leftKerningGroup = E;
+rightKerningGroup = E;
+unicode = 00C9;
+},
+{
+glyphname = Ebreve;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = E;
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, 51, 304}";
+}
+);
+layerId = UUID0;
+width = 691;
+},
+{
+components = (
+{
+name = E;
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, 50, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 696;
+}
+);
+leftKerningGroup = E;
+rightKerningGroup = E;
+unicode = 0114;
+},
+{
+glyphname = Ecaron;
+lastChange = "2016-08-22 12:07:50 +0000";
+layers = (
+{
+components = (
+{
+name = E;
+},
+{
+name = caron.case;
+transform = "{1, 0, 0, 1, 176, 1}";
+}
+);
+layerId = UUID0;
+width = 691;
+},
+{
+components = (
+{
+name = E;
+},
+{
+name = caron.case;
+transform = "{1, 0, 0, 1, 134, 2}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 696;
+}
+);
+leftKerningGroup = E;
+rightKerningGroup = E;
+unicode = 011A;
+},
+{
+glyphname = Ecircumflex;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = E;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 56, 304}";
+}
+);
+layerId = UUID0;
+width = 691;
+},
+{
+components = (
+{
+name = E;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 52, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 696;
+}
+);
+leftKerningGroup = E;
+rightKerningGroup = E;
+unicode = 00CA;
+},
+{
+glyphname = Ecircumflexacute;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = E;
+},
+{
+name = circumflexcomb_acutecomb;
+transform = "{1, 0, 0, 1, 56, 304}";
+}
+);
+layerId = UUID0;
+width = 691;
+},
+{
+components = (
+{
+name = E;
+},
+{
+name = circumflexcomb_acutecomb;
+transform = "{1, 0, 0, 1, 52, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 696;
+}
+);
+leftKerningGroup = E;
+rightKerningGroup = E;
+unicode = 1EBE;
+},
+{
+glyphname = Ecircumflexdotbelow;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = E;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 62, 0}";
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 56, 304}";
+}
+);
+layerId = UUID0;
+width = 691;
+},
+{
+components = (
+{
+name = E;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 55, 0}";
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 52, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 696;
+}
+);
+leftKerningGroup = E;
+rightKerningGroup = E;
+unicode = 1EC6;
+},
+{
+glyphname = Ecircumflexgrave;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = E;
+},
+{
+name = circumflexcomb_gravecomb;
+transform = "{1, 0, 0, 1, 56, 304}";
+}
+);
+layerId = UUID0;
+width = 691;
+},
+{
+components = (
+{
+name = E;
+},
+{
+name = circumflexcomb_gravecomb;
+transform = "{1, 0, 0, 1, 52, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 696;
+}
+);
+leftKerningGroup = E;
+rightKerningGroup = E;
+unicode = 1EC0;
+},
+{
+glyphname = Ecircumflexhookabove;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = E;
+},
+{
+name = circumflexcomb_hookabovecomb;
+transform = "{1, 0, 0, 1, 56, 304}";
+}
+);
+layerId = UUID0;
+width = 691;
+},
+{
+components = (
+{
+name = E;
+},
+{
+name = circumflexcomb_hookabovecomb;
+transform = "{1, 0, 0, 1, 52, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 696;
+}
+);
+leftKerningGroup = E;
+rightKerningGroup = E;
+unicode = 1EC2;
+},
+{
+glyphname = Ecircumflextilde;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = E;
+},
+{
+name = circumflexcomb_tildecomb;
+transform = "{1, 0, 0, 1, 56, 304}";
+}
+);
+layerId = UUID0;
+width = 691;
+},
+{
+components = (
+{
+name = E;
+},
+{
+name = circumflexcomb_tildecomb;
+transform = "{1, 0, 0, 1, 52, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 696;
+}
+);
+leftKerningGroup = E;
+rightKerningGroup = E;
+unicode = 1EC4;
+},
+{
+glyphname = Edblgrave;
+lastChange = "2016-08-22 12:07:48 +0000";
+layers = (
+{
+components = (
+{
+name = E;
+},
+{
+name = dblgravecomb.cap;
+transform = "{1, 0, 0, 1, 133, 0}";
+}
+);
+layerId = UUID0;
+width = 691;
+},
+{
+components = (
+{
+name = E;
+},
+{
+name = dblgravecomb.cap;
+transform = "{1, 0, 0, 1, 80, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 696;
+}
+);
+leftKerningGroup = E;
+rightKerningGroup = E;
+unicode = 0204;
+},
+{
+glyphname = Edieresis;
+lastChange = "2016-08-22 12:07:48 +0000";
+layers = (
+{
+components = (
+{
+name = E;
+},
+{
+name = dieresis.case;
+transform = "{1, 0, 0, 1, 182, 0}";
+}
+);
+layerId = UUID0;
+width = 691;
+},
+{
+components = (
+{
+name = E;
+},
+{
+name = dieresis.case;
+transform = "{1, 0, 0, 1, 178, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 696;
+}
+);
+leftKerningGroup = E;
+rightKerningGroup = E;
+unicode = 00CB;
+},
+{
+glyphname = Edotaccent;
+lastChange = "2016-08-22 12:08:14 +0000";
+layers = (
+{
+components = (
+{
+name = E;
+},
+{
+name = dotaccent.case;
+transform = "{1, 0, 0, 1, 271, 5}";
+}
+);
+layerId = UUID0;
+width = 691;
+},
+{
+components = (
+{
+name = E;
+},
+{
+name = dotaccent.case;
+transform = "{1, 0, 0, 1, 269, 2}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 696;
+}
+);
+leftKerningGroup = E;
+rightKerningGroup = E;
+unicode = 0116;
+},
+{
+glyphname = Edotbelow;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = E;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 62, 0}";
+}
+);
+layerId = UUID0;
+width = 691;
+},
+{
+components = (
+{
+name = E;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 55, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 696;
+}
+);
+leftKerningGroup = E;
+rightKerningGroup = E;
+unicode = 1EB8;
+},
+{
+glyphname = Egrave;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = E;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 59, 304}";
+}
+);
+layerId = UUID0;
+width = 691;
+},
+{
+components = (
+{
+name = E;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 99, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 696;
+}
+);
+leftKerningGroup = E;
+rightKerningGroup = E;
+unicode = 00C8;
+},
+{
+glyphname = Ehookabove;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = E;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 61, 304}";
+}
+);
+layerId = UUID0;
+width = 691;
+},
+{
+components = (
+{
+name = E;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 64, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 696;
+}
+);
+leftKerningGroup = E;
+rightKerningGroup = E;
+unicode = 1EBA;
+},
+{
+glyphname = Einvertedbreve;
+lastChange = "2016-08-22 12:07:48 +0000";
+layers = (
+{
+components = (
+{
+name = E;
+},
+{
+name = breveinvertedcomb.cap;
+transform = "{1, 0, 0, 1, 179, 0}";
+}
+);
+layerId = UUID0;
+width = 691;
+},
+{
+components = (
+{
+name = E;
+},
+{
+name = breveinvertedcomb.cap;
+transform = "{1, 0, 0, 1, 171, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 696;
+}
+);
+leftKerningGroup = E;
+rightKerningGroup = E;
+unicode = 0206;
+},
+{
+glyphname = Emacron;
+lastChange = "2016-08-22 12:07:48 +0000";
+layers = (
+{
+components = (
+{
+name = E;
+},
+{
+name = macron.case;
+transform = "{1, 0, 0, 1, 178, 0}";
+}
+);
+layerId = UUID0;
+width = 691;
+},
+{
+components = (
+{
+name = E;
+},
+{
+name = macron.case;
+transform = "{1, 0, 0, 1, 176, -1}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 696;
+}
+);
+leftKerningGroup = E;
+rightKerningGroup = E;
+unicode = 0112;
+},
+{
+glyphname = Eogonek;
+lastChange = "2016-08-22 12:12:51 +0000";
+layers = (
+{
+components = (
+{
+name = E;
+},
+{
+name = ogonek;
+transform = "{1, 0, 0, 1, 323, 0}";
+}
+);
+layerId = UUID0;
+width = 691;
+},
+{
+components = (
+{
+name = E;
+},
+{
+name = ogonek;
+transform = "{1, 0, 0, 1, 356, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 696;
+}
+);
+leftKerningGroup = E;
+rightKerningGroup = E;
+unicode = 0118;
+},
+{
+glyphname = Etilde;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = E;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, 55, 304}";
+}
+);
+layerId = UUID0;
+width = 691;
+},
+{
+components = (
+{
+name = E;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, 35, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 696;
+}
+);
+leftKerningGroup = E;
+rightKerningGroup = E;
+unicode = 1EBC;
+},
+{
+glyphname = F;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{329, 0}";
+},
+{
+name = top;
+position = "{329, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"129 15 LINE",
+"263 15 LINE",
+"263 754 LINE",
+"129 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"11 0 LINE",
+"373 0 LINE",
+"373 25 LINE",
+"11 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"453 526 LINE",
+"418 526 LINE",
+"418 418 OFFCURVE",
+"384 388 OFFCURVE",
+"260 388 CURVE",
+"260 363 LINE",
+"384 363 OFFCURVE",
+"415 328 OFFCURVE",
+"418 216 CURVE",
+"453 216 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"11 729 LINE",
+"429 729 LINE SMOOTH",
+"528 729 OFFCURVE",
+"585 626 OFFCURVE",
+"587 509 CURVE",
+"622 509 LINE",
+"622 754 LINE",
+"11 754 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"622 509 LINE",
+"622 754 LINE",
+"11 754 LINE",
+"11 729 LINE",
+"429 729 LINE SMOOTH",
+"528 729 OFFCURVE",
+"585 626 OFFCURVE",
+"587 509 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"373 0 LINE",
+"373 25 LINE",
+"11 25 LINE",
+"11 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"263 15 LINE",
+"263 754 LINE",
+"129 754 LINE",
+"129 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"453 216 LINE",
+"453 526 LINE",
+"418 526 LINE",
+"418 418 OFFCURVE",
+"384 388 OFFCURVE",
+"260 388 CURVE",
+"260 363 LINE",
+"384 363 OFFCURVE",
+"415 328 OFFCURVE",
+"418 216 CURVE"
+);
+}
+);
+width = 658;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{351, 0}";
+},
+{
+name = top;
+position = "{351, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"115 14 LINE",
+"273 14 LINE",
+"273 754 LINE",
+"115 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 724 LINE",
+"443 724 LINE SMOOTH",
+"545 724 OFFCURVE",
+"604 639 OFFCURVE",
+"606 539 CURVE",
+"646 539 LINE",
+"646 754 LINE",
+"20 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"156 355 LINE",
+"269 355 LINE SMOOTH",
+"401 355 OFFCURVE",
+"450 311 OFFCURVE",
+"452 215 CURVE",
+"492 215 LINE",
+"492 515 LINE",
+"452 515 LINE",
+"450 426 OFFCURVE",
+"401 385 OFFCURVE",
+"269 385 CURVE SMOOTH",
+"156 385 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 0 LINE",
+"401 0 LINE",
+"401 30 LINE",
+"20 30 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"646 539 LINE",
+"646 754 LINE",
+"20 754 LINE",
+"20 724 LINE",
+"443 724 LINE SMOOTH",
+"545 724 OFFCURVE",
+"604 639 OFFCURVE",
+"606 539 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"401 0 LINE",
+"401 30 LINE",
+"20 30 LINE",
+"20 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"273 14 LINE",
+"273 754 LINE",
+"115 754 LINE",
+"115 14 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"492 215 LINE",
+"492 515 LINE",
+"452 515 LINE",
+"450 426 OFFCURVE",
+"401 385 OFFCURVE",
+"269 385 CURVE SMOOTH",
+"269 355 LINE",
+"401 355 OFFCURVE",
+"450 311 OFFCURVE",
+"452 215 CURVE"
+);
+}
+);
+width = 702;
+}
+);
+unicode = 0046;
+},
+{
+glyphname = G;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{369, 0}";
+},
+{
+name = top;
+position = "{369, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"532 -12 OFFCURVE",
+"665 89 OFFCURVE",
+"665 259 CURVE SMOOTH",
+"665 283 LINE",
+"516 283 LINE",
+"516 140 LINE SMOOTH",
+"516 64 OFFCURVE",
+"465 20 OFFCURVE",
+"378 20 CURVE SMOOTH",
+"270 20 OFFCURVE",
+"205 87 OFFCURVE",
+"205 365 CURVE SMOOTH",
+"205 667 OFFCURVE",
+"282 736 OFFCURVE",
+"394 736 CURVE SMOOTH",
+"525 736 OFFCURVE",
+"580 640 OFFCURVE",
+"602 528 CURVE",
+"627 528 LINE",
+"627 754 LINE",
+"602 754 LINE",
+"558 704 LINE",
+"508 747 OFFCURVE",
+"457 766 OFFCURVE",
+"394 766 CURVE SMOOTH",
+"195 766 OFFCURVE",
+"45 579 OFFCURVE",
+"45 370 CURVE SMOOTH",
+"45 177 OFFCURVE",
+"174 -12 OFFCURVE",
+"381 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"393 268 LINE",
+"723 268 LINE",
+"723 293 LINE",
+"393 293 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"532 -12 OFFCURVE",
+"665 89 OFFCURVE",
+"665 259 CURVE SMOOTH",
+"665 283 LINE",
+"516 283 LINE",
+"516 140 LINE SMOOTH",
+"516 64 OFFCURVE",
+"465 20 OFFCURVE",
+"378 20 CURVE SMOOTH",
+"270 20 OFFCURVE",
+"205 87 OFFCURVE",
+"205 365 CURVE SMOOTH",
+"205 667 OFFCURVE",
+"282 736 OFFCURVE",
+"394 736 CURVE SMOOTH",
+"525 736 OFFCURVE",
+"580 640 OFFCURVE",
+"602 528 CURVE",
+"627 528 LINE",
+"627 754 LINE",
+"602 754 LINE",
+"558 704 LINE",
+"508 747 OFFCURVE",
+"457 766 OFFCURVE",
+"394 766 CURVE SMOOTH",
+"195 766 OFFCURVE",
+"45 579 OFFCURVE",
+"45 370 CURVE SMOOTH",
+"45 177 OFFCURVE",
+"174 -12 OFFCURVE",
+"381 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"723 268 LINE",
+"723 293 LINE",
+"393 293 LINE",
+"393 268 LINE"
+);
+}
+);
+width = 737;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{395, 0}";
+},
+{
+name = top;
+position = "{395, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"551 -13 OFFCURVE",
+"657 42 OFFCURVE",
+"701 130 CURVE",
+"701 262 LINE",
+"519 262 LINE",
+"519 145 LINE SMOOTH",
+"519 69 OFFCURVE",
+"477 24 OFFCURVE",
+"395 24 CURVE SMOOTH",
+"296 24 OFFCURVE",
+"240 91 OFFCURVE",
+"240 358 CURVE SMOOTH",
+"240 672 OFFCURVE",
+"317 728 OFFCURVE",
+"420 728 CURVE SMOOTH",
+"557 728 OFFCURVE",
+"612 628 OFFCURVE",
+"632 523 CURVE",
+"662 523 LINE",
+"662 754 LINE",
+"632 754 LINE",
+"593 704 LINE",
+"536 747 OFFCURVE",
+"492 763 OFFCURVE",
+"427 763 CURVE SMOOTH",
+"206 763 OFFCURVE",
+"50 578 OFFCURVE",
+"50 369 CURVE SMOOTH",
+"50 192 OFFCURVE",
+"163 -13 OFFCURVE",
+"419 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"423 250 LINE",
+"778 250 LINE",
+"778 280 LINE",
+"423 280 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"532 -13 OFFCURVE",
+"669 68 OFFCURVE",
+"701 170 CURVE",
+"701 282 LINE",
+"519 282 LINE",
+"519 145 LINE SMOOTH",
+"519 69 OFFCURVE",
+"477 24 OFFCURVE",
+"395 24 CURVE SMOOTH",
+"296 24 OFFCURVE",
+"240 91 OFFCURVE",
+"240 358 CURVE SMOOTH",
+"240 672 OFFCURVE",
+"317 728 OFFCURVE",
+"420 728 CURVE SMOOTH",
+"557 728 OFFCURVE",
+"616 622 OFFCURVE",
+"632 518 CURVE",
+"662 518 LINE",
+"662 754 LINE",
+"632 754 LINE",
+"593 704 LINE",
+"536 747 OFFCURVE",
+"492 763 OFFCURVE",
+"427 763 CURVE SMOOTH",
+"215 763 OFFCURVE",
+"50 589 OFFCURVE",
+"50 367 CURVE SMOOTH",
+"50 155 OFFCURVE",
+"202 -13 OFFCURVE",
+"397 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"778 270 LINE",
+"778 300 LINE",
+"423 300 LINE",
+"423 270 LINE"
+);
+}
+);
+width = 790;
+}
+);
+leftKerningGroup = G;
+rightKerningGroup = G;
+unicode = 0047;
+},
+{
+glyphname = Gacute;
+lastChange = "2016-08-22 11:53:09 +0000";
+layers = (
+{
+components = (
+{
+name = G;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 44, 304}";
+}
+);
+layerId = UUID0;
+width = 737;
+},
+{
+components = (
+{
+name = G;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 5, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 790;
+}
+);
+leftKerningGroup = G;
+rightKerningGroup = G;
+unicode = 01F4;
+},
+{
+glyphname = Gbreve;
+lastChange = "2016-08-22 11:53:09 +0000";
+layers = (
+{
+components = (
+{
+name = G;
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, 74, 304}";
+}
+);
+layerId = UUID0;
+width = 737;
+},
+{
+components = (
+{
+name = G;
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, 97, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 790;
+}
+);
+leftKerningGroup = G;
+rightKerningGroup = G;
+unicode = 011E;
+},
+{
+glyphname = Gcircumflex;
+lastChange = "2016-08-22 11:53:09 +0000";
+layers = (
+{
+components = (
+{
+name = G;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 79, 304}";
+}
+);
+layerId = UUID0;
+width = 737;
+},
+{
+components = (
+{
+name = G;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 99, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 790;
+}
+);
+leftKerningGroup = G;
+rightKerningGroup = G;
+unicode = 011C;
+},
+{
+glyphname = Gcommaaccent;
+lastChange = "2016-08-22 12:07:47 +0000";
+layers = (
+{
+components = (
+{
+name = G;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 283, 0}";
+}
+);
+layerId = UUID0;
+width = 737;
+},
+{
+components = (
+{
+name = G;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 302, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 790;
+}
+);
+leftKerningGroup = G;
+rightKerningGroup = G;
+unicode = 0122;
+},
+{
+glyphname = Gdotaccent;
+lastChange = "2016-08-22 12:08:14 +0000";
+layers = (
+{
+components = (
+{
+name = G;
+},
+{
+name = dotaccent.case;
+transform = "{1, 0, 0, 1, 294, 5}";
+}
+);
+layerId = UUID0;
+width = 737;
+},
+{
+components = (
+{
+name = G;
+},
+{
+name = dotaccent.case;
+transform = "{1, 0, 0, 1, 316, 2}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 790;
+}
+);
+leftKerningGroup = G;
+rightKerningGroup = G;
+unicode = 0120;
+},
+{
+glyphname = H;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{401, 0}";
+},
+{
+name = center;
+position = "{401, 377}";
+},
+{
+name = top;
+position = "{401, 754}";
+},
+{
+name = topleft;
+position = "{20, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"123 15 LINE",
+"257 15 LINE",
+"257 754 LINE",
+"123 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"13 0 LINE",
+"367 0 LINE",
+"367 25 LINE",
+"13 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"13 729 LINE",
+"367 729 LINE",
+"367 754 LINE",
+"13 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"545 15 LINE",
+"679 15 LINE",
+"679 754 LINE",
+"545 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"435 0 LINE",
+"789 0 LINE",
+"789 25 LINE",
+"435 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"435 729 LINE",
+"789 729 LINE",
+"789 754 LINE",
+"435 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"225 375 LINE",
+"580 375 LINE",
+"580 400 LINE",
+"225 400 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"367 0 LINE",
+"367 25 LINE",
+"257 25 LINE",
+"257 375 LINE",
+"545 375 LINE",
+"545 25 LINE",
+"435 25 LINE",
+"435 0 LINE",
+"789 0 LINE",
+"789 25 LINE",
+"679 25 LINE",
+"679 729 LINE",
+"789 729 LINE",
+"789 754 LINE",
+"435 754 LINE",
+"435 729 LINE",
+"545 729 LINE",
+"545 400 LINE",
+"257 400 LINE",
+"257 729 LINE",
+"367 729 LINE",
+"367 754 LINE",
+"13 754 LINE",
+"13 729 LINE",
+"123 729 LINE",
+"123 25 LINE",
+"13 25 LINE",
+"13 0 LINE"
+);
+}
+);
+width = 801;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{413, 0}";
+},
+{
+name = center;
+position = "{413, 377}";
+},
+{
+name = top;
+position = "{413, 754}";
+},
+{
+name = topleft;
+position = "{20, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"115 15 LINE",
+"273 15 LINE",
+"273 754 LINE",
+"115 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 0 LINE",
+"371 0 LINE",
+"371 30 LINE",
+"20 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 724 LINE",
+"371 724 LINE",
+"371 754 LINE",
+"20 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"556 15 LINE",
+"714 15 LINE",
+"714 754 LINE",
+"556 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"458 0 LINE",
+"811 0 LINE",
+"811 30 LINE",
+"458 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"458 724 LINE",
+"811 724 LINE",
+"811 754 LINE",
+"458 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"219 374 LINE",
+"613 374 LINE",
+"613 404 LINE",
+"219 404 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"371 0 LINE",
+"371 30 LINE",
+"273 30 LINE",
+"273 374 LINE",
+"556 374 LINE",
+"556 30 LINE",
+"458 30 LINE",
+"458 0 LINE",
+"811 0 LINE",
+"811 30 LINE",
+"714 30 LINE",
+"714 724 LINE",
+"811 724 LINE",
+"811 754 LINE",
+"458 754 LINE",
+"458 724 LINE",
+"556 724 LINE",
+"556 404 LINE",
+"273 404 LINE",
+"273 724 LINE",
+"371 724 LINE",
+"371 754 LINE",
+"20 754 LINE",
+"20 724 LINE",
+"115 724 LINE",
+"115 30 LINE",
+"20 30 LINE",
+"20 0 LINE"
+);
+}
+);
+width = 826;
+}
+);
+leftKerningGroup = H;
+rightKerningGroup = H;
+unicode = 0048;
+},
+{
+glyphname = Hbar;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+components = (
+{
+name = H;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"789 548 LINE",
+"789 578 LINE",
+"20 578 LINE",
+"20 548 LINE"
+);
+}
+);
+width = 801;
+},
+{
+components = (
+{
+name = H;
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"789 541 LINE",
+"789 578 LINE",
+"20 578 LINE",
+"20 541 LINE"
+);
+}
+);
+width = 826;
+}
+);
+unicode = 0126;
+},
+{
+glyphname = Hcircumflex;
+lastChange = "2016-08-22 11:53:09 +0000";
+layers = (
+{
+components = (
+{
+name = H;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 111, 304}";
+}
+);
+layerId = UUID0;
+width = 801;
+},
+{
+components = (
+{
+name = H;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 117, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 826;
+}
+);
+leftKerningGroup = H;
+rightKerningGroup = H;
+unicode = 0124;
+},
+{
+glyphname = Hdotbelow;
+lastChange = "2016-08-22 11:53:08 +0000";
+layers = (
+{
+components = (
+{
+name = H;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 117, 0}";
+}
+);
+layerId = UUID0;
+width = 801;
+},
+{
+components = (
+{
+name = H;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 120, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 826;
+}
+);
+leftKerningGroup = H;
+rightKerningGroup = H;
+unicode = 1E24;
+},
+{
+glyphname = I;
+lastChange = "2016-08-22 09:51:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{190, 0}";
+},
+{
+name = ogonek;
+position = "{341, 10}";
+},
+{
+name = top;
+position = "{190, 754}";
+},
+{
+name = topleft;
+position = "{20, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"127 15 LINE",
+"261 15 LINE",
+"261 754 LINE",
+"127 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"17 0 LINE",
+"371 0 LINE",
+"371 25 LINE",
+"17 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"17 729 LINE",
+"371 729 LINE",
+"371 754 LINE",
+"17 754 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"257 15 LINE",
+"257 754 LINE",
+"123 754 LINE",
+"123 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"367 0 LINE",
+"367 25 LINE",
+"13 25 LINE",
+"13 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"367 729 LINE",
+"367 754 LINE",
+"13 754 LINE",
+"13 729 LINE"
+);
+}
+);
+width = 379;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{193, 0}";
+},
+{
+name = ogonek;
+position = "{347, 10}";
+},
+{
+name = top;
+position = "{193, 754}";
+},
+{
+name = topleft;
+position = "{20, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"13 729 OFFCURVE",
+"9 713 OFFCURVE",
+"18 702 CURVE",
+"25 697 LINE",
+"58 697 LINE",
+"95 699 OFFCURVE",
+"102 699 OFFCURVE",
+"106 692 CURVE",
+"109 689 OFFCURVE",
+"109 611 OFFCURVE",
+"108 537 CURVE",
+"105 456 OFFCURVE",
+"105 436 OFFCURVE",
+"106 419 CURVE",
+"108 412 OFFCURVE",
+"108 404 OFFCURVE",
+"108 404 CURVE",
+"108 403 OFFCURVE",
+"108 392 OFFCURVE",
+"106 379 CURVE",
+"106 366 OFFCURVE",
+"106 355 OFFCURVE",
+"106 352 CURVE SMOOTH",
+"106 345 OFFCURVE",
+"106 289 OFFCURVE",
+"106 244 CURVE SMOOTH",
+"106 224 OFFCURVE",
+"106 171 OFFCURVE",
+"106 126 CURVE",
+"108 49 OFFCURVE",
+"106 46 OFFCURVE",
+"103 40 CURVE SMOOTH",
+"100 35 LINE",
+"66 35 LINE",
+"23 38 OFFCURVE",
+"18 38 OFFCURVE",
+"13 33 CURVE SMOOTH",
+"2 24 OFFCURVE",
+"5 8 OFFCURVE",
+"18 3 CURVE",
+"23 0 OFFCURVE",
+"29 0 OFFCURVE",
+"45 1 CURVE SMOOTH",
+"77 3 OFFCURVE",
+"265 3 OFFCURVE",
+"290 1 CURVE SMOOTH",
+"338 -2 OFFCURVE",
+"364 -2 OFFCURVE",
+"367 0 CURVE SMOOTH",
+"377 4 OFFCURVE",
+"380 19 OFFCURVE",
+"377 28 CURVE",
+"372 35 OFFCURVE",
+"367 36 OFFCURVE",
+"324 36 CURVE SMOOTH",
+"295 36 OFFCURVE",
+"284 38 OFFCURVE",
+"282 40 CURVE SMOOTH",
+"279 43 OFFCURVE",
+"277 78 OFFCURVE",
+"279 121 CURVE",
+"281 142 OFFCURVE",
+"282 262 OFFCURVE",
+"282 387 CURVE SMOOTH",
+"282 513 OFFCURVE",
+"282 632 OFFCURVE",
+"282 651 CURVE",
+"284 683 OFFCURVE",
+"284 688 OFFCURVE",
+"287 691 CURVE SMOOTH",
+"291 696 OFFCURVE",
+"291 696 OFFCURVE",
+"330 694 CURVE SMOOTH",
+"367 692 OFFCURVE",
+"369 692 OFFCURVE",
+"373 697 CURVE",
+"385 705 OFFCURVE",
+"383 723 OFFCURVE",
+"370 729 CURVE SMOOTH",
+"365 731 OFFCURVE",
+"362 732 OFFCURVE",
+"343 731 CURVE SMOOTH",
+"314 729 OFFCURVE",
+"140 728 OFFCURVE",
+"117 729 CURVE",
+"92 732 OFFCURVE",
+"36 732 OFFCURVE",
+"28 731 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"273 15 LINE",
+"273 754 LINE",
+"115 754 LINE",
+"115 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"371 0 LINE",
+"371 30 LINE",
+"20 30 LINE",
+"20 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"371 724 LINE",
+"371 754 LINE",
+"20 754 LINE",
+"20 724 LINE"
+);
+}
+);
+width = 386;
+}
+);
+leftKerningGroup = I;
+rightKerningGroup = I;
+unicode = 0049;
+},
+{
+glyphname = IJ;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = I;
+},
+{
+name = J;
+transform = "{1, 0, 0, 1, 379, 0}";
+}
+);
+layerId = UUID0;
+width = 839;
+},
+{
+components = (
+{
+name = I;
+},
+{
+name = J;
+transform = "{1, 0, 0, 1, 386, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 772;
+}
+);
+leftKerningGroup = I;
+rightKerningGroup = J;
+unicode = 0132;
+},
+{
+glyphname = Iacute;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = I;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -135, 304}";
+}
+);
+layerId = UUID0;
+width = 379;
+},
+{
+components = (
+{
+name = I;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -197, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 386;
+}
+);
+leftKerningGroup = I;
+rightKerningGroup = I;
+unicode = 00CD;
+},
+{
+glyphname = Ibreve;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = I;
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, -105, 304}";
+}
+);
+layerId = UUID0;
+width = 379;
+},
+{
+components = (
+{
+name = I;
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, -105, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 386;
+}
+);
+leftKerningGroup = I;
+rightKerningGroup = I;
+unicode = 012C;
+},
+{
+glyphname = Icircumflex;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = I;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -100, 304}";
+}
+);
+layerId = UUID0;
+width = 379;
+},
+{
+components = (
+{
+name = I;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -103, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 386;
+}
+);
+leftKerningGroup = I;
+rightKerningGroup = I;
+unicode = 00CE;
+},
+{
+glyphname = Idblgrave;
+lastChange = "2016-08-22 12:07:47 +0000";
+layers = (
+{
+components = (
+{
+name = I;
+},
+{
+name = dblgravecomb.cap;
+transform = "{1, 0, 0, 1, -23, 0}";
+}
+);
+layerId = UUID0;
+width = 379;
+},
+{
+components = (
+{
+name = I;
+},
+{
+name = dblgravecomb.cap;
+transform = "{1, 0, 0, 1, -75, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 386;
+}
+);
+leftKerningGroup = I;
+rightKerningGroup = I;
+unicode = 0208;
+},
+{
+glyphname = Idieresis;
+lastChange = "2016-08-22 12:07:47 +0000";
+layers = (
+{
+components = (
+{
+name = I;
+},
+{
+name = dieresis.case;
+transform = "{1, 0, 0, 1, 26, 0}";
+}
+);
+layerId = UUID0;
+width = 379;
+},
+{
+components = (
+{
+name = I;
+},
+{
+name = dieresis.case;
+transform = "{1, 0, 0, 1, 23, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 386;
+}
+);
+leftKerningGroup = I;
+rightKerningGroup = I;
+unicode = 00CF;
+},
+{
+glyphname = Idotaccent;
+lastChange = "2016-08-22 12:08:14 +0000";
+layers = (
+{
+components = (
+{
+name = I;
+},
+{
+name = dotaccent.case;
+transform = "{1, 0, 0, 1, 115, 5}";
+}
+);
+layerId = UUID0;
+width = 379;
+},
+{
+components = (
+{
+name = I;
+},
+{
+name = dotaccent.case;
+transform = "{1, 0, 0, 1, 114, 2}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 386;
+}
+);
+leftKerningGroup = I;
+rightKerningGroup = I;
+unicode = 0130;
+},
+{
+glyphname = Idotbelow;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = I;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -94, 0}";
+}
+);
+layerId = UUID0;
+width = 379;
+},
+{
+components = (
+{
+name = I;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -100, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 386;
+}
+);
+leftKerningGroup = I;
+rightKerningGroup = I;
+unicode = 1ECA;
+},
+{
+glyphname = Igrave;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = I;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, -97, 304}";
+}
+);
+layerId = UUID0;
+width = 379;
+},
+{
+components = (
+{
+name = I;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, -56, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 386;
+}
+);
+leftKerningGroup = I;
+rightKerningGroup = I;
+unicode = 00CC;
+},
+{
+glyphname = Ihookabove;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = I;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, -95, 304}";
+}
+);
+layerId = UUID0;
+width = 379;
+},
+{
+components = (
+{
+name = I;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, -91, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 386;
+}
+);
+unicode = 1EC8;
+},
+{
+glyphname = Iinvertedbreve;
+lastChange = "2016-08-22 12:07:47 +0000";
+layers = (
+{
+components = (
+{
+name = I;
+},
+{
+name = breveinvertedcomb.cap;
+transform = "{1, 0, 0, 1, 23, 0}";
+}
+);
+layerId = UUID0;
+width = 379;
+},
+{
+components = (
+{
+name = I;
+},
+{
+name = breveinvertedcomb.cap;
+transform = "{1, 0, 0, 1, 16, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 386;
+}
+);
+leftKerningGroup = I;
+rightKerningGroup = I;
+unicode = 020A;
+},
+{
+glyphname = Imacron;
+lastChange = "2016-08-22 12:07:47 +0000";
+layers = (
+{
+components = (
+{
+name = I;
+},
+{
+name = macron.case;
+transform = "{1, 0, 0, 1, 22, 0}";
+}
+);
+layerId = UUID0;
+width = 379;
+},
+{
+components = (
+{
+name = I;
+},
+{
+name = macron.case;
+transform = "{1, 0, 0, 1, 21, -1}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 386;
+}
+);
+leftKerningGroup = I;
+rightKerningGroup = I;
+unicode = 012A;
+},
+{
+glyphname = Iogonek;
+lastChange = "2016-08-22 12:13:41 +0000";
+layers = (
+{
+components = (
+{
+name = I;
+},
+{
+name = ogonek;
+transform = "{1, 0, 0, 1, 34, 0}";
+}
+);
+layerId = UUID0;
+width = 379;
+},
+{
+components = (
+{
+name = I;
+},
+{
+name = ogonek;
+transform = "{1, 0, 0, 1, 39, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 386;
+}
+);
+leftKerningGroup = I;
+rightKerningGroup = I;
+unicode = 012E;
+},
+{
+glyphname = Itilde;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = I;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, -101, 304}";
+}
+);
+layerId = UUID0;
+width = 379;
+},
+{
+components = (
+{
+name = I;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, -120, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 386;
+}
+);
+leftKerningGroup = I;
+rightKerningGroup = I;
+unicode = 0128;
+},
+{
+glyphname = J;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{230, 0}";
+},
+{
+name = top;
+position = "{230, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"46 729 LINE",
+"400 729 LINE",
+"400 754 LINE",
+"46 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"176 125 LINE SMOOTH",
+"176 -33 OFFCURVE",
+"144 -75 OFFCURVE",
+"108 -75 CURVE SMOOTH",
+"95 -75 OFFCURVE",
+"84 -69 OFFCURVE",
+"84 -55 CURVE SMOOTH",
+"84 -37 OFFCURVE",
+"102 -21 OFFCURVE",
+"102 7 CURVE SMOOTH",
+"102 42 OFFCURVE",
+"75 70 OFFCURVE",
+"39 70 CURVE SMOOTH",
+"4 70 OFFCURVE",
+"-29 44 OFFCURVE",
+"-29 -5 CURVE SMOOTH",
+"-29 -63 OFFCURVE",
+"17 -108 OFFCURVE",
+"91 -108 CURVE SMOOTH",
+"204 -108 OFFCURVE",
+"310 -1 OFFCURVE",
+"310 125 CURVE SMOOTH",
+"310 754 LINE",
+"176 754 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"204 -108 OFFCURVE",
+"310 -1 OFFCURVE",
+"310 125 CURVE SMOOTH",
+"310 754 LINE",
+"176 754 LINE",
+"176 125 LINE SMOOTH",
+"176 -33 OFFCURVE",
+"144 -75 OFFCURVE",
+"108 -75 CURVE SMOOTH",
+"95 -75 OFFCURVE",
+"84 -69 OFFCURVE",
+"84 -55 CURVE SMOOTH",
+"84 -37 OFFCURVE",
+"102 -21 OFFCURVE",
+"102 7 CURVE SMOOTH",
+"102 42 OFFCURVE",
+"75 70 OFFCURVE",
+"39 70 CURVE SMOOTH",
+"4 70 OFFCURVE",
+"-29 44 OFFCURVE",
+"-29 -5 CURVE SMOOTH",
+"-29 -63 OFFCURVE",
+"17 -108 OFFCURVE",
+"91 -108 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"400 729 LINE",
+"400 754 LINE",
+"46 754 LINE",
+"46 729 LINE"
+);
+}
+);
+width = 460;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{193, 0}";
+},
+{
+name = top;
+position = "{193, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"273 754 LINE",
+"115 754 LINE",
+"115 27 LINE SMOOTH",
+"115 -45 OFFCURVE",
+"75 -64 OFFCURVE",
+"51 -64 CURVE SMOOTH",
+"38 -64 OFFCURVE",
+"23 -59 OFFCURVE",
+"23 -45 CURVE SMOOTH",
+"23 -31 OFFCURVE",
+"41 -11 OFFCURVE",
+"41 20 CURVE SMOOTH",
+"41 65 OFFCURVE",
+"2 91 OFFCURVE",
+"-35 91 CURVE SMOOTH",
+"-81 91 OFFCURVE",
+"-115 51 OFFCURVE",
+"-115 1 CURVE SMOOTH",
+"-115 -60 OFFCURVE",
+"-63 -102 OFFCURVE",
+"35 -102 CURVE SMOOTH",
+"168 -102 OFFCURVE",
+"273 -24 OFFCURVE",
+"273 137 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 724 LINE",
+"371 724 LINE",
+"371 754 LINE",
+"20 754 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"168 -102 OFFCURVE",
+"273 -24 OFFCURVE",
+"273 137 CURVE SMOOTH",
+"273 754 LINE",
+"115 754 LINE",
+"115 27 LINE SMOOTH",
+"115 -45 OFFCURVE",
+"75 -64 OFFCURVE",
+"51 -64 CURVE SMOOTH",
+"38 -64 OFFCURVE",
+"23 -59 OFFCURVE",
+"23 -45 CURVE SMOOTH",
+"23 -31 OFFCURVE",
+"41 -11 OFFCURVE",
+"41 20 CURVE SMOOTH",
+"41 65 OFFCURVE",
+"2 91 OFFCURVE",
+"-35 91 CURVE SMOOTH",
+"-81 91 OFFCURVE",
+"-115 51 OFFCURVE",
+"-115 1 CURVE SMOOTH",
+"-115 -60 OFFCURVE",
+"-63 -102 OFFCURVE",
+"35 -102 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"371 724 LINE",
+"371 754 LINE",
+"20 754 LINE",
+"20 724 LINE"
+);
+}
+);
+width = 386;
+}
+);
+leftKerningGroup = J;
+rightKerningGroup = J;
+unicode = 004A;
+},
+{
+glyphname = Jcircumflex;
+lastChange = "2016-08-22 11:53:08 +0000";
+layers = (
+{
+components = (
+{
+name = J;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -60, 304}";
+}
+);
+layerId = UUID0;
+width = 460;
+},
+{
+components = (
+{
+name = J;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -103, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 386;
+}
+);
+leftKerningGroup = J;
+rightKerningGroup = J;
+unicode = 0134;
+},
+{
+glyphname = K;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{365, 0}";
+},
+{
+name = top;
+position = "{365, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"13 729 LINE",
+"123 729 LINE",
+"123 25 LINE",
+"13 25 LINE",
+"13 0 LINE",
+"357 0 LINE",
+"357 25 LINE",
+"257 25 LINE",
+"257 729 LINE",
+"357 729 LINE",
+"357 754 LINE",
+"13 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"436 0 LINE",
+"784 0 LINE",
+"784 25 LINE",
+"436 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"555 15 LINE",
+"723 15 LINE",
+"362 469 LINE",
+"267 384 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"438 729 LINE",
+"721 729 LINE",
+"721 754 LINE",
+"438 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"235 361 LINE",
+"235 310 LINE",
+"612 736 LINE",
+"569 736 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"357 0 LINE",
+"357 25 LINE",
+"257 25 LINE",
+"257 729 LINE",
+"357 729 LINE",
+"357 754 LINE",
+"13 754 LINE",
+"13 729 LINE",
+"123 729 LINE",
+"123 25 LINE",
+"13 25 LINE",
+"13 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"784 0 LINE",
+"784 25 LINE",
+"436 25 LINE",
+"436 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"723 15 LINE",
+"362 469 LINE",
+"267 384 LINE",
+"555 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"612 736 LINE",
+"569 736 LINE",
+"235 361 LINE",
+"235 310 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"721 729 LINE",
+"721 754 LINE",
+"438 754 LINE",
+"438 729 LINE"
+);
+}
+);
+width = 729;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{406, 0}";
+},
+{
+name = top;
+position = "{406, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"20 724 LINE",
+"115 724 LINE",
+"115 30 LINE",
+"20 30 LINE",
+"20 0 LINE",
+"371 0 LINE",
+"371 30 LINE",
+"273 30 LINE",
+"273 724 LINE",
+"371 724 LINE",
+"371 754 LINE",
+"20 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"440 0 LINE",
+"826 0 LINE",
+"826 31 LINE",
+"440 31 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"559 15 LINE",
+"757 15 LINE",
+"423 500 LINE",
+"298 385 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"482 724 LINE",
+"765 724 LINE",
+"765 754 LINE",
+"482 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"249 364 LINE",
+"249 314 LINE",
+"659 736 LINE",
+"613 736 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"371 0 LINE",
+"371 30 LINE",
+"273 30 LINE",
+"273 724 LINE",
+"371 724 LINE",
+"371 754 LINE",
+"20 754 LINE",
+"20 724 LINE",
+"115 724 LINE",
+"115 30 LINE",
+"20 30 LINE",
+"20 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"826 0 LINE",
+"826 31 LINE",
+"440 31 LINE",
+"440 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"757 15 LINE",
+"423 500 LINE",
+"298 385 LINE",
+"559 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"659 736 LINE",
+"613 736 LINE",
+"249 364 LINE",
+"249 314 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"765 724 LINE",
+"765 754 LINE",
+"482 754 LINE",
+"482 724 LINE"
+);
+}
+);
+width = 811;
+}
+);
+leftKerningGroup = K;
+rightKerningGroup = K;
+unicode = 004B;
+},
+{
+glyphname = Kcommaaccent;
+lastChange = "2016-08-22 12:07:46 +0000";
+layers = (
+{
+components = (
+{
+name = K;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 279, 0}";
+}
+);
+layerId = UUID0;
+width = 729;
+},
+{
+components = (
+{
+name = K;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 313, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 811;
+}
+);
+leftKerningGroup = K;
+rightKerningGroup = K;
+unicode = 0136;
+},
+{
+glyphname = L;
+lastChange = "2016-08-22 12:04:07 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{331, 0}";
+},
+{
+name = center;
+position = "{331, 377}";
+},
+{
+name = top;
+position = "{192, 754}";
+},
+{
+name = topright;
+position = "{642, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"128 15 LINE",
+"262 15 LINE",
+"262 754 LINE",
+"128 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"10 729 LINE",
+"383 729 LINE",
+"383 754 LINE",
+"10 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"10 0 LINE",
+"626 0 LINE",
+"626 235 LINE",
+"591 235 LINE",
+"589 123 OFFCURVE",
+"532 25 OFFCURVE",
+"433 25 CURVE SMOOTH",
+"10 25 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"629 0 LINE",
+"629 235 LINE",
+"594 235 LINE",
+"592 123 OFFCURVE",
+"535 25 OFFCURVE",
+"436 25 CURVE SMOOTH",
+"13 25 LINE",
+"13 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"265 15 LINE",
+"265 754 LINE",
+"131 754 LINE",
+"131 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"386 729 LINE",
+"386 754 LINE",
+"13 754 LINE",
+"13 729 LINE"
+);
+}
+);
+width = 662;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{341, 0}";
+},
+{
+name = center;
+position = "{341, 377}";
+},
+{
+name = top;
+position = "{186, 754}";
+},
+{
+name = topright;
+position = "{661, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"22 749 OFFCURVE",
+"19 744 OFFCURVE",
+"21 732 CURVE",
+"21 724 OFFCURVE",
+"21 723 OFFCURVE",
+"26 719 CURVE SMOOTH",
+"30 716 OFFCURVE",
+"35 716 OFFCURVE",
+"72 714 CURVE SMOOTH",
+"96 714 OFFCURVE",
+"113 714 OFFCURVE",
+"116 714 CURVE SMOOTH",
+"121 714 OFFCURVE",
+"122 704 OFFCURVE",
+"121 644 CURVE",
+"119 613 OFFCURVE",
+"119 586 OFFCURVE",
+"119 585 CURVE SMOOTH",
+"121 583 OFFCURVE",
+"119 422 OFFCURVE",
+"118 397 CURVE SMOOTH",
+"118 395 OFFCURVE",
+"119 374 OFFCURVE",
+"119 350 CURVE SMOOTH",
+"119 327 OFFCURVE",
+"121 292 OFFCURVE",
+"121 274 CURVE",
+"119 256 OFFCURVE",
+"119 196 OFFCURVE",
+"119 139 CURVE SMOOTH",
+"119 50 OFFCURVE",
+"119 38 OFFCURVE",
+"116 34 CURVE SMOOTH",
+"112 29 LINE",
+"71 29 LINE",
+"27 29 LINE",
+"22 25 LINE",
+"22 17 OFFCURVE",
+"22 3 OFFCURVE",
+"22 -2 CURVE",
+"28 -8 OFFCURVE",
+"34 -10 OFFCURVE",
+"57 -8 CURVE",
+"99 -7 OFFCURVE",
+"260 -5 OFFCURVE",
+"411 -7 CURVE",
+"628 -8 OFFCURVE",
+"649 -8 OFFCURVE",
+"655 -5 CURVE SMOOTH",
+"658 -4 OFFCURVE",
+"661 0 OFFCURVE",
+"664 3 CURVE SMOOTH",
+"666 7 OFFCURVE",
+"666 23 OFFCURVE",
+"666 43 CURVE SMOOTH",
+"666 84 OFFCURVE",
+"669 154 OFFCURVE",
+"672 189 CURVE",
+"677 228 OFFCURVE",
+"677 234 OFFCURVE",
+"670 239 CURVE",
+"666 244 OFFCURVE",
+"664 244 OFFCURVE",
+"653 244 CURVE SMOOTH",
+"639 244 OFFCURVE",
+"632 241 OFFCURVE",
+"628 229 CURVE",
+"622 200 OFFCURVE",
+"616 183 OFFCURVE",
+"605 159 CURVE",
+"597 145 OFFCURVE",
+"592 133 OFFCURVE",
+"592 131 CURVE SMOOTH",
+"592 126 OFFCURVE",
+"562 88 OFFCURVE",
+"544 70 CURVE SMOOTH",
+"534 60 OFFCURVE",
+"512 46 OFFCURVE",
+"503 43 CURVE",
+"495 42 OFFCURVE",
+"489 38 OFFCURVE",
+"484 37 CURVE",
+"473 32 OFFCURVE",
+"464 29 OFFCURVE",
+"392 29 CURVE SMOOTH",
+"358 29 OFFCURVE",
+"325 28 OFFCURVE",
+"320 28 CURVE",
+"310 26 OFFCURVE",
+"310 26 OFFCURVE",
+"304 32 CURVE SMOOTH",
+"301 35 OFFCURVE",
+"300 37 OFFCURVE",
+"300 63 CURVE SMOOTH",
+"300 79 OFFCURVE",
+"300 109 OFFCURVE",
+"300 131 CURVE SMOOTH",
+"300 153 OFFCURVE",
+"301 286 OFFCURVE",
+"301 428 CURVE SMOOTH",
+"301 571 OFFCURVE",
+"301 694 OFFCURVE",
+"301 701 CURVE",
+"303 712 OFFCURVE",
+"303 712 OFFCURVE",
+"309 716 CURVE",
+"309 718 OFFCURVE",
+"317 718 OFFCURVE",
+"335 716 CURVE",
+"344 716 OFFCURVE",
+"365 714 OFFCURVE",
+"376 714 CURVE SMOOTH",
+"399 714 OFFCURVE",
+"399 714 OFFCURVE",
+"404 718 CURVE",
+"404 724 OFFCURVE",
+"404 742 OFFCURVE",
+"404 749 CURVE",
+"401 751 OFFCURVE",
+"386 752 OFFCURVE",
+"317 751 CURVE SMOOTH",
+"196 749 OFFCURVE",
+"122 749 OFFCURVE",
+"55 752 CURVE",
+"47 754 OFFCURVE",
+"38 752 OFFCURVE",
+"32 752 CURVE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"661 0 LINE",
+"661 245 LINE",
+"621 245 LINE",
+"619 131 OFFCURVE",
+"554 30 OFFCURVE",
+"443 30 CURVE SMOOTH",
+"20 30 LINE",
+"20 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"273 15 LINE",
+"273 754 LINE",
+"115 754 LINE",
+"115 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"391 724 LINE",
+"391 754 LINE",
+"20 754 LINE",
+"20 724 LINE"
+);
+}
+);
+width = 681;
+}
+);
+leftKerningGroup = L;
+rightKerningGroup = L;
+unicode = 004C;
+},
+{
+glyphname = LJ;
+lastChange = "2016-08-22 12:11:18 +0000";
+layers = (
+{
+components = (
+{
+name = L;
+},
+{
+alignment = -1;
+name = J;
+transform = "{1, 0, 0, 1, 690, 0}";
+}
+);
+layerId = UUID0;
+width = 1122;
+},
+{
+components = (
+{
+name = L;
+},
+{
+alignment = -1;
+name = J;
+transform = "{1, 0, 0, 1, 815, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 1236;
+}
+);
+leftKerningGroup = L;
+rightKerningGroup = J;
+unicode = 01C7;
+},
+{
+glyphname = Lacute;
+lastChange = "2016-08-22 12:07:46 +0000";
+layers = (
+{
+components = (
+{
+name = L;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -133, 304}";
+}
+);
+layerId = UUID0;
+width = 662;
+},
+{
+components = (
+{
+name = L;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -204, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 681;
+}
+);
+leftKerningGroup = L;
+rightKerningGroup = L;
+unicode = 0139;
+},
+{
+glyphname = Lcaron;
+lastChange = "2016-08-22 12:04:07 +0000";
+layers = (
+{
+components = (
+{
+name = L;
+},
+{
+name = caron.case;
+transform = "{1, 0, 0, 1, 22, 1}";
+}
+);
+layerId = UUID0;
+width = 662;
+},
+{
+components = (
+{
+name = L;
+},
+{
+name = caron.case;
+transform = "{1, 0, 0, 1, -28, 2}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 681;
+}
+);
+leftKerningGroup = L;
+unicode = 013D;
+},
+{
+glyphname = Lcommaaccent;
+lastChange = "2016-08-22 12:07:46 +0000";
+layers = (
+{
+components = (
+{
+name = L;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 245, 0}";
+}
+);
+layerId = UUID0;
+width = 662;
+},
+{
+components = (
+{
+name = L;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 248, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 681;
+}
+);
+leftKerningGroup = L;
+rightKerningGroup = L;
+unicode = 013B;
+},
+{
+glyphname = Ldot;
+lastChange = "2016-08-22 12:06:52 +0000";
+layers = (
+{
+components = (
+{
+name = L;
+},
+{
+alignment = -1;
+name = periodcentered;
+transform = "{1, 0, 0, 1, 344, 108}";
+}
+);
+layerId = UUID0;
+width = 828;
+},
+{
+components = (
+{
+name = L;
+},
+{
+alignment = -1;
+name = periodcentered;
+transform = "{1, 0, 0, 1, 310, 116}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 955;
+}
+);
+leftKerningGroup = L;
+unicode = 013F;
+},
+{
+glyphname = Lj;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = L;
+},
+{
+name = j;
+transform = "{1, 0, 0, 1, 662, 0}";
+}
+);
+layerId = UUID0;
+width = 992;
+},
+{
+components = (
+{
+name = L;
+},
+{
+name = j;
+transform = "{1, 0, 0, 1, 681, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 999;
+}
+);
+leftKerningGroup = L;
+rightKerningGroup = j;
+unicode = 01C8;
+},
+{
+glyphname = Lslash;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+components = (
+{
+name = L;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"415 463 LINE",
+"415 503 LINE",
+"28 277 LINE",
+"28 237 LINE"
+);
+}
+);
+width = 662;
+},
+{
+components = (
+{
+name = L;
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"415 463 LINE",
+"415 503 LINE",
+"28 277 LINE",
+"28 237 LINE"
+);
+}
+);
+width = 681;
+}
+);
+unicode = 0141;
+},
+{
+glyphname = M;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{442, 0}";
+},
+{
+name = top;
+position = "{442, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"635 15 LINE",
+"769 15 LINE",
+"769 754 LINE",
+"635 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"525 0 LINE",
+"879 0 LINE",
+"879 25 LINE",
+"525 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"649 729 LINE",
+"879 729 LINE",
+"879 754 LINE",
+"649 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"129 15 LINE",
+"168 15 LINE",
+"168 754 LINE",
+"129 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"19 0 LINE",
+"278 0 LINE",
+"278 25 LINE",
+"19 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"19 729 LINE",
+"278 729 LINE",
+"278 754 LINE",
+"19 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"290 754 LINE",
+"156 754 LINE",
+"168 665 LINE",
+"172 665 LINE",
+"386 -9 LINE",
+"416 -9 LINE",
+"464 160 LINE",
+"453 226 LINE",
+"449 226 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"432 160 LINE",
+"386 -9 LINE",
+"422 -9 LINE",
+"631 665 LINE",
+"635 665 LINE",
+"655 744 LINE",
+"640 754 LINE",
+"616 754 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"415 -9 LINE",
+"624 665 LINE",
+"628 665 LINE",
+"628 25 LINE",
+"518 25 LINE",
+"518 0 LINE",
+"872 0 LINE",
+"872 25 LINE",
+"762 25 LINE",
+"762 729 LINE",
+"872 729 LINE",
+"872 754 LINE",
+"609 754 LINE",
+"446 226 LINE",
+"442 226 LINE",
+"283 754 LINE",
+"12 754 LINE",
+"12 729 LINE",
+"122 729 LINE",
+"122 25 LINE",
+"12 25 LINE",
+"12 0 LINE",
+"271 0 LINE",
+"271 25 LINE",
+"161 25 LINE",
+"161 665 LINE",
+"165 665 LINE",
+"379 -9 LINE"
+);
+}
+);
+width = 884;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{464, 0}";
+},
+{
+name = top;
+position = "{464, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"35 749 LINE SMOOTH",
+"28 743 OFFCURVE",
+"27 731 OFFCURVE",
+"31 724 CURVE SMOOTH",
+"34 719 OFFCURVE",
+"53 716 OFFCURVE",
+"64 718 CURVE",
+"69 718 OFFCURVE",
+"86 718 OFFCURVE",
+"102 718 CURVE SMOOTH",
+"126 719 OFFCURVE",
+"126 718 OFFCURVE",
+"131 716 CURVE",
+"135 713 OFFCURVE",
+"135 704 OFFCURVE",
+"135 633 CURVE",
+"133 590 OFFCURVE",
+"133 525 OFFCURVE",
+"133 490 CURVE",
+"131 432 OFFCURVE",
+"131 161 OFFCURVE",
+"131 98 CURVE",
+"133 38 OFFCURVE",
+"123 29 OFFCURVE",
+"65 29 CURVE SMOOTH",
+"35 29 OFFCURVE",
+"27 28 OFFCURVE",
+"23 18 CURVE",
+"22 12 OFFCURVE",
+"23 3 OFFCURVE",
+"28 -2 CURVE SMOOTH",
+"30 -5 OFFCURVE",
+"40 -5 OFFCURVE",
+"150 -5 CURVE SMOOTH",
+"213 -5 OFFCURVE",
+"266 -4 OFFCURVE",
+"268 -4 CURVE",
+"276 0 OFFCURVE",
+"277 17 OFFCURVE",
+"271 25 CURVE",
+"266 28 OFFCURVE",
+"239 34 OFFCURVE",
+"230 29 CURVE",
+"214 26 OFFCURVE",
+"181 37 OFFCURVE",
+"175 48 CURVE",
+"168 56 OFFCURVE",
+"166 78 OFFCURVE",
+"166 106 CURVE",
+"168 133 OFFCURVE",
+"168 289 OFFCURVE",
+"168 557 CURVE SMOOTH",
+"168 623 OFFCURVE",
+"168 679 OFFCURVE",
+"168 681 CURVE",
+"169 682 OFFCURVE",
+"171 684 OFFCURVE",
+"175 682 CURVE",
+"177 682 OFFCURVE",
+"180 677 OFFCURVE",
+"185 661 CURVE SMOOTH",
+"189 649 OFFCURVE",
+"193 636 OFFCURVE",
+"194 633 CURVE",
+"194 624 OFFCURVE",
+"208 591 OFFCURVE",
+"214 568 CURVE",
+"218 557 OFFCURVE",
+"222 536 OFFCURVE",
+"227 525 CURVE",
+"230 513 OFFCURVE",
+"233 500 OFFCURVE",
+"235 497 CURVE",
+"236 493 OFFCURVE",
+"239 482 OFFCURVE",
+"243 470 CURVE SMOOTH",
+"246 460 OFFCURVE",
+"251 442 OFFCURVE",
+"255 428 CURVE",
+"260 417 OFFCURVE",
+"263 402 OFFCURVE",
+"264 399 CURVE SMOOTH",
+"268 382 OFFCURVE",
+"290 319 OFFCURVE",
+"294 302 CURVE",
+"296 297 OFFCURVE",
+"299 286 OFFCURVE",
+"302 278 CURVE SMOOTH",
+"320 220 OFFCURVE",
+"331 179 OFFCURVE",
+"334 171 CURVE SMOOTH",
+"339 161 OFFCURVE",
+"346 136 OFFCURVE",
+"347 129 CURVE SMOOTH",
+"347 125 OFFCURVE",
+"351 117 OFFCURVE",
+"352 108 CURVE",
+"355 100 OFFCURVE",
+"359 84 OFFCURVE",
+"363 73 CURVE SMOOTH",
+"366 62 OFFCURVE",
+"369 48 OFFCURVE",
+"371 43 CURVE SMOOTH",
+"372 38 OFFCURVE",
+"376 26 OFFCURVE",
+"377 20 CURVE",
+"380 12 OFFCURVE",
+"384 3 OFFCURVE",
+"385 1 CURVE",
+"385 -4 OFFCURVE",
+"409 -5 OFFCURVE",
+"409 -4 CURVE",
+"417 -2 OFFCURVE",
+"421 1 OFFCURVE",
+"440 76 CURVE",
+"446 104 OFFCURVE",
+"446 109 OFFCURVE",
+"468 171 CURVE SMOOTH",
+"475 189 OFFCURVE",
+"482 219 OFFCURVE",
+"488 234 CURVE",
+"493 251 OFFCURVE",
+"499 267 OFFCURVE",
+"501 272 CURVE SMOOTH",
+"502 275 OFFCURVE",
+"505 287 OFFCURVE",
+"507 295 CURVE SMOOTH",
+"510 303 OFFCURVE",
+"515 320 OFFCURVE",
+"518 333 CURVE",
+"528 355 OFFCURVE",
+"528 362 OFFCURVE",
+"537 389 CURVE",
+"538 399 OFFCURVE",
+"545 417 OFFCURVE",
+"548 428 CURVE",
+"554 440 OFFCURVE",
+"557 455 OFFCURVE",
+"559 458 CURVE",
+"559 463 OFFCURVE",
+"562 472 OFFCURVE",
+"563 477 CURVE SMOOTH",
+"567 488 OFFCURVE",
+"576 519 OFFCURVE",
+"582 535 CURVE",
+"586 558 OFFCURVE",
+"595 583 OFFCURVE",
+"600 590 CURVE",
+"601 594 OFFCURVE",
+"603 599 OFFCURVE",
+"603 602 CURVE SMOOTH",
+"603 607 OFFCURVE",
+"604 615 OFFCURVE",
+"609 621 CURVE",
+"610 627 OFFCURVE",
+"613 635 OFFCURVE",
+"613 636 CURVE SMOOTH",
+"613 638 OFFCURVE",
+"615 644 OFFCURVE",
+"618 651 CURVE SMOOTH",
+"620 657 OFFCURVE",
+"623 668 OFFCURVE",
+"625 673 CURVE",
+"626 681 OFFCURVE",
+"631 682 OFFCURVE",
+"635 676 CURVE SMOOTH",
+"638 673 OFFCURVE",
+"638 636 OFFCURVE",
+"638 585 CURVE SMOOTH",
+"638 543 OFFCURVE",
+"638 447 OFFCURVE",
+"638 395 CURVE SMOOTH",
+"638 374 OFFCURVE",
+"638 347 OFFCURVE",
+"638 336 CURVE SMOOTH",
+"638 325 OFFCURVE",
+"637 283 OFFCURVE",
+"637 241 CURVE SMOOTH",
+"637 118 OFFCURVE",
+"637 46 OFFCURVE",
+"635 40 CURVE SMOOTH",
+"631 31 OFFCURVE",
+"629 31 OFFCURVE",
+"604 29 CURVE",
+"573 29 OFFCURVE",
+"548 26 OFFCURVE",
+"545 23 CURVE SMOOTH",
+"540 20 OFFCURVE",
+"538 12 OFFCURVE",
+"540 4 CURVE",
+"542 0 OFFCURVE",
+"545 -2 OFFCURVE",
+"550 -4 CURVE SMOOTH",
+"554 -5 OFFCURVE",
+"587 -5 OFFCURVE",
+"623 -5 CURVE SMOOTH",
+"776 -4 OFFCURVE",
+"814 -4 OFFCURVE",
+"874 -7 CURVE SMOOTH",
+"906 -8 LINE",
+"912 -2 LINE SMOOTH",
+"919 4 OFFCURVE",
+"919 12 OFFCURVE",
+"916 21 CURVE",
+"911 29 OFFCURVE",
+"903 29 OFFCURVE",
+"861 29 CURVE",
+"826 28 OFFCURVE",
+"820 28 OFFCURVE",
+"819 31 CURVE SMOOTH",
+"816 35 OFFCURVE",
+"814 43 OFFCURVE",
+"816 56 CURVE",
+"816 90 OFFCURVE",
+"817 287 OFFCURVE",
+"817 380 CURVE SMOOTH",
+"817 447 OFFCURVE",
+"817 503 OFFCURVE",
+"817 507 CURVE SMOOTH",
+"817 508 OFFCURVE",
+"817 525 OFFCURVE",
+"817 541 CURVE SMOOTH",
+"816 610 OFFCURVE",
+"817 699 OFFCURVE",
+"819 706 CURVE SMOOTH",
+"820 710 OFFCURVE",
+"822 715 OFFCURVE",
+"825 716 CURVE",
+"828 719 OFFCURVE",
+"846 719 OFFCURVE",
+"879 716 CURVE",
+"902 715 OFFCURVE",
+"911 716 OFFCURVE",
+"916 724 CURVE SMOOTH",
+"919 731 OFFCURVE",
+"919 741 OFFCURVE",
+"912 746 CURVE",
+"908 751 LINE",
+"858 751 LINE",
+"794 749 OFFCURVE",
+"736 749 OFFCURVE",
+"671 751 CURVE",
+"620 751 LINE",
+"615 746 LINE SMOOTH",
+"613 743 OFFCURVE",
+"609 729 OFFCURVE",
+"603 713 CURVE SMOOTH",
+"598 698 OFFCURVE",
+"590 674 OFFCURVE",
+"587 661 CURVE",
+"582 648 OFFCURVE",
+"576 632 OFFCURVE",
+"575 623 CURVE",
+"567 593 OFFCURVE",
+"559 569 OFFCURVE",
+"554 557 CURVE SMOOTH",
+"551 548 OFFCURVE",
+"548 538 OFFCURVE",
+"546 535 CURVE",
+"546 528 OFFCURVE",
+"538 505 OFFCURVE",
+"529 475 CURVE",
+"526 461 OFFCURVE",
+"521 449 OFFCURVE",
+"520 444 CURVE",
+"520 438 OFFCURVE",
+"518 432 OFFCURVE",
+"517 428 CURVE SMOOTH",
+"513 420 OFFCURVE",
+"510 411 OFFCURVE",
+"509 402 CURVE",
+"507 399 OFFCURVE",
+"502 382 OFFCURVE",
+"496 367 CURVE",
+"492 350 OFFCURVE",
+"487 336 OFFCURVE",
+"487 333 CURVE SMOOTH",
+"485 324 OFFCURVE",
+"480 316 OFFCURVE",
+"477 316 CURVE SMOOTH",
+"476 316 OFFCURVE",
+"474 320 OFFCURVE",
+"472 325 CURVE SMOOTH",
+"470 330 OFFCURVE",
+"467 337 OFFCURVE",
+"465 342 CURVE SMOOTH",
+"463 349 OFFCURVE",
+"455 374 OFFCURVE",
+"446 410 CURVE",
+"442 420 OFFCURVE",
+"437 435 OFFCURVE",
+"434 447 CURVE SMOOTH",
+"432 457 OFFCURVE",
+"426 475 OFFCURVE",
+"422 486 CURVE",
+"419 499 OFFCURVE",
+"413 513 OFFCURVE",
+"412 521 CURVE",
+"410 528 OFFCURVE",
+"405 540 OFFCURVE",
+"404 546 CURVE SMOOTH",
+"402 553 OFFCURVE",
+"401 561 OFFCURVE",
+"399 566 CURVE SMOOTH",
+"397 571 OFFCURVE",
+"394 582 OFFCURVE",
+"391 590 CURVE SMOOTH",
+"388 598 OFFCURVE",
+"385 607 OFFCURVE",
+"385 608 CURVE SMOOTH",
+"382 621 OFFCURVE",
+"374 649 OFFCURVE",
+"371 656 CURVE SMOOTH",
+"369 660 OFFCURVE",
+"366 669 OFFCURVE",
+"364 677 CURVE SMOOTH",
+"357 709 OFFCURVE",
+"355 718 OFFCURVE",
+"352 731 CURVE SMOOTH",
+"346 752 OFFCURVE",
+"352 751 OFFCURVE",
+"255 751 CURVE SMOOTH",
+"208 751 OFFCURVE",
+"139 752 OFFCURVE",
+"105 752 CURVE",
+"40 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"388 291 OFFCURVE",
+"387 291 OFFCURVE",
+"385 291 CURVE SMOOTH",
+"385 291 OFFCURVE",
+"385 291 OFFCURVE",
+"385 292 CURVE SMOOTH",
+"387 295 OFFCURVE",
+"393 294 OFFCURVE",
+"391 292 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"415 237 OFFCURVE",
+"415 237 OFFCURVE",
+"415 236 CURVE SMOOTH",
+"412 233 OFFCURVE",
+"407 236 OFFCURVE",
+"409 239 CURVE SMOOTH",
+"410 242 OFFCURVE",
+"412 244 OFFCURVE",
+"415 241 CURVE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"433 -9 LINE",
+"646 684 LINE",
+"650 684 LINE",
+"650 30 LINE",
+"543 30 LINE",
+"543 0 LINE",
+"912 0 LINE",
+"912 30 LINE",
+"808 30 LINE",
+"808 724 LINE",
+"912 724 LINE",
+"912 754 LINE",
+"622 754 LINE",
+"481 299 LINE",
+"477 299 LINE",
+"336 754 LINE",
+"20 754 LINE",
+"20 724 LINE",
+"130 724 LINE",
+"130 30 LINE",
+"20 30 LINE",
+"20 0 LINE",
+"284 0 LINE",
+"284 30 LINE",
+"174 30 LINE",
+"174 684 LINE",
+"178 684 LINE",
+"392 -9 LINE"
+);
+}
+);
+width = 927;
+}
+);
+unicode = 004D;
+},
+{
+glyphname = N;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{372, 0}";
+},
+{
+name = top;
+position = "{372, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"125 15 LINE",
+"164 15 LINE",
+"164 754 LINE",
+"125 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"15 0 LINE",
+"274 0 LINE",
+"274 25 LINE",
+"15 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"15 729 LINE",
+"274 729 LINE",
+"274 754 LINE",
+"15 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"596 223 LINE",
+"604 -13 LINE",
+"635 -13 LINE",
+"635 754 LINE",
+"596 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"496 729 LINE",
+"735 729 LINE",
+"735 754 LINE",
+"496 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"286 754 LINE",
+"152 754 LINE",
+"164 683 LINE",
+"168 683 LINE",
+"604 -13 LINE",
+"626 -13 LINE",
+"596 268 LINE",
+"592 268 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"633 -12 LINE",
+"633 729 LINE",
+"733 729 LINE",
+"733 754 LINE",
+"494 754 LINE",
+"494 729 LINE",
+"594 729 LINE",
+"594 268 LINE",
+"590 268 LINE",
+"284 754 LINE",
+"13 754 LINE",
+"13 729 LINE",
+"123 729 LINE",
+"123 25 LINE",
+"13 25 LINE",
+"13 0 LINE",
+"272 0 LINE",
+"272 25 LINE",
+"162 25 LINE",
+"162 683 LINE",
+"166 683 LINE",
+"602 -12 LINE"
+);
+}
+);
+width = 744;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{396, 0}";
+},
+{
+name = top;
+position = "{396, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"748 751 OFFCURVE",
+"701 751 OFFCURVE",
+"647 751 CURVE SMOOTH",
+"543 751 LINE",
+"538 746 LINE SMOOTH",
+"534 743 OFFCURVE",
+"533 742 OFFCURVE",
+"534 734 CURVE SMOOTH",
+"536 718 OFFCURVE",
+"544 713 OFFCURVE",
+"584 712 CURVE",
+"616 709 OFFCURVE",
+"625 706 OFFCURVE",
+"631 690 CURVE",
+"634 679 OFFCURVE",
+"634 662 OFFCURVE",
+"634 545 CURVE SMOOTH",
+"634 538 OFFCURVE",
+"634 505 OFFCURVE",
+"634 473 CURVE",
+"636 442 OFFCURVE",
+"636 402 OFFCURVE",
+"636 384 CURVE SMOOTH",
+"636 320 OFFCURVE",
+"636 318 OFFCURVE",
+"630 320 CURVE SMOOTH",
+"625 321 OFFCURVE",
+"608 343 OFFCURVE",
+"589 371 CURVE",
+"570 402 OFFCURVE",
+"555 423 OFFCURVE",
+"545 435 CURVE",
+"539 440 OFFCURVE",
+"533 451 OFFCURVE",
+"528 459 CURVE SMOOTH",
+"523 467 OFFCURVE",
+"513 480 OFFCURVE",
+"506 488 CURVE SMOOTH",
+"500 496 OFFCURVE",
+"492 509 OFFCURVE",
+"486 515 CURVE",
+"483 520 OFFCURVE",
+"478 529 OFFCURVE",
+"476 530 CURVE",
+"473 534 OFFCURVE",
+"465 545 OFFCURVE",
+"456 557 CURVE SMOOTH",
+"448 568 OFFCURVE",
+"440 582 OFFCURVE",
+"438 584 CURVE SMOOTH",
+"428 596 OFFCURVE",
+"415 617 OFFCURVE",
+"408 625 CURVE SMOOTH",
+"405 629 OFFCURVE",
+"397 642 OFFCURVE",
+"389 651 CURVE SMOOTH",
+"380 662 OFFCURVE",
+"375 671 OFFCURVE",
+"375 673 CURVE SMOOTH",
+"375 673 OFFCURVE",
+"370 682 OFFCURVE",
+"364 690 CURVE SMOOTH",
+"351 704 OFFCURVE",
+"343 717 OFFCURVE",
+"336 729 CURVE SMOOTH",
+"325 750 OFFCURVE",
+"320 753 OFFCURVE",
+"280 750 CURVE",
+"256 750 OFFCURVE",
+"183 750 OFFCURVE",
+"80 751 CURVE",
+"26 753 LINE",
+"23 748 LINE SMOOTH",
+"18 742 OFFCURVE",
+"18 728 OFFCURVE",
+"22 721 CURVE",
+"25 718 OFFCURVE",
+"25 718 OFFCURVE",
+"57 717 CURVE",
+"104 717 OFFCURVE",
+"111 715 OFFCURVE",
+"125 695 CURVE SMOOTH",
+"130 687 LINE",
+"130 617 LINE",
+"131 578 OFFCURVE",
+"131 540 OFFCURVE",
+"131 530 CURVE SMOOTH",
+"131 521 OFFCURVE",
+"130 413 OFFCURVE",
+"130 290 CURVE SMOOTH",
+"130 165 OFFCURVE",
+"128 62 OFFCURVE",
+"128 57 CURVE",
+"126 47 OFFCURVE",
+"120 38 OFFCURVE",
+"112 34 CURVE SMOOTH",
+"103 29 LINE",
+"65 29 LINE",
+"26 29 LINE",
+"22 22 LINE",
+"22 15 OFFCURVE",
+"22 4 OFFCURVE",
+"22 -3 CURVE",
+"28 -8 LINE",
+"148 -8 LINE SMOOTH",
+"220 -8 OFFCURVE",
+"270 -8 OFFCURVE",
+"272 -6 CURVE SMOOTH",
+"278 -1 OFFCURVE",
+"281 10 OFFCURVE",
+"276 21 CURVE SMOOTH",
+"273 27 OFFCURVE",
+"267 29 OFFCURVE",
+"228 29 CURVE SMOOTH",
+"193 29 OFFCURVE",
+"187 30 OFFCURVE",
+"176 40 CURVE",
+"167 54 OFFCURVE",
+"165 63 OFFCURVE",
+"165 159 CURVE SMOOTH",
+"165 205 OFFCURVE",
+"165 326 OFFCURVE",
+"165 427 CURVE SMOOTH",
+"165 529 OFFCURVE",
+"165 617 OFFCURVE",
+"167 623 CURVE",
+"169 642 OFFCURVE",
+"172 645 OFFCURVE",
+"181 635 CURVE",
+"185 634 OFFCURVE",
+"190 626 OFFCURVE",
+"192 623 CURVE",
+"192 618 OFFCURVE",
+"214 604 OFFCURVE",
+"214 592 CURVE",
+"221 580 OFFCURVE",
+"231 567 OFFCURVE",
+"231 565 CURVE",
+"233 562 OFFCURVE",
+"237 557 OFFCURVE",
+"240 553 CURVE SMOOTH",
+"243 550 OFFCURVE",
+"249 542 OFFCURVE",
+"253 535 CURVE SMOOTH",
+"267 515 OFFCURVE",
+"300 467 OFFCURVE",
+"317 445 CURVE",
+"323 432 OFFCURVE",
+"330 425 OFFCURVE",
+"336 415 CURVE",
+"343 409 OFFCURVE",
+"350 396 OFFCURVE",
+"370 370 CURVE",
+"376 360 OFFCURVE",
+"381 352 OFFCURVE",
+"381 352 CURVE",
+"381 351 OFFCURVE",
+"384 345 OFFCURVE",
+"390 340 CURVE",
+"394 335 OFFCURVE",
+"403 323 OFFCURVE",
+"408 313 CURVE",
+"416 305 OFFCURVE",
+"423 293 OFFCURVE",
+"426 288 CURVE",
+"438 274 OFFCURVE",
+"448 263 OFFCURVE",
+"456 249 CURVE",
+"462 242 OFFCURVE",
+"470 229 OFFCURVE",
+"476 220 CURVE",
+"484 212 OFFCURVE",
+"489 201 OFFCURVE",
+"493 196 CURVE SMOOTH",
+"497 192 OFFCURVE",
+"500 185 OFFCURVE",
+"503 184 CURVE",
+"505 180 OFFCURVE",
+"509 176 OFFCURVE",
+"511 170 CURVE",
+"514 167 OFFCURVE",
+"520 159 OFFCURVE",
+"523 155 CURVE SMOOTH",
+"526 151 OFFCURVE",
+"534 140 OFFCURVE",
+"539 132 CURVE SMOOTH",
+"544 124 OFFCURVE",
+"553 113 OFFCURVE",
+"558 109 CURVE",
+"563 102 OFFCURVE",
+"569 93 OFFCURVE",
+"573 88 CURVE",
+"577 79 OFFCURVE",
+"585 67 OFFCURVE",
+"603 37 CURVE SMOOTH",
+"615 17 OFFCURVE",
+"639 -13 OFFCURVE",
+"641 -15 CURVE",
+"641 -18 OFFCURVE",
+"641 -20 OFFCURVE",
+"664 -18 CURVE",
+"675 -15 OFFCURVE",
+"676 -10 OFFCURVE",
+"676 22 CURVE SMOOTH",
+"676 37 OFFCURVE",
+"675 55 OFFCURVE",
+"675 65 CURVE",
+"673 80 OFFCURVE",
+"672 402 OFFCURVE",
+"673 588 CURVE SMOOTH",
+"673 675 OFFCURVE",
+"675 688 OFFCURVE",
+"683 701 CURVE SMOOTH",
+"692 715 OFFCURVE",
+"696 715 OFFCURVE",
+"736 715 CURVE SMOOTH",
+"769 715 LINE",
+"773 720 LINE SMOOTH",
+"783 731 OFFCURVE",
+"778 748 OFFCURVE",
+"766 753 CURVE",
+"758 754 OFFCURVE",
+"751 754 OFFCURVE",
+"750 753 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"676 -13 LINE",
+"676 724 LINE",
+"776 724 LINE",
+"776 754 LINE",
+"532 754 LINE",
+"532 724 LINE",
+"632 724 LINE",
+"632 309 LINE",
+"628 309 LINE",
+"312 754 LINE",
+"20 754 LINE",
+"20 724 LINE",
+"130 724 LINE",
+"130 30 LINE",
+"20 30 LINE",
+"20 0 LINE",
+"284 0 LINE",
+"284 30 LINE",
+"174 30 LINE",
+"174 641 LINE",
+"178 641 LINE",
+"632 -13 LINE"
+);
+}
+);
+width = 791;
+}
+);
+leftKerningGroup = N;
+rightKerningGroup = N;
+unicode = 004E;
+},
+{
+glyphname = NJ;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = N;
+},
+{
+name = J;
+transform = "{1, 0, 0, 1, 744, 0}";
+}
+);
+layerId = UUID0;
+width = 1204;
+},
+{
+components = (
+{
+name = N;
+},
+{
+name = J;
+transform = "{1, 0, 0, 1, 791, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 1177;
+}
+);
+leftKerningGroup = N;
+rightKerningGroup = J;
+unicode = 01CA;
+},
+{
+glyphname = Nacute;
+lastChange = "2016-08-22 11:53:08 +0000";
+layers = (
+{
+components = (
+{
+name = N;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 47, 304}";
+}
+);
+layerId = UUID0;
+width = 744;
+},
+{
+components = (
+{
+name = N;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 6, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 791;
+}
+);
+leftKerningGroup = N;
+rightKerningGroup = N;
+unicode = 0143;
+},
+{
+glyphname = Ncaron;
+lastChange = "2016-08-22 12:07:45 +0000";
+layers = (
+{
+components = (
+{
+name = N;
+},
+{
+name = caron.case;
+transform = "{1, 0, 0, 1, 202, 1}";
+}
+);
+layerId = UUID0;
+width = 744;
+},
+{
+components = (
+{
+name = N;
+},
+{
+name = caron.case;
+transform = "{1, 0, 0, 1, 182, 2}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 791;
+}
+);
+leftKerningGroup = N;
+rightKerningGroup = N;
+unicode = 0147;
+},
+{
+glyphname = Ncommaaccent;
+lastChange = "2016-08-22 12:07:45 +0000";
+layers = (
+{
+components = (
+{
+name = N;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 286, 0}";
+}
+);
+layerId = UUID0;
+width = 744;
+},
+{
+components = (
+{
+name = N;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 303, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 791;
+}
+);
+leftKerningGroup = N;
+rightKerningGroup = N;
+unicode = 0145;
+},
+{
+glyphname = Ndotaccent;
+lastChange = "2016-08-22 12:08:14 +0000";
+layers = (
+{
+components = (
+{
+name = N;
+},
+{
+name = dotaccent.case;
+transform = "{1, 0, 0, 1, 297, 5}";
+}
+);
+layerId = UUID0;
+width = 744;
+},
+{
+components = (
+{
+name = N;
+},
+{
+name = dotaccent.case;
+transform = "{1, 0, 0, 1, 317, 2}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 791;
+}
+);
+leftKerningGroup = N;
+rightKerningGroup = N;
+unicode = 1E44;
+},
+{
+glyphname = Eng;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"597 76 LINE SMOOTH",
+"597 -82 OFFCURVE",
+"565 -124 OFFCURVE",
+"529 -124 CURVE SMOOTH",
+"516 -124 OFFCURVE",
+"505 -118 OFFCURVE",
+"505 -104 CURVE SMOOTH",
+"505 -86 OFFCURVE",
+"523 -70 OFFCURVE",
+"523 -42 CURVE SMOOTH",
+"523 -7 OFFCURVE",
+"496 21 OFFCURVE",
+"460 21 CURVE SMOOTH",
+"425 21 OFFCURVE",
+"392 -5 OFFCURVE",
+"392 -54 CURVE SMOOTH",
+"392 -112 OFFCURVE",
+"438 -157 OFFCURVE",
+"513 -157 CURVE SMOOTH",
+"574 -157 OFFCURVE",
+"635 -127 OFFCURVE",
+"635 76 CURVE SMOOTH",
+"635 735 LINE",
+"597 735 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"125 15 LINE",
+"164 15 LINE",
+"164 754 LINE",
+"125 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"15 0 LINE",
+"274 0 LINE",
+"274 25 LINE",
+"15 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"15 729 LINE",
+"274 729 LINE",
+"274 754 LINE",
+"15 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"496 729 LINE",
+"735 729 LINE",
+"735 754 LINE",
+"496 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"286 754 LINE",
+"152 754 LINE",
+"164 683 LINE",
+"168 683 LINE",
+"604 47 LINE",
+"626 47 LINE",
+"597 328 LINE",
+"593 328 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"574 -157 OFFCURVE",
+"635 -127 OFFCURVE",
+"635 76 CURVE SMOOTH",
+"635 729 LINE",
+"735 729 LINE",
+"735 754 LINE",
+"496 754 LINE",
+"496 729 LINE",
+"597 729 LINE",
+"597 328 LINE",
+"593 328 LINE",
+"286 754 LINE",
+"15 754 LINE",
+"15 729 LINE",
+"125 729 LINE",
+"125 25 LINE",
+"15 25 LINE",
+"15 0 LINE",
+"274 0 LINE",
+"274 25 LINE",
+"164 25 LINE",
+"164 683 LINE",
+"168 683 LINE",
+"597 57 LINE",
+"597 25 LINE SMOOTH",
+"597 -82 OFFCURVE",
+"560 -124 OFFCURVE",
+"529 -124 CURVE SMOOTH",
+"516 -124 OFFCURVE",
+"505 -118 OFFCURVE",
+"505 -104 CURVE SMOOTH",
+"505 -86 OFFCURVE",
+"523 -70 OFFCURVE",
+"523 -42 CURVE SMOOTH",
+"523 -7 OFFCURVE",
+"496 21 OFFCURVE",
+"460 21 CURVE SMOOTH",
+"425 21 OFFCURVE",
+"392 -5 OFFCURVE",
+"392 -54 CURVE SMOOTH",
+"392 -112 OFFCURVE",
+"438 -157 OFFCURVE",
+"513 -157 CURVE SMOOTH",
+"513 -157 LINE SMOOTH"
+);
+}
+);
+width = 743;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"676 686 LINE",
+"632 686 LINE",
+"632 21 LINE SMOOTH",
+"632 -104 OFFCURVE",
+"592 -122 OFFCURVE",
+"567 -122 CURVE SMOOTH",
+"554 -122 OFFCURVE",
+"540 -117 OFFCURVE",
+"540 -104 CURVE SMOOTH",
+"540 -89 OFFCURVE",
+"558 -76 OFFCURVE",
+"558 -47 CURVE SMOOTH",
+"558 -4 OFFCURVE",
+"519 23 OFFCURVE",
+"482 23 CURVE SMOOTH",
+"436 23 OFFCURVE",
+"402 -17 OFFCURVE",
+"402 -67 CURVE SMOOTH",
+"402 -128 OFFCURVE",
+"452 -170 OFFCURVE",
+"536 -170 CURVE SMOOTH",
+"642 -170 OFFCURVE",
+"676 -102 OFFCURVE",
+"676 20 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"130 15 LINE",
+"174 15 LINE",
+"174 754 LINE",
+"130 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 0 LINE",
+"284 0 LINE",
+"284 30 LINE",
+"20 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 724 LINE",
+"284 724 LINE",
+"284 754 LINE",
+"20 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"632 57 LINE",
+"676 57 LINE",
+"676 754 LINE",
+"632 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"532 724 LINE",
+"776 724 LINE",
+"776 754 LINE",
+"532 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"312 754 LINE",
+"162 754 LINE",
+"174 641 LINE",
+"178 641 LINE",
+"632 57 LINE",
+"662 57 LINE",
+"632 379 LINE",
+"628 379 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"642 -170 OFFCURVE",
+"676 -102 OFFCURVE",
+"676 20 CURVE SMOOTH",
+"676 724 LINE",
+"776 724 LINE",
+"776 754 LINE",
+"532 754 LINE",
+"532 724 LINE",
+"632 724 LINE",
+"632 379 LINE",
+"628 379 LINE",
+"312 754 LINE",
+"20 754 LINE",
+"20 724 LINE",
+"130 724 LINE",
+"130 30 LINE",
+"20 30 LINE",
+"20 0 LINE",
+"284 0 LINE",
+"284 30 LINE",
+"174 30 LINE",
+"174 641 LINE",
+"178 641 LINE",
+"632 57 LINE",
+"632 21 LINE SMOOTH",
+"632 -104 OFFCURVE",
+"592 -122 OFFCURVE",
+"567 -122 CURVE SMOOTH",
+"554 -122 OFFCURVE",
+"540 -117 OFFCURVE",
+"540 -104 CURVE SMOOTH",
+"540 -89 OFFCURVE",
+"558 -76 OFFCURVE",
+"558 -47 CURVE SMOOTH",
+"558 -4 OFFCURVE",
+"519 23 OFFCURVE",
+"482 23 CURVE SMOOTH",
+"436 23 OFFCURVE",
+"402 -17 OFFCURVE",
+"402 -67 CURVE SMOOTH",
+"402 -128 OFFCURVE",
+"452 -170 OFFCURVE",
+"536 -170 CURVE SMOOTH",
+"536 -170 LINE"
+);
+}
+);
+width = 791;
+}
+);
+leftKerningGroup = N;
+unicode = 014A;
+},
+{
+glyphname = Nj;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = N;
+},
+{
+name = j;
+transform = "{1, 0, 0, 1, 744, 0}";
+}
+);
+layerId = UUID0;
+width = 1074;
+},
+{
+components = (
+{
+name = N;
+},
+{
+name = j;
+transform = "{1, 0, 0, 1, 791, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 1109;
+}
+);
+leftKerningGroup = N;
+rightKerningGroup = j;
+unicode = 01CB;
+},
+{
+glyphname = Ntilde;
+lastChange = "2016-08-22 11:53:08 +0000";
+layers = (
+{
+components = (
+{
+name = N;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, 81, 304}";
+}
+);
+layerId = UUID0;
+width = 744;
+},
+{
+components = (
+{
+name = N;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, 83, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 791;
+}
+);
+leftKerningGroup = N;
+rightKerningGroup = N;
+unicode = 00D1;
+},
+{
+glyphname = O;
+lastChange = "2016-08-22 09:33:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{391, 0}";
+},
+{
+name = center;
+position = "{391, 377}";
+},
+{
+name = ogonek;
+position = "{704, 10}";
+},
+{
+name = top;
+position = "{391, 754}";
+},
+{
+name = topleft;
+position = "{20, 754}";
+},
+{
+name = topright;
+position = "{550, 701}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"0 172 OFFCURVE",
+"152 -13 OFFCURVE",
+"346 -13 CURVE SMOOTH",
+"540 -13 OFFCURVE",
+"693 172 OFFCURVE",
+"693 380 CURVE SMOOTH",
+"693 582 OFFCURVE",
+"540 763 OFFCURVE",
+"346 763 CURVE SMOOTH",
+"152 763 OFFCURVE",
+"0 582 OFFCURVE",
+"0 380 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"160 666 OFFCURVE",
+"209 733 OFFCURVE",
+"345 733 CURVE SMOOTH",
+"482 733 OFFCURVE",
+"533 665 OFFCURVE",
+"533 378 CURVE SMOOTH",
+"533 86 OFFCURVE",
+"483 17 OFFCURVE",
+"346 17 CURVE SMOOTH",
+"209 17 OFFCURVE",
+"160 85 OFFCURVE",
+"160 380 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"585 -12 OFFCURVE",
+"738 169 OFFCURVE",
+"738 377 CURVE SMOOTH",
+"738 585 OFFCURVE",
+"585 766 OFFCURVE",
+"391 766 CURVE SMOOTH",
+"197 766 OFFCURVE",
+"44 585 OFFCURVE",
+"44 377 CURVE SMOOTH",
+"44 169 OFFCURVE",
+"197 -12 OFFCURVE",
+"391 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"255 18 OFFCURVE",
+"204 91 OFFCURVE",
+"204 377 CURVE SMOOTH",
+"204 663 OFFCURVE",
+"255 736 OFFCURVE",
+"391 736 CURVE SMOOTH",
+"527 736 OFFCURVE",
+"578 664 OFFCURVE",
+"578 378 CURVE SMOOTH",
+"578 92 OFFCURVE",
+"527 18 OFFCURVE",
+"391 18 CURVE SMOOTH"
+);
+}
+);
+width = 782;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{412, 0}";
+},
+{
+name = center;
+position = "{412, 377}";
+},
+{
+name = ogonek;
+position = "{741, 10}";
+},
+{
+name = top;
+position = "{412, 754}";
+},
+{
+name = topleft;
+position = "{20, 754}";
+},
+{
+name = topright;
+position = "{451, 702}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"351 753 OFFCURVE",
+"340 751 OFFCURVE",
+"330 748 CURVE SMOOTH",
+"321 746 OFFCURVE",
+"310 743 OFFCURVE",
+"305 741 CURVE SMOOTH",
+"294 738 OFFCURVE",
+"236 713 OFFCURVE",
+"220 703 CURVE SMOOTH",
+"204 692 OFFCURVE",
+"175 669 OFFCURVE",
+"167 661 CURVE SMOOTH",
+"159 652 OFFCURVE",
+"153 647 OFFCURVE",
+"138 631 CURVE",
+"130 625 OFFCURVE",
+"119 613 OFFCURVE",
+"113 605 CURVE SMOOTH",
+"100 589 OFFCURVE",
+"68 537 OFFCURVE",
+"68 532 CURVE SMOOTH",
+"68 530 OFFCURVE",
+"68 529 OFFCURVE",
+"66 527 CURVE SMOOTH",
+"65 525 OFFCURVE",
+"54 501 OFFCURVE",
+"49 489 CURVE SMOOTH",
+"41 465 OFFCURVE",
+"39 457 OFFCURVE",
+"38 442 CURVE",
+"33 405 OFFCURVE",
+"31 394 OFFCURVE",
+"31 393 CURVE SMOOTH",
+"31 391 OFFCURVE",
+"31 380 OFFCURVE",
+"33 367 CURVE SMOOTH",
+"34 354 OFFCURVE",
+"34 343 OFFCURVE",
+"34 341 CURVE SMOOTH",
+"33 335 OFFCURVE",
+"38 292 OFFCURVE",
+"47 273 CURVE",
+"58 241 OFFCURVE",
+"70 207 OFFCURVE",
+"81 194 CURVE",
+"105 156 OFFCURVE",
+"110 149 OFFCURVE",
+"140 117 CURVE SMOOTH",
+"175 81 OFFCURVE",
+"218 49 OFFCURVE",
+"255 33 CURVE SMOOTH",
+"259 31 OFFCURVE",
+"264 28 OFFCURVE",
+"273 25 CURVE",
+"277 21 OFFCURVE",
+"285 20 OFFCURVE",
+"286 20 CURVE SMOOTH",
+"286 20 OFFCURVE",
+"290 18 OFFCURVE",
+"295 15 CURVE",
+"311 9 OFFCURVE",
+"354 -1 OFFCURVE",
+"382 -3 CURVE SMOOTH",
+"447 -6 OFFCURVE",
+"500 7 OFFCURVE",
+"570 47 CURVE SMOOTH",
+"610 69 OFFCURVE",
+"654 109 OFFCURVE",
+"694 159 CURVE",
+"705 175 OFFCURVE",
+"738 239 OFFCURVE",
+"743 257 CURVE SMOOTH",
+"752 285 OFFCURVE",
+"761 314 OFFCURVE",
+"761 335 CURVE SMOOTH",
+"761 362 OFFCURVE",
+"761 401 OFFCURVE",
+"761 417 CURVE",
+"759 433 OFFCURVE",
+"751 469 OFFCURVE",
+"746 479 CURVE",
+"745 485 OFFCURVE",
+"743 490 OFFCURVE",
+"743 492 CURVE SMOOTH",
+"743 497 OFFCURVE",
+"732 525 OFFCURVE",
+"726 538 CURVE SMOOTH",
+"710 569 OFFCURVE",
+"676 615 OFFCURVE",
+"650 641 CURVE",
+"630 663 OFFCURVE",
+"586 697 OFFCURVE",
+"567 708 CURVE SMOOTH",
+"564 709 OFFCURVE",
+"514 733 OFFCURVE",
+"510 735 CURVE SMOOTH",
+"500 740 OFFCURVE",
+"476 745 OFFCURVE",
+"466 745 CURVE SMOOTH",
+"463 745 OFFCURVE",
+"457 746 OFFCURVE",
+"454 748 CURVE SMOOTH",
+"442 753 OFFCURVE",
+"377 756 OFFCURVE",
+"354 753 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"490 705 OFFCURVE",
+"510 693 OFFCURVE",
+"516 687 CURVE SMOOTH",
+"528 674 OFFCURVE",
+"540 652 OFFCURVE",
+"540 636 CURVE",
+"542 628 OFFCURVE",
+"543 618 OFFCURVE",
+"545 615 CURVE",
+"545 612 OFFCURVE",
+"545 607 OFFCURVE",
+"545 605 CURVE SMOOTH",
+"545 604 OFFCURVE",
+"545 594 OFFCURVE",
+"546 583 CURVE",
+"548 573 OFFCURVE",
+"550 554 OFFCURVE",
+"550 541 CURVE SMOOTH",
+"550 530 OFFCURVE",
+"551 513 OFFCURVE",
+"551 503 CURVE",
+"553 493 OFFCURVE",
+"554 473 OFFCURVE",
+"554 457 CURVE",
+"556 433 OFFCURVE",
+"556 426 OFFCURVE",
+"553 412 CURVE SMOOTH",
+"550 397 OFFCURVE",
+"550 393 OFFCURVE",
+"551 386 CURVE",
+"553 380 OFFCURVE",
+"554 361 OFFCURVE",
+"553 314 CURVE SMOOTH",
+"553 279 OFFCURVE",
+"551 247 OFFCURVE",
+"551 244 CURVE SMOOTH",
+"551 242 OFFCURVE",
+"550 229 OFFCURVE",
+"548 217 CURVE",
+"543 153 OFFCURVE",
+"538 125 OFFCURVE",
+"532 105 CURVE SMOOTH",
+"524 82 OFFCURVE",
+"521 74 OFFCURVE",
+"510 65 CURVE",
+"497 52 OFFCURVE",
+"478 44 OFFCURVE",
+"446 36 CURVE SMOOTH",
+"431 33 OFFCURVE",
+"430 33 OFFCURVE",
+"425 34 CURVE",
+"418 37 OFFCURVE",
+"418 37 OFFCURVE",
+"409 34 CURVE SMOOTH",
+"404 33 OFFCURVE",
+"398 31 OFFCURVE",
+"393 31 CURVE",
+"390 33 OFFCURVE",
+"385 33 OFFCURVE",
+"382 33 CURVE SMOOTH",
+"356 33 OFFCURVE",
+"335 36 OFFCURVE",
+"327 41 CURVE",
+"322 42 OFFCURVE",
+"316 45 OFFCURVE",
+"313 45 CURVE",
+"302 49 OFFCURVE",
+"284 61 OFFCURVE",
+"284 66 CURVE SMOOTH",
+"284 68 OFFCURVE",
+"281 69 OFFCURVE",
+"279 71 CURVE SMOOTH",
+"276 73 OFFCURVE",
+"271 76 OFFCURVE",
+"270 77 CURVE SMOOTH",
+"265 84 OFFCURVE",
+"255 108 OFFCURVE",
+"250 127 CURVE",
+"247 143 OFFCURVE",
+"239 215 OFFCURVE",
+"239 241 CURVE SMOOTH",
+"239 287 OFFCURVE",
+"239 474 OFFCURVE",
+"239 495 CURVE",
+"241 508 OFFCURVE",
+"241 519 OFFCURVE",
+"241 521 CURVE SMOOTH",
+"241 522 OFFCURVE",
+"241 530 OFFCURVE",
+"241 538 CURVE SMOOTH",
+"242 548 OFFCURVE",
+"244 569 OFFCURVE",
+"246 586 CURVE SMOOTH",
+"249 613 OFFCURVE",
+"250 620 OFFCURVE",
+"257 641 CURVE SMOOTH",
+"261 655 OFFCURVE",
+"266 668 OFFCURVE",
+"270 671 CURVE",
+"271 673 OFFCURVE",
+"273 677 OFFCURVE",
+"273 679 CURVE",
+"276 684 OFFCURVE",
+"280 689 OFFCURVE",
+"290 697 CURVE",
+"303 705 OFFCURVE",
+"312 708 OFFCURVE",
+"330 711 CURVE",
+"340 711 OFFCURVE",
+"352 714 OFFCURVE",
+"362 716 CURVE SMOOTH",
+"372 717 OFFCURVE",
+"386 717 OFFCURVE",
+"414 717 CURVE SMOOTH",
+"448 716 OFFCURVE",
+"453 716 OFFCURVE",
+"468 711 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"620 -13 OFFCURVE",
+"783 173 OFFCURVE",
+"783 378 CURVE SMOOTH",
+"783 583 OFFCURVE",
+"620 763 OFFCURVE",
+"411 763 CURVE SMOOTH",
+"202 763 OFFCURVE",
+"40 583 OFFCURVE",
+"40 378 CURVE SMOOTH",
+"40 173 OFFCURVE",
+"202 -13 OFFCURVE",
+"411 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"278 22 OFFCURVE",
+"230 88 OFFCURVE",
+"230 378 CURVE SMOOTH",
+"230 661 OFFCURVE",
+"276 728 OFFCURVE",
+"410 728 CURVE SMOOTH",
+"545 728 OFFCURVE",
+"593 660 OFFCURVE",
+"593 376 CURVE SMOOTH",
+"593 91 OFFCURVE",
+"545 22 OFFCURVE",
+"410 22 CURVE SMOOTH"
+);
+}
+);
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 004F;
+},
+{
+glyphname = Oacute;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = O;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 66, 304}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+name = O;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 22, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 00D3;
+},
+{
+glyphname = Obreve;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = O;
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, 96, 304}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+name = O;
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, 114, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 014E;
+},
+{
+glyphname = Ocircumflex;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = O;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 101, 304}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+name = O;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 116, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 00D4;
+},
+{
+glyphname = Ocircumflexacute;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = O;
+},
+{
+name = circumflexcomb_acutecomb;
+transform = "{1, 0, 0, 1, 101, 304}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+name = O;
+},
+{
+name = circumflexcomb_acutecomb;
+transform = "{1, 0, 0, 1, 116, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 1ED0;
+},
+{
+glyphname = Ocircumflexdotbelow;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = O;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 107, 0}";
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 101, 304}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+name = O;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 119, 0}";
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 116, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 1ED8;
+},
+{
+glyphname = Ocircumflexgrave;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = O;
+},
+{
+name = circumflexcomb_gravecomb;
+transform = "{1, 0, 0, 1, 101, 304}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+name = O;
+},
+{
+name = circumflexcomb_gravecomb;
+transform = "{1, 0, 0, 1, 116, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 1ED2;
+},
+{
+glyphname = Ocircumflexhookabove;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = O;
+},
+{
+name = circumflexcomb_hookabovecomb;
+transform = "{1, 0, 0, 1, 101, 304}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+name = O;
+},
+{
+name = circumflexcomb_hookabovecomb;
+transform = "{1, 0, 0, 1, 116, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 1ED4;
+},
+{
+glyphname = Ocircumflextilde;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = O;
+},
+{
+name = circumflexcomb_tildecomb;
+transform = "{1, 0, 0, 1, 101, 304}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+name = O;
+},
+{
+name = circumflexcomb_tildecomb;
+transform = "{1, 0, 0, 1, 116, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 1ED6;
+},
+{
+glyphname = Odblgrave;
+lastChange = "2016-08-22 12:07:45 +0000";
+layers = (
+{
+components = (
+{
+name = O;
+},
+{
+name = dblgravecomb.cap;
+transform = "{1, 0, 0, 1, 178, 0}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+name = O;
+},
+{
+name = dblgravecomb.cap;
+transform = "{1, 0, 0, 1, 144, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 020C;
+},
+{
+glyphname = Odieresis;
+lastChange = "2016-08-22 12:07:45 +0000";
+layers = (
+{
+components = (
+{
+name = O;
+},
+{
+name = dieresis.case;
+transform = "{1, 0, 0, 1, 227, 0}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+name = O;
+},
+{
+name = dieresis.case;
+transform = "{1, 0, 0, 1, 242, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 00D6;
+},
+{
+glyphname = Odotbelow;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = O;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 107, 0}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+name = O;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 119, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 1ECC;
+},
+{
+glyphname = Ograve;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = O;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 104, 304}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+name = O;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 163, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 00D2;
+},
+{
+glyphname = Ohookabove;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = O;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 106, 304}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+name = O;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 128, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 1ECE;
+},
+{
+glyphname = Ohorn;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = O;
+},
+{
+name = horncomb;
+transform = "{1, 0, 0, 1, 238, 251}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+name = O;
+},
+{
+name = horncomb;
+transform = "{1, 0, 0, 1, 252, 252}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 01A0;
+},
+{
+glyphname = Ohornacute;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = Ohorn;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 66, 304}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+name = Ohorn;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 22, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 1EDA;
+},
+{
+glyphname = Ohorndotbelow;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = Ohorn;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 107, 0}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+name = Ohorn;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 119, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 1EE2;
+},
+{
+glyphname = Ohorngrave;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = Ohorn;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 104, 304}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+name = Ohorn;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 163, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 1EDC;
+},
+{
+glyphname = Ohornhookabove;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = Ohorn;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 106, 304}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+name = Ohorn;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 128, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 1EDE;
+},
+{
+glyphname = Ohorntilde;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = Ohorn;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, 100, 304}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+name = Ohorn;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, 99, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 1EE0;
+},
+{
+glyphname = Ohungarumlaut;
+lastChange = "2016-08-22 12:14:50 +0000";
+layers = (
+{
+components = (
+{
+name = O;
+},
+{
+name = hungarumlaut.case;
+transform = "{1, 0, 0, 1, 259, 0}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+name = O;
+},
+{
+name = hungarumlaut.case;
+transform = "{1, 0, 0, 1, 214, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 0150;
+},
+{
+glyphname = Oinvertedbreve;
+lastChange = "2016-08-22 12:07:45 +0000";
+layers = (
+{
+components = (
+{
+name = O;
+},
+{
+name = breveinvertedcomb.cap;
+transform = "{1, 0, 0, 1, 224, 0}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+name = O;
+},
+{
+name = breveinvertedcomb.cap;
+transform = "{1, 0, 0, 1, 235, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 020E;
+},
+{
+glyphname = Omacron;
+lastChange = "2016-08-22 12:07:45 +0000";
+layers = (
+{
+components = (
+{
+name = O;
+},
+{
+name = macron.case;
+transform = "{1, 0, 0, 1, 223, 0}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+name = O;
+},
+{
+name = macron.case;
+transform = "{1, 0, 0, 1, 240, -1}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 014C;
+},
+{
+glyphname = Oogonek;
+lastChange = "2016-08-22 12:15:04 +0000";
+layers = (
+{
+components = (
+{
+name = O;
+},
+{
+name = ogonek;
+transform = "{1, 0, 0, 1, 234, -14}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+name = O;
+},
+{
+name = ogonek;
+transform = "{1, 0, 0, 1, 250, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 01EA;
+},
+{
+glyphname = Oslash;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"570 -13 OFFCURVE",
+"723 172 OFFCURVE",
+"723 380 CURVE SMOOTH",
+"723 582 OFFCURVE",
+"570 763 OFFCURVE",
+"376 763 CURVE SMOOTH",
+"182 763 OFFCURVE",
+"30 582 OFFCURVE",
+"30 380 CURVE SMOOTH",
+"30 172 OFFCURVE",
+"182 -13 OFFCURVE",
+"376 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"118 -53 LINE",
+"673 804 LINE",
+"635 804 LINE",
+"80 -53 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"239 17 OFFCURVE",
+"190 85 OFFCURVE",
+"190 380 CURVE SMOOTH",
+"190 666 OFFCURVE",
+"239 733 OFFCURVE",
+"375 733 CURVE SMOOTH",
+"512 733 OFFCURVE",
+"563 665 OFFCURVE",
+"563 378 CURVE SMOOTH",
+"563 86 OFFCURVE",
+"513 17 OFFCURVE",
+"376 17 CURVE SMOOTH"
+);
+}
+);
+width = 753;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"620 -13 OFFCURVE",
+"783 173 OFFCURVE",
+"783 378 CURVE SMOOTH",
+"783 583 OFFCURVE",
+"620 763 OFFCURVE",
+"411 763 CURVE SMOOTH",
+"202 763 OFFCURVE",
+"40 583 OFFCURVE",
+"40 378 CURVE SMOOTH",
+"40 173 OFFCURVE",
+"202 -13 OFFCURVE",
+"411 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"165 -53 LINE",
+"720 804 LINE",
+"662 804 LINE",
+"107 -53 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"278 22 OFFCURVE",
+"230 88 OFFCURVE",
+"230 378 CURVE SMOOTH",
+"230 661 OFFCURVE",
+"276 728 OFFCURVE",
+"410 728 CURVE SMOOTH",
+"545 728 OFFCURVE",
+"593 660 OFFCURVE",
+"593 376 CURVE SMOOTH",
+"593 91 OFFCURVE",
+"545 22 OFFCURVE",
+"410 22 CURVE SMOOTH"
+);
+}
+);
+width = 823;
+}
+);
+unicode = 00D8;
+},
+{
+glyphname = Oslashacute;
+lastChange = "2016-08-22 12:15:18 +0000";
+layers = (
+{
+components = (
+{
+name = Oslash;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 87, 279}";
+}
+);
+layerId = UUID0;
+width = 779;
+},
+{
+components = (
+{
+name = Oslash;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 61, 292}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+unicode = 01FE;
+},
+{
+glyphname = Otilde;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = O;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, 100, 304}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+name = O;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, 99, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 00D5;
+},
+{
+glyphname = OE;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"1056 0 LINE",
+"1056 235 LINE",
+"1021 235 LINE",
+"1019 123 OFFCURVE",
+"962 25 OFFCURVE",
+"863 25 CURVE SMOOTH",
+"677 25 LINE",
+"677 363 LINE",
+"798 362 OFFCURVE",
+"829 327 OFFCURVE",
+"832 216 CURVE",
+"867 216 LINE",
+"867 526 LINE",
+"832 526 LINE",
+"832 419 OFFCURVE",
+"798 388 OFFCURVE",
+"677 388 CURVE",
+"677 729 LINE",
+"833 729 LINE SMOOTH",
+"932 729 OFFCURVE",
+"989 646 OFFCURVE",
+"991 549 CURVE",
+"1026 549 LINE",
+"1026 754 LINE",
+"376 754 LINE SMOOTH",
+"182 754 OFFCURVE",
+"30 578 OFFCURVE",
+"30 380 CURVE SMOOTH",
+"30 180 OFFCURVE",
+"182 0 OFFCURVE",
+"376 0 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"190 659 OFFCURVE",
+"239 724 OFFCURVE",
+"375 724 CURVE SMOOTH",
+"492 724 OFFCURVE",
+"543 658 OFFCURVE",
+"543 367 CURVE SMOOTH",
+"543 94 OFFCURVE",
+"490 30 OFFCURVE",
+"376 30 CURVE SMOOTH",
+"239 30 OFFCURVE",
+"190 96 OFFCURVE",
+"190 380 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"1056 0 LINE",
+"1056 235 LINE",
+"1021 235 LINE",
+"1019 123 OFFCURVE",
+"962 25 OFFCURVE",
+"863 25 CURVE SMOOTH",
+"677 25 LINE",
+"677 363 LINE",
+"798 362 OFFCURVE",
+"829 327 OFFCURVE",
+"832 216 CURVE",
+"867 216 LINE",
+"867 526 LINE",
+"832 526 LINE",
+"832 419 OFFCURVE",
+"798 388 OFFCURVE",
+"677 388 CURVE",
+"677 729 LINE",
+"833 729 LINE SMOOTH",
+"932 729 OFFCURVE",
+"989 646 OFFCURVE",
+"991 549 CURVE",
+"1026 549 LINE",
+"1026 754 LINE",
+"376 754 LINE SMOOTH",
+"182 754 OFFCURVE",
+"30 578 OFFCURVE",
+"30 380 CURVE SMOOTH",
+"30 180 OFFCURVE",
+"182 0 OFFCURVE",
+"376 0 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"239 30 OFFCURVE",
+"190 96 OFFCURVE",
+"190 380 CURVE SMOOTH",
+"190 659 OFFCURVE",
+"239 724 OFFCURVE",
+"375 724 CURVE SMOOTH",
+"492 724 OFFCURVE",
+"543 658 OFFCURVE",
+"543 367 CURVE SMOOTH",
+"543 94 OFFCURVE",
+"490 30 OFFCURVE",
+"376 30 CURVE SMOOTH"
+);
+}
+);
+width = 1093;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"40 181 OFFCURVE",
+"202 0 OFFCURVE",
+"413 0 CURVE SMOOTH",
+"1144 0 LINE",
+"1144 245 LINE",
+"1104 245 LINE",
+"1102 131 OFFCURVE",
+"1037 30 OFFCURVE",
+"926 30 CURVE SMOOTH",
+"756 30 LINE",
+"756 356 LINE",
+"885 355 OFFCURVE",
+"933 311 OFFCURVE",
+"935 216 CURVE",
+"975 216 LINE",
+"975 516 LINE",
+"935 516 LINE",
+"933 428 OFFCURVE",
+"885 387 OFFCURVE",
+"756 386 CURVE",
+"756 724 LINE",
+"926 724 LINE SMOOTH",
+"1028 724 OFFCURVE",
+"1087 646 OFFCURVE",
+"1089 554 CURVE",
+"1129 554 LINE",
+"1129 754 LINE",
+"411 754 LINE SMOOTH",
+"202 754 OFFCURVE",
+"40 579 OFFCURVE",
+"40 378 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"230 654 OFFCURVE",
+"276 719 OFFCURVE",
+"410 719 CURVE SMOOTH",
+"545 719 OFFCURVE",
+"593 653 OFFCURVE",
+"593 376 CURVE SMOOTH",
+"593 102 OFFCURVE",
+"545 35 OFFCURVE",
+"410 35 CURVE SMOOTH",
+"278 35 OFFCURVE",
+"230 99 OFFCURVE",
+"230 378 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"1144 0 LINE",
+"1144 245 LINE",
+"1104 245 LINE",
+"1102 131 OFFCURVE",
+"1037 30 OFFCURVE",
+"926 30 CURVE SMOOTH",
+"756 30 LINE",
+"756 356 LINE",
+"885 355 OFFCURVE",
+"933 311 OFFCURVE",
+"935 216 CURVE",
+"975 216 LINE",
+"975 516 LINE",
+"935 516 LINE",
+"933 428 OFFCURVE",
+"885 387 OFFCURVE",
+"756 386 CURVE",
+"756 724 LINE",
+"926 724 LINE SMOOTH",
+"1028 724 OFFCURVE",
+"1087 646 OFFCURVE",
+"1089 554 CURVE",
+"1129 554 LINE",
+"1129 754 LINE",
+"411 754 LINE SMOOTH",
+"202 754 OFFCURVE",
+"40 579 OFFCURVE",
+"40 378 CURVE SMOOTH",
+"40 181 OFFCURVE",
+"202 0 OFFCURVE",
+"413 0 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"278 35 OFFCURVE",
+"230 99 OFFCURVE",
+"230 378 CURVE SMOOTH",
+"230 654 OFFCURVE",
+"276 719 OFFCURVE",
+"410 719 CURVE SMOOTH",
+"545 719 OFFCURVE",
+"593 653 OFFCURVE",
+"593 376 CURVE SMOOTH",
+"593 102 OFFCURVE",
+"545 35 OFFCURVE",
+"410 35 CURVE SMOOTH"
+);
+}
+);
+width = 1179;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = E;
+unicode = 0152;
+},
+{
+glyphname = P;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{342, 0}";
+},
+{
+name = top;
+position = "{342, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"121 15 LINE",
+"255 15 LINE",
+"255 754 LINE",
+"121 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"11 0 LINE",
+"385 0 LINE",
+"385 25 LINE",
+"11 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"307 342 LINE SMOOTH",
+"522 342 OFFCURVE",
+"652 427 OFFCURVE",
+"652 552 CURVE SMOOTH",
+"652 669 OFFCURVE",
+"540 754 OFFCURVE",
+"397 754 CURVE SMOOTH",
+"11 754 LINE",
+"11 729 LINE",
+"357 729 LINE SMOOTH",
+"450 729 OFFCURVE",
+"497 700 OFFCURVE",
+"497 558 CURVE SMOOTH",
+"497 405 OFFCURVE",
+"443 372 OFFCURVE",
+"307 372 CURVE SMOOTH",
+"224 372 LINE",
+"224 342 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"307 342 LINE SMOOTH",
+"522 342 OFFCURVE",
+"652 427 OFFCURVE",
+"652 552 CURVE SMOOTH",
+"652 669 OFFCURVE",
+"540 754 OFFCURVE",
+"397 754 CURVE SMOOTH",
+"11 754 LINE",
+"11 729 LINE",
+"357 729 LINE SMOOTH",
+"450 729 OFFCURVE",
+"497 700 OFFCURVE",
+"497 558 CURVE SMOOTH",
+"497 405 OFFCURVE",
+"443 372 OFFCURVE",
+"307 372 CURVE SMOOTH",
+"224 372 LINE",
+"224 342 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"385 0 LINE",
+"385 25 LINE",
+"11 25 LINE",
+"11 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"255 15 LINE",
+"255 754 LINE",
+"121 754 LINE",
+"121 15 LINE"
+);
+}
+);
+width = 684;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{350, 0}";
+},
+{
+name = top;
+position = "{350, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"115 15 LINE",
+"273 15 LINE",
+"273 754 LINE",
+"115 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 0 LINE",
+"391 0 LINE",
+"391 30 LINE",
+"20 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"350 342 LINE SMOOTH",
+"565 342 OFFCURVE",
+"695 427 OFFCURVE",
+"695 552 CURVE SMOOTH",
+"695 669 OFFCURVE",
+"583 754 OFFCURVE",
+"440 754 CURVE SMOOTH",
+"20 754 LINE",
+"20 724 LINE",
+"390 724 LINE SMOOTH",
+"465 724 OFFCURVE",
+"505 696 OFFCURVE",
+"505 555 CURVE SMOOTH",
+"505 405 OFFCURVE",
+"460 372 OFFCURVE",
+"350 372 CURVE SMOOTH",
+"267 372 LINE",
+"267 342 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"350 342 LINE SMOOTH",
+"565 342 OFFCURVE",
+"695 427 OFFCURVE",
+"695 552 CURVE SMOOTH",
+"695 669 OFFCURVE",
+"583 754 OFFCURVE",
+"440 754 CURVE SMOOTH",
+"20 754 LINE",
+"20 724 LINE",
+"390 724 LINE SMOOTH",
+"465 724 OFFCURVE",
+"505 696 OFFCURVE",
+"505 555 CURVE SMOOTH",
+"505 405 OFFCURVE",
+"460 372 OFFCURVE",
+"350 372 CURVE SMOOTH",
+"267 372 LINE",
+"267 342 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"391 0 LINE",
+"391 30 LINE",
+"20 30 LINE",
+"20 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"273 15 LINE",
+"273 754 LINE",
+"115 754 LINE",
+"115 15 LINE"
+);
+}
+);
+width = 700;
+}
+);
+leftKerningGroup = P;
+unicode = 0050;
+},
+{
+glyphname = Thorn;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"391 0 LINE",
+"391 25 LINE",
+"261 25 LINE",
+"261 179 LINE",
+"313 179 LINE SMOOTH",
+"528 179 OFFCURVE",
+"658 264 OFFCURVE",
+"658 389 CURVE SMOOTH",
+"658 506 OFFCURVE",
+"546 591 OFFCURVE",
+"403 591 CURVE SMOOTH",
+"261 591 LINE",
+"261 728 LINE",
+"391 728 LINE",
+"391 753 LINE",
+"17 753 LINE",
+"17 728 LINE",
+"127 728 LINE",
+"127 25 LINE",
+"17 25 LINE",
+"17 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"261 566 LINE",
+"363 566 LINE SMOOTH",
+"456 566 OFFCURVE",
+"503 537 OFFCURVE",
+"503 395 CURVE SMOOTH",
+"503 242 OFFCURVE",
+"449 209 OFFCURVE",
+"313 209 CURVE SMOOTH",
+"261 209 LINE"
+);
+}
+);
+width = 680;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"391 0 LINE",
+"391 30 LINE",
+"273 30 LINE",
+"273 181 LINE",
+"350 181 LINE SMOOTH",
+"565 181 OFFCURVE",
+"695 266 OFFCURVE",
+"695 391 CURVE SMOOTH",
+"695 508 OFFCURVE",
+"583 593 OFFCURVE",
+"440 593 CURVE SMOOTH",
+"273 593 LINE",
+"273 724 LINE",
+"391 724 LINE",
+"391 754 LINE",
+"20 754 LINE",
+"20 724 LINE",
+"115 724 LINE",
+"115 30 LINE",
+"20 30 LINE",
+"20 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"273 563 LINE",
+"390 563 LINE SMOOTH",
+"465 563 OFFCURVE",
+"505 535 OFFCURVE",
+"505 394 CURVE SMOOTH",
+"505 244 OFFCURVE",
+"460 211 OFFCURVE",
+"350 211 CURVE SMOOTH",
+"273 211 LINE"
+);
+}
+);
+width = 700;
+}
+);
+unicode = 00DE;
+},
+{
+glyphname = Q;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{391, 0}";
+},
+{
+name = top;
+position = "{391, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"585 -12 OFFCURVE",
+"738 169 OFFCURVE",
+"738 377 CURVE SMOOTH",
+"738 585 OFFCURVE",
+"585 766 OFFCURVE",
+"391 766 CURVE SMOOTH",
+"197 766 OFFCURVE",
+"45 585 OFFCURVE",
+"45 377 CURVE SMOOTH",
+"45 169 OFFCURVE",
+"197 -12 OFFCURVE",
+"391 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"685 -226 LINE",
+"548 -226 OFFCURVE",
+"470 -195 OFFCURVE",
+"470 -49 CURVE SMOOTH",
+"470 -33 OFFCURVE",
+"471 -12 OFFCURVE",
+"473 7 CURVE",
+"312 7 LINE",
+"312 -192 OFFCURVE",
+"409 -256 OFFCURVE",
+"685 -256 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"255 18 OFFCURVE",
+"205 91 OFFCURVE",
+"205 377 CURVE SMOOTH",
+"205 663 OFFCURVE",
+"254 736 OFFCURVE",
+"390 736 CURVE SMOOTH",
+"526 736 OFFCURVE",
+"578 664 OFFCURVE",
+"578 378 CURVE SMOOTH",
+"578 92 OFFCURVE",
+"527 18 OFFCURVE",
+"391 18 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"585 -12 OFFCURVE",
+"738 169 OFFCURVE",
+"738 377 CURVE SMOOTH",
+"738 585 OFFCURVE",
+"585 766 OFFCURVE",
+"391 766 CURVE SMOOTH",
+"197 766 OFFCURVE",
+"45 585 OFFCURVE",
+"45 377 CURVE SMOOTH",
+"45 169 OFFCURVE",
+"197 -12 OFFCURVE",
+"391 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"685 -226 LINE",
+"548 -226 OFFCURVE",
+"470 -195 OFFCURVE",
+"470 -49 CURVE SMOOTH",
+"470 -33 OFFCURVE",
+"471 -12 OFFCURVE",
+"473 7 CURVE",
+"312 7 LINE",
+"312 -192 OFFCURVE",
+"409 -256 OFFCURVE",
+"685 -256 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"255 18 OFFCURVE",
+"205 91 OFFCURVE",
+"205 377 CURVE SMOOTH",
+"205 663 OFFCURVE",
+"254 736 OFFCURVE",
+"390 736 CURVE SMOOTH",
+"526 736 OFFCURVE",
+"578 664 OFFCURVE",
+"578 378 CURVE SMOOTH",
+"578 92 OFFCURVE",
+"527 18 OFFCURVE",
+"391 18 CURVE SMOOTH"
+);
+}
+);
+width = 782;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{412, 0}";
+},
+{
+name = top;
+position = "{412, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"620 -13 OFFCURVE",
+"783 173 OFFCURVE",
+"783 378 CURVE SMOOTH",
+"783 583 OFFCURVE",
+"620 763 OFFCURVE",
+"411 763 CURVE SMOOTH",
+"202 763 OFFCURVE",
+"40 583 OFFCURVE",
+"40 378 CURVE SMOOTH",
+"40 173 OFFCURVE",
+"202 -13 OFFCURVE",
+"411 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"715 -201 LINE",
+"583 -201 OFFCURVE",
+"510 -175 OFFCURVE",
+"510 -48 CURVE SMOOTH",
+"510 -33 OFFCURVE",
+"511 -12 OFFCURVE",
+"513 7 CURVE",
+"312 7 LINE",
+"312 -176 OFFCURVE",
+"418 -236 OFFCURVE",
+"715 -236 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"278 22 OFFCURVE",
+"230 88 OFFCURVE",
+"230 378 CURVE SMOOTH",
+"230 661 OFFCURVE",
+"276 728 OFFCURVE",
+"410 728 CURVE SMOOTH",
+"545 728 OFFCURVE",
+"593 660 OFFCURVE",
+"593 376 CURVE SMOOTH",
+"593 91 OFFCURVE",
+"545 22 OFFCURVE",
+"410 22 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"620 -13 OFFCURVE",
+"783 173 OFFCURVE",
+"783 378 CURVE SMOOTH",
+"783 583 OFFCURVE",
+"620 763 OFFCURVE",
+"411 763 CURVE SMOOTH",
+"202 763 OFFCURVE",
+"40 583 OFFCURVE",
+"40 378 CURVE SMOOTH",
+"40 173 OFFCURVE",
+"202 -13 OFFCURVE",
+"411 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"715 -201 LINE",
+"583 -201 OFFCURVE",
+"510 -175 OFFCURVE",
+"510 -48 CURVE SMOOTH",
+"510 -33 OFFCURVE",
+"511 -12 OFFCURVE",
+"513 7 CURVE",
+"312 7 LINE",
+"312 -176 OFFCURVE",
+"418 -236 OFFCURVE",
+"715 -236 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"278 22 OFFCURVE",
+"230 88 OFFCURVE",
+"230 378 CURVE SMOOTH",
+"230 661 OFFCURVE",
+"276 728 OFFCURVE",
+"410 728 CURVE SMOOTH",
+"545 728 OFFCURVE",
+"593 660 OFFCURVE",
+"593 376 CURVE SMOOTH",
+"593 91 OFFCURVE",
+"545 22 OFFCURVE",
+"410 22 CURVE SMOOTH"
+);
+}
+);
+width = 823;
+}
+);
+leftKerningGroup = O;
+unicode = 0051;
+},
+{
+glyphname = R;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{346, 0}";
+},
+{
+name = top;
+position = "{346, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"123 15 LINE",
+"257 15 LINE",
+"257 754 LINE",
+"123 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"13 754 LINE",
+"13 729 LINE",
+"359 729 LINE SMOOTH",
+"440 729 OFFCURVE",
+"479 706 OFFCURVE",
+"479 585 CURVE SMOOTH",
+"479 447 OFFCURVE",
+"429 417 OFFCURVE",
+"309 417 CURVE SMOOTH",
+"226 417 LINE",
+"226 387 LINE",
+"309 387 LINE SMOOTH",
+"513 387 OFFCURVE",
+"634 466 OFFCURVE",
+"634 582 CURVE SMOOTH",
+"634 691 OFFCURVE",
+"529 754 OFFCURVE",
+"399 754 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"13 0 LINE",
+"387 0 LINE",
+"387 25 LINE",
+"13 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"711 0 LINE",
+"711 25 LINE",
+"673 25 LINE SMOOTH",
+"621 25 OFFCURVE",
+"604 52 OFFCURVE",
+"604 144 CURVE SMOOTH",
+"604 196 LINE SMOOTH",
+"604 291 OFFCURVE",
+"515 374 OFFCURVE",
+"430 394 CURVE",
+"430 398 LINE",
+"393 398 LINE",
+"317 387 LINE",
+"395 387 OFFCURVE",
+"451 337 OFFCURVE",
+"455 232 CURVE SMOOTH",
+"458 153 LINE SMOOTH",
+"461 60 OFFCURVE",
+"535 0 OFFCURVE",
+"634 0 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"309 387 LINE SMOOTH",
+"513 387 OFFCURVE",
+"634 466 OFFCURVE",
+"634 582 CURVE SMOOTH",
+"634 691 OFFCURVE",
+"529 754 OFFCURVE",
+"399 754 CURVE SMOOTH",
+"13 754 LINE",
+"13 729 LINE",
+"359 729 LINE SMOOTH",
+"440 729 OFFCURVE",
+"479 706 OFFCURVE",
+"479 585 CURVE SMOOTH",
+"479 447 OFFCURVE",
+"429 417 OFFCURVE",
+"309 417 CURVE SMOOTH",
+"226 417 LINE",
+"226 387 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"387 0 LINE",
+"387 25 LINE",
+"13 25 LINE",
+"13 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"257 15 LINE",
+"257 754 LINE",
+"123 754 LINE",
+"123 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"711 0 LINE",
+"711 25 LINE",
+"673 25 LINE SMOOTH",
+"621 25 OFFCURVE",
+"604 52 OFFCURVE",
+"604 144 CURVE SMOOTH",
+"604 196 LINE SMOOTH",
+"604 291 OFFCURVE",
+"515 374 OFFCURVE",
+"430 394 CURVE",
+"430 398 LINE",
+"393 398 LINE",
+"317 387 LINE",
+"395 387 OFFCURVE",
+"451 337 OFFCURVE",
+"455 232 CURVE SMOOTH",
+"458 153 LINE SMOOTH",
+"461 60 OFFCURVE",
+"535 0 OFFCURVE",
+"634 0 CURVE SMOOTH"
+);
+}
+);
+width = 691;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{370, 0}";
+},
+{
+name = top;
+position = "{370, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"273 754 LINE",
+"115 754 LINE",
+"115 15 LINE",
+"273 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"350 392 LINE SMOOTH",
+"553 392 OFFCURVE",
+"675 459 OFFCURVE",
+"675 582 CURVE SMOOTH",
+"675 691 OFFCURVE",
+"563 754 OFFCURVE",
+"420 754 CURVE SMOOTH",
+"20 754 LINE",
+"20 724 LINE",
+"370 724 LINE SMOOTH",
+"445 724 OFFCURVE",
+"485 700 OFFCURVE",
+"485 575 CURVE SMOOTH",
+"485 449 OFFCURVE",
+"446 422 OFFCURVE",
+"350 422 CURVE SMOOTH",
+"267 422 LINE",
+"267 392 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 0 LINE",
+"391 0 LINE",
+"391 30 LINE",
+"20 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"755 0 LINE",
+"755 32 LINE",
+"717 32 LINE SMOOTH",
+"665 32 OFFCURVE",
+"648 59 OFFCURVE",
+"648 151 CURVE SMOOTH",
+"648 196 LINE SMOOTH",
+"648 291 OFFCURVE",
+"554 374 OFFCURVE",
+"464 394 CURVE",
+"464 398 LINE",
+"397 398 LINE",
+"321 392 LINE",
+"396 392 OFFCURVE",
+"448 351 OFFCURVE",
+"452 262 CURVE SMOOTH",
+"457 153 LINE SMOOTH",
+"461 60 OFFCURVE",
+"538 0 OFFCURVE",
+"638 0 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"350 392 LINE SMOOTH",
+"553 392 OFFCURVE",
+"675 459 OFFCURVE",
+"675 582 CURVE SMOOTH",
+"675 691 OFFCURVE",
+"563 754 OFFCURVE",
+"420 754 CURVE SMOOTH",
+"20 754 LINE",
+"20 724 LINE",
+"370 724 LINE SMOOTH",
+"445 724 OFFCURVE",
+"485 700 OFFCURVE",
+"485 575 CURVE SMOOTH",
+"485 449 OFFCURVE",
+"446 422 OFFCURVE",
+"350 422 CURVE SMOOTH",
+"267 422 LINE",
+"267 392 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"391 0 LINE",
+"391 30 LINE",
+"20 30 LINE",
+"20 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"273 15 LINE",
+"273 754 LINE",
+"115 754 LINE",
+"115 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"755 0 LINE",
+"755 32 LINE",
+"717 32 LINE SMOOTH",
+"665 32 OFFCURVE",
+"648 59 OFFCURVE",
+"648 151 CURVE SMOOTH",
+"648 196 LINE SMOOTH",
+"648 291 OFFCURVE",
+"554 374 OFFCURVE",
+"464 394 CURVE",
+"464 398 LINE",
+"397 398 LINE",
+"321 392 LINE",
+"396 392 OFFCURVE",
+"448 351 OFFCURVE",
+"452 262 CURVE SMOOTH",
+"457 153 LINE SMOOTH",
+"461 60 OFFCURVE",
+"538 0 OFFCURVE",
+"638 0 CURVE SMOOTH"
+);
+}
+);
+width = 740;
+}
+);
+leftKerningGroup = P;
+rightKerningGroup = R;
+unicode = 0052;
+},
+{
+glyphname = Racute;
+lastChange = "2016-08-22 11:53:08 +0000";
+layers = (
+{
+components = (
+{
+name = R;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 21, 304}";
+}
+);
+layerId = UUID0;
+width = 691;
+},
+{
+components = (
+{
+name = R;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -20, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 740;
+}
+);
+leftKerningGroup = P;
+rightKerningGroup = R;
+unicode = 0154;
+},
+{
+glyphname = Rcaron;
+lastChange = "2016-08-22 12:07:43 +0000";
+layers = (
+{
+components = (
+{
+name = R;
+},
+{
+name = caron.case;
+transform = "{1, 0, 0, 1, 176, 1}";
+}
+);
+layerId = UUID0;
+width = 691;
+},
+{
+components = (
+{
+name = R;
+},
+{
+name = caron.case;
+transform = "{1, 0, 0, 1, 156, 2}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 740;
+}
+);
+leftKerningGroup = P;
+rightKerningGroup = R;
+unicode = 0158;
+},
+{
+glyphname = Rcommaaccent;
+lastChange = "2016-08-22 12:07:43 +0000";
+layers = (
+{
+components = (
+{
+name = R;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 260, 0}";
+}
+);
+layerId = UUID0;
+width = 691;
+},
+{
+components = (
+{
+name = R;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 277, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 740;
+}
+);
+leftKerningGroup = P;
+rightKerningGroup = R;
+unicode = 0156;
+},
+{
+glyphname = Rdblgrave;
+lastChange = "2016-08-22 12:07:43 +0000";
+layers = (
+{
+components = (
+{
+name = R;
+},
+{
+name = dblgravecomb.cap;
+transform = "{1, 0, 0, 1, 133, 0}";
+}
+);
+layerId = UUID0;
+width = 691;
+},
+{
+components = (
+{
+name = R;
+},
+{
+name = dblgravecomb.cap;
+transform = "{1, 0, 0, 1, 102, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 740;
+}
+);
+leftKerningGroup = P;
+rightKerningGroup = R;
+unicode = 0210;
+},
+{
+glyphname = Rdotbelow;
+lastChange = "2016-08-22 11:53:08 +0000";
+layers = (
+{
+components = (
+{
+name = R;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 62, 0}";
+}
+);
+layerId = UUID0;
+width = 691;
+},
+{
+components = (
+{
+name = R;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 77, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 740;
+}
+);
+leftKerningGroup = P;
+rightKerningGroup = R;
+unicode = 1E5A;
+},
+{
+glyphname = Rinvertedbreve;
+lastChange = "2016-08-22 12:07:43 +0000";
+layers = (
+{
+components = (
+{
+name = R;
+},
+{
+name = breveinvertedcomb.cap;
+transform = "{1, 0, 0, 1, 179, 0}";
+}
+);
+layerId = UUID0;
+width = 691;
+},
+{
+components = (
+{
+name = R;
+},
+{
+name = breveinvertedcomb.cap;
+transform = "{1, 0, 0, 1, 193, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 740;
+}
+);
+leftKerningGroup = P;
+rightKerningGroup = R;
+unicode = 0212;
+},
+{
+glyphname = S;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{287, 0}";
+},
+{
+name = top;
+position = "{287, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"115 47 LINE",
+"164 8 OFFCURVE",
+"211 -12 OFFCURVE",
+"283 -12 CURVE SMOOTH",
+"438 -12 OFFCURVE",
+"524 81 OFFCURVE",
+"524 232 CURVE SMOOTH",
+"524 372 OFFCURVE",
+"450 438 OFFCURVE",
+"307 477 CURVE SMOOTH",
+"204 505 OFFCURVE",
+"139 526 OFFCURVE",
+"139 608 CURVE SMOOTH",
+"139 681 OFFCURVE",
+"200 736 OFFCURVE",
+"283 736 CURVE SMOOTH",
+"374 736 OFFCURVE",
+"437 675 OFFCURVE",
+"469 549 CURVE",
+"494 550 LINE",
+"494 754 LINE",
+"469 754 LINE",
+"443 710 LINE",
+"394 749 OFFCURVE",
+"351 766 OFFCURVE",
+"287 766 CURVE SMOOTH",
+"169 766 OFFCURVE",
+"60 688 OFFCURVE",
+"60 543 CURVE SMOOTH",
+"60 425 OFFCURVE",
+"123 350 OFFCURVE",
+"267 316 CURVE SMOOTH",
+"383 289 OFFCURVE",
+"450 251 OFFCURVE",
+"450 165 CURVE SMOOTH",
+"450 92 OFFCURVE",
+"404 19 OFFCURVE",
+"291 19 CURVE SMOOTH",
+"163 19 OFFCURVE",
+"104 114 OFFCURVE",
+"80 210 CURVE",
+"54 210 LINE",
+"54 0 LINE",
+"79 0 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"438 -12 OFFCURVE",
+"524 81 OFFCURVE",
+"524 232 CURVE SMOOTH",
+"524 372 OFFCURVE",
+"450 438 OFFCURVE",
+"307 477 CURVE SMOOTH",
+"204 505 OFFCURVE",
+"129 526 OFFCURVE",
+"129 608 CURVE SMOOTH",
+"129 681 OFFCURVE",
+"200 736 OFFCURVE",
+"283 736 CURVE SMOOTH",
+"374 736 OFFCURVE",
+"437 675 OFFCURVE",
+"469 549 CURVE",
+"494 550 LINE",
+"494 754 LINE",
+"469 754 LINE",
+"443 710 LINE",
+"394 749 OFFCURVE",
+"351 766 OFFCURVE",
+"287 766 CURVE SMOOTH",
+"169 766 OFFCURVE",
+"60 688 OFFCURVE",
+"60 543 CURVE SMOOTH",
+"60 425 OFFCURVE",
+"123 350 OFFCURVE",
+"267 316 CURVE SMOOTH",
+"383 289 OFFCURVE",
+"460 251 OFFCURVE",
+"460 165 CURVE SMOOTH",
+"460 92 OFFCURVE",
+"404 19 OFFCURVE",
+"291 19 CURVE SMOOTH",
+"163 19 OFFCURVE",
+"104 114 OFFCURVE",
+"80 210 CURVE",
+"54 210 LINE",
+"54 0 LINE",
+"79 0 LINE",
+"115 47 LINE",
+"164 8 OFFCURVE",
+"211 -12 OFFCURVE",
+"283 -12 CURVE SMOOTH"
+);
+}
+);
+width = 574;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{285, 0}";
+},
+{
+name = top;
+position = "{285, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"231 763 OFFCURVE",
+"212 759 OFFCURVE",
+"198 755 CURVE SMOOTH",
+"182 751 OFFCURVE",
+"145 734 OFFCURVE",
+"132 724 CURVE SMOOTH",
+"118 713 OFFCURVE",
+"90 687 OFFCURVE",
+"82 676 CURVE SMOOTH",
+"79 672 OFFCURVE",
+"74 664 OFFCURVE",
+"71 661 CURVE SMOOTH",
+"59 649 OFFCURVE",
+"46 616 OFFCURVE",
+"38 583 CURVE SMOOTH",
+"32 561 OFFCURVE",
+"32 533 OFFCURVE",
+"35 492 CURVE",
+"38 470 OFFCURVE",
+"39 465 OFFCURVE",
+"44 450 CURVE SMOOTH",
+"50 431 OFFCURVE",
+"57 420 OFFCURVE",
+"63 414 CURVE SMOOTH",
+"66 411 OFFCURVE",
+"69 406 OFFCURVE",
+"72 401 CURVE SMOOTH",
+"76 394 OFFCURVE",
+"102 370 OFFCURVE",
+"115 357 CURVE SMOOTH",
+"124 349 OFFCURVE",
+"159 331 OFFCURVE",
+"178 323 CURVE SMOOTH",
+"196 315 OFFCURVE",
+"245 301 OFFCURVE",
+"270 298 CURVE",
+"270 298 OFFCURVE",
+"291 295 OFFCURVE",
+"291 293 CURVE",
+"296 291 OFFCURVE",
+"306 288 OFFCURVE",
+"320 287 CURVE",
+"335 283 OFFCURVE",
+"349 279 OFFCURVE",
+"355 276 CURVE SMOOTH",
+"361 274 OFFCURVE",
+"368 271 OFFCURVE",
+"370 271 CURVE SMOOTH",
+"374 271 OFFCURVE",
+"400 258 OFFCURVE",
+"411 251 CURVE SMOOTH",
+"428 241 OFFCURVE",
+"435 230 OFFCURVE",
+"452 205 CURVE",
+"458 193 OFFCURVE",
+"458 191 OFFCURVE",
+"458 167 CURVE",
+"460 144 OFFCURVE",
+"460 139 OFFCURVE",
+"455 124 CURVE",
+"450 104 OFFCURVE",
+"440 89 OFFCURVE",
+"422 67 CURVE",
+"400 44 OFFCURVE",
+"385 33 OFFCURVE",
+"366 26 CURVE SMOOTH",
+"339 16 OFFCURVE",
+"331 14 OFFCURVE",
+"300 13 CURVE SMOOTH",
+"270 13 OFFCURVE",
+"259 13 OFFCURVE",
+"231 17 CURVE",
+"223 20 OFFCURVE",
+"196 33 OFFCURVE",
+"195 36 CURVE",
+"193 36 OFFCURVE",
+"188 39 OFFCURVE",
+"185 41 CURVE",
+"159 51 OFFCURVE",
+"127 80 OFFCURVE",
+"99 121 CURVE SMOOTH",
+"93 129 OFFCURVE",
+"80 162 OFFCURVE",
+"72 185 CURVE",
+"68 200 OFFCURVE",
+"66 204 OFFCURVE",
+"59 207 CURVE SMOOTH",
+"52 210 OFFCURVE",
+"46 210 OFFCURVE",
+"35 208 CURVE SMOOTH",
+"30 207 OFFCURVE",
+"27 204 OFFCURVE",
+"26 199 CURVE",
+"22 193 OFFCURVE",
+"22 187 OFFCURVE",
+"24 125 CURVE",
+"24 66 OFFCURVE",
+"24 56 OFFCURVE",
+"24 38 CURVE",
+"22 25 OFFCURVE",
+"21 13 OFFCURVE",
+"22 6 CURVE",
+"22 -2 OFFCURVE",
+"24 -5 OFFCURVE",
+"29 -7 CURVE",
+"35 -12 OFFCURVE",
+"52 -12 OFFCURVE",
+"62 -7 CURVE",
+"62 -5 OFFCURVE",
+"80 5 OFFCURVE",
+"88 14 CURVE",
+"101 25 OFFCURVE",
+"113 33 OFFCURVE",
+"113 33 CURVE",
+"113 33 OFFCURVE",
+"135 26 OFFCURVE",
+"135 22 CURVE SMOOTH",
+"135 14 OFFCURVE",
+"159 8 OFFCURVE",
+"159 6 CURVE",
+"175 -5 OFFCURVE",
+"212 -17 OFFCURVE",
+"243 -22 CURVE SMOOTH",
+"258 -25 OFFCURVE",
+"308 -25 OFFCURVE",
+"322 -24 CURVE",
+"322 -22 OFFCURVE",
+"344 -20 OFFCURVE",
+"344 -20 CURVE",
+"358 -17 OFFCURVE",
+"388 -5 OFFCURVE",
+"407 5 CURVE SMOOTH",
+"458 31 OFFCURVE",
+"503 83 OFFCURVE",
+"523 136 CURVE SMOOTH",
+"537 172 OFFCURVE",
+"543 193 OFFCURVE",
+"543 232 CURVE",
+"546 278 OFFCURVE",
+"541 307 OFFCURVE",
+"524 349 CURVE SMOOTH",
+"508 390 OFFCURVE",
+"480 422 OFFCURVE",
+"440 447 CURVE SMOOTH",
+"430 453 OFFCURVE",
+"419 462 OFFCURVE",
+"416 464 CURVE SMOOTH",
+"407 469 OFFCURVE",
+"383 478 OFFCURVE",
+"382 477 CURVE",
+"382 477 OFFCURVE",
+"375 478 OFFCURVE",
+"366 481 CURVE SMOOTH",
+"331 495 OFFCURVE",
+"291 505 OFFCURVE",
+"264 506 CURVE",
+"258 508 OFFCURVE",
+"248 510 OFFCURVE",
+"243 511 CURVE",
+"237 511 OFFCURVE",
+"225 514 OFFCURVE",
+"217 519 CURVE",
+"193 523 OFFCURVE",
+"175 528 OFFCURVE",
+"167 533 CURVE SMOOTH",
+"157 538 OFFCURVE",
+"140 552 OFFCURVE",
+"134 560 CURVE",
+"118 575 OFFCURVE",
+"112 603 OFFCURVE",
+"115 629 CURVE",
+"115 651 OFFCURVE",
+"115 663 OFFCURVE",
+"137 674 CURVE",
+"142 680 OFFCURVE",
+"148 685 OFFCURVE",
+"148 687 CURVE SMOOTH",
+"148 687 OFFCURVE",
+"148 691 OFFCURVE",
+"151 694 CURVE SMOOTH",
+"157 701 OFFCURVE",
+"174 709 OFFCURVE",
+"190 713 CURVE SMOOTH",
+"202 715 OFFCURVE",
+"202 718 OFFCURVE",
+"215 722 CURVE SMOOTH",
+"225 726 OFFCURVE",
+"230 726 OFFCURVE",
+"262 727 CURVE SMOOTH",
+"287 727 OFFCURVE",
+"302 727 OFFCURVE",
+"311 726 CURVE",
+"326 722 OFFCURVE",
+"359 705 OFFCURVE",
+"370 697 CURVE SMOOTH",
+"374 694 OFFCURVE",
+"383 688 OFFCURVE",
+"385 685 CURVE",
+"391 682 OFFCURVE",
+"395 677 OFFCURVE",
+"397 674 CURVE",
+"401 671 OFFCURVE",
+"406 659 OFFCURVE",
+"416 649 CURVE",
+"431 626 OFFCURVE",
+"440 605 OFFCURVE",
+"450 578 CURVE",
+"453 566 OFFCURVE",
+"458 556 OFFCURVE",
+"461 553 CURVE SMOOTH",
+"465 547 OFFCURVE",
+"465 547 OFFCURVE",
+"480 547 CURVE SMOOTH",
+"491 547 OFFCURVE",
+"493 548 OFFCURVE",
+"496 552 CURVE SMOOTH",
+"499 556 OFFCURVE",
+"499 556 OFFCURVE",
+"498 610 CURVE SMOOTH",
+"498 633 OFFCURVE",
+"496 671 OFFCURVE",
+"496 696 CURVE SMOOTH",
+"496 740 LINE",
+"491 745 LINE",
+"488 746 OFFCURVE",
+"485 749 OFFCURVE",
+"475 746 CURVE",
+"461 746 OFFCURVE",
+"461 746 OFFCURVE",
+"436 727 CURVE",
+"432 722 OFFCURVE",
+"424 717 OFFCURVE",
+"422 715 CURVE",
+"417 713 OFFCURVE",
+"416 715 OFFCURVE",
+"411 718 CURVE",
+"410 722 OFFCURVE",
+"407 724 OFFCURVE",
+"405 724 CURVE SMOOTH",
+"405 724 OFFCURVE",
+"402 726 OFFCURVE",
+"399 727 CURVE",
+"397 729 OFFCURVE",
+"394 730 OFFCURVE",
+"392 730 CURVE SMOOTH",
+"391 730 OFFCURVE",
+"382 734 OFFCURVE",
+"374 738 CURVE SMOOTH",
+"349 752 OFFCURVE",
+"329 759 OFFCURVE",
+"306 762 CURVE SMOOTH",
+"292 763 OFFCURVE",
+"256 765 OFFCURVE",
+"245 763 CURVE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"457 -13 OFFCURVE",
+"544 80 OFFCURVE",
+"544 237 CURVE SMOOTH",
+"544 391 OFFCURVE",
+"461 460 OFFCURVE",
+"310 497 CURVE SMOOTH",
+"231 516 OFFCURVE",
+"120 531 OFFCURVE",
+"120 617 CURVE SMOOTH",
+"120 685 OFFCURVE",
+"189 728 OFFCURVE",
+"276 728 CURVE SMOOTH",
+"371 728 OFFCURVE",
+"435 677 OFFCURVE",
+"474 550 CURVE",
+"504 550 LINE",
+"504 754 LINE",
+"473 754 LINE",
+"434 712 LINE",
+"381 745 OFFCURVE",
+"338 763 OFFCURVE",
+"278 763 CURVE SMOOTH",
+"155 763 OFFCURVE",
+"43 690 OFFCURVE",
+"43 537 CURVE SMOOTH",
+"43 397 OFFCURVE",
+"138 331 OFFCURVE",
+"278 296 CURVE SMOOTH",
+"356 276 OFFCURVE",
+"465 264 OFFCURVE",
+"465 159 CURVE SMOOTH",
+"465 82 OFFCURVE",
+"406 22 OFFCURVE",
+"295 22 CURVE SMOOTH",
+"159 22 OFFCURVE",
+"89 111 OFFCURVE",
+"66 210 CURVE",
+"35 210 LINE",
+"35 0 LINE",
+"65 0 LINE",
+"112 48 LINE",
+"161 12 OFFCURVE",
+"216 -13 OFFCURVE",
+"298 -13 CURVE SMOOTH"
+);
+}
+);
+width = 569;
+}
+);
+leftKerningGroup = S;
+rightKerningGroup = S;
+unicode = 0053;
+},
+{
+glyphname = Sacute;
+lastChange = "2016-08-22 11:53:08 +0000";
+layers = (
+{
+components = (
+{
+name = S;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -38, 304}";
+}
+);
+layerId = UUID0;
+width = 574;
+},
+{
+components = (
+{
+name = S;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -105, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 569;
+}
+);
+leftKerningGroup = S;
+rightKerningGroup = S;
+unicode = 015A;
+},
+{
+glyphname = Scaron;
+lastChange = "2016-08-22 12:07:43 +0000";
+layers = (
+{
+components = (
+{
+name = S;
+},
+{
+name = caron.case;
+transform = "{1, 0, 0, 1, 117, 1}";
+}
+);
+layerId = UUID0;
+width = 574;
+},
+{
+components = (
+{
+name = S;
+},
+{
+name = caron.case;
+transform = "{1, 0, 0, 1, 71, 2}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 569;
+}
+);
+leftKerningGroup = S;
+rightKerningGroup = S;
+unicode = 0160;
+},
+{
+glyphname = Scedilla;
+lastChange = "2016-08-22 12:07:43 +0000";
+layers = (
+{
+components = (
+{
+name = S;
+},
+{
+name = cedilla;
+transform = "{1, 0, 0, 1, 182, 6}";
+}
+);
+layerId = UUID0;
+width = 574;
+},
+{
+components = (
+{
+name = S;
+},
+{
+name = cedilla;
+transform = "{1, 0, 0, 1, 168, 13}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 569;
+}
+);
+leftKerningGroup = S;
+rightKerningGroup = S;
+unicode = 015E;
+},
+{
+glyphname = Scircumflex;
+lastChange = "2016-08-22 11:53:08 +0000";
+layers = (
+{
+components = (
+{
+name = S;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -3, 304}";
+}
+);
+layerId = UUID0;
+width = 574;
+},
+{
+components = (
+{
+name = S;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -11, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 569;
+}
+);
+leftKerningGroup = S;
+rightKerningGroup = S;
+unicode = 015C;
+},
+{
+glyphname = Scommaaccent;
+lastChange = "2016-08-22 12:07:43 +0000";
+layers = (
+{
+components = (
+{
+name = S;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 201, 0}";
+}
+);
+layerId = UUID0;
+width = 574;
+},
+{
+components = (
+{
+name = S;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 192, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 569;
+}
+);
+leftKerningGroup = S;
+rightKerningGroup = S;
+unicode = 0218;
+},
+{
+glyphname = Sdotbelow;
+lastChange = "2016-08-22 11:53:08 +0000";
+layers = (
+{
+components = (
+{
+name = S;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 3, 0}";
+}
+);
+layerId = UUID0;
+width = 574;
+},
+{
+components = (
+{
+name = S;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -8, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 569;
+}
+);
+leftKerningGroup = S;
+rightKerningGroup = S;
+unicode = 1E62;
+},
+{
+glyphname = Schwa;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"587 -13 OFFCURVE",
+"723 187 OFFCURVE",
+"723 378 CURVE SMOOTH",
+"723 581 OFFCURVE",
+"570 764 OFFCURVE",
+"377 764 CURVE SMOOTH",
+"235 764 OFFCURVE",
+"101 664 OFFCURVE",
+"57 513 CURVE",
+"91 513 LINE",
+"136 645 OFFCURVE",
+"251 733 OFFCURVE",
+"382 733 CURVE SMOOTH",
+"516 733 OFFCURVE",
+"563 642 OFFCURVE",
+"563 374 CURVE SMOOTH",
+"563 85 OFFCURVE",
+"508 17 OFFCURVE",
+"380 17 CURVE SMOOTH",
+"269 17 OFFCURVE",
+"215 69 OFFCURVE",
+"215 183 CURVE SMOOTH",
+"215 309 LINE",
+"596 309 LINE",
+"596 343 LINE",
+"52 343 LINE",
+"52 333 LINE SMOOTH",
+"52 120 OFFCURVE",
+"206 -13 OFFCURVE",
+"377 -13 CURVE SMOOTH"
+);
+}
+);
+width = 753;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"611 -13 OFFCURVE",
+"755 187 OFFCURVE",
+"755 378 CURVE SMOOTH",
+"755 581 OFFCURVE",
+"594 764 OFFCURVE",
+"385 764 CURVE SMOOTH",
+"243 764 OFFCURVE",
+"109 664 OFFCURVE",
+"65 513 CURVE",
+"104 513 LINE",
+"147 642 OFFCURVE",
+"258 728 OFFCURVE",
+"385 728 CURVE SMOOTH",
+"518 728 OFFCURVE",
+"566 638 OFFCURVE",
+"566 374 CURVE SMOOTH",
+"566 89 OFFCURVE",
+"511 21 OFFCURVE",
+"388 21 CURVE SMOOTH",
+"277 21 OFFCURVE",
+"223 73 OFFCURVE",
+"223 183 CURVE SMOOTH",
+"223 309 LINE",
+"604 309 LINE",
+"604 348 LINE",
+"40 348 LINE",
+"40 333 LINE SMOOTH",
+"40 120 OFFCURVE",
+"204 -13 OFFCURVE",
+"385 -13 CURVE SMOOTH"
+);
+}
+);
+width = 795;
+}
+);
+unicode = 018F;
+},
+{
+glyphname = T;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{353, 0}";
+},
+{
+name = center;
+position = "{353, 377}";
+},
+{
+name = top;
+position = "{353, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"677 754 LINE",
+"29 754 LINE",
+"29 509 LINE",
+"64 509 LINE",
+"66 623 OFFCURVE",
+"120 724 OFFCURVE",
+"214 729 CURVE",
+"290 729 LINE",
+"290 25 LINE",
+"160 25 LINE",
+"160 0 LINE",
+"554 0 LINE",
+"554 25 LINE",
+"424 25 LINE",
+"424 729 LINE",
+"484 729 LINE SMOOTH",
+"583 729 OFFCURVE",
+"640 626 OFFCURVE",
+"642 509 CURVE",
+"677 509 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"554 0 LINE",
+"554 25 LINE",
+"424 25 LINE",
+"424 729 LINE",
+"484 729 LINE SMOOTH",
+"583 729 OFFCURVE",
+"640 626 OFFCURVE",
+"642 509 CURVE",
+"677 509 LINE",
+"677 754 LINE",
+"29 754 LINE",
+"29 509 LINE",
+"64 509 LINE",
+"66 623 OFFCURVE",
+"120 724 OFFCURVE",
+"214 729 CURVE",
+"290 729 LINE",
+"290 25 LINE",
+"160 25 LINE",
+"160 0 LINE"
+);
+}
+);
+width = 705;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{362, 0}";
+},
+{
+name = center;
+position = "{362, 377}";
+},
+{
+name = top;
+position = "{362, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"158 0 LINE",
+"559 0 LINE",
+"559 30 LINE",
+"441 30 LINE",
+"441 724 LINE",
+"491 724 LINE SMOOTH",
+"602 724 OFFCURVE",
+"667 623 OFFCURVE",
+"669 509 CURVE",
+"709 509 LINE",
+"709 754 LINE",
+"15 754 LINE",
+"15 509 LINE",
+"55 509 LINE",
+"57 623 OFFCURVE",
+"122 724 OFFCURVE",
+"233 724 CURVE SMOOTH",
+"283 724 LINE",
+"283 30 LINE",
+"158 30 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"559 0 LINE",
+"559 30 LINE",
+"441 30 LINE",
+"441 724 LINE",
+"491 724 LINE SMOOTH",
+"602 724 OFFCURVE",
+"667 623 OFFCURVE",
+"669 509 CURVE",
+"709 509 LINE",
+"709 754 LINE",
+"15 754 LINE",
+"15 509 LINE",
+"55 509 LINE",
+"57 623 OFFCURVE",
+"122 724 OFFCURVE",
+"233 724 CURVE SMOOTH",
+"283 724 LINE",
+"283 30 LINE",
+"158 30 LINE",
+"158 0 LINE"
+);
+}
+);
+width = 724;
+}
+);
+leftKerningGroup = T;
+rightKerningGroup = T;
+unicode = 0054;
+},
+{
+glyphname = Tbar;
+lastChange = "2016-08-22 12:16:12 +0000";
+layers = (
+{
+components = (
+{
+name = T;
+},
+{
+alignment = -1;
+name = strokeshortcomb;
+transform = "{1, 0, 0, 1, 565, 406}";
+}
+);
+layerId = UUID0;
+width = 705;
+},
+{
+components = (
+{
+name = T;
+},
+{
+alignment = -1;
+name = strokeshortcomb;
+transform = "{1, 0, 0, 1, 107, 393}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 724;
+}
+);
+unicode = 0166;
+},
+{
+glyphname = Tcaron;
+lastChange = "2016-08-22 12:07:43 +0000";
+layers = (
+{
+components = (
+{
+name = T;
+},
+{
+name = caron.case;
+transform = "{1, 0, 0, 1, 183, 1}";
+}
+);
+layerId = UUID0;
+width = 705;
+},
+{
+components = (
+{
+name = T;
+},
+{
+name = caron.case;
+transform = "{1, 0, 0, 1, 148, 2}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 724;
+}
+);
+leftKerningGroup = T;
+rightKerningGroup = T;
+unicode = 0164;
+},
+{
+glyphname = Tcedilla;
+lastChange = "2016-08-22 12:07:43 +0000";
+layers = (
+{
+components = (
+{
+name = T;
+},
+{
+name = cedilla;
+transform = "{1, 0, 0, 1, 248, 6}";
+}
+);
+layerId = UUID0;
+width = 705;
+},
+{
+components = (
+{
+name = T;
+},
+{
+name = cedilla;
+transform = "{1, 0, 0, 1, 245, 13}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 724;
+}
+);
+leftKerningGroup = T;
+rightKerningGroup = T;
+unicode = 0162;
+},
+{
+glyphname = Tcommaaccent;
+lastChange = "2016-08-22 12:07:43 +0000";
+layers = (
+{
+components = (
+{
+name = T;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 267, 0}";
+}
+);
+layerId = UUID0;
+width = 705;
+},
+{
+components = (
+{
+name = T;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 269, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 724;
+}
+);
+leftKerningGroup = T;
+rightKerningGroup = T;
+unicode = 021A;
+},
+{
+glyphname = Tdotbelow;
+lastChange = "2016-08-22 11:53:08 +0000";
+layers = (
+{
+components = (
+{
+name = T;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 69, 0}";
+}
+);
+layerId = UUID0;
+width = 705;
+},
+{
+components = (
+{
+name = T;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 69, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 724;
+}
+);
+leftKerningGroup = T;
+rightKerningGroup = T;
+unicode = 1E6C;
+},
+{
+glyphname = U;
+lastChange = "2016-08-22 09:34:02 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{369, 0}";
+},
+{
+name = ogonek;
+position = "{663, 10}";
+},
+{
+name = top;
+position = "{369, 754}";
+},
+{
+name = topright;
+position = "{680, 701}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"10 729 LINE",
+"127 729 LINE",
+"127 194 LINE SMOOTH",
+"127 53 OFFCURVE",
+"231 -13 OFFCURVE",
+"391 -13 CURVE SMOOTH",
+"549 -13 OFFCURVE",
+"629 52 OFFCURVE",
+"629 195 CURVE SMOOTH",
+"629 729 LINE",
+"734 729 LINE",
+"734 754 LINE",
+"491 754 LINE",
+"491 729 LINE",
+"596 729 LINE",
+"596 195 LINE SMOOTH",
+"596 79 OFFCURVE",
+"529 22 OFFCURVE",
+"422 22 CURVE SMOOTH",
+"322 22 OFFCURVE",
+"261 71 OFFCURVE",
+"261 195 CURVE SMOOTH",
+"261 729 LINE",
+"356 729 LINE",
+"356 754 LINE",
+"10 754 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"545 -12 OFFCURVE",
+"625 53 OFFCURVE",
+"625 196 CURVE SMOOTH",
+"625 729 LINE",
+"730 729 LINE",
+"730 754 LINE",
+"487 754 LINE",
+"487 729 LINE",
+"592 729 LINE",
+"592 196 LINE SMOOTH",
+"592 80 OFFCURVE",
+"525 23 OFFCURVE",
+"418 23 CURVE SMOOTH",
+"318 23 OFFCURVE",
+"257 72 OFFCURVE",
+"257 196 CURVE SMOOTH",
+"257 729 LINE",
+"352 729 LINE",
+"352 754 LINE",
+"6 754 LINE",
+"6 729 LINE",
+"123 729 LINE",
+"123 195 LINE SMOOTH",
+"123 54 OFFCURVE",
+"227 -12 OFFCURVE",
+"387 -12 CURVE SMOOTH"
+);
+}
+);
+width = 737;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{387, 0}";
+},
+{
+name = ogonek;
+position = "{697, 10}";
+},
+{
+name = top;
+position = "{387, 754}";
+},
+{
+name = topright;
+position = "{605, 700}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"22 746 OFFCURVE",
+"21 738 OFFCURVE",
+"24 729 CURVE",
+"26 719 OFFCURVE",
+"30 719 OFFCURVE",
+"68 719 CURVE",
+"107 721 OFFCURVE",
+"115 719 OFFCURVE",
+"119 714 CURVE",
+"119 711 OFFCURVE",
+"121 674 OFFCURVE",
+"121 633 CURVE SMOOTH",
+"121 589 OFFCURVE",
+"121 555 OFFCURVE",
+"121 552 CURVE SMOOTH",
+"121 550 OFFCURVE",
+"121 522 OFFCURVE",
+"121 489 CURVE SMOOTH",
+"119 388 OFFCURVE",
+"118 258 OFFCURVE",
+"118 239 CURVE SMOOTH",
+"118 203 OFFCURVE",
+"121 147 OFFCURVE",
+"122 143 CURVE",
+"124 142 OFFCURVE",
+"126 136 OFFCURVE",
+"126 131 CURVE",
+"132 108 OFFCURVE",
+"148 75 OFFCURVE",
+"160 64 CURVE",
+"184 36 OFFCURVE",
+"193 30 OFFCURVE",
+"204 22 CURVE SMOOTH",
+"210 17 OFFCURVE",
+"217 14 OFFCURVE",
+"218 14 CURVE SMOOTH",
+"220 14 OFFCURVE",
+"227 9 OFFCURVE",
+"232 6 CURVE SMOOTH",
+"253 -5 OFFCURVE",
+"304 -19 OFFCURVE",
+"338 -24 CURVE",
+"366 -27 OFFCURVE",
+"434 -27 OFFCURVE",
+"471 -25 CURVE",
+"507 -22 OFFCURVE",
+"526 -17 OFFCURVE",
+"555 -5 CURVE",
+"596 14 OFFCURVE",
+"617 31 OFFCURVE",
+"645 75 CURVE SMOOTH",
+"667 108 OFFCURVE",
+"680 145 OFFCURVE",
+"680 213 CURVE",
+"682 247 OFFCURVE",
+"682 397 OFFCURVE",
+"682 602 CURVE SMOOTH",
+"682 686 OFFCURVE",
+"682 692 OFFCURVE",
+"690 700 CURVE",
+"700 714 OFFCURVE",
+"706 714 OFFCURVE",
+"745 716 CURVE",
+"778 716 LINE",
+"784 721 LINE",
+"793 732 OFFCURVE",
+"785 752 OFFCURVE",
+"768 752 CURVE SMOOTH",
+"751 752 OFFCURVE",
+"651 752 OFFCURVE",
+"604 752 CURVE SMOOTH",
+"552 752 LINE",
+"546 747 LINE",
+"542 741 OFFCURVE",
+"540 729 OFFCURVE",
+"545 722 CURVE",
+"545 719 OFFCURVE",
+"552 719 OFFCURVE",
+"565 717 CURVE",
+"590 716 OFFCURVE",
+"615 713 OFFCURVE",
+"620 711 CURVE SMOOTH",
+"626 709 OFFCURVE",
+"640 699 OFFCURVE",
+"640 691 CURVE SMOOTH",
+"640 684 OFFCURVE",
+"640 606 OFFCURVE",
+"640 586 CURVE SMOOTH",
+"640 577 OFFCURVE",
+"640 569 OFFCURVE",
+"640 561 CURVE SMOOTH",
+"640 547 OFFCURVE",
+"640 464 OFFCURVE",
+"640 431 CURVE",
+"638 419 OFFCURVE",
+"638 408 OFFCURVE",
+"638 405 CURVE SMOOTH",
+"638 401 OFFCURVE",
+"638 391 OFFCURVE",
+"638 381 CURVE SMOOTH",
+"638 371 OFFCURVE",
+"638 358 OFFCURVE",
+"638 351 CURVE",
+"640 334 OFFCURVE",
+"640 283 OFFCURVE",
+"642 276 CURVE",
+"642 273 OFFCURVE",
+"640 250 OFFCURVE",
+"640 223 CURVE",
+"637 176 OFFCURVE",
+"637 173 OFFCURVE",
+"626 128 CURVE SMOOTH",
+"620 101 OFFCURVE",
+"607 81 OFFCURVE",
+"580 55 CURVE SMOOTH",
+"565 40 OFFCURVE",
+"554 33 OFFCURVE",
+"521 25 CURVE",
+"502 18 LINE",
+"455 18 LINE SMOOTH",
+"405 18 OFFCURVE",
+"402 18 OFFCURVE",
+"372 33 CURVE SMOOTH",
+"347 45 OFFCURVE",
+"342 50 OFFCURVE",
+"322 81 CURVE SMOOTH",
+"313 95 OFFCURVE",
+"310 105 OFFCURVE",
+"309 114 CURVE",
+"307 120 OFFCURVE",
+"307 130 OFFCURVE",
+"305 136 CURVE",
+"301 159 OFFCURVE",
+"301 208 OFFCURVE",
+"301 286 CURVE SMOOTH",
+"302 373 OFFCURVE",
+"302 505 OFFCURVE",
+"302 627 CURVE",
+"301 672 OFFCURVE",
+"302 704 OFFCURVE",
+"304 708 CURVE SMOOTH",
+"308 717 OFFCURVE",
+"314 717 OFFCURVE",
+"352 716 CURVE",
+"352 716 OFFCURVE",
+"374 716 OFFCURVE",
+"374 717 CURVE",
+"396 717 OFFCURVE",
+"396 719 OFFCURVE",
+"396 722 CURVE SMOOTH",
+"396 729 OFFCURVE",
+"396 742 OFFCURVE",
+"396 749 CURVE",
+"390 752 LINE",
+"342 752 LINE SMOOTH",
+"315 752 OFFCURVE",
+"280 752 OFFCURVE",
+"262 752 CURVE SMOOTH",
+"244 752 OFFCURVE",
+"185 752 OFFCURVE",
+"130 752 CURVE",
+"36 754 OFFCURVE",
+"32 754 OFFCURVE",
+"29 750 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"230 467 OFFCURVE",
+"230 467 OFFCURVE",
+"227 467 CURVE SMOOTH",
+"221 467 OFFCURVE",
+"219 469 OFFCURVE",
+"222 471 CURVE",
+"226 472 OFFCURVE",
+"227 472 OFFCURVE",
+"229 469 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"574 -13 OFFCURVE",
+"659 51 OFFCURVE",
+"659 195 CURVE SMOOTH",
+"659 724 LINE",
+"764 724 LINE",
+"764 754 LINE",
+"526 754 LINE",
+"526 724 LINE",
+"621 724 LINE",
+"621 200 LINE SMOOTH",
+"621 84 OFFCURVE",
+"553 27 OFFCURVE",
+"441 27 CURVE SMOOTH",
+"337 27 OFFCURVE",
+"270 76 OFFCURVE",
+"270 200 CURVE SMOOTH",
+"270 724 LINE",
+"376 724 LINE",
+"376 754 LINE",
+"15 754 LINE",
+"15 724 LINE",
+"112 724 LINE",
+"112 194 LINE SMOOTH",
+"112 53 OFFCURVE",
+"229 -13 OFFCURVE",
+"403 -13 CURVE SMOOTH"
+);
+}
+);
+width = 774;
+}
+);
+leftKerningGroup = U;
+rightKerningGroup = U;
+unicode = 0055;
+},
+{
+glyphname = Uacute;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = U;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 44, 304}";
+}
+);
+layerId = UUID0;
+width = 737;
+},
+{
+components = (
+{
+name = U;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -3, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 774;
+}
+);
+leftKerningGroup = U;
+rightKerningGroup = U;
+unicode = 00DA;
+},
+{
+glyphname = Ubreve;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = U;
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, 74, 304}";
+}
+);
+layerId = UUID0;
+width = 737;
+},
+{
+components = (
+{
+name = U;
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, 89, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 774;
+}
+);
+leftKerningGroup = U;
+rightKerningGroup = U;
+unicode = 016C;
+},
+{
+glyphname = Ucircumflex;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = U;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 79, 304}";
+}
+);
+layerId = UUID0;
+width = 737;
+},
+{
+components = (
+{
+name = U;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 91, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 774;
+}
+);
+leftKerningGroup = U;
+rightKerningGroup = U;
+unicode = 00DB;
+},
+{
+glyphname = Udblgrave;
+lastChange = "2016-08-22 12:07:43 +0000";
+layers = (
+{
+components = (
+{
+name = U;
+},
+{
+name = dblgravecomb.cap;
+transform = "{1, 0, 0, 1, 156, 0}";
+}
+);
+layerId = UUID0;
+width = 737;
+},
+{
+components = (
+{
+name = U;
+},
+{
+name = dblgravecomb.cap;
+transform = "{1, 0, 0, 1, 119, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 774;
+}
+);
+leftKerningGroup = U;
+rightKerningGroup = U;
+unicode = 0214;
+},
+{
+glyphname = Udieresis;
+lastChange = "2016-08-22 12:16:34 +0000";
+layers = (
+{
+components = (
+{
+name = U;
+},
+{
+alignment = -1;
+name = dieresis.case;
+transform = "{1, 0, 0, 1, 253, 0}";
+}
+);
+layerId = UUID0;
+width = 737;
+},
+{
+components = (
+{
+name = U;
+},
+{
+alignment = -1;
+name = dieresis.case;
+transform = "{1, 0, 0, 1, 270, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 774;
+}
+);
+leftKerningGroup = U;
+rightKerningGroup = U;
+unicode = 00DC;
+},
+{
+glyphname = Udotbelow;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = U;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 85, 0}";
+}
+);
+layerId = UUID0;
+width = 737;
+},
+{
+components = (
+{
+name = U;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 94, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 774;
+}
+);
+leftKerningGroup = U;
+rightKerningGroup = U;
+unicode = 1EE4;
+},
+{
+glyphname = Ugrave;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = U;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 82, 304}";
+}
+);
+layerId = UUID0;
+width = 737;
+},
+{
+components = (
+{
+name = U;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 138, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 774;
+}
+);
+leftKerningGroup = U;
+rightKerningGroup = U;
+unicode = 00D9;
+},
+{
+glyphname = Uhookabove;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = U;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 84, 304}";
+}
+);
+layerId = UUID0;
+width = 737;
+},
+{
+components = (
+{
+name = U;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 103, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 774;
+}
+);
+leftKerningGroup = U;
+rightKerningGroup = U;
+unicode = 1EE6;
+},
+{
+glyphname = Uhorn;
+lastChange = "2016-08-22 12:18:08 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{369, 0}";
+},
+{
+name = ogonek;
+position = "{663, 10}";
+},
+{
+name = top;
+position = "{369, 754}";
+},
+{
+name = topright;
+position = "{680, 701}";
+}
+);
+components = (
+{
+name = horncomb;
+transform = "{1, 0, 0, 1, 368, 251}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"545 -12 OFFCURVE",
+"625 53 OFFCURVE",
+"625 196 CURVE SMOOTH",
+"625 754 LINE",
+"487 754 LINE",
+"487 729 LINE",
+"592 729 LINE",
+"592 196 LINE SMOOTH",
+"592 80 OFFCURVE",
+"525 23 OFFCURVE",
+"418 23 CURVE SMOOTH",
+"318 23 OFFCURVE",
+"257 72 OFFCURVE",
+"257 196 CURVE SMOOTH",
+"257 729 LINE",
+"352 729 LINE",
+"352 754 LINE",
+"6 754 LINE",
+"6 729 LINE",
+"123 729 LINE",
+"123 195 LINE SMOOTH",
+"123 54 OFFCURVE",
+"227 -12 OFFCURVE",
+"387 -12 CURVE SMOOTH"
+);
+}
+);
+width = 737;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{387, 0}";
+},
+{
+name = ogonek;
+position = "{697, 10}";
+},
+{
+name = top;
+position = "{387, 754}";
+},
+{
+name = topright;
+position = "{605, 700}";
+}
+);
+components = (
+{
+name = horncomb;
+transform = "{1, 0, 0, 1, 406, 250}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"574 -13 OFFCURVE",
+"659 51 OFFCURVE",
+"659 195 CURVE SMOOTH",
+"659 754 LINE",
+"526 754 LINE",
+"526 724 LINE",
+"621 724 LINE",
+"621 200 LINE SMOOTH",
+"621 84 OFFCURVE",
+"553 27 OFFCURVE",
+"441 27 CURVE SMOOTH",
+"337 27 OFFCURVE",
+"270 76 OFFCURVE",
+"270 200 CURVE SMOOTH",
+"270 724 LINE",
+"376 724 LINE",
+"376 754 LINE",
+"15 754 LINE",
+"15 724 LINE",
+"112 724 LINE",
+"112 194 LINE SMOOTH",
+"112 53 OFFCURVE",
+"229 -13 OFFCURVE",
+"403 -13 CURVE SMOOTH"
+);
+}
+);
+width = 774;
+}
+);
+leftKerningGroup = U;
+rightKerningGroup = U;
+unicode = 01AF;
+},
+{
+glyphname = Uhornacute;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = Uhorn;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 44, 304}";
+}
+);
+layerId = UUID0;
+width = 737;
+},
+{
+components = (
+{
+name = Uhorn;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -3, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 774;
+}
+);
+leftKerningGroup = U;
+rightKerningGroup = U;
+unicode = 1EE8;
+},
+{
+glyphname = Uhorndotbelow;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = Uhorn;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 85, 0}";
+}
+);
+layerId = UUID0;
+width = 737;
+},
+{
+components = (
+{
+name = Uhorn;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 94, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 774;
+}
+);
+leftKerningGroup = U;
+rightKerningGroup = U;
+unicode = 1EF0;
+},
+{
+glyphname = Uhorngrave;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = Uhorn;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 82, 304}";
+}
+);
+layerId = UUID0;
+width = 737;
+},
+{
+components = (
+{
+name = Uhorn;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 138, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 774;
+}
+);
+leftKerningGroup = U;
+rightKerningGroup = U;
+unicode = 1EEA;
+},
+{
+glyphname = Uhornhookabove;
+lastChange = "2016-08-22 12:17:06 +0000";
+layers = (
+{
+components = (
+{
+name = Uhorn;
+},
+{
+alignment = -1;
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 140, 304}";
+}
+);
+layerId = UUID0;
+width = 737;
+},
+{
+components = (
+{
+name = Uhorn;
+},
+{
+alignment = -1;
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 164, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 774;
+}
+);
+leftKerningGroup = U;
+rightKerningGroup = U;
+unicode = 1EEC;
+},
+{
+glyphname = Uhorntilde;
+lastChange = "2016-08-22 12:17:21 +0000";
+layers = (
+{
+components = (
+{
+name = Uhorn;
+},
+{
+alignment = -1;
+name = tildecomb;
+transform = "{1, 0, 0, 1, 148, 277}";
+}
+);
+layerId = UUID0;
+width = 737;
+},
+{
+components = (
+{
+name = Uhorn;
+},
+{
+alignment = -1;
+name = tildecomb;
+transform = "{1, 0, 0, 1, 148, 289}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 774;
+}
+);
+leftKerningGroup = U;
+rightKerningGroup = U;
+unicode = 1EEE;
+},
+{
+glyphname = Uhungarumlaut;
+lastChange = "2016-08-22 12:16:51 +0000";
+layers = (
+{
+components = (
+{
+name = U;
+},
+{
+name = hungarumlaut.case;
+transform = "{1, 0, 0, 1, 272, 0}";
+}
+);
+layerId = UUID0;
+width = 737;
+},
+{
+components = (
+{
+name = U;
+},
+{
+name = hungarumlaut.case;
+transform = "{1, 0, 0, 1, 226, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 774;
+}
+);
+leftKerningGroup = U;
+rightKerningGroup = U;
+unicode = 0170;
+},
+{
+glyphname = Uinvertedbreve;
+lastChange = "2016-08-22 12:18:27 +0000";
+layers = (
+{
+components = (
+{
+name = U;
+},
+{
+alignment = -1;
+name = breveinvertedcomb.cap;
+transform = "{1, 0, 0, 1, 263, 0}";
+}
+);
+layerId = UUID0;
+width = 737;
+},
+{
+components = (
+{
+name = U;
+},
+{
+alignment = -1;
+name = breveinvertedcomb.cap;
+transform = "{1, 0, 0, 1, 272, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 774;
+}
+);
+leftKerningGroup = U;
+rightKerningGroup = U;
+unicode = 0216;
+},
+{
+glyphname = Umacron;
+lastChange = "2016-08-22 12:07:43 +0000";
+layers = (
+{
+components = (
+{
+name = U;
+},
+{
+name = macron.case;
+transform = "{1, 0, 0, 1, 201, 0}";
+}
+);
+layerId = UUID0;
+width = 737;
+},
+{
+components = (
+{
+name = U;
+},
+{
+name = macron.case;
+transform = "{1, 0, 0, 1, 215, -1}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 774;
+}
+);
+leftKerningGroup = U;
+rightKerningGroup = U;
+unicode = 016A;
+},
+{
+glyphname = Uogonek;
+lastChange = "2016-08-22 12:18:37 +0000";
+layers = (
+{
+components = (
+{
+name = U;
+},
+{
+name = ogonek;
+transform = "{1, 0, 0, 1, 250, 0}";
+}
+);
+layerId = UUID0;
+width = 737;
+},
+{
+components = (
+{
+name = U;
+},
+{
+name = ogonek;
+transform = "{1, 0, 0, 1, 265, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 774;
+}
+);
+leftKerningGroup = U;
+rightKerningGroup = U;
+unicode = 0172;
+},
+{
+glyphname = Uring;
+lastChange = "2016-08-22 12:07:43 +0000";
+layers = (
+{
+components = (
+{
+name = U;
+},
+{
+name = ring.case;
+transform = "{1, 0, 0, 1, 268, 40}";
+}
+);
+layerId = UUID0;
+width = 737;
+},
+{
+components = (
+{
+name = U;
+},
+{
+name = ring.case;
+transform = "{1, 0, 0, 1, 279, 80}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 774;
+}
+);
+leftKerningGroup = U;
+rightKerningGroup = U;
+unicode = 016E;
+},
+{
+glyphname = Utilde;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = U;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, 78, 304}";
+}
+);
+layerId = UUID0;
+width = 737;
+},
+{
+components = (
+{
+name = U;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, 74, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 774;
+}
+);
+leftKerningGroup = U;
+rightKerningGroup = U;
+unicode = 0168;
+},
+{
+glyphname = V;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{357, 0}";
+},
+{
+name = top;
+position = "{357, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"237 739 LINE",
+"103 739 LINE",
+"359 -9 LINE",
+"389 -9 LINE",
+"437 160 LINE",
+"427 194 LINE",
+"423 194 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"357 754 LINE",
+"10 754 LINE",
+"10 729 LINE",
+"357 729 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"735 754 LINE",
+"491 754 LINE",
+"491 729 LINE",
+"735 729 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"417 165 LINE",
+"359 -9 LINE",
+"389 -9 LINE",
+"645 739 LINE",
+"612 739 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"373 -12 LINE",
+"421 160 LINE",
+"411 194 LINE",
+"407 194 LINE",
+"221 739 LINE",
+"87 739 LINE",
+"343 -12 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"373 -12 LINE",
+"629 739 LINE",
+"596 739 LINE",
+"401 165 LINE",
+"343 -12 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"341 729 LINE",
+"341 754 LINE",
+"-6 754 LINE",
+"-6 729 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"719 729 LINE",
+"719 754 LINE",
+"475 754 LINE",
+"475 729 LINE"
+);
+}
+);
+width = 714;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{334, 0}";
+},
+{
+name = top;
+position = "{334, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"66 754 OFFCURVE",
+"43 754 OFFCURVE",
+"19 752 CURVE",
+"-32 752 OFFCURVE",
+"-32 752 OFFCURVE",
+"-33 740 CURVE",
+"-35 730 OFFCURVE",
+"-33 724 OFFCURVE",
+"-25 719 CURVE",
+"-25 717 OFFCURVE",
+"-25 717 OFFCURVE",
+"-2 719 CURVE",
+"16 722 OFFCURVE",
+"39 722 OFFCURVE",
+"41 719 CURVE SMOOTH",
+"43 717 OFFCURVE",
+"50 702 OFFCURVE",
+"56 686 CURVE SMOOTH",
+"62 671 OFFCURVE",
+"70 655 OFFCURVE",
+"73 652 CURVE",
+"74 649 OFFCURVE",
+"76 642 OFFCURVE",
+"77 638 CURVE SMOOTH",
+"77 635 OFFCURVE",
+"84 621 OFFCURVE",
+"90 606 CURVE",
+"97 594 OFFCURVE",
+"101 578 OFFCURVE",
+"101 577 CURVE SMOOTH",
+"101 575 OFFCURVE",
+"103 572 OFFCURVE",
+"105 569 CURVE SMOOTH",
+"106 567 OFFCURVE",
+"109 559 OFFCURVE",
+"111 553 CURVE SMOOTH",
+"113 546 OFFCURVE",
+"119 532 OFFCURVE",
+"123 522 CURVE",
+"127 512 OFFCURVE",
+"135 497 OFFCURVE",
+"136 489 CURVE",
+"139 481 OFFCURVE",
+"142 473 OFFCURVE",
+"144 470 CURVE SMOOTH",
+"150 462 OFFCURVE",
+"157 439 OFFCURVE",
+"163 421 CURVE",
+"185 393 OFFCURVE",
+"185 380 OFFCURVE",
+"185 369 CURVE",
+"206 340 OFFCURVE",
+"206 328 OFFCURVE",
+"206 317 CURVE",
+"209 309 OFFCURVE",
+"215 291 OFFCURVE",
+"220 278 CURVE",
+"227 264 OFFCURVE",
+"232 250 OFFCURVE",
+"233 245 CURVE SMOOTH",
+"235 240 OFFCURVE",
+"236 234 OFFCURVE",
+"239 231 CURVE SMOOTH",
+"241 228 OFFCURVE",
+"245 220 OFFCURVE",
+"248 212 CURVE",
+"248 195 OFFCURVE",
+"269 166 OFFCURVE",
+"269 158 CURVE",
+"273 150 OFFCURVE",
+"278 136 OFFCURVE",
+"287 114 CURVE",
+"288 106 OFFCURVE",
+"292 98 OFFCURVE",
+"295 93 CURVE SMOOTH",
+"296 90 OFFCURVE",
+"300 81 OFFCURVE",
+"301 74 CURVE",
+"305 61 OFFCURVE",
+"311 37 OFFCURVE",
+"320 26 CURVE",
+"321 20 OFFCURVE",
+"323 16 OFFCURVE",
+"323 14 CURVE SMOOTH",
+"323 9 OFFCURVE",
+"332 -2 OFFCURVE",
+"336 -5 CURVE",
+"336 -7 OFFCURVE",
+"357 -7 OFFCURVE",
+"357 -4 CURVE",
+"358 -4 OFFCURVE",
+"360 1 OFFCURVE",
+"361 3 CURVE",
+"361 9 OFFCURVE",
+"385 50 OFFCURVE",
+"385 66 CURVE SMOOTH",
+"385 74 OFFCURVE",
+"402 117 OFFCURVE",
+"410 144 CURVE",
+"434 209 OFFCURVE",
+"445 240 OFFCURVE",
+"445 244 CURVE SMOOTH",
+"445 245 OFFCURVE",
+"448 255 OFFCURVE",
+"451 263 CURVE SMOOTH",
+"455 273 OFFCURVE",
+"461 288 OFFCURVE",
+"463 296 CURVE SMOOTH",
+"466 304 OFFCURVE",
+"471 318 OFFCURVE",
+"474 325 CURVE SMOOTH",
+"477 333 OFFCURVE",
+"479 342 OFFCURVE",
+"480 343 CURVE",
+"480 345 OFFCURVE",
+"483 353 OFFCURVE",
+"485 359 CURVE SMOOTH",
+"487 366 OFFCURVE",
+"490 374 OFFCURVE",
+"492 375 CURVE SMOOTH",
+"494 378 OFFCURVE",
+"496 385 OFFCURVE",
+"497 391 CURVE SMOOTH",
+"499 399 OFFCURVE",
+"504 408 OFFCURVE",
+"507 416 CURVE SMOOTH",
+"515 442 OFFCURVE",
+"520 455 OFFCURVE",
+"523 462 CURVE",
+"527 480 OFFCURVE",
+"531 497 OFFCURVE",
+"552 549 CURVE",
+"556 559 OFFCURVE",
+"561 572 OFFCURVE",
+"564 582 CURVE SMOOTH",
+"567 590 OFFCURVE",
+"572 611 OFFCURVE",
+"580 627 CURVE",
+"586 644 OFFCURVE",
+"592 662 OFFCURVE",
+"593 668 CURVE",
+"601 692 OFFCURVE",
+"611 708 OFFCURVE",
+"630 716 CURVE SMOOTH",
+"638 719 OFFCURVE",
+"641 719 OFFCURVE",
+"664 719 CURVE",
+"695 717 OFFCURVE",
+"697 717 OFFCURVE",
+"702 727 CURVE SMOOTH",
+"707 735 OFFCURVE",
+"705 746 OFFCURVE",
+"697 749 CURVE SMOOTH",
+"692 752 OFFCURVE",
+"686 752 OFFCURVE",
+"581 752 CURVE SMOOTH",
+"471 752 LINE",
+"467 748 LINE",
+"467 743 OFFCURVE",
+"467 732 OFFCURVE",
+"467 727 CURVE",
+"471 720 OFFCURVE",
+"488 717 OFFCURVE",
+"497 719 CURVE SMOOTH",
+"503 720 OFFCURVE",
+"510 720 OFFCURVE",
+"523 719 CURVE SMOOTH",
+"545 716 OFFCURVE",
+"556 712 OFFCURVE",
+"561 702 CURVE",
+"564 694 OFFCURVE",
+"564 692 OFFCURVE",
+"562 681 CURVE SMOOTH",
+"561 675 OFFCURVE",
+"559 668 OFFCURVE",
+"559 668 CURVE",
+"557 667 OFFCURVE",
+"554 659 OFFCURVE",
+"552 651 CURVE",
+"548 640 OFFCURVE",
+"542 624 OFFCURVE",
+"537 610 CURVE SMOOTH",
+"532 597 OFFCURVE",
+"523 570 OFFCURVE",
+"516 553 CURVE",
+"510 535 OFFCURVE",
+"504 515 OFFCURVE",
+"502 510 CURVE SMOOTH",
+"492 489 OFFCURVE",
+"472 432 OFFCURVE",
+"469 419 CURVE",
+"466 411 OFFCURVE",
+"459 390 OFFCURVE",
+"453 370 CURVE",
+"450 364 OFFCURVE",
+"448 358 OFFCURVE",
+"448 353 CURVE",
+"447 350 OFFCURVE",
+"445 343 OFFCURVE",
+"443 338 CURVE",
+"440 333 OFFCURVE",
+"437 323 OFFCURVE",
+"434 315 CURVE",
+"426 288 OFFCURVE",
+"423 281 OFFCURVE",
+"420 275 CURVE SMOOTH",
+"415 264 OFFCURVE",
+"410 264 OFFCURVE",
+"407 273 CURVE",
+"406 280 OFFCURVE",
+"398 299 OFFCURVE",
+"390 313 CURVE",
+"388 320 OFFCURVE",
+"383 331 OFFCURVE",
+"380 342 CURVE SMOOTH",
+"377 351 OFFCURVE",
+"372 366 OFFCURVE",
+"366 374 CURVE",
+"363 382 OFFCURVE",
+"360 391 OFFCURVE",
+"360 393 CURVE SMOOTH",
+"360 394 OFFCURVE",
+"353 410 OFFCURVE",
+"347 426 CURVE SMOOTH",
+"341 442 OFFCURVE",
+"334 464 OFFCURVE",
+"331 470 CURVE SMOOTH",
+"328 478 OFFCURVE",
+"325 488 OFFCURVE",
+"323 491 CURVE SMOOTH",
+"321 494 OFFCURVE",
+"320 500 OFFCURVE",
+"318 505 CURVE",
+"317 512 OFFCURVE",
+"309 533 OFFCURVE",
+"300 556 CURVE SMOOTH",
+"298 561 OFFCURVE",
+"293 572 OFFCURVE",
+"288 584 CURVE SMOOTH",
+"277 608 OFFCURVE",
+"272 622 OFFCURVE",
+"263 651 CURVE",
+"258 662 OFFCURVE",
+"253 676 OFFCURVE",
+"252 683 CURVE",
+"248 687 OFFCURVE",
+"247 697 OFFCURVE",
+"247 702 CURVE SMOOTH",
+"247 716 OFFCURVE",
+"252 717 OFFCURVE",
+"274 717 CURVE SMOOTH",
+"301 717 OFFCURVE",
+"313 719 OFFCURVE",
+"317 725 CURVE",
+"317 732 OFFCURVE",
+"317 740 OFFCURVE",
+"317 746 CURVE",
+"312 752 LINE",
+"195 752 LINE SMOOTH",
+"131 752 OFFCURVE",
+"77 754 OFFCURVE",
+"74 754 CURVE SMOOTH",
+"73 754 OFFCURVE",
+"69 754 OFFCURVE",
+"68 754 CURVE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"347 -9 LINE",
+"413 205 LINE",
+"407 242 LINE",
+"403 242 LINE",
+"222 739 LINE",
+"49 739 LINE",
+"321 -9 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"347 -9 LINE",
+"622 739 LINE",
+"589 739 LINE",
+"373 150 LINE",
+"321 -9 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"307 724 LINE",
+"307 754 LINE",
+"-25 754 LINE",
+"-25 724 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"687 724 LINE",
+"687 754 LINE",
+"466 754 LINE",
+"466 724 LINE"
+);
+}
+);
+width = 667;
+}
+);
+unicode = 0056;
+},
+{
+glyphname = W;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{454, 0}";
+},
+{
+name = top;
+position = "{454, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"181 739 LINE",
+"47 739 LINE",
+"303 -12 LINE",
+"333 -12 LINE",
+"381 160 LINE",
+"372 192 LINE",
+"368 192 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"673 754 LINE",
+"-26 754 LINE",
+"-26 729 LINE",
+"673 729 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"362 163 LINE",
+"303 -12 LINE",
+"333 -12 LINE",
+"510 487 LINE",
+"476 487 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"451 739 LINE",
+"317 739 LINE",
+"573 -12 LINE",
+"603 -12 LINE",
+"651 160 LINE",
+"644 189 LINE",
+"640 189 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"626 160 LINE",
+"573 -12 LINE",
+"603 -12 LINE",
+"864 739 LINE",
+"831 739 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"932 754 LINE",
+"724 754 LINE",
+"724 729 LINE",
+"932 729 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"500 495 LINE",
+"532 495 LINE",
+"621 742 LINE",
+"586 742 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"333 -12 LINE",
+"455 333 LINE",
+"573 -12 LINE",
+"603 -12 LINE",
+"860 729 LINE",
+"932 729 LINE",
+"932 754 LINE",
+"724 754 LINE",
+"724 729 LINE",
+"827 729 LINE",
+"640 192 LINE",
+"636 192 LINE",
+"533 499 LINE",
+"616 729 LINE",
+"673 729 LINE",
+"673 754 LINE",
+"-26 754 LINE",
+"-26 729 LINE",
+"50 729 LINE",
+"303 -12 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"184 729 LINE",
+"320 729 LINE",
+"439 381 LINE",
+"372 192 LINE",
+"368 192 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"454 729 LINE",
+"581 729 LINE",
+"517 545 LINE"
+);
+}
+);
+width = 907;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{510, 0}";
+},
+{
+name = top;
+position = "{510, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"227 739 LINE",
+"54 739 LINE",
+"338 -9 LINE",
+"364 -9 LINE",
+"439 178 LINE",
+"435 208 LINE",
+"431 208 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"770 754 LINE",
+"-20 754 LINE",
+"-20 724 LINE",
+"770 724 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"1039 754 LINE",
+"818 754 LINE",
+"818 724 LINE",
+"1039 724 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"708 150 LINE",
+"656 -9 LINE",
+"682 -9 LINE",
+"957 739 LINE",
+"924 739 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"545 739 LINE",
+"372 739 LINE",
+"656 -9 LINE",
+"682 -9 LINE",
+"744 195 LINE",
+"738 232 LINE",
+"734 232 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"410 150 LINE",
+"358 -9 LINE",
+"384 -9 LINE",
+"547 393 LINE",
+"514 393 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"574 454 LINE",
+"607 454 LINE",
+"711 737 LINE",
+"678 737 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"384 -9 LINE",
+"524 337 LINE",
+"656 -9 LINE",
+"682 -9 LINE",
+"951 724 LINE",
+"1039 724 LINE",
+"1039 754 LINE",
+"818 754 LINE",
+"818 724 LINE",
+"918 724 LINE",
+"738 232 LINE",
+"734 232 LINE",
+"629 514 LINE",
+"706 724 LINE",
+"770 724 LINE",
+"770 754 LINE",
+"-20 754 LINE",
+"-20 724 LINE",
+"59 724 LINE",
+"338 -9 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"233 724 LINE",
+"377 724 LINE",
+"508 379 LINE",
+"435 208 LINE",
+"431 208 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"550 724 LINE",
+"673 724 LINE",
+"612 558 LINE"
+);
+}
+);
+width = 1019;
+}
+);
+leftKerningGroup = W;
+rightKerningGroup = W;
+unicode = 0057;
+},
+{
+glyphname = Wacute;
+lastChange = "2016-08-22 11:53:08 +0000";
+layers = (
+{
+components = (
+{
+name = W;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 129, 304}";
+}
+);
+layerId = UUID0;
+width = 907;
+},
+{
+components = (
+{
+name = W;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 120, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 1019;
+}
+);
+leftKerningGroup = W;
+rightKerningGroup = W;
+unicode = 1E82;
+},
+{
+glyphname = Wcircumflex;
+lastChange = "2016-08-22 11:53:08 +0000";
+layers = (
+{
+components = (
+{
+name = W;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 164, 304}";
+}
+);
+layerId = UUID0;
+width = 907;
+},
+{
+components = (
+{
+name = W;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 214, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 1019;
+}
+);
+leftKerningGroup = W;
+rightKerningGroup = W;
+unicode = 0174;
+},
+{
+glyphname = Wdieresis;
+lastChange = "2016-08-22 12:07:43 +0000";
+layers = (
+{
+components = (
+{
+name = W;
+},
+{
+name = dieresis.case;
+transform = "{1, 0, 0, 1, 290, 0}";
+}
+);
+layerId = UUID0;
+width = 907;
+},
+{
+components = (
+{
+name = W;
+},
+{
+name = dieresis.case;
+transform = "{1, 0, 0, 1, 340, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 1019;
+}
+);
+leftKerningGroup = W;
+rightKerningGroup = W;
+unicode = 1E84;
+},
+{
+glyphname = Wgrave;
+lastChange = "2016-08-22 11:53:08 +0000";
+layers = (
+{
+components = (
+{
+name = W;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 167, 304}";
+}
+);
+layerId = UUID0;
+width = 907;
+},
+{
+components = (
+{
+name = W;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 261, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 1019;
+}
+);
+leftKerningGroup = W;
+rightKerningGroup = W;
+unicode = 1E80;
+},
+{
+glyphname = X;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{337, 0}";
+},
+{
+name = top;
+position = "{337, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"223 739 LINE",
+"73 739 LINE",
+"487 0 LINE",
+"632 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"337 754 LINE",
+"-7 754 LINE",
+"-7 729 LINE",
+"337 729 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"674 754 LINE",
+"425 754 LINE",
+"425 729 LINE",
+"674 729 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"337 400 LINE",
+"374 400 LINE",
+"584 739 LINE",
+"551 739 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"696 25 LINE",
+"354 25 LINE",
+"354 0 LINE",
+"696 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"240 25 LINE",
+"-22 25 LINE",
+"-22 0 LINE",
+"240 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"70 20 LINE",
+"107 20 LINE",
+"329 379 LINE",
+"293 379 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"240 0 LINE",
+"240 25 LINE",
+"110 25 LINE",
+"300 333 LINE",
+"473 25 LINE",
+"354 25 LINE",
+"354 0 LINE",
+"696 0 LINE",
+"696 25 LINE",
+"618 25 LINE",
+"393 431 LINE",
+"578 729 LINE",
+"674 729 LINE",
+"674 754 LINE",
+"425 754 LINE",
+"425 729 LINE",
+"544 729 LINE",
+"376 462 LINE",
+"228 729 LINE",
+"337 729 LINE",
+"337 754 LINE",
+"-7 754 LINE",
+"-7 729 LINE",
+"78 729 LINE",
+"283 363 LINE",
+"73 25 LINE",
+"-22 25 LINE",
+"-22 0 LINE"
+);
+}
+);
+width = 674;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{360, 0}";
+},
+{
+name = top;
+position = "{360, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"237 739 LINE",
+"49 739 LINE",
+"488 0 LINE",
+"677 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"347 754 LINE",
+"-15 754 LINE",
+"-15 724 LINE",
+"347 724 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"676 754 LINE",
+"445 754 LINE",
+"445 724 LINE",
+"676 724 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"312 356 LINE",
+"345 350 LINE",
+"597 739 LINE",
+"561 739 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"-11 0 LINE",
+"240 0 LINE",
+"240 30 LINE",
+"-11 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"363 398 LINE",
+"330 404 LINE",
+"78 15 LINE",
+"114 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"379 0 LINE",
+"734 0 LINE",
+"734 30 LINE",
+"379 30 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"240 0 LINE",
+"240 30 LINE",
+"124 30 LINE",
+"304 308 LINE",
+"470 30 LINE",
+"379 30 LINE",
+"379 0 LINE",
+"734 0 LINE",
+"734 30 LINE",
+"659 30 LINE",
+"409 449 LINE",
+"587 724 LINE",
+"676 724 LINE",
+"676 754 LINE",
+"445 754 LINE",
+"445 724 LINE",
+"551 724 LINE",
+"392 479 LINE",
+"246 724 LINE",
+"347 724 LINE",
+"347 754 LINE",
+"-15 754 LINE",
+"-15 724 LINE",
+"58 724 LINE",
+"287 338 LINE",
+"87 30 LINE",
+"-11 30 LINE",
+"-11 0 LINE"
+);
+}
+);
+width = 719;
+}
+);
+unicode = 0058;
+},
+{
+glyphname = Y;
+lastChange = "2016-08-22 09:54:01 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{329, 0}";
+},
+{
+name = top;
+position = "{329, 754}";
+},
+{
+name = topleft;
+position = "{20, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"271 15 LINE",
+"405 15 LINE",
+"405 384 LINE",
+"271 384 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"151 0 LINE",
+"525 0 LINE",
+"525 25 LINE",
+"151 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"191 739 LINE",
+"41 739 LINE",
+"284 321 LINE",
+"401 375 LINE",
+"390 402 LINE",
+"386 402 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"305 754 LINE",
+"-42 754 LINE",
+"-42 729 LINE",
+"305 729 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"698 754 LINE",
+"433 754 LINE",
+"433 729 LINE",
+"698 729 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"360 347 LINE",
+"397 347 LINE",
+"608 739 LINE",
+"575 739 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"525 0 LINE",
+"525 25 LINE",
+"405 25 LINE",
+"405 362 LINE",
+"602 729 LINE",
+"698 729 LINE",
+"698 754 LINE",
+"433 754 LINE",
+"433 729 LINE",
+"569 729 LINE",
+"390 402 LINE",
+"386 402 LINE",
+"197 729 LINE",
+"305 729 LINE",
+"305 754 LINE",
+"-42 754 LINE",
+"-42 729 LINE",
+"47 729 LINE",
+"271 343 LINE",
+"271 25 LINE",
+"151 25 LINE",
+"151 0 LINE"
+);
+}
+);
+width = 657;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{383, 0}";
+},
+{
+name = top;
+position = "{383, 754}";
+},
+{
+name = topleft;
+position = "{20, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"317 15 LINE",
+"475 15 LINE",
+"475 384 LINE",
+"317 384 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"202 0 LINE",
+"593 0 LINE",
+"593 30 LINE",
+"202 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"267 739 LINE",
+"69 739 LINE",
+"375 234 LINE",
+"406 234 LINE",
+"472 368 LINE",
+"468 403 LINE",
+"464 403 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"362 754 LINE",
+"10 754 LINE",
+"10 724 LINE",
+"362 724 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"756 754 LINE",
+"521 754 LINE",
+"521 724 LINE",
+"756 724 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"416 301 LINE",
+"454 301 LINE",
+"675 739 LINE",
+"637 739 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"593 0 LINE",
+"593 30 LINE",
+"475 30 LINE",
+"475 342 LINE",
+"667 724 LINE",
+"756 724 LINE",
+"756 754 LINE",
+"521 754 LINE",
+"521 724 LINE",
+"629 724 LINE",
+"468 403 LINE",
+"464 403 LINE",
+"276 724 LINE",
+"362 724 LINE",
+"362 754 LINE",
+"10 754 LINE",
+"10 724 LINE",
+"78 724 LINE",
+"317 329 LINE",
+"317 30 LINE",
+"202 30 LINE",
+"202 0 LINE"
+);
+}
+);
+width = 766;
+}
+);
+leftKerningGroup = Y;
+rightKerningGroup = Y;
+unicode = 0059;
+},
+{
+glyphname = Yacute;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = Y;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 4, 304}";
+}
+);
+layerId = UUID0;
+width = 657;
+},
+{
+components = (
+{
+name = Y;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -7, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 766;
+}
+);
+leftKerningGroup = Y;
+rightKerningGroup = Y;
+unicode = 00DD;
+},
+{
+glyphname = Ycircumflex;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = Y;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 39, 304}";
+}
+);
+layerId = UUID0;
+width = 657;
+},
+{
+components = (
+{
+name = Y;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 87, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 766;
+}
+);
+leftKerningGroup = Y;
+rightKerningGroup = Y;
+unicode = 0176;
+},
+{
+glyphname = Ydieresis;
+lastChange = "2016-08-22 12:07:43 +0000";
+layers = (
+{
+components = (
+{
+name = Y;
+},
+{
+name = dieresis.case;
+transform = "{1, 0, 0, 1, 165, 0}";
+}
+);
+layerId = UUID0;
+width = 657;
+},
+{
+components = (
+{
+name = Y;
+},
+{
+name = dieresis.case;
+transform = "{1, 0, 0, 1, 213, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 766;
+}
+);
+leftKerningGroup = Y;
+rightKerningGroup = Y;
+unicode = 0178;
+},
+{
+glyphname = Ydotbelow;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = Y;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 45, 0}";
+}
+);
+layerId = UUID0;
+width = 657;
+},
+{
+components = (
+{
+name = Y;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 90, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 766;
+}
+);
+leftKerningGroup = Y;
+rightKerningGroup = Y;
+unicode = 1EF4;
+},
+{
+glyphname = Ygrave;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = Y;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 42, 304}";
+}
+);
+layerId = UUID0;
+width = 657;
+},
+{
+components = (
+{
+name = Y;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 134, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 766;
+}
+);
+leftKerningGroup = Y;
+rightKerningGroup = Y;
+unicode = 1EF2;
+},
+{
+glyphname = Yhookabove;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = Y;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 44, 304}";
+}
+);
+layerId = UUID0;
+width = 657;
+},
+{
+components = (
+{
+name = Y;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 99, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 766;
+}
+);
+leftKerningGroup = Y;
+rightKerningGroup = Y;
+unicode = 1EF6;
+},
+{
+glyphname = Ytilde;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = Y;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, 38, 304}";
+}
+);
+layerId = UUID0;
+width = 657;
+},
+{
+components = (
+{
+name = Y;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, 70, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 766;
+}
+);
+leftKerningGroup = Y;
+rightKerningGroup = Y;
+unicode = 1EF8;
+},
+{
+glyphname = Z;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{326, 0}";
+},
+{
+name = top;
+position = "{326, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"15 0 LINE",
+"601 0 LINE",
+"601 245 LINE",
+"566 245 LINE",
+"564 128 OFFCURVE",
+"507 25 OFFCURVE",
+"408 25 CURVE SMOOTH",
+"15 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"601 754 LINE",
+"65 754 LINE",
+"65 549 LINE",
+"100 549 LINE",
+"102 646 OFFCURVE",
+"159 729 OFFCURVE",
+"258 729 CURVE SMOOTH",
+"601 729 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"15 32 LINE",
+"15 7 LINE",
+"180 18 LINE",
+"180 29 LINE",
+"601 719 LINE",
+"601 737 LINE",
+"439 731 LINE",
+"439 725 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"193 18 LINE",
+"193 29 LINE",
+"608 719 LINE",
+"608 737 LINE",
+"446 731 LINE",
+"446 725 LINE",
+"28 32 LINE",
+"28 7 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"608 0 LINE",
+"608 245 LINE",
+"573 245 LINE",
+"571 128 OFFCURVE",
+"514 25 OFFCURVE",
+"415 25 CURVE SMOOTH",
+"28 25 LINE",
+"28 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"103 549 LINE",
+"105 646 OFFCURVE",
+"162 729 OFFCURVE",
+"261 729 CURVE SMOOTH",
+"608 729 LINE",
+"608 754 LINE",
+"68 754 LINE",
+"68 549 LINE"
+);
+}
+);
+width = 651;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{311, 0}";
+},
+{
+name = top;
+position = "{311, 754}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"81 751 OFFCURVE",
+"78 747 OFFCURVE",
+"78 692 CURVE SMOOTH",
+"78 658 OFFCURVE",
+"76 638 OFFCURVE",
+"72 581 CURVE",
+"69 553 OFFCURVE",
+"72 547 OFFCURVE",
+"90 544 CURVE",
+"97 542 OFFCURVE",
+"100 544 OFFCURVE",
+"103 547 CURVE SMOOTH",
+"106 551 OFFCURVE",
+"110 556 OFFCURVE",
+"112 561 CURVE SMOOTH",
+"114 567 OFFCURVE",
+"117 576 OFFCURVE",
+"118 581 CURVE SMOOTH",
+"120 586 OFFCURVE",
+"123 594 OFFCURVE",
+"125 600 CURVE SMOOTH",
+"134 621 OFFCURVE",
+"143 638 OFFCURVE",
+"151 648 CURVE SMOOTH",
+"156 655 OFFCURVE",
+"162 661 OFFCURVE",
+"164 666 CURVE",
+"169 673 OFFCURVE",
+"184 684 OFFCURVE",
+"193 691 CURVE",
+"197 692 OFFCURVE",
+"201 697 OFFCURVE",
+"206 698 CURVE",
+"216 708 OFFCURVE",
+"234 714 OFFCURVE",
+"254 717 CURVE",
+"270 722 OFFCURVE",
+"397 722 OFFCURVE",
+"409 719 CURVE SMOOTH",
+"415 717 OFFCURVE",
+"415 716 OFFCURVE",
+"417 711 CURVE",
+"417 703 OFFCURVE",
+"407 683 OFFCURVE",
+"395 663 CURVE SMOOTH",
+"392 658 OFFCURVE",
+"387 650 OFFCURVE",
+"385 644 CURVE SMOOTH",
+"384 639 OFFCURVE",
+"379 633 OFFCURVE",
+"377 630 CURVE SMOOTH",
+"373 626 OFFCURVE",
+"367 616 OFFCURVE",
+"362 606 CURVE SMOOTH",
+"357 597 OFFCURVE",
+"350 586 OFFCURVE",
+"347 581 CURVE SMOOTH",
+"340 571 OFFCURVE",
+"323 541 OFFCURVE",
+"315 526 CURVE",
+"314 521 OFFCURVE",
+"309 514 OFFCURVE",
+"307 511 CURVE SMOOTH",
+"304 506 OFFCURVE",
+"300 501 OFFCURVE",
+"300 500 CURVE SMOOTH",
+"298 497 OFFCURVE",
+"295 491 OFFCURVE",
+"292 484 CURVE",
+"287 478 OFFCURVE",
+"276 459 OFFCURVE",
+"270 444 CURVE SMOOTH",
+"264 430 OFFCURVE",
+"254 414 OFFCURVE",
+"250 411 CURVE SMOOTH",
+"247 408 OFFCURVE",
+"243 400 OFFCURVE",
+"242 396 CURVE SMOOTH",
+"240 392 OFFCURVE",
+"232 380 OFFCURVE",
+"225 369 CURVE SMOOTH",
+"214 350 OFFCURVE",
+"197 324 OFFCURVE",
+"189 308 CURVE SMOOTH",
+"187 305 OFFCURVE",
+"181 294 OFFCURVE",
+"175 286 CURVE",
+"170 275 OFFCURVE",
+"165 266 OFFCURVE",
+"162 261 CURVE SMOOTH",
+"160 256 OFFCURVE",
+"156 249 OFFCURVE",
+"153 246 CURVE SMOOTH",
+"150 242 OFFCURVE",
+"148 238 OFFCURVE",
+"147 236 CURVE",
+"147 233 OFFCURVE",
+"145 230 OFFCURVE",
+"142 225 CURVE SMOOTH",
+"137 217 OFFCURVE",
+"120 189 OFFCURVE",
+"120 186 CURVE SMOOTH",
+"120 186 OFFCURVE",
+"117 181 OFFCURVE",
+"114 175 CURVE",
+"110 171 OFFCURVE",
+"103 163 OFFCURVE",
+"100 156 CURVE SMOOTH",
+"93 142 OFFCURVE",
+"78 116 OFFCURVE",
+"70 104 CURVE",
+"67 97 OFFCURVE",
+"59 86 OFFCURVE",
+"53 77 CURVE SMOOTH",
+"47 67 OFFCURVE",
+"40 55 OFFCURVE",
+"37 52 CURVE SMOOTH",
+"23 36 OFFCURVE",
+"18 14 OFFCURVE",
+"25 2 CURVE",
+"31 -4 OFFCURVE",
+"39 -6 OFFCURVE",
+"85 -4 CURVE SMOOTH",
+"131 -3 OFFCURVE",
+"209 -3 OFFCURVE",
+"559 -6 CURVE SMOOTH",
+"580 -6 OFFCURVE",
+"602 -6 OFFCURVE",
+"604 -4 CURVE",
+"614 -3 OFFCURVE",
+"616 2 OFFCURVE",
+"618 52 CURVE",
+"618 75 OFFCURVE",
+"620 106 OFFCURVE",
+"623 119 CURVE",
+"626 155 OFFCURVE",
+"626 167 OFFCURVE",
+"627 191 CURVE SMOOTH",
+"627 202 OFFCURVE",
+"629 216 OFFCURVE",
+"629 219 CURVE SMOOTH",
+"632 236 OFFCURVE",
+"623 246 OFFCURVE",
+"604 242 CURVE",
+"595 241 OFFCURVE",
+"593 241 OFFCURVE",
+"589 231 CURVE",
+"585 225 OFFCURVE",
+"582 216 OFFCURVE",
+"581 211 CURVE SMOOTH",
+"579 205 OFFCURVE",
+"576 192 OFFCURVE",
+"570 183 CURVE",
+"567 172 OFFCURVE",
+"562 161 OFFCURVE",
+"560 158 CURVE",
+"560 152 OFFCURVE",
+"554 142 OFFCURVE",
+"547 133 CURVE",
+"542 124 OFFCURVE",
+"535 114 OFFCURVE",
+"534 111 CURVE SMOOTH",
+"531 102 OFFCURVE",
+"502 72 OFFCURVE",
+"487 61 CURVE SMOOTH",
+"465 44 OFFCURVE",
+"435 33 OFFCURVE",
+"409 29 CURVE SMOOTH",
+"392 27 OFFCURVE",
+"232 27 OFFCURVE",
+"229 29 CURVE",
+"226 29 OFFCURVE",
+"226 33 OFFCURVE",
+"226 34 CURVE SMOOTH",
+"226 39 OFFCURVE",
+"236 59 OFFCURVE",
+"245 72 CURVE",
+"253 86 OFFCURVE",
+"266 106 OFFCURVE",
+"284 139 CURVE",
+"284 156 OFFCURVE",
+"306 172 OFFCURVE",
+"306 175 CURVE",
+"315 186 OFFCURVE",
+"343 234 OFFCURVE",
+"347 247 CURVE SMOOTH",
+"350 255 OFFCURVE",
+"359 267 OFFCURVE",
+"364 275 CURVE SMOOTH",
+"369 284 OFFCURVE",
+"378 296 OFFCURVE",
+"381 300 CURVE",
+"382 308 OFFCURVE",
+"387 317 OFFCURVE",
+"392 324 CURVE SMOOTH",
+"395 330 OFFCURVE",
+"398 336 OFFCURVE",
+"398 338 CURVE SMOOTH",
+"398 338 OFFCURVE",
+"402 341 OFFCURVE",
+"404 344 CURVE SMOOTH",
+"407 347 OFFCURVE",
+"410 355 OFFCURVE",
+"414 361 CURVE",
+"415 366 OFFCURVE",
+"422 375 OFFCURVE",
+"426 383 CURVE SMOOTH",
+"430 389 OFFCURVE",
+"435 399 OFFCURVE",
+"439 405 CURVE",
+"439 409 OFFCURVE",
+"450 424 OFFCURVE",
+"460 439 CURVE SMOOTH",
+"480 471 OFFCURVE",
+"483 481 OFFCURVE",
+"493 494 CURVE",
+"510 521 OFFCURVE",
+"522 544 OFFCURVE",
+"534 566 CURVE",
+"539 578 OFFCURVE",
+"546 589 OFFCURVE",
+"549 592 CURVE SMOOTH",
+"551 594 OFFCURVE",
+"560 605 OFFCURVE",
+"564 614 CURVE",
+"575 626 OFFCURVE",
+"585 641 OFFCURVE",
+"585 650 CURVE",
+"590 658 OFFCURVE",
+"599 671 OFFCURVE",
+"602 678 CURVE",
+"607 684 OFFCURVE",
+"615 697 OFFCURVE",
+"618 703 CURVE",
+"634 725 OFFCURVE",
+"635 742 OFFCURVE",
+"623 750 CURVE",
+"615 753 OFFCURVE",
+"585 756 OFFCURVE",
+"570 753 CURVE",
+"565 753 OFFCURVE",
+"537 751 OFFCURVE",
+"510 751 CURVE SMOOTH",
+"456 751 OFFCURVE",
+"201 753 OFFCURVE",
+"143 753 CURVE",
+"122 755 OFFCURVE",
+"101 755 OFFCURVE",
+"97 753 CURVE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"195 23 LINE",
+"195 36 LINE",
+"616 714 LINE",
+"616 732 LINE",
+"424 726 LINE",
+"424 720 LINE",
+"10 39 LINE",
+"10 7 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"606 0 LINE",
+"606 245 LINE",
+"566 245 LINE",
+"564 133 OFFCURVE",
+"491 32 OFFCURVE",
+"368 32 CURVE SMOOTH",
+"10 32 LINE",
+"10 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"100 549 LINE",
+"102 643 OFFCURVE",
+"171 724 OFFCURVE",
+"288 724 CURVE SMOOTH",
+"616 724 LINE",
+"616 754 LINE",
+"60 754 LINE",
+"60 549 LINE"
+);
+}
+);
+width = 621;
+}
+);
+leftKerningGroup = Z;
+rightKerningGroup = Z;
+unicode = 005A;
+},
+{
+glyphname = Zacute;
+lastChange = "2016-08-22 11:53:08 +0000";
+layers = (
+{
+components = (
+{
+name = Z;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 1, 304}";
+}
+);
+layerId = UUID0;
+width = 651;
+},
+{
+components = (
+{
+name = Z;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -79, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 621;
+}
+);
+leftKerningGroup = Z;
+rightKerningGroup = Z;
+unicode = 0179;
+},
+{
+glyphname = Zcaron;
+lastChange = "2016-08-22 12:07:41 +0000";
+layers = (
+{
+components = (
+{
+name = Z;
+},
+{
+name = caron.case;
+transform = "{1, 0, 0, 1, 156, 1}";
+}
+);
+layerId = UUID0;
+width = 651;
+},
+{
+components = (
+{
+name = Z;
+},
+{
+name = caron.case;
+transform = "{1, 0, 0, 1, 97, 2}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 621;
+}
+);
+leftKerningGroup = Z;
+rightKerningGroup = Z;
+unicode = 017D;
+},
+{
+glyphname = Zdotaccent;
+lastChange = "2016-08-22 12:32:08 +0000";
+layers = (
+{
+components = (
+{
+name = Z;
+},
+{
+name = dotaccent.case;
+transform = "{1, 0, 0, 1, 251, 5}";
+}
+);
+layerId = UUID0;
+width = 651;
+},
+{
+components = (
+{
+name = Z;
+},
+{
+name = dotaccent.case;
+transform = "{1, 0, 0, 1, 232, 2}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 621;
+}
+);
+leftKerningGroup = Z;
+rightKerningGroup = Z;
+unicode = 017B;
+},
+{
+glyphname = Zdotbelow;
+lastChange = "2016-08-22 11:53:08 +0000";
+layers = (
+{
+components = (
+{
+name = Z;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 42, 0}";
+}
+);
+layerId = UUID0;
+width = 651;
+},
+{
+components = (
+{
+name = Z;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 18, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 621;
+}
+);
+leftKerningGroup = Z;
+rightKerningGroup = Z;
+unicode = 1E92;
+},
+{
+glyphname = a;
+lastChange = "2016-08-22 09:54:01 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{253, 0}";
+},
+{
+name = ogonek;
+position = "{455, 10}";
+},
+{
+name = top;
+position = "{253, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"292 146 LINE SMOOTH",
+"292 77 OFFCURVE",
+"252 43 OFFCURVE",
+"207 43 CURVE SMOOTH",
+"166 43 OFFCURVE",
+"141 69 OFFCURVE",
+"141 119 CURVE SMOOTH",
+"141 184 OFFCURVE",
+"183 227 OFFCURVE",
+"292 227 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"266 421 OFFCURVE",
+"292 404 OFFCURVE",
+"292 372 CURVE SMOOTH",
+"292 253 LINE",
+"115 253 OFFCURVE",
+"25 188 OFFCURVE",
+"25 99 CURVE SMOOTH",
+"25 30 OFFCURVE",
+"78 -12 OFFCURVE",
+"147 -12 CURVE SMOOTH",
+"204 -12 OFFCURVE",
+"266 17 OFFCURVE",
+"292 62 CURVE",
+"296 62 LINE",
+"305 17 OFFCURVE",
+"336 -12 OFFCURVE",
+"383 -12 CURVE SMOOTH",
+"418 -12 OFFCURVE",
+"446 4 OFFCURVE",
+"473 39 CURVE",
+"459 55 LINE",
+"443 38 OFFCURVE",
+"434 32 OFFCURVE",
+"425 32 CURVE SMOOTH",
+"415 32 OFFCURVE",
+"402 38 OFFCURVE",
+"402 51 CURVE SMOOTH",
+"402 355 LINE SMOOTH",
+"402 412 OFFCURVE",
+"339 452 OFFCURVE",
+"240 452 CURVE SMOOTH",
+"125 452 OFFCURVE",
+"58 399 OFFCURVE",
+"58 345 CURVE SMOOTH",
+"58 317 OFFCURVE",
+"77 294 OFFCURVE",
+"110 294 CURVE SMOOTH",
+"140 294 OFFCURVE",
+"165 312 OFFCURVE",
+"165 342 CURVE SMOOTH",
+"165 364 OFFCURVE",
+"151 371 OFFCURVE",
+"151 385 CURVE SMOOTH",
+"151 404 OFFCURVE",
+"174 421 OFFCURVE",
+"220 421 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"222 -12 OFFCURVE",
+"283 19 OFFCURVE",
+"308 62 CURVE",
+"312 62 LINE",
+"322 15 OFFCURVE",
+"353 -12 OFFCURVE",
+"400 -12 CURVE SMOOTH",
+"441 -12 OFFCURVE",
+"473 9 OFFCURVE",
+"505 55 CURVE",
+"491 71 LINE",
+"467 44 OFFCURVE",
+"452 32 OFFCURVE",
+"440 32 CURVE SMOOTH",
+"428 32 OFFCURVE",
+"418 42 OFFCURVE",
+"418 55 CURVE SMOOTH",
+"418 359 LINE SMOOTH",
+"418 420 OFFCURVE",
+"350 462 OFFCURVE",
+"253 462 CURVE SMOOTH",
+"151 462 OFFCURVE",
+"72 415 OFFCURVE",
+"72 355 CURVE SMOOTH",
+"72 325 OFFCURVE",
+"92 304 OFFCURVE",
+"124 304 CURVE SMOOTH",
+"156 304 OFFCURVE",
+"179 324 OFFCURVE",
+"179 352 CURVE SMOOTH",
+"179 374 OFFCURVE",
+"165 381 OFFCURVE",
+"165 395 CURVE SMOOTH",
+"165 416 OFFCURVE",
+"193 431 OFFCURVE",
+"233 431 CURVE SMOOTH",
+"280 431 OFFCURVE",
+"308 410 OFFCURVE",
+"308 375 CURVE SMOOTH",
+"308 253 LINE",
+"143 253 OFFCURVE",
+"41 195 OFFCURVE",
+"41 100 CURVE SMOOTH",
+"41 33 OFFCURVE",
+"91 -12 OFFCURVE",
+"163 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"181 43 OFFCURVE",
+"157 71 OFFCURVE",
+"157 119 CURVE SMOOTH",
+"157 190 OFFCURVE",
+"208 227 OFFCURVE",
+"308 227 CURVE",
+"308 146 LINE SMOOTH",
+"308 84 OFFCURVE",
+"274 43 OFFCURVE",
+"223 43 CURVE SMOOTH"
+);
+}
+);
+width = 506;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{271, 0}";
+},
+{
+name = ogonek;
+position = "{487, 10}";
+},
+{
+name = top;
+position = "{271, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"321 150 LINE SMOOTH",
+"321 80 OFFCURVE",
+"286 45 OFFCURVE",
+"245 45 CURVE SMOOTH",
+"208 45 OFFCURVE",
+"187 76 OFFCURVE",
+"187 124 CURVE SMOOTH",
+"187 184 OFFCURVE",
+"221 225 OFFCURVE",
+"321 225 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"296 429 OFFCURVE",
+"321 410 OFFCURVE",
+"321 378 CURVE SMOOTH",
+"321 256 LINE",
+"131 256 OFFCURVE",
+"42 190 OFFCURVE",
+"42 102 CURVE SMOOTH",
+"42 31 OFFCURVE",
+"96 -13 OFFCURVE",
+"171 -13 CURVE SMOOTH",
+"231 -13 OFFCURVE",
+"295 14 OFFCURVE",
+"321 56 CURVE",
+"325 56 LINE",
+"335 14 OFFCURVE",
+"371 -13 OFFCURVE",
+"425 -13 CURVE SMOOTH",
+"466 -13 OFFCURVE",
+"506 3 OFFCURVE",
+"536 44 CURVE",
+"516 64 LINE",
+"500 49 OFFCURVE",
+"491 46 OFFCURVE",
+"483 46 CURVE SMOOTH",
+"472 46 OFFCURVE",
+"459 52 OFFCURVE",
+"459 76 CURVE SMOOTH",
+"459 376 LINE SMOOTH",
+"459 427 OFFCURVE",
+"384 462 OFFCURVE",
+"276 462 CURVE SMOOTH",
+"139 462 OFFCURVE",
+"74 405 OFFCURVE",
+"74 343 CURVE SMOOTH",
+"74 306 OFFCURVE",
+"97 275 OFFCURVE",
+"139 275 CURVE SMOOTH",
+"179 275 OFFCURVE",
+"209 302 OFFCURVE",
+"209 340 CURVE SMOOTH",
+"209 370 OFFCURVE",
+"190 381 OFFCURVE",
+"190 396 CURVE SMOOTH",
+"190 416 OFFCURVE",
+"221 429 OFFCURVE",
+"254 429 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"245 -12 OFFCURVE",
+"297 22 OFFCURVE",
+"321 57 CURVE",
+"325 57 LINE",
+"335 15 OFFCURVE",
+"366 -12 OFFCURVE",
+"421 -12 CURVE SMOOTH",
+"470 -12 OFFCURVE",
+"508 9 OFFCURVE",
+"546 55 CURVE",
+"526 78 LINE",
+"503 52 OFFCURVE",
+"493 45 OFFCURVE",
+"482 45 CURVE SMOOTH",
+"468 45 OFFCURVE",
+"459 56 OFFCURVE",
+"459 68 CURVE SMOOTH",
+"459 359 LINE SMOOTH",
+"459 420 OFFCURVE",
+"382 462 OFFCURVE",
+"275 462 CURVE SMOOTH",
+"158 462 OFFCURVE",
+"73 411 OFFCURVE",
+"73 343 CURVE SMOOTH",
+"73 304 OFFCURVE",
+"101 274 OFFCURVE",
+"140 274 CURVE SMOOTH",
+"179 274 OFFCURVE",
+"210 305 OFFCURVE",
+"210 340 CURVE SMOOTH",
+"210 368 OFFCURVE",
+"189 375 OFFCURVE",
+"189 393 CURVE SMOOTH",
+"189 414 OFFCURVE",
+"217 429 OFFCURVE",
+"252 429 CURVE SMOOTH",
+"293 429 OFFCURVE",
+"321 408 OFFCURVE",
+"321 373 CURVE SMOOTH",
+"321 256 LINE",
+"152 256 OFFCURVE",
+"42 197 OFFCURVE",
+"42 101 CURVE SMOOTH",
+"42 33 OFFCURVE",
+"98 -12 OFFCURVE",
+"177 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"207 43 OFFCURVE",
+"187 72 OFFCURVE",
+"187 118 CURVE SMOOTH",
+"187 189 OFFCURVE",
+"235 225 OFFCURVE",
+"321 225 CURVE",
+"321 146 LINE SMOOTH",
+"321 84 OFFCURVE",
+"287 43 OFFCURVE",
+"244 43 CURVE SMOOTH"
+);
+}
+);
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 0061;
+},
+{
+glyphname = aacute;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -72, 0}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -119, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 00E1;
+},
+{
+glyphname = abreve;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, -42, 0}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, -27, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 0103;
+},
+{
+glyphname = abreveacute;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = brevecomb_acutecomb;
+transform = "{1, 0, 0, 1, -42, 0}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = brevecomb_acutecomb;
+transform = "{1, 0, 0, 1, -27, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 1EAF;
+},
+{
+glyphname = abrevedotbelow;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -31, 0}";
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, -42, 0}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -22, 0}";
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, -27, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 1EB7;
+},
+{
+glyphname = abrevegrave;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = brevecomb_gravecomb;
+transform = "{1, 0, 0, 1, -42, 0}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = brevecomb_gravecomb;
+transform = "{1, 0, 0, 1, -27, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 1EB1;
+},
+{
+glyphname = abrevehookabove;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = brevecomb_hookabovecomb;
+transform = "{1, 0, 0, 1, -42, 0}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = brevecomb_hookabovecomb;
+transform = "{1, 0, 0, 1, -27, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 1EB3;
+},
+{
+glyphname = abrevetilde;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = brevecomb_tildecomb;
+transform = "{1, 0, 0, 1, -42, 0}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = brevecomb_tildecomb;
+transform = "{1, 0, 0, 1, -27, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 1EB5;
+},
+{
+glyphname = acircumflex;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -37, 0}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -25, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 00E2;
+},
+{
+glyphname = acircumflexacute;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = circumflexcomb_acutecomb;
+transform = "{1, 0, 0, 1, -37, 0}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = circumflexcomb_acutecomb;
+transform = "{1, 0, 0, 1, -25, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 1EA5;
+},
+{
+glyphname = acircumflexdotbelow;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -31, 0}";
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -37, 0}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -22, 0}";
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -25, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 1EAD;
+},
+{
+glyphname = acircumflexgrave;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = circumflexcomb_gravecomb;
+transform = "{1, 0, 0, 1, -37, 0}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = circumflexcomb_gravecomb;
+transform = "{1, 0, 0, 1, -25, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 1EA7;
+},
+{
+glyphname = acircumflexhookabove;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = circumflexcomb_hookabovecomb;
+transform = "{1, 0, 0, 1, -37, 0}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = circumflexcomb_hookabovecomb;
+transform = "{1, 0, 0, 1, -25, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 1EA9;
+},
+{
+glyphname = acircumflextilde;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = circumflexcomb_tildecomb;
+transform = "{1, 0, 0, 1, -37, 0}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = circumflexcomb_tildecomb;
+transform = "{1, 0, 0, 1, -25, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 1EAB;
+},
+{
+glyphname = adblgrave;
+lastChange = "2016-08-22 12:07:41 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = dblgravecomb;
+transform = "{1, 0, 0, 1, 40, 0}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = dblgravecomb;
+transform = "{1, 0, 0, 1, 37, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 0201;
+},
+{
+glyphname = adieresis;
+lastChange = "2016-08-22 12:19:29 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = dieresis;
+transform = "{1, 0, 0, 1, 99, 0}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = dieresis;
+transform = "{1, 0, 0, 1, 109, -2}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 00E4;
+},
+{
+glyphname = adotbelow;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -31, 0}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -22, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 1EA1;
+},
+{
+glyphname = agrave;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, -34, 0}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 22, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 00E0;
+},
+{
+glyphname = ahookabove;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, -32, 0}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, -13, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 1EA3;
+},
+{
+glyphname = ainvertedbreve;
+lastChange = "2016-08-22 12:07:41 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = breveinvertedcomb;
+transform = "{1, 0, 0, 1, 86, 0}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = breveinvertedcomb;
+transform = "{1, 0, 0, 1, 94, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 0203;
+},
+{
+glyphname = amacron;
+lastChange = "2016-08-22 12:20:05 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = macron;
+transform = "{1, 0, 0, 1, 87, 0}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = macron;
+transform = "{1, 0, 0, 1, 97, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 0101;
+},
+{
+glyphname = aogonek;
+lastChange = "2016-08-22 12:20:45 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = ogonek;
+transform = "{1, 0, 0, 1, 245, 0}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = ogonek;
+transform = "{1, 0, 0, 1, 283, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 0105;
+},
+{
+glyphname = aring;
+lastChange = "2016-08-22 12:20:56 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = ring;
+transform = "{1, 0, 0, 1, 146, 0}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = ring;
+transform = "{1, 0, 0, 1, 165, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 00E5;
+},
+{
+glyphname = aringacute;
+lastChange = "2016-08-22 12:22:17 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = ring;
+transform = "{1, 0, 0, 1, 145, -26}";
+},
+{
+alignment = -1;
+name = acutecomb;
+transform = "{1, 0, 0, 1, -22, 166}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = ring;
+transform = "{1, 0, 0, 1, 163, 0}";
+},
+{
+alignment = -1;
+name = acutecomb;
+transform = "{1, 0, 0, 1, -56, 190}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 01FB;
+},
+{
+glyphname = atilde;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, -38, 0}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, -42, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 00E3;
+},
+{
+glyphname = ae;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"307 145 LINE SMOOTH",
+"307 76 OFFCURVE",
+"267 42 OFFCURVE",
+"222 42 CURVE SMOOTH",
+"181 42 OFFCURVE",
+"156 69 OFFCURVE",
+"156 119 CURVE SMOOTH",
+"156 184 OFFCURVE",
+"198 227 OFFCURVE",
+"307 227 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"281 421 OFFCURVE",
+"307 404 OFFCURVE",
+"307 372 CURVE SMOOTH",
+"307 253 LINE",
+"129 253 OFFCURVE",
+"40 187 OFFCURVE",
+"40 97 CURVE SMOOTH",
+"40 34 OFFCURVE",
+"84 -13 OFFCURVE",
+"167 -13 CURVE SMOOTH",
+"226 -13 OFFCURVE",
+"298 11 OFFCURVE",
+"340 101 CURVE",
+"344 101 LINE",
+"417 50 LINE",
+"417 355 LINE SMOOTH",
+"417 412 OFFCURVE",
+"354 451 OFFCURVE",
+"255 451 CURVE SMOOTH",
+"140 451 OFFCURVE",
+"73 399 OFFCURVE",
+"73 345 CURVE SMOOTH",
+"73 317 OFFCURVE",
+"92 294 OFFCURVE",
+"125 294 CURVE SMOOTH",
+"155 294 OFFCURVE",
+"180 312 OFFCURVE",
+"180 342 CURVE SMOOTH",
+"180 364 OFFCURVE",
+"166 371 OFFCURVE",
+"166 385 CURVE SMOOTH",
+"166 404 OFFCURVE",
+"189 421 OFFCURVE",
+"235 421 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"590 289 LINE",
+"379 289 LINE",
+"379 264 LINE",
+"706 264 LINE",
+"706 270 LINE SMOOTH",
+"706 384 OFFCURVE",
+"621 454 OFFCURVE",
+"520 454 CURVE SMOOTH",
+"390 454 OFFCURVE",
+"312 339 OFFCURVE",
+"312 224 CURVE SMOOTH",
+"312 101 OFFCURVE",
+"403 -13 OFFCURVE",
+"523 -13 CURVE SMOOTH",
+"605 -13 OFFCURVE",
+"681 40 OFFCURVE",
+"709 138 CURVE",
+"681 138 LINE",
+"645 49 OFFCURVE",
+"593 17 OFFCURVE",
+"523 17 CURVE SMOOTH",
+"444 17 OFFCURVE",
+"417 58 OFFCURVE",
+"417 220 CURVE SMOOTH",
+"417 378 OFFCURVE",
+"443 427 OFFCURVE",
+"510 427 CURVE SMOOTH",
+"563 427 OFFCURVE",
+"590 396 OFFCURVE",
+"590 336 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"613 -12 OFFCURVE",
+"687 46 OFFCURVE",
+"713 139 CURVE",
+"685 139 LINE",
+"650 52 OFFCURVE",
+"598 18 OFFCURVE",
+"528 18 CURVE SMOOTH",
+"448 18 OFFCURVE",
+"421 62 OFFCURVE",
+"421 225 CURVE SMOOTH",
+"421 384 OFFCURVE",
+"447 435 OFFCURVE",
+"514 435 CURVE SMOOTH",
+"567 435 OFFCURVE",
+"594 404 OFFCURVE",
+"594 344 CURVE SMOOTH",
+"594 287 LINE",
+"383 287 LINE",
+"383 262 LINE",
+"710 262 LINE",
+"710 268 LINE SMOOTH",
+"710 382 OFFCURVE",
+"626 462 OFFCURVE",
+"521 462 CURVE SMOOTH",
+"396 462 OFFCURVE",
+"314 347 OFFCURVE",
+"314 228 CURVE SMOOTH",
+"314 102 OFFCURVE",
+"407 -12 OFFCURVE",
+"527 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"184 43 OFFCURVE",
+"160 71 OFFCURVE",
+"160 119 CURVE SMOOTH",
+"160 190 OFFCURVE",
+"211 227 OFFCURVE",
+"311 227 CURVE",
+"311 146 LINE SMOOTH",
+"311 84 OFFCURVE",
+"277 43 OFFCURVE",
+"226 43 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"245 -12 OFFCURVE",
+"308 35 OFFCURVE",
+"339 109 CURVE",
+"343 109 LINE",
+"421 55 LINE",
+"421 359 LINE SMOOTH",
+"421 420 OFFCURVE",
+"353 462 OFFCURVE",
+"256 462 CURVE SMOOTH",
+"154 462 OFFCURVE",
+"75 415 OFFCURVE",
+"75 355 CURVE SMOOTH",
+"75 325 OFFCURVE",
+"95 304 OFFCURVE",
+"127 304 CURVE SMOOTH",
+"159 304 OFFCURVE",
+"182 324 OFFCURVE",
+"182 352 CURVE SMOOTH",
+"182 374 OFFCURVE",
+"168 381 OFFCURVE",
+"168 395 CURVE SMOOTH",
+"168 416 OFFCURVE",
+"196 431 OFFCURVE",
+"236 431 CURVE SMOOTH",
+"283 431 OFFCURVE",
+"311 410 OFFCURVE",
+"311 375 CURVE SMOOTH",
+"311 253 LINE",
+"146 253 OFFCURVE",
+"44 195 OFFCURVE",
+"44 99 CURVE SMOOTH",
+"44 33 OFFCURVE",
+"93 -12 OFFCURVE",
+"168 -12 CURVE SMOOTH"
+);
+}
+);
+width = 755;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"321 150 LINE SMOOTH",
+"321 80 OFFCURVE",
+"286 45 OFFCURVE",
+"245 45 CURVE SMOOTH",
+"208 45 OFFCURVE",
+"187 74 OFFCURVE",
+"187 119 CURVE SMOOTH",
+"187 179 OFFCURVE",
+"221 220 OFFCURVE",
+"321 220 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"296 418 OFFCURVE",
+"321 399 OFFCURVE",
+"321 367 CURVE SMOOTH",
+"321 251 LINE",
+"131 251 OFFCURVE",
+"42 185 OFFCURVE",
+"42 97 CURVE SMOOTH",
+"42 29 OFFCURVE",
+"96 -13 OFFCURVE",
+"171 -13 CURVE SMOOTH",
+"231 -13 OFFCURVE",
+"295 14 OFFCURVE",
+"321 56 CURVE",
+"325 56 LINE",
+"459 76 LINE",
+"459 365 LINE SMOOTH",
+"459 416 OFFCURVE",
+"384 451 OFFCURVE",
+"276 451 CURVE SMOOTH",
+"139 451 OFFCURVE",
+"74 394 OFFCURVE",
+"74 332 CURVE SMOOTH",
+"74 295 OFFCURVE",
+"97 264 OFFCURVE",
+"139 264 CURVE SMOOTH",
+"179 264 OFFCURVE",
+"209 291 OFFCURVE",
+"209 329 CURVE SMOOTH",
+"209 360 OFFCURVE",
+"190 370 OFFCURVE",
+"190 385 CURVE SMOOTH",
+"190 405 OFFCURVE",
+"221 418 OFFCURVE",
+"254 418 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"637 279 LINE",
+"431 279 LINE",
+"431 249 LINE",
+"778 249 LINE",
+"778 260 LINE SMOOTH",
+"778 380 OFFCURVE",
+"687 454 OFFCURVE",
+"568 454 CURVE SMOOTH",
+"419 454 OFFCURVE",
+"324 338 OFFCURVE",
+"324 224 CURVE SMOOTH",
+"324 101 OFFCURVE",
+"434 -13 OFFCURVE",
+"574 -13 CURVE SMOOTH",
+"674 -13 OFFCURVE",
+"753 46 OFFCURVE",
+"781 138 CURVE",
+"748 138 LINE",
+"709 53 OFFCURVE",
+"649 22 OFFCURVE",
+"579 22 CURVE SMOOTH",
+"503 22 OFFCURVE",
+"479 59 OFFCURVE",
+"479 218 CURVE SMOOTH",
+"479 373 OFFCURVE",
+"502 422 OFFCURVE",
+"566 422 CURVE SMOOTH",
+"613 422 OFFCURVE",
+"637 393 OFFCURVE",
+"637 336 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"653 -13 OFFCURVE",
+"735 49 OFFCURVE",
+"761 138 CURVE",
+"728 138 LINE",
+"689 53 OFFCURVE",
+"629 22 OFFCURVE",
+"559 22 CURVE SMOOTH",
+"483 22 OFFCURVE",
+"459 60 OFFCURVE",
+"459 222 CURVE SMOOTH",
+"459 380 OFFCURVE",
+"482 430 OFFCURVE",
+"545 430 CURVE SMOOTH",
+"593 430 OFFCURVE",
+"617 401 OFFCURVE",
+"617 344 CURVE SMOOTH",
+"617 283 LINE",
+"411 283 LINE",
+"411 253 LINE",
+"758 253 LINE",
+"758 264 LINE SMOOTH",
+"758 386 OFFCURVE",
+"664 462 OFFCURVE",
+"553 462 CURVE SMOOTH",
+"414 462 OFFCURVE",
+"334 343 OFFCURVE",
+"334 228 CURVE SMOOTH",
+"334 103 OFFCURVE",
+"429 -13 OFFCURVE",
+"558 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"207 43 OFFCURVE",
+"187 72 OFFCURVE",
+"187 118 CURVE SMOOTH",
+"187 189 OFFCURVE",
+"235 225 OFFCURVE",
+"321 225 CURVE",
+"321 146 LINE SMOOTH",
+"321 84 OFFCURVE",
+"287 43 OFFCURVE",
+"244 43 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"261 -12 OFFCURVE",
+"332 30 OFFCURVE",
+"357 115 CURVE",
+"361 115 LINE",
+"459 68 LINE",
+"459 359 LINE SMOOTH",
+"459 420 OFFCURVE",
+"382 462 OFFCURVE",
+"275 462 CURVE SMOOTH",
+"158 462 OFFCURVE",
+"73 411 OFFCURVE",
+"73 343 CURVE SMOOTH",
+"73 304 OFFCURVE",
+"101 274 OFFCURVE",
+"140 274 CURVE SMOOTH",
+"179 274 OFFCURVE",
+"210 305 OFFCURVE",
+"210 340 CURVE SMOOTH",
+"210 368 OFFCURVE",
+"189 375 OFFCURVE",
+"189 393 CURVE SMOOTH",
+"189 414 OFFCURVE",
+"217 429 OFFCURVE",
+"252 429 CURVE SMOOTH",
+"293 429 OFFCURVE",
+"321 408 OFFCURVE",
+"321 373 CURVE SMOOTH",
+"321 256 LINE",
+"152 256 OFFCURVE",
+"42 197 OFFCURVE",
+"42 101 CURVE SMOOTH",
+"42 33 OFFCURVE",
+"97 -12 OFFCURVE",
+"180 -12 CURVE SMOOTH"
+);
+}
+);
+width = 796;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = e;
+unicode = 00E6;
+},
+{
+glyphname = aeacute;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = ae;
+},
+{
+name = acutecomb;
+}
+);
+layerId = UUID0;
+width = 755;
+},
+{
+components = (
+{
+name = ae;
+},
+{
+name = acutecomb;
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 816;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = e;
+unicode = 01FD;
+},
+{
+glyphname = b;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{285, 0}";
+},
+{
+name = top;
+position = "{285, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"3 729 LINE",
+"192 729 LINE",
+"192 754 LINE",
+"3 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"82 15 LINE",
+"192 15 LINE",
+"192 738 LINE",
+"82 738 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"3 0 LINE",
+"192 0 LINE",
+"192 25 LINE",
+"3 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"245 22 OFFCURVE",
+"192 88 OFFCURVE",
+"192 213 CURVE",
+"172 57 LINE",
+"196 57 LINE",
+"219 18 OFFCURVE",
+"267 -13 OFFCURVE",
+"322 -13 CURVE SMOOTH",
+"422 -13 OFFCURVE",
+"523 83 OFFCURVE",
+"523 220 CURVE SMOOTH",
+"523 352 OFFCURVE",
+"429 454 OFFCURVE",
+"324 454 CURVE SMOOTH",
+"261 454 OFFCURVE",
+"218 420 OFFCURVE",
+"196 381 CURVE",
+"172 381 LINE",
+"192 234 LINE",
+"192 366 OFFCURVE",
+"247 419 OFFCURVE",
+"317 419 CURVE SMOOTH",
+"374 419 OFFCURVE",
+"395 384 OFFCURVE",
+"395 219 CURVE SMOOTH",
+"395 62 OFFCURVE",
+"376 22 OFFCURVE",
+"319 22 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"430 -12 OFFCURVE",
+"524 83 OFFCURVE",
+"524 225 CURVE SMOOTH",
+"524 367 OFFCURVE",
+"431 462 OFFCURVE",
+"331 462 CURVE SMOOTH",
+"269 462 OFFCURVE",
+"219 432 OFFCURVE",
+"197 392 CURVE",
+"173 392 LINE",
+"193 240 LINE",
+"193 370 OFFCURVE",
+"246 428 OFFCURVE",
+"318 428 CURVE SMOOTH",
+"374 428 OFFCURVE",
+"396 389 OFFCURVE",
+"396 224 CURVE SMOOTH",
+"396 59 OFFCURVE",
+"375 22 OFFCURVE",
+"319 22 CURVE SMOOTH",
+"247 22 OFFCURVE",
+"193 80 OFFCURVE",
+"193 210 CURVE",
+"173 58 LINE",
+"197 58 LINE",
+"219 18 OFFCURVE",
+"268 -12 OFFCURVE",
+"330 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"193 0 LINE",
+"193 25 LINE",
+"4 25 LINE",
+"4 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"193 15 LINE",
+"193 738 LINE",
+"83 738 LINE",
+"83 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"193 729 LINE",
+"193 754 LINE",
+"4 754 LINE",
+"4 729 LINE"
+);
+}
+);
+width = 570;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{315, 0}";
+},
+{
+name = top;
+position = "{315, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"20 724 LINE",
+"239 724 LINE",
+"239 754 LINE",
+"20 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"101 15 LINE",
+"239 15 LINE",
+"239 738 LINE",
+"101 738 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 0 LINE",
+"239 0 LINE",
+"239 30 LINE",
+"20 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"413 414 OFFCURVE",
+"430 372 OFFCURVE",
+"430 223 CURVE SMOOTH",
+"429 63 OFFCURVE",
+"407 27 OFFCURVE",
+"355 27 CURVE SMOOTH",
+"286 27 OFFCURVE",
+"238 92 OFFCURVE",
+"238 217 CURVE",
+"218 55 LINE",
+"242 55 LINE",
+"262 17 OFFCURVE",
+"299 -13 OFFCURVE",
+"363 -13 CURVE SMOOTH",
+"478 -13 OFFCURVE",
+"584 84 OFFCURVE",
+"585 224 CURVE SMOOTH",
+"585 362 OFFCURVE",
+"485 454 OFFCURVE",
+"377 454 CURVE SMOOTH",
+"313 454 OFFCURVE",
+"268 422 OFFCURVE",
+"243 379 CURVE",
+"219 379 LINE",
+"238 218 LINE",
+"239 346 OFFCURVE",
+"288 414 OFFCURVE",
+"358 414 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"486 -12 OFFCURVE",
+"585 83 OFFCURVE",
+"585 225 CURVE SMOOTH",
+"585 367 OFFCURVE",
+"487 462 OFFCURVE",
+"377 462 CURVE SMOOTH",
+"315 462 OFFCURVE",
+"265 432 OFFCURVE",
+"243 392 CURVE",
+"219 392 LINE",
+"239 240 LINE",
+"239 364 OFFCURVE",
+"287 423 OFFCURVE",
+"353 423 CURVE SMOOTH",
+"405 423 OFFCURVE",
+"430 386 OFFCURVE",
+"430 223 CURVE SMOOTH",
+"430 63 OFFCURVE",
+"406 27 OFFCURVE",
+"354 27 CURVE SMOOTH",
+"288 27 OFFCURVE",
+"239 85 OFFCURVE",
+"239 210 CURVE",
+"219 58 LINE",
+"243 58 LINE",
+"265 18 OFFCURVE",
+"314 -12 OFFCURVE",
+"376 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"239 0 LINE",
+"239 30 LINE",
+"20 30 LINE",
+"20 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"239 15 LINE",
+"239 738 LINE",
+"101 738 LINE",
+"101 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"239 724 LINE",
+"239 754 LINE",
+"20 754 LINE",
+"20 724 LINE"
+);
+}
+);
+width = 630;
+}
+);
+unicode = 0062;
+},
+{
+glyphname = c;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{253, 0}";
+},
+{
+name = top;
+position = "{253, 450}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"377 -12 OFFCURVE",
+"441 53 OFFCURVE",
+"467 149 CURVE",
+"439 149 LINE",
+"403 54 OFFCURVE",
+"357 18 OFFCURVE",
+"284 18 CURVE SMOOTH",
+"207 18 OFFCURVE",
+"179 62 OFFCURVE",
+"179 224 CURVE SMOOTH",
+"179 395 OFFCURVE",
+"210 435 OFFCURVE",
+"288 435 CURVE SMOOTH",
+"329 435 OFFCURVE",
+"351 425 OFFCURVE",
+"351 403 CURVE SMOOTH",
+"351 379 OFFCURVE",
+"327 375 OFFCURVE",
+"327 341 CURVE SMOOTH",
+"327 304 OFFCURVE",
+"357 285 OFFCURVE",
+"389 285 CURVE SMOOTH",
+"424 285 OFFCURVE",
+"449 309 OFFCURVE",
+"449 348 CURVE SMOOTH",
+"449 415 OFFCURVE",
+"377 462 OFFCURVE",
+"289 462 CURVE SMOOTH",
+"150 462 OFFCURVE",
+"49 343 OFFCURVE",
+"49 226 CURVE SMOOTH",
+"49 107 OFFCURVE",
+"154 -12 OFFCURVE",
+"281 -12 CURVE SMOOTH"
+);
+}
+);
+width = 505;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{260, 0}";
+},
+{
+name = top;
+position = "{260, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"332 422 OFFCURVE",
+"347 414 OFFCURVE",
+"347 398 CURVE SMOOTH",
+"347 377 OFFCURVE",
+"318 364 OFFCURVE",
+"318 323 CURVE SMOOTH",
+"318 282 OFFCURVE",
+"347 257 OFFCURVE",
+"390 257 CURVE SMOOTH",
+"435 257 OFFCURVE",
+"469 285 OFFCURVE",
+"469 331 CURVE SMOOTH",
+"469 403 OFFCURVE",
+"388 454 OFFCURVE",
+"293 454 CURVE SMOOTH",
+"149 454 OFFCURVE",
+"45 338 OFFCURVE",
+"45 222 CURVE SMOOTH",
+"45 102 OFFCURVE",
+"155 -13 OFFCURVE",
+"292 -13 CURVE SMOOTH",
+"395 -13 OFFCURVE",
+"463 52 OFFCURVE",
+"490 148 CURVE",
+"457 148 LINE",
+"420 57 OFFCURVE",
+"372 22 OFFCURVE",
+"300 22 CURVE SMOOTH",
+"224 22 OFFCURVE",
+"200 61 OFFCURVE",
+"200 215 CURVE SMOOTH",
+"200 388 OFFCURVE",
+"230 422 OFFCURVE",
+"299 422 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"395 -13 OFFCURVE",
+"463 52 OFFCURVE",
+"490 148 CURVE",
+"457 148 LINE",
+"421 58 OFFCURVE",
+"373 21 OFFCURVE",
+"301 21 CURVE SMOOTH",
+"226 21 OFFCURVE",
+"200 61 OFFCURVE",
+"200 210 CURVE SMOOTH",
+"200 393 OFFCURVE",
+"239 430 OFFCURVE",
+"297 430 CURVE SMOOTH",
+"328 430 OFFCURVE",
+"347 419 OFFCURVE",
+"347 399 CURVE SMOOTH",
+"347 374 OFFCURVE",
+"318 370 OFFCURVE",
+"318 331 CURVE SMOOTH",
+"318 291 OFFCURVE",
+"347 265 OFFCURVE",
+"390 265 CURVE SMOOTH",
+"435 265 OFFCURVE",
+"469 292 OFFCURVE",
+"469 339 CURVE SMOOTH",
+"469 411 OFFCURVE",
+"388 462 OFFCURVE",
+"293 462 CURVE SMOOTH",
+"149 462 OFFCURVE",
+"45 344 OFFCURVE",
+"45 226 CURVE SMOOTH",
+"45 104 OFFCURVE",
+"155 -13 OFFCURVE",
+"292 -13 CURVE SMOOTH"
+);
+}
+);
+width = 520;
+}
+);
+leftKerningGroup = c;
+rightKerningGroup = c;
+unicode = 0063;
+},
+{
+glyphname = cacute;
+lastChange = "2016-08-22 11:53:08 +0000";
+layers = (
+{
+components = (
+{
+name = c;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -72, 0}";
+}
+);
+layerId = UUID0;
+width = 505;
+},
+{
+components = (
+{
+name = c;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -130, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 520;
+}
+);
+leftKerningGroup = c;
+rightKerningGroup = c;
+unicode = 0107;
+},
+{
+glyphname = ccaron;
+lastChange = "2016-08-22 12:22:57 +0000";
+layers = (
+{
+components = (
+{
+name = c;
+},
+{
+name = caron;
+transform = "{1, 0, 0, 1, 88, -9}";
+}
+);
+layerId = UUID0;
+width = 505;
+},
+{
+components = (
+{
+name = c;
+},
+{
+name = caron;
+transform = "{1, 0, 0, 1, 70, -9}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 520;
+}
+);
+leftKerningGroup = c;
+rightKerningGroup = c;
+unicode = 010D;
+},
+{
+glyphname = ccedilla;
+lastChange = "2016-08-22 12:07:41 +0000";
+layers = (
+{
+components = (
+{
+name = c;
+},
+{
+name = cedilla;
+transform = "{1, 0, 0, 1, 148, 6}";
+}
+);
+layerId = UUID0;
+width = 505;
+},
+{
+components = (
+{
+name = c;
+},
+{
+name = cedilla;
+transform = "{1, 0, 0, 1, 143, 13}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 520;
+}
+);
+leftKerningGroup = c;
+rightKerningGroup = c;
+unicode = 00E7;
+},
+{
+glyphname = ccircumflex;
+lastChange = "2016-08-22 11:53:08 +0000";
+layers = (
+{
+components = (
+{
+name = c;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -37, 0}";
+}
+);
+layerId = UUID0;
+width = 505;
+},
+{
+components = (
+{
+name = c;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -36, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 520;
+}
+);
+leftKerningGroup = c;
+rightKerningGroup = c;
+unicode = 0109;
+},
+{
+glyphname = cdotaccent;
+lastChange = "2016-08-22 12:07:41 +0000";
+layers = (
+{
+components = (
+{
+name = c;
+},
+{
+name = dotaccent;
+transform = "{1, 0, 0, 1, 179, -3}";
+}
+);
+layerId = UUID0;
+width = 505;
+},
+{
+components = (
+{
+name = c;
+},
+{
+name = dotaccent;
+transform = "{1, 0, 0, 1, 172, -7}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 520;
+}
+);
+leftKerningGroup = c;
+rightKerningGroup = c;
+unicode = 010B;
+},
+{
+glyphname = d;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{284, 0}";
+},
+{
+name = center;
+position = "{284, 225}";
+},
+{
+name = top;
+position = "{284, 450}";
+},
+{
+name = topright;
+position = "{548, 450}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"304 -12 OFFCURVE",
+"353 18 OFFCURVE",
+"375 58 CURVE",
+"399 58 LINE",
+"379 210 LINE",
+"379 80 OFFCURVE",
+"325 22 OFFCURVE",
+"253 22 CURVE SMOOTH",
+"197 22 OFFCURVE",
+"176 59 OFFCURVE",
+"176 224 CURVE SMOOTH",
+"176 389 OFFCURVE",
+"198 428 OFFCURVE",
+"254 428 CURVE SMOOTH",
+"326 428 OFFCURVE",
+"379 370 OFFCURVE",
+"379 240 CURVE",
+"399 392 LINE",
+"375 392 LINE",
+"353 432 OFFCURVE",
+"303 462 OFFCURVE",
+"241 462 CURVE SMOOTH",
+"141 462 OFFCURVE",
+"48 367 OFFCURVE",
+"48 225 CURVE SMOOTH",
+"48 83 OFFCURVE",
+"142 -12 OFFCURVE",
+"242 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"557 0 LINE",
+"557 25 LINE",
+"379 25 LINE",
+"379 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"489 15 LINE",
+"489 738 LINE",
+"379 738 LINE",
+"379 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"489 729 LINE",
+"489 754 LINE",
+"280 754 LINE",
+"280 729 LINE"
+);
+}
+);
+width = 568;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{316, 0}";
+},
+{
+name = center;
+position = "{316, 225}";
+},
+{
+name = top;
+position = "{316, 450}";
+},
+{
+name = topright;
+position = "{611, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"530 754 LINE",
+"301 754 LINE",
+"301 724 LINE",
+"530 724 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"530 738 LINE",
+"392 738 LINE",
+"392 15 LINE",
+"530 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"611 30 LINE",
+"392 30 LINE",
+"392 0 LINE",
+"611 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"218 27 OFFCURVE",
+"200 69 OFFCURVE",
+"200 213 CURVE SMOOTH",
+"200 379 OFFCURVE",
+"224 414 OFFCURVE",
+"275 414 CURVE SMOOTH",
+"344 414 OFFCURVE",
+"392 349 OFFCURVE",
+"392 224 CURVE",
+"412 386 LINE",
+"388 386 LINE",
+"368 420 OFFCURVE",
+"321 454 OFFCURVE",
+"258 454 CURVE SMOOTH",
+"150 454 OFFCURVE",
+"45 354 OFFCURVE",
+"45 216 CURVE SMOOTH",
+"45 79 OFFCURVE",
+"145 -13 OFFCURVE",
+"253 -13 CURVE SMOOTH",
+"317 -13 OFFCURVE",
+"362 19 OFFCURVE",
+"387 62 CURVE",
+"411 62 LINE",
+"392 223 LINE",
+"391 95 OFFCURVE",
+"342 27 OFFCURVE",
+"272 27 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"317 -12 OFFCURVE",
+"366 18 OFFCURVE",
+"388 58 CURVE",
+"412 58 LINE",
+"392 210 LINE",
+"392 83 OFFCURVE",
+"342 27 OFFCURVE",
+"276 27 CURVE SMOOTH",
+"221 27 OFFCURVE",
+"200 63 OFFCURVE",
+"200 224 CURVE SMOOTH",
+"200 385 OFFCURVE",
+"222 423 OFFCURVE",
+"277 423 CURVE SMOOTH",
+"343 423 OFFCURVE",
+"392 367 OFFCURVE",
+"392 240 CURVE",
+"412 392 LINE",
+"388 392 LINE",
+"366 432 OFFCURVE",
+"316 462 OFFCURVE",
+"254 462 CURVE SMOOTH",
+"148 462 OFFCURVE",
+"45 367 OFFCURVE",
+"45 225 CURVE SMOOTH",
+"45 83 OFFCURVE",
+"149 -12 OFFCURVE",
+"255 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"611 0 LINE",
+"611 30 LINE",
+"392 30 LINE",
+"392 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"530 15 LINE",
+"530 738 LINE",
+"392 738 LINE",
+"392 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"530 724 LINE",
+"530 754 LINE",
+"293 754 LINE",
+"293 724 LINE"
+);
+}
+);
+width = 631;
+}
+);
+leftKerningGroup = d;
+rightKerningGroup = d;
+unicode = 0064;
+},
+{
+glyphname = eth;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"431 -13 OFFCURVE",
+"544 103 OFFCURVE",
+"544 297 CURVE SMOOTH",
+"544 544 OFFCURVE",
+"361 716 OFFCURVE",
+"169 752 CURVE",
+"160 725 LINE",
+"330 683 OFFCURVE",
+"392 576 OFFCURVE",
+"392 416 CURVE",
+"389 415 LINE",
+"357 435 OFFCURVE",
+"319 444 OFFCURVE",
+"277 444 CURVE SMOOTH",
+"139 444 OFFCURVE",
+"27 345 OFFCURVE",
+"27 219 CURVE SMOOTH",
+"27 84 OFFCURVE",
+"155 -13 OFFCURVE",
+"287 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"201 17 OFFCURVE",
+"172 54 OFFCURVE",
+"172 212 CURVE SMOOTH",
+"172 375 OFFCURVE",
+"203 414 OFFCURVE",
+"275 414 CURVE SMOOTH",
+"323 414 OFFCURVE",
+"366 397 OFFCURVE",
+"396 358 CURVE",
+"404 307 OFFCURVE",
+"406 245 OFFCURVE",
+"406 201 CURVE SMOOTH",
+"406 51 OFFCURVE",
+"375 17 OFFCURVE",
+"290 17 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"216 557 LINE",
+"519 662 LINE",
+"508 695 LINE",
+"204 590 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"431 -13 OFFCURVE",
+"544 103 OFFCURVE",
+"544 297 CURVE SMOOTH",
+"544 544 OFFCURVE",
+"361 716 OFFCURVE",
+"169 752 CURVE",
+"160 725 LINE",
+"330 683 OFFCURVE",
+"392 576 OFFCURVE",
+"392 416 CURVE",
+"389 415 LINE",
+"357 435 OFFCURVE",
+"319 444 OFFCURVE",
+"277 444 CURVE SMOOTH",
+"139 444 OFFCURVE",
+"27 345 OFFCURVE",
+"27 219 CURVE SMOOTH",
+"27 84 OFFCURVE",
+"155 -13 OFFCURVE",
+"287 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"201 17 OFFCURVE",
+"172 54 OFFCURVE",
+"172 212 CURVE SMOOTH",
+"172 375 OFFCURVE",
+"203 414 OFFCURVE",
+"275 414 CURVE SMOOTH",
+"323 414 OFFCURVE",
+"366 397 OFFCURVE",
+"396 358 CURVE",
+"404 307 OFFCURVE",
+"406 245 OFFCURVE",
+"406 201 CURVE SMOOTH",
+"406 51 OFFCURVE",
+"375 17 OFFCURVE",
+"290 17 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"519 662 LINE",
+"508 695 LINE",
+"204 590 LINE",
+"216 557 LINE"
+);
+}
+);
+width = 579;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"493 -11 OFFCURVE",
+"622 107 OFFCURVE",
+"622 301 CURVE SMOOTH",
+"622 531 OFFCURVE",
+"439 726 OFFCURVE",
+"235 734 CURVE",
+"225 705 LINE",
+"341 687 OFFCURVE",
+"425 578 OFFCURVE",
+"435 413 CURVE",
+"432 412 LINE",
+"400 434 OFFCURVE",
+"366 446 OFFCURVE",
+"314 446 CURVE SMOOTH",
+"184 446 OFFCURVE",
+"65 357 OFFCURVE",
+"65 235 CURVE SMOOTH",
+"65 96 OFFCURVE",
+"192 -11 OFFCURVE",
+"339 -11 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"268 24 OFFCURVE",
+"240 75 OFFCURVE",
+"240 217 CURVE SMOOTH",
+"240 374 OFFCURVE",
+"282 406 OFFCURVE",
+"338 406 CURVE SMOOTH",
+"390 406 OFFCURVE",
+"424 379 OFFCURVE",
+"444 345 CURVE",
+"454 305 OFFCURVE",
+"454 257 OFFCURVE",
+"454 223 CURVE SMOOTH",
+"454 74 OFFCURVE",
+"425 24 OFFCURVE",
+"347 24 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"266 527 LINE",
+"609 672 LINE",
+"588 715 LINE",
+"244 570 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"493 -11 OFFCURVE",
+"622 107 OFFCURVE",
+"622 301 CURVE SMOOTH",
+"622 531 OFFCURVE",
+"439 726 OFFCURVE",
+"235 734 CURVE",
+"225 705 LINE",
+"341 687 OFFCURVE",
+"425 578 OFFCURVE",
+"435 413 CURVE",
+"432 412 LINE",
+"400 434 OFFCURVE",
+"366 446 OFFCURVE",
+"314 446 CURVE SMOOTH",
+"184 446 OFFCURVE",
+"65 357 OFFCURVE",
+"65 235 CURVE SMOOTH",
+"65 96 OFFCURVE",
+"192 -11 OFFCURVE",
+"339 -11 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"268 24 OFFCURVE",
+"240 75 OFFCURVE",
+"240 217 CURVE SMOOTH",
+"240 374 OFFCURVE",
+"282 406 OFFCURVE",
+"338 406 CURVE SMOOTH",
+"390 406 OFFCURVE",
+"424 379 OFFCURVE",
+"444 345 CURVE",
+"454 305 OFFCURVE",
+"454 257 OFFCURVE",
+"454 223 CURVE SMOOTH",
+"454 74 OFFCURVE",
+"425 24 OFFCURVE",
+"347 24 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"609 672 LINE",
+"588 715 LINE",
+"244 570 LINE",
+"266 527 LINE"
+);
+}
+);
+width = 692;
+}
+);
+unicode = 00F0;
+},
+{
+glyphname = dcaron;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = d;
+},
+{
+name = caron.alt;
+}
+);
+layerId = UUID0;
+width = 639;
+},
+{
+components = (
+{
+name = d;
+},
+{
+name = caron.alt;
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 728;
+}
+);
+leftKerningGroup = d;
+unicode = 010F;
+},
+{
+glyphname = dcroat;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+components = (
+{
+name = d;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"558 576 LINE",
+"558 611 LINE",
+"263 611 LINE",
+"263 576 LINE"
+);
+}
+);
+width = 568;
+},
+{
+components = (
+{
+name = d;
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"611 567 LINE",
+"611 611 LINE",
+"253 611 LINE",
+"253 567 LINE"
+);
+}
+);
+width = 631;
+}
+);
+leftKerningGroup = d;
+unicode = 0111;
+},
+{
+glyphname = ddotbelow;
+lastChange = "2016-08-22 11:53:08 +0000";
+layers = (
+{
+components = (
+{
+name = d;
+},
+{
+name = dotbelowcomb;
+}
+);
+layerId = UUID0;
+width = 568;
+},
+{
+components = (
+{
+name = d;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 23, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 631;
+}
+);
+leftKerningGroup = d;
+rightKerningGroup = d;
+unicode = 1E0D;
+},
+{
+glyphname = dz;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = d;
+},
+{
+name = z;
+transform = "{1, 0, 0, 1, 568, 0}";
+}
+);
+layerId = UUID0;
+width = 1048;
+},
+{
+components = (
+{
+name = d;
+},
+{
+name = z;
+transform = "{1, 0, 0, 1, 631, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 1107;
+}
+);
+leftKerningGroup = d;
+rightKerningGroup = z;
+unicode = 01F3;
+},
+{
+glyphname = dzcaron;
+lastChange = "2016-08-22 12:32:08 +0000";
+layers = (
+{
+components = (
+{
+name = dz;
+},
+{
+name = caron;
+transform = "{1, 0, 0, 1, 643, -9}";
+}
+);
+layerId = UUID0;
+width = 1048;
+},
+{
+components = (
+{
+name = dz;
+},
+{
+name = caron;
+transform = "{1, 0, 0, 1, 679, -9}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 1107;
+}
+);
+leftKerningGroup = d;
+rightKerningGroup = z;
+unicode = 01C6;
+},
+{
+glyphname = e;
+lastChange = "2016-08-22 09:54:01 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{253, 0}";
+},
+{
+name = ogonek;
+position = "{454, 10}";
+},
+{
+name = top;
+position = "{253, 450}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"365 -12 OFFCURVE",
+"436 45 OFFCURVE",
+"463 139 CURVE",
+"435 139 LINE",
+"399 50 OFFCURVE",
+"347 18 OFFCURVE",
+"277 18 CURVE SMOOTH",
+"198 18 OFFCURVE",
+"171 63 OFFCURVE",
+"171 225 CURVE SMOOTH",
+"171 383 OFFCURVE",
+"197 435 OFFCURVE",
+"264 435 CURVE SMOOTH",
+"317 435 OFFCURVE",
+"344 404 OFFCURVE",
+"344 344 CURVE SMOOTH",
+"344 287 LINE",
+"133 287 LINE",
+"133 262 LINE",
+"460 262 LINE",
+"460 268 LINE SMOOTH",
+"460 382 OFFCURVE",
+"377 462 OFFCURVE",
+"269 462 CURVE SMOOTH",
+"131 462 OFFCURVE",
+"41 347 OFFCURVE",
+"41 225 CURVE SMOOTH",
+"41 103 OFFCURVE",
+"145 -12 OFFCURVE",
+"274 -12 CURVE SMOOTH"
+);
+}
+);
+width = 505;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{269, 0}";
+},
+{
+name = ogonek;
+position = "{483, 10}";
+},
+{
+name = top;
+position = "{269, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"358 279 LINE",
+"152 279 LINE",
+"152 249 LINE",
+"499 249 LINE",
+"499 260 LINE SMOOTH",
+"499 380 OFFCURVE",
+"408 454 OFFCURVE",
+"289 454 CURVE SMOOTH",
+"140 454 OFFCURVE",
+"45 338 OFFCURVE",
+"45 224 CURVE SMOOTH",
+"45 101 OFFCURVE",
+"155 -13 OFFCURVE",
+"295 -13 CURVE SMOOTH",
+"395 -13 OFFCURVE",
+"474 46 OFFCURVE",
+"502 138 CURVE",
+"469 138 LINE",
+"430 53 OFFCURVE",
+"370 22 OFFCURVE",
+"300 22 CURVE SMOOTH",
+"224 22 OFFCURVE",
+"200 59 OFFCURVE",
+"200 218 CURVE SMOOTH",
+"200 373 OFFCURVE",
+"223 422 OFFCURVE",
+"287 422 CURVE SMOOTH",
+"334 422 OFFCURVE",
+"358 393 OFFCURVE",
+"358 336 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"395 -13 OFFCURVE",
+"474 46 OFFCURVE",
+"502 138 CURVE",
+"469 138 LINE",
+"430 53 OFFCURVE",
+"370 22 OFFCURVE",
+"300 22 CURVE SMOOTH",
+"224 22 OFFCURVE",
+"200 60 OFFCURVE",
+"200 222 CURVE SMOOTH",
+"200 380 OFFCURVE",
+"223 430 OFFCURVE",
+"286 430 CURVE SMOOTH",
+"334 430 OFFCURVE",
+"358 401 OFFCURVE",
+"358 344 CURVE SMOOTH",
+"358 283 LINE",
+"152 283 LINE",
+"152 253 LINE",
+"499 253 LINE",
+"499 264 LINE SMOOTH",
+"499 386 OFFCURVE",
+"408 462 OFFCURVE",
+"289 462 CURVE SMOOTH",
+"140 462 OFFCURVE",
+"45 344 OFFCURVE",
+"45 228 CURVE SMOOTH",
+"45 103 OFFCURVE",
+"155 -13 OFFCURVE",
+"295 -13 CURVE SMOOTH"
+);
+}
+);
+width = 537;
+}
+);
+leftKerningGroup = e;
+rightKerningGroup = e;
+unicode = 0065;
+},
+{
+glyphname = eacute;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = e;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -72, 0}";
+}
+);
+layerId = UUID0;
+width = 505;
+},
+{
+components = (
+{
+name = e;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -121, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 537;
+}
+);
+leftKerningGroup = e;
+rightKerningGroup = e;
+unicode = 00E9;
+},
+{
+glyphname = ebreve;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = e;
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, -42, 0}";
+}
+);
+layerId = UUID0;
+width = 505;
+},
+{
+components = (
+{
+name = e;
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, -29, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 537;
+}
+);
+leftKerningGroup = e;
+rightKerningGroup = e;
+unicode = 0115;
+},
+{
+glyphname = ecaron;
+lastChange = "2016-08-22 12:32:08 +0000";
+layers = (
+{
+components = (
+{
+name = e;
+},
+{
+name = caron;
+transform = "{1, 0, 0, 1, 88, -9}";
+}
+);
+layerId = UUID0;
+width = 505;
+},
+{
+components = (
+{
+name = e;
+},
+{
+name = caron;
+transform = "{1, 0, 0, 1, 79, -9}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 537;
+}
+);
+leftKerningGroup = e;
+rightKerningGroup = e;
+unicode = 011B;
+},
+{
+glyphname = ecircumflex;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = e;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -37, 0}";
+}
+);
+layerId = UUID0;
+width = 505;
+},
+{
+components = (
+{
+name = e;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -27, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 537;
+}
+);
+leftKerningGroup = e;
+rightKerningGroup = e;
+unicode = 00EA;
+},
+{
+glyphname = ecircumflexacute;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = e;
+},
+{
+name = circumflexcomb_acutecomb;
+transform = "{1, 0, 0, 1, -37, 0}";
+}
+);
+layerId = UUID0;
+width = 505;
+},
+{
+components = (
+{
+name = e;
+},
+{
+name = circumflexcomb_acutecomb;
+transform = "{1, 0, 0, 1, -27, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 537;
+}
+);
+leftKerningGroup = e;
+rightKerningGroup = e;
+unicode = 1EBF;
+},
+{
+glyphname = ecircumflexdotbelow;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = e;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -31, 0}";
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -37, 0}";
+}
+);
+layerId = UUID0;
+width = 505;
+},
+{
+components = (
+{
+name = e;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -24, 0}";
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -27, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 537;
+}
+);
+leftKerningGroup = e;
+rightKerningGroup = e;
+unicode = 1EC7;
+},
+{
+glyphname = ecircumflexgrave;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = e;
+},
+{
+name = circumflexcomb_gravecomb;
+transform = "{1, 0, 0, 1, -37, 0}";
+}
+);
+layerId = UUID0;
+width = 505;
+},
+{
+components = (
+{
+name = e;
+},
+{
+name = circumflexcomb_gravecomb;
+transform = "{1, 0, 0, 1, -27, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 537;
+}
+);
+leftKerningGroup = e;
+rightKerningGroup = e;
+unicode = 1EC1;
+},
+{
+glyphname = ecircumflexhookabove;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = e;
+},
+{
+name = circumflexcomb_hookabovecomb;
+transform = "{1, 0, 0, 1, -37, 0}";
+}
+);
+layerId = UUID0;
+width = 505;
+},
+{
+components = (
+{
+name = e;
+},
+{
+name = circumflexcomb_hookabovecomb;
+transform = "{1, 0, 0, 1, -27, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 537;
+}
+);
+leftKerningGroup = e;
+rightKerningGroup = e;
+unicode = 1EC3;
+},
+{
+glyphname = ecircumflextilde;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = e;
+},
+{
+name = circumflexcomb_tildecomb;
+transform = "{1, 0, 0, 1, -37, 0}";
+}
+);
+layerId = UUID0;
+width = 505;
+},
+{
+components = (
+{
+name = e;
+},
+{
+name = circumflexcomb_tildecomb;
+transform = "{1, 0, 0, 1, -27, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 537;
+}
+);
+leftKerningGroup = e;
+rightKerningGroup = e;
+unicode = 1EC5;
+},
+{
+glyphname = edblgrave;
+lastChange = "2016-08-22 12:07:41 +0000";
+layers = (
+{
+components = (
+{
+name = e;
+},
+{
+name = dblgravecomb;
+transform = "{1, 0, 0, 1, 40, 0}";
+}
+);
+layerId = UUID0;
+width = 505;
+},
+{
+components = (
+{
+name = e;
+},
+{
+name = dblgravecomb;
+transform = "{1, 0, 0, 1, 35, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 537;
+}
+);
+leftKerningGroup = e;
+rightKerningGroup = e;
+unicode = 0205;
+},
+{
+glyphname = edieresis;
+lastChange = "2016-08-22 12:32:08 +0000";
+layers = (
+{
+components = (
+{
+name = e;
+},
+{
+name = dieresis;
+transform = "{1, 0, 0, 1, 99, 0}";
+}
+);
+layerId = UUID0;
+width = 505;
+},
+{
+components = (
+{
+name = e;
+},
+{
+name = dieresis;
+transform = "{1, 0, 0, 1, 107, -2}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 537;
+}
+);
+leftKerningGroup = e;
+rightKerningGroup = e;
+unicode = 00EB;
+},
+{
+glyphname = edotaccent;
+lastChange = "2016-08-22 12:07:41 +0000";
+layers = (
+{
+components = (
+{
+name = e;
+},
+{
+name = dotaccent;
+transform = "{1, 0, 0, 1, 179, -3}";
+}
+);
+layerId = UUID0;
+width = 505;
+},
+{
+components = (
+{
+name = e;
+},
+{
+name = dotaccent;
+transform = "{1, 0, 0, 1, 181, -7}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 537;
+}
+);
+leftKerningGroup = e;
+rightKerningGroup = e;
+unicode = 0117;
+},
+{
+glyphname = edotbelow;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = e;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -31, 0}";
+}
+);
+layerId = UUID0;
+width = 505;
+},
+{
+components = (
+{
+name = e;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -24, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 537;
+}
+);
+leftKerningGroup = e;
+rightKerningGroup = e;
+unicode = 1EB9;
+},
+{
+glyphname = egrave;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = e;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, -34, 0}";
+}
+);
+layerId = UUID0;
+width = 505;
+},
+{
+components = (
+{
+name = e;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 20, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 537;
+}
+);
+leftKerningGroup = e;
+rightKerningGroup = e;
+unicode = 00E8;
+},
+{
+glyphname = ehookabove;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = e;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, -32, 0}";
+}
+);
+layerId = UUID0;
+width = 505;
+},
+{
+components = (
+{
+name = e;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, -15, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 537;
+}
+);
+leftKerningGroup = e;
+rightKerningGroup = e;
+unicode = 1EBB;
+},
+{
+glyphname = einvertedbreve;
+lastChange = "2016-08-22 12:07:41 +0000";
+layers = (
+{
+components = (
+{
+name = e;
+},
+{
+name = breveinvertedcomb;
+transform = "{1, 0, 0, 1, 86, 0}";
+}
+);
+layerId = UUID0;
+width = 505;
+},
+{
+components = (
+{
+name = e;
+},
+{
+name = breveinvertedcomb;
+transform = "{1, 0, 0, 1, 92, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 537;
+}
+);
+leftKerningGroup = e;
+rightKerningGroup = e;
+unicode = 0207;
+},
+{
+glyphname = emacron;
+lastChange = "2016-08-22 12:32:08 +0000";
+layers = (
+{
+components = (
+{
+name = e;
+},
+{
+name = macron;
+transform = "{1, 0, 0, 1, 87, 0}";
+}
+);
+layerId = UUID0;
+width = 505;
+},
+{
+components = (
+{
+name = e;
+},
+{
+name = macron;
+transform = "{1, 0, 0, 1, 95, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 537;
+}
+);
+leftKerningGroup = e;
+rightKerningGroup = e;
+unicode = 0113;
+},
+{
+glyphname = eogonek;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = e;
+},
+{
+name = ogonek;
+}
+);
+layerId = UUID0;
+width = 508;
+},
+{
+components = (
+{
+name = e;
+},
+{
+name = ogonek;
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 537;
+}
+);
+leftKerningGroup = e;
+rightKerningGroup = e;
+unicode = 0119;
+},
+{
+glyphname = etilde;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = e;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, -38, 0}";
+}
+);
+layerId = UUID0;
+width = 505;
+},
+{
+components = (
+{
+name = e;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, -44, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 537;
+}
+);
+leftKerningGroup = e;
+rightKerningGroup = e;
+unicode = 1EBD;
+},
+{
+glyphname = schwa;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"146 152 LINE",
+"357 152 LINE",
+"357 177 LINE",
+"30 177 LINE",
+"30 171 LINE SMOOTH",
+"30 57 OFFCURVE",
+"113 -13 OFFCURVE",
+"221 -13 CURVE SMOOTH",
+"359 -13 OFFCURVE",
+"449 103 OFFCURVE",
+"449 217 CURVE SMOOTH",
+"449 340 OFFCURVE",
+"347 454 OFFCURVE",
+"221 454 CURVE SMOOTH",
+"127 454 OFFCURVE",
+"54 397 OFFCURVE",
+"27 303 CURVE",
+"55 303 LINE",
+"92 392 OFFCURVE",
+"146 424 OFFCURVE",
+"218 424 CURVE SMOOTH",
+"294 424 OFFCURVE",
+"319 383 OFFCURVE",
+"319 221 CURVE SMOOTH",
+"319 63 OFFCURVE",
+"293 14 OFFCURVE",
+"226 14 CURVE SMOOTH",
+"173 14 OFFCURVE",
+"146 45 OFFCURVE",
+"146 105 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"374 -12 OFFCURVE",
+"464 103 OFFCURVE",
+"464 225 CURVE SMOOTH",
+"464 347 OFFCURVE",
+"360 462 OFFCURVE",
+"231 462 CURVE SMOOTH",
+"140 462 OFFCURVE",
+"69 405 OFFCURVE",
+"42 311 CURVE",
+"70 311 LINE",
+"106 400 OFFCURVE",
+"158 432 OFFCURVE",
+"228 432 CURVE SMOOTH",
+"307 432 OFFCURVE",
+"334 387 OFFCURVE",
+"334 225 CURVE SMOOTH",
+"334 67 OFFCURVE",
+"308 15 OFFCURVE",
+"241 15 CURVE SMOOTH",
+"188 15 OFFCURVE",
+"161 46 OFFCURVE",
+"161 106 CURVE SMOOTH",
+"161 163 LINE",
+"372 163 LINE",
+"372 188 LINE",
+"45 188 LINE",
+"45 182 LINE SMOOTH",
+"45 68 OFFCURVE",
+"128 -12 OFFCURVE",
+"236 -12 CURVE SMOOTH"
+);
+}
+);
+width = 508;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"397 -13 OFFCURVE",
+"492 105 OFFCURVE",
+"492 221 CURVE SMOOTH",
+"492 346 OFFCURVE",
+"382 462 OFFCURVE",
+"242 462 CURVE SMOOTH",
+"142 462 OFFCURVE",
+"63 403 OFFCURVE",
+"35 311 CURVE",
+"68 311 LINE",
+"107 396 OFFCURVE",
+"167 427 OFFCURVE",
+"237 427 CURVE SMOOTH",
+"313 427 OFFCURVE",
+"337 389 OFFCURVE",
+"337 227 CURVE SMOOTH",
+"337 69 OFFCURVE",
+"314 19 OFFCURVE",
+"251 19 CURVE SMOOTH",
+"203 19 OFFCURVE",
+"179 48 OFFCURVE",
+"179 105 CURVE",
+"179 166 LINE",
+"385 166 LINE",
+"385 196 LINE",
+"38 196 LINE",
+"38 185 LINE SMOOTH",
+"38 63 OFFCURVE",
+"129 -13 OFFCURVE",
+"248 -13 CURVE SMOOTH"
+);
+}
+);
+width = 537;
+}
+);
+unicode = 0259;
+},
+{
+glyphname = f;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{181, 0}";
+},
+{
+name = top;
+position = "{181, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"116 0 LINE",
+"226 0 LINE",
+"226 618 LINE SMOOTH",
+"226 704 OFFCURVE",
+"242 738 OFFCURVE",
+"282 738 CURVE SMOOTH",
+"298 738 OFFCURVE",
+"305 733 OFFCURVE",
+"305 721 CURVE SMOOTH",
+"305 704 OFFCURVE",
+"291 698 OFFCURVE",
+"291 674 CURVE SMOOTH",
+"291 646 OFFCURVE",
+"311 627 OFFCURVE",
+"341 627 CURVE SMOOTH",
+"374 627 OFFCURVE",
+"397 650 OFFCURVE",
+"397 685 CURVE SMOOTH",
+"397 733 OFFCURVE",
+"355 765 OFFCURVE",
+"287 765 CURVE SMOOTH",
+"171 765 OFFCURVE",
+"116 672 OFFCURVE",
+"116 478 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"19 0 LINE",
+"339 0 LINE",
+"339 25 LINE",
+"19 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"19 425 LINE",
+"349 425 LINE",
+"349 450 LINE",
+"19 450 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"226 0 LINE",
+"226 618 LINE SMOOTH",
+"226 704 OFFCURVE",
+"242 738 OFFCURVE",
+"282 738 CURVE SMOOTH",
+"298 738 OFFCURVE",
+"305 733 OFFCURVE",
+"305 721 CURVE SMOOTH",
+"305 704 OFFCURVE",
+"291 698 OFFCURVE",
+"291 674 CURVE SMOOTH",
+"291 646 OFFCURVE",
+"311 627 OFFCURVE",
+"341 627 CURVE SMOOTH",
+"374 627 OFFCURVE",
+"397 650 OFFCURVE",
+"397 685 CURVE SMOOTH",
+"397 733 OFFCURVE",
+"355 765 OFFCURVE",
+"287 765 CURVE SMOOTH",
+"171 765 OFFCURVE",
+"116 672 OFFCURVE",
+"116 478 CURVE SMOOTH",
+"116 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"339 0 LINE",
+"339 25 LINE",
+"19 25 LINE",
+"19 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"349 425 LINE",
+"349 450 LINE",
+"19 450 LINE",
+"19 425 LINE"
+);
+}
+);
+width = 362;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{173, 0}";
+},
+{
+name = top;
+position = "{173, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"241 0 LINE",
+"241 629 LINE SMOOTH",
+"241 712 OFFCURVE",
+"276 734 OFFCURVE",
+"317 734 CURVE SMOOTH",
+"340 734 OFFCURVE",
+"350 727 OFFCURVE",
+"350 715 CURVE SMOOTH",
+"350 697 OFFCURVE",
+"326 693 OFFCURVE",
+"326 659 CURVE SMOOTH",
+"326 621 OFFCURVE",
+"355 603 OFFCURVE",
+"387 603 CURVE SMOOTH",
+"427 603 OFFCURVE",
+"456 630 OFFCURVE",
+"456 670 CURVE SMOOTH",
+"456 722 OFFCURVE",
+"405 766 OFFCURVE",
+"323 766 CURVE SMOOTH",
+"188 766 OFFCURVE",
+"103 649 OFFCURVE",
+"103 479 CURVE SMOOTH",
+"103 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"23 0 LINE",
+"342 0 LINE",
+"342 30 LINE",
+"23 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 410 LINE",
+"349 410 LINE",
+"349 440 LINE",
+"20 440 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"241 0 LINE",
+"241 629 LINE SMOOTH",
+"241 712 OFFCURVE",
+"276 734 OFFCURVE",
+"317 734 CURVE SMOOTH",
+"340 734 OFFCURVE",
+"350 727 OFFCURVE",
+"350 715 CURVE SMOOTH",
+"350 697 OFFCURVE",
+"326 693 OFFCURVE",
+"326 659 CURVE SMOOTH",
+"326 621 OFFCURVE",
+"355 603 OFFCURVE",
+"387 603 CURVE SMOOTH",
+"427 603 OFFCURVE",
+"456 630 OFFCURVE",
+"456 670 CURVE SMOOTH",
+"456 722 OFFCURVE",
+"405 766 OFFCURVE",
+"323 766 CURVE SMOOTH",
+"188 766 OFFCURVE",
+"103 649 OFFCURVE",
+"103 479 CURVE SMOOTH",
+"103 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"342 0 LINE",
+"342 30 LINE",
+"23 30 LINE",
+"23 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"349 410 LINE",
+"349 440 LINE",
+"20 440 LINE",
+"20 410 LINE"
+);
+}
+);
+width = 346;
+}
+);
+leftKerningGroup = f;
+rightKerningGroup = f;
+unicode = 0066;
+},
+{
+glyphname = g;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{259, 0}";
+},
+{
+name = top;
+position = "{259, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"379 -326 OFFCURVE",
+"472 -232 OFFCURVE",
+"472 -90 CURVE SMOOTH",
+"472 0 OFFCURVE",
+"435 40 OFFCURVE",
+"349 40 CURVE SMOOTH",
+"142 40 LINE SMOOTH",
+"108 40 OFFCURVE",
+"87 56 OFFCURVE",
+"87 82 CURVE SMOOTH",
+"87 118 OFFCURVE",
+"126 141 OFFCURVE",
+"179 141 CURVE SMOOTH",
+"242 141 LINE SMOOTH",
+"332 141 OFFCURVE",
+"414 218 OFFCURVE",
+"414 301 CURVE SMOOTH",
+"414 327 OFFCURVE",
+"406 352 OFFCURVE",
+"392 375 CURVE",
+"394 400 OFFCURVE",
+"400 409 OFFCURVE",
+"411 409 CURVE SMOOTH",
+"435 409 OFFCURVE",
+"426 372 OFFCURVE",
+"463 372 CURVE SMOOTH",
+"488 372 OFFCURVE",
+"504 389 OFFCURVE",
+"504 414 CURVE SMOOTH",
+"504 442 OFFCURVE",
+"482 462 OFFCURVE",
+"450 462 CURVE SMOOTH",
+"415 462 OFFCURVE",
+"386 438 OFFCURVE",
+"371 402 CURVE",
+"339 438 OFFCURVE",
+"292 462 OFFCURVE",
+"242 462 CURVE SMOOTH",
+"152 462 OFFCURVE",
+"71 384 OFFCURVE",
+"71 301 CURVE SMOOTH",
+"71 246 OFFCURVE",
+"106 194 OFFCURVE",
+"156 165 CURVE",
+"86 158 OFFCURVE",
+"47 119 OFFCURVE",
+"47 52 CURVE SMOOTH",
+"47 -1 OFFCURVE",
+"71 -38 OFFCURVE",
+"120 -59 CURVE",
+"120 -63 LINE",
+"72 -89 OFFCURVE",
+"43 -132 OFFCURVE",
+"43 -181 CURVE SMOOTH",
+"43 -263 OFFCURVE",
+"127 -326 OFFCURVE",
+"240 -326 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"171 -296 OFFCURVE",
+"115 -244 OFFCURVE",
+"115 -172 CURVE SMOOTH",
+"115 -129 OFFCURVE",
+"135 -80 OFFCURVE",
+"159 -62 CURVE",
+"370 -62 LINE SMOOTH",
+"408 -62 OFFCURVE",
+"431 -88 OFFCURVE",
+"431 -132 CURVE SMOOTH",
+"431 -218 OFFCURVE",
+"345 -296 OFFCURVE",
+"249 -296 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"187 168 OFFCURVE",
+"174 196 OFFCURVE",
+"174 300 CURVE SMOOTH",
+"174 403 OFFCURVE",
+"187 430 OFFCURVE",
+"241 430 CURVE SMOOTH",
+"297 430 OFFCURVE",
+"311 402 OFFCURVE",
+"311 300 CURVE SMOOTH",
+"311 197 OFFCURVE",
+"297 168 OFFCURVE",
+"241 168 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"379 -326 OFFCURVE",
+"472 -232 OFFCURVE",
+"472 -90 CURVE SMOOTH",
+"472 0 OFFCURVE",
+"435 40 OFFCURVE",
+"349 40 CURVE SMOOTH",
+"142 40 LINE SMOOTH",
+"108 40 OFFCURVE",
+"87 56 OFFCURVE",
+"87 82 CURVE SMOOTH",
+"87 118 OFFCURVE",
+"126 141 OFFCURVE",
+"179 141 CURVE SMOOTH",
+"242 141 LINE SMOOTH",
+"332 141 OFFCURVE",
+"414 218 OFFCURVE",
+"414 301 CURVE SMOOTH",
+"414 327 OFFCURVE",
+"406 352 OFFCURVE",
+"392 375 CURVE",
+"394 400 OFFCURVE",
+"400 409 OFFCURVE",
+"411 409 CURVE SMOOTH",
+"435 409 OFFCURVE",
+"426 372 OFFCURVE",
+"463 372 CURVE SMOOTH",
+"488 372 OFFCURVE",
+"504 389 OFFCURVE",
+"504 414 CURVE SMOOTH",
+"504 442 OFFCURVE",
+"482 462 OFFCURVE",
+"450 462 CURVE SMOOTH",
+"415 462 OFFCURVE",
+"386 438 OFFCURVE",
+"371 402 CURVE",
+"339 438 OFFCURVE",
+"292 462 OFFCURVE",
+"242 462 CURVE SMOOTH",
+"152 462 OFFCURVE",
+"71 384 OFFCURVE",
+"71 301 CURVE SMOOTH",
+"71 246 OFFCURVE",
+"106 194 OFFCURVE",
+"156 165 CURVE",
+"86 158 OFFCURVE",
+"47 119 OFFCURVE",
+"47 52 CURVE SMOOTH",
+"47 -1 OFFCURVE",
+"71 -38 OFFCURVE",
+"120 -59 CURVE",
+"120 -63 LINE",
+"72 -89 OFFCURVE",
+"43 -132 OFFCURVE",
+"43 -181 CURVE SMOOTH",
+"43 -263 OFFCURVE",
+"127 -326 OFFCURVE",
+"240 -326 CURVE SMOOTH",
+"240 -326 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"171 -296 OFFCURVE",
+"115 -244 OFFCURVE",
+"115 -172 CURVE SMOOTH",
+"115 -129 OFFCURVE",
+"135 -80 OFFCURVE",
+"159 -62 CURVE",
+"370 -62 LINE SMOOTH",
+"408 -62 OFFCURVE",
+"431 -88 OFFCURVE",
+"431 -132 CURVE SMOOTH",
+"431 -218 OFFCURVE",
+"345 -296 OFFCURVE",
+"249 -296 CURVE SMOOTH",
+"249 -296 LINE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"187 168 OFFCURVE",
+"174 196 OFFCURVE",
+"174 300 CURVE SMOOTH",
+"174 403 OFFCURVE",
+"187 430 OFFCURVE",
+"241 430 CURVE SMOOTH",
+"297 430 OFFCURVE",
+"311 402 OFFCURVE",
+"311 300 CURVE SMOOTH",
+"311 197 OFFCURVE",
+"297 168 OFFCURVE",
+"241 168 CURVE SMOOTH"
+);
+}
+);
+width = 518;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{283, 0}";
+},
+{
+name = top;
+position = "{283, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"405 -324 OFFCURVE",
+"533 -251 OFFCURVE",
+"533 -92 CURVE SMOOTH",
+"533 20 OFFCURVE",
+"469 50 OFFCURVE",
+"368 50 CURVE SMOOTH",
+"156 50 LINE SMOOTH",
+"119 50 OFFCURVE",
+"103 68 OFFCURVE",
+"103 86 CURVE SMOOTH",
+"103 115 OFFCURVE",
+"145 137 OFFCURVE",
+"210 137 CURVE SMOOTH",
+"272 137 LINE SMOOTH",
+"385 137 OFFCURVE",
+"478 196 OFFCURVE",
+"478 299 CURVE SMOOTH",
+"478 323 OFFCURVE",
+"472 345 OFFCURVE",
+"463 365 CURVE",
+"465 389 OFFCURVE",
+"471 396 OFFCURVE",
+"483 396 CURVE SMOOTH",
+"509 396 OFFCURVE",
+"503 364 OFFCURVE",
+"542 364 CURVE SMOOTH",
+"571 364 OFFCURVE",
+"585 382 OFFCURVE",
+"585 406 CURVE SMOOTH",
+"585 443 OFFCURVE",
+"554 464 OFFCURVE",
+"521 464 CURVE SMOOTH",
+"482 464 OFFCURVE",
+"456 435 OFFCURVE",
+"442 397 CURVE",
+"404 439 OFFCURVE",
+"342 462 OFFCURVE",
+"272 462 CURVE SMOOTH",
+"159 462 OFFCURVE",
+"69 402 OFFCURVE",
+"69 299 CURVE SMOOTH",
+"69 236 OFFCURVE",
+"102 189 OFFCURVE",
+"154 163 CURVE",
+"79 150 OFFCURVE",
+"43 107 OFFCURVE",
+"43 47 CURVE SMOOTH",
+"43 -12 OFFCURVE",
+"79 -42 OFFCURVE",
+"136 -63 CURVE",
+"136 -67 LINE",
+"81 -89 OFFCURVE",
+"40 -128 OFFCURVE",
+"40 -181 CURVE SMOOTH",
+"40 -260 OFFCURVE",
+"133 -324 OFFCURVE",
+"264 -324 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"197 -289 OFFCURVE",
+"148 -238 OFFCURVE",
+"148 -168 CURVE SMOOTH",
+"148 -135 OFFCURVE",
+"159 -86 OFFCURVE",
+"178 -66 CURVE",
+"413 -66 LINE SMOOTH",
+"461 -66 OFFCURVE",
+"477 -83 OFFCURVE",
+"477 -124 CURVE SMOOTH",
+"477 -228 OFFCURVE",
+"377 -289 OFFCURVE",
+"283 -289 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"224 173 OFFCURVE",
+"209 194 OFFCURVE",
+"209 301 CURVE SMOOTH",
+"209 408 OFFCURVE",
+"224 431 OFFCURVE",
+"273 431 CURVE SMOOTH",
+"321 431 OFFCURVE",
+"338 409 OFFCURVE",
+"338 300 CURVE SMOOTH",
+"338 195 OFFCURVE",
+"322 173 OFFCURVE",
+"273 173 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"405 -324 OFFCURVE",
+"533 -251 OFFCURVE",
+"533 -92 CURVE SMOOTH",
+"533 20 OFFCURVE",
+"469 50 OFFCURVE",
+"368 50 CURVE SMOOTH",
+"156 50 LINE SMOOTH",
+"119 50 OFFCURVE",
+"103 68 OFFCURVE",
+"103 86 CURVE SMOOTH",
+"103 115 OFFCURVE",
+"145 137 OFFCURVE",
+"210 137 CURVE SMOOTH",
+"272 137 LINE SMOOTH",
+"385 137 OFFCURVE",
+"478 196 OFFCURVE",
+"478 299 CURVE SMOOTH",
+"478 323 OFFCURVE",
+"472 345 OFFCURVE",
+"463 365 CURVE",
+"465 389 OFFCURVE",
+"471 396 OFFCURVE",
+"483 396 CURVE SMOOTH",
+"509 396 OFFCURVE",
+"503 364 OFFCURVE",
+"542 364 CURVE SMOOTH",
+"571 364 OFFCURVE",
+"585 382 OFFCURVE",
+"585 406 CURVE SMOOTH",
+"585 443 OFFCURVE",
+"554 464 OFFCURVE",
+"521 464 CURVE SMOOTH",
+"482 464 OFFCURVE",
+"456 435 OFFCURVE",
+"442 397 CURVE",
+"404 439 OFFCURVE",
+"342 462 OFFCURVE",
+"272 462 CURVE SMOOTH",
+"159 462 OFFCURVE",
+"69 402 OFFCURVE",
+"69 299 CURVE SMOOTH",
+"69 236 OFFCURVE",
+"102 189 OFFCURVE",
+"154 163 CURVE",
+"79 150 OFFCURVE",
+"43 107 OFFCURVE",
+"43 47 CURVE SMOOTH",
+"43 -12 OFFCURVE",
+"79 -42 OFFCURVE",
+"136 -63 CURVE",
+"136 -67 LINE",
+"81 -89 OFFCURVE",
+"40 -128 OFFCURVE",
+"40 -181 CURVE SMOOTH",
+"40 -260 OFFCURVE",
+"133 -324 OFFCURVE",
+"264 -324 CURVE SMOOTH",
+"264 -324 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"197 -289 OFFCURVE",
+"148 -238 OFFCURVE",
+"148 -168 CURVE SMOOTH",
+"148 -135 OFFCURVE",
+"159 -86 OFFCURVE",
+"178 -66 CURVE",
+"413 -66 LINE SMOOTH",
+"461 -66 OFFCURVE",
+"477 -83 OFFCURVE",
+"477 -124 CURVE SMOOTH",
+"477 -228 OFFCURVE",
+"377 -289 OFFCURVE",
+"283 -289 CURVE SMOOTH",
+"283 -289 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"224 173 OFFCURVE",
+"209 194 OFFCURVE",
+"209 301 CURVE SMOOTH",
+"209 408 OFFCURVE",
+"224 431 OFFCURVE",
+"273 431 CURVE SMOOTH",
+"321 431 OFFCURVE",
+"338 409 OFFCURVE",
+"338 300 CURVE SMOOTH",
+"338 195 OFFCURVE",
+"322 173 OFFCURVE",
+"273 173 CURVE SMOOTH"
+);
+}
+);
+width = 565;
+}
+);
+leftKerningGroup = g;
+rightKerningGroup = g;
+unicode = 0067;
+},
+{
+glyphname = gacute;
+lastChange = "2016-08-22 11:53:43 +0000";
+layers = (
+{
+components = (
+{
+name = g;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -66, 0}";
+}
+);
+layerId = UUID0;
+width = 518;
+},
+{
+components = (
+{
+name = g;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -107, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 565;
+}
+);
+leftKerningGroup = g;
+rightKerningGroup = g;
+unicode = 01F5;
+},
+{
+glyphname = gbreve;
+lastChange = "2016-08-22 11:53:43 +0000";
+layers = (
+{
+components = (
+{
+name = g;
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, -36, 0}";
+}
+);
+layerId = UUID0;
+width = 518;
+},
+{
+components = (
+{
+name = g;
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, -15, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 565;
+}
+);
+leftKerningGroup = g;
+rightKerningGroup = g;
+unicode = 011F;
+},
+{
+glyphname = gcircumflex;
+lastChange = "2016-08-22 11:53:43 +0000";
+layers = (
+{
+components = (
+{
+name = g;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -31, 0}";
+}
+);
+layerId = UUID0;
+width = 518;
+},
+{
+components = (
+{
+name = g;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -13, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 565;
+}
+);
+leftKerningGroup = g;
+rightKerningGroup = g;
+unicode = 011D;
+},
+{
+glyphname = gcommaaccent;
+lastChange = "2016-08-22 12:07:41 +0000";
+layers = (
+{
+components = (
+{
+name = g;
+},
+{
+name = commaaccentcomb;
+transform = "{-1, 0, 0, -1, 345, 450}";
+}
+);
+layerId = UUID0;
+width = 518;
+},
+{
+components = (
+{
+name = g;
+},
+{
+name = commaaccentcomb;
+transform = "{-1, 0, 0, -1, 376, 450}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 565;
+}
+);
+leftKerningGroup = g;
+rightKerningGroup = g;
+unicode = 0123;
+},
+{
+glyphname = gdotaccent;
+lastChange = "2016-08-22 12:07:41 +0000";
+layers = (
+{
+components = (
+{
+name = g;
+},
+{
+name = dotaccent;
+transform = "{1, 0, 0, 1, 185, -3}";
+}
+);
+layerId = UUID0;
+width = 518;
+},
+{
+components = (
+{
+name = g;
+},
+{
+name = dotaccent;
+transform = "{1, 0, 0, 1, 195, -7}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 565;
+}
+);
+leftKerningGroup = g;
+rightKerningGroup = g;
+unicode = 0121;
+},
+{
+glyphname = h;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{298, 0}";
+},
+{
+name = center;
+position = "{298, 225}";
+},
+{
+name = top;
+position = "{298, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"17 415 LINE",
+"206 415 LINE",
+"206 440 LINE",
+"17 440 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"96 15 LINE",
+"206 15 LINE",
+"206 424 LINE",
+"96 424 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"17 0 LINE",
+"271 0 LINE",
+"271 25 LINE",
+"17 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"311 0 LINE",
+"565 0 LINE",
+"565 25 LINE",
+"311 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"497 343 LINE SMOOTH",
+"497 404 OFFCURVE",
+"441 452 OFFCURVE",
+"362 452 CURVE SMOOTH",
+"285 452 OFFCURVE",
+"238 412 OFFCURVE",
+"210 357 CURVE",
+"186 357 LINE",
+"206 212 LINE",
+"206 329 OFFCURVE",
+"260 418 OFFCURVE",
+"327 418 CURVE SMOOTH",
+"365 418 OFFCURVE",
+"387 393 OFFCURVE",
+"387 343 CURVE SMOOTH",
+"387 15 LINE",
+"497 15 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"506 15 LINE",
+"506 353 LINE SMOOTH",
+"506 414 OFFCURVE",
+"449 462 OFFCURVE",
+"368 462 CURVE SMOOTH",
+"289 462 OFFCURVE",
+"242 422 OFFCURVE",
+"213 367 CURVE",
+"189 367 LINE",
+"209 222 LINE",
+"209 339 OFFCURVE",
+"264 428 OFFCURVE",
+"333 428 CURVE SMOOTH",
+"373 428 OFFCURVE",
+"396 403 OFFCURVE",
+"396 353 CURVE SMOOTH",
+"396 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"274 0 LINE",
+"274 25 LINE",
+"20 25 LINE",
+"20 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"574 0 LINE",
+"574 25 LINE",
+"320 25 LINE",
+"320 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"209 15 LINE",
+"209 738 LINE",
+"99 738 LINE",
+"99 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"209 729 LINE",
+"209 754 LINE",
+"20 754 LINE",
+"20 729 LINE"
+);
+}
+);
+width = 596;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{310, 0}";
+},
+{
+name = center;
+position = "{310, 225}";
+},
+{
+name = top;
+position = "{310, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"20 724 LINE",
+"239 724 LINE",
+"239 754 LINE",
+"20 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"101 15 LINE",
+"239 15 LINE",
+"239 738 LINE",
+"101 738 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 0 LINE",
+"304 0 LINE",
+"304 30 LINE",
+"20 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"335 0 LINE",
+"604 0 LINE",
+"604 30 LINE",
+"335 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"541 342 LINE SMOOTH",
+"541 403 OFFCURVE",
+"482 451 OFFCURVE",
+"396 451 CURVE SMOOTH",
+"318 451 OFFCURVE",
+"269 415 OFFCURVE",
+"243 356 CURVE",
+"219 356 LINE",
+"239 201 LINE",
+"239 318 OFFCURVE",
+"292 407 OFFCURVE",
+"358 407 CURVE SMOOTH",
+"386 407 OFFCURVE",
+"403 390 OFFCURVE",
+"403 357 CURVE SMOOTH",
+"403 15 LINE",
+"541 15 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"541 15 LINE",
+"541 353 LINE SMOOTH",
+"541 414 OFFCURVE",
+"483 462 OFFCURVE",
+"395 462 CURVE SMOOTH",
+"319 462 OFFCURVE",
+"269 426 OFFCURVE",
+"243 367 CURVE",
+"219 367 LINE",
+"239 212 LINE",
+"239 330 OFFCURVE",
+"292 418 OFFCURVE",
+"359 418 CURVE SMOOTH",
+"386 418 OFFCURVE",
+"403 404 OFFCURVE",
+"403 358 CURVE SMOOTH",
+"403 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"304 0 LINE",
+"304 30 LINE",
+"20 30 LINE",
+"20 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"604 0 LINE",
+"604 30 LINE",
+"335 30 LINE",
+"335 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"239 15 LINE",
+"239 738 LINE",
+"101 738 LINE",
+"101 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"239 724 LINE",
+"239 754 LINE",
+"20 754 LINE",
+"20 724 LINE"
+);
+}
+);
+width = 619;
+}
+);
+leftKerningGroup = h;
+rightKerningGroup = h;
+unicode = 0068;
+},
+{
+glyphname = hbar;
+lastChange = "2016-08-22 12:23:51 +0000";
+layers = (
+{
+components = (
+{
+name = h;
+},
+{
+alignment = -1;
+name = strokeshortcomb;
+transform = "{1, 0, 0, 1, 417, 578}";
+}
+);
+layerId = UUID0;
+width = 596;
+},
+{
+components = (
+{
+name = h;
+},
+{
+alignment = -1;
+name = strokeshortcomb;
+transform = "{1, 0, 0, 1, -27, 573}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 619;
+}
+);
+rightKerningGroup = h;
+unicode = 0127;
+},
+{
+glyphname = hcircumflex;
+lastChange = "2016-08-22 12:24:05 +0000";
+layers = (
+{
+components = (
+{
+name = h;
+},
+{
+alignment = -1;
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 88, 31}";
+}
+);
+layerId = UUID0;
+width = 596;
+},
+{
+components = (
+{
+name = h;
+},
+{
+alignment = -1;
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 127, 29}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 619;
+}
+);
+leftKerningGroup = h;
+rightKerningGroup = h;
+unicode = 0125;
+},
+{
+glyphname = hdotbelow;
+lastChange = "2016-08-22 11:53:20 +0000";
+layers = (
+{
+components = (
+{
+name = h;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 14, 0}";
+}
+);
+layerId = UUID0;
+width = 596;
+},
+{
+components = (
+{
+name = h;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 17, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 619;
+}
+);
+leftKerningGroup = h;
+rightKerningGroup = h;
+unicode = 1E25;
+},
+{
+glyphname = i;
+lastChange = "2016-08-22 12:07:32 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{165, 0}";
+},
+{
+name = top;
+position = "{175, 450}";
+}
+);
+components = (
+{
+name = idotless;
+},
+{
+name = dotaccent;
+transform = "{1, 0, 0, 1, 91, -3}";
+}
+);
+layerId = UUID0;
+width = 330;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{160, 0}";
+},
+{
+name = top;
+position = "{177, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"20 410 LINE",
+"239 410 LINE",
+"239 440 LINE",
+"20 440 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"101 15 LINE",
+"239 15 LINE",
+"239 424 LINE",
+"101 424 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 0 LINE",
+"304 0 LINE",
+"304 30 LINE",
+"20 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"87 610 OFFCURVE",
+"124 573 OFFCURVE",
+"167 573 CURVE SMOOTH",
+"211 573 OFFCURVE",
+"248 610 OFFCURVE",
+"248 653 CURVE SMOOTH",
+"248 697 OFFCURVE",
+"211 734 OFFCURVE",
+"167 734 CURVE SMOOTH",
+"124 734 OFFCURVE",
+"87 697 OFFCURVE",
+"87 653 CURVE SMOOTH"
+);
+}
+);
+};
+components = (
+{
+name = idotless;
+},
+{
+name = dotaccent;
+transform = "{1, 0, 0, 1, 72, -7}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 319;
+}
+);
+leftKerningGroup = i;
+rightKerningGroup = i;
+unicode = 0069;
+},
+{
+glyphname = idotless;
+lastChange = "2016-08-22 10:12:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{165, 0}";
+},
+{
+name = ogonek;
+position = "{297, 10}";
+},
+{
+name = top;
+position = "{165, 450}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"224 15 LINE",
+"224 425 LINE",
+"114 425 LINE",
+"114 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"304 0 LINE",
+"304 25 LINE",
+"35 25 LINE",
+"35 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"224 416 LINE",
+"224 441 LINE",
+"25 441 LINE",
+"25 416 LINE"
+);
+}
+);
+width = 330;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{160, 0}";
+},
+{
+name = ogonek;
+position = "{287, 10}";
+},
+{
+name = top;
+position = "{160, 450}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"239 15 LINE",
+"239 434 LINE",
+"101 434 LINE",
+"101 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"304 0 LINE",
+"304 30 LINE",
+"20 30 LINE",
+"20 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"239 420 LINE",
+"239 450 LINE",
+"20 450 LINE",
+"20 420 LINE"
+);
+}
+);
+width = 319;
+}
+);
+unicode = 0131;
+},
+{
+glyphname = iacute;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = idotless;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -160, 0}";
+}
+);
+layerId = UUID0;
+width = 330;
+},
+{
+components = (
+{
+name = idotless;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -230, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 319;
+}
+);
+leftKerningGroup = i;
+rightKerningGroup = i;
+unicode = 00ED;
+},
+{
+glyphname = ibreve;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = idotless;
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, -130, 0}";
+}
+);
+layerId = UUID0;
+width = 330;
+},
+{
+components = (
+{
+name = idotless;
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, -138, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 319;
+}
+);
+leftKerningGroup = i;
+rightKerningGroup = i;
+unicode = 012D;
+},
+{
+glyphname = icircumflex;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = idotless;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -125, 0}";
+}
+);
+layerId = UUID0;
+width = 330;
+},
+{
+components = (
+{
+name = idotless;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -136, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 319;
+}
+);
+leftKerningGroup = i;
+rightKerningGroup = i;
+unicode = 00EE;
+},
+{
+glyphname = idblgrave;
+lastChange = "2016-08-22 12:07:41 +0000";
+layers = (
+{
+components = (
+{
+name = idotless;
+},
+{
+name = dblgravecomb;
+transform = "{1, 0, 0, 1, -48, 0}";
+}
+);
+layerId = UUID0;
+width = 330;
+},
+{
+components = (
+{
+name = idotless;
+},
+{
+name = dblgravecomb;
+transform = "{1, 0, 0, 1, -74, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 319;
+}
+);
+leftKerningGroup = i;
+rightKerningGroup = i;
+unicode = 0209;
+},
+{
+glyphname = idieresis;
+lastChange = "2016-08-22 12:32:08 +0000";
+layers = (
+{
+components = (
+{
+name = idotless;
+},
+{
+name = dieresis;
+transform = "{1, 0, 0, 1, 11, 0}";
+}
+);
+layerId = UUID0;
+width = 330;
+},
+{
+components = (
+{
+name = idotless;
+},
+{
+name = dieresis;
+transform = "{1, 0, 0, 1, -2, -2}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 319;
+}
+);
+leftKerningGroup = i;
+rightKerningGroup = i;
+unicode = 00EF;
+},
+{
+glyphname = idotbelow;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = i;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -119, 0}";
+}
+);
+layerId = UUID0;
+width = 330;
+},
+{
+components = (
+{
+name = i;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -133, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 319;
+}
+);
+leftKerningGroup = i;
+rightKerningGroup = i;
+unicode = 1ECB;
+},
+{
+glyphname = igrave;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = idotless;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, -122, 0}";
+}
+);
+layerId = UUID0;
+width = 330;
+},
+{
+components = (
+{
+name = idotless;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, -89, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 319;
+}
+);
+leftKerningGroup = i;
+rightKerningGroup = i;
+unicode = 00EC;
+},
+{
+glyphname = ihookabove;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = idotless;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, -120, 0}";
+}
+);
+layerId = UUID0;
+width = 330;
+},
+{
+components = (
+{
+name = idotless;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, -124, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 319;
+}
+);
+leftKerningGroup = i;
+rightKerningGroup = i;
+unicode = 1EC9;
+},
+{
+glyphname = iinvertedbreve;
+lastChange = "2016-08-22 12:07:41 +0000";
+layers = (
+{
+components = (
+{
+name = idotless;
+},
+{
+name = breveinvertedcomb;
+transform = "{1, 0, 0, 1, -2, 0}";
+}
+);
+layerId = UUID0;
+width = 330;
+},
+{
+components = (
+{
+name = idotless;
+},
+{
+name = breveinvertedcomb;
+transform = "{1, 0, 0, 1, -17, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 319;
+}
+);
+leftKerningGroup = i;
+rightKerningGroup = i;
+unicode = 020B;
+},
+{
+glyphname = ij;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = i;
+},
+{
+name = j;
+transform = "{1, 0, 0, 1, 310, 0}";
+}
+);
+layerId = UUID0;
+width = 640;
+},
+{
+components = (
+{
+name = i;
+},
+{
+name = j;
+transform = "{1, 0, 0, 1, 319, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 637;
+}
+);
+leftKerningGroup = i;
+rightKerningGroup = j;
+unicode = 0133;
+},
+{
+glyphname = imacron;
+lastChange = "2016-08-22 12:32:08 +0000";
+layers = (
+{
+components = (
+{
+name = idotless;
+},
+{
+name = macron;
+transform = "{1, 0, 0, 1, -1, 0}";
+}
+);
+layerId = UUID0;
+width = 330;
+},
+{
+components = (
+{
+name = idotless;
+},
+{
+name = macron;
+transform = "{1, 0, 0, 1, -14, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 319;
+}
+);
+leftKerningGroup = i;
+rightKerningGroup = i;
+unicode = 012B;
+},
+{
+glyphname = iogonek;
+lastChange = "2016-08-22 12:07:41 +0000";
+layers = (
+{
+components = (
+{
+name = idotless;
+},
+{
+name = dotaccent;
+transform = "{1, 0, 0, 1, 91, -3}";
+},
+{
+name = ogonek;
+}
+);
+layerId = UUID0;
+width = 330;
+},
+{
+components = (
+{
+name = idotless;
+},
+{
+name = dotaccent;
+transform = "{1, 0, 0, 1, 72, -7}";
+},
+{
+name = ogonek;
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 319;
+}
+);
+leftKerningGroup = i;
+rightKerningGroup = i;
+unicode = 012F;
+},
+{
+glyphname = itilde;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = idotless;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, -126, 0}";
+}
+);
+layerId = UUID0;
+width = 330;
+},
+{
+components = (
+{
+name = idotless;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, -153, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 319;
+}
+);
+leftKerningGroup = i;
+rightKerningGroup = i;
+unicode = 0129;
+},
+{
+glyphname = j;
+lastChange = "2016-08-22 12:32:08 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"146 -326 OFFCURVE",
+"224 -236 OFFCURVE",
+"224 -47 CURVE SMOOTH",
+"224 450 LINE",
+"25 450 LINE",
+"25 425 LINE",
+"114 425 LINE",
+"114 -197 LINE SMOOTH",
+"114 -273 OFFCURVE",
+"95 -293 OFFCURVE",
+"79 -293 CURVE SMOOTH",
+"71 -293 OFFCURVE",
+"61 -288 OFFCURVE",
+"61 -274 CURVE SMOOTH",
+"61 -266 OFFCURVE",
+"64 -251 OFFCURVE",
+"64 -242 CURVE SMOOTH",
+"64 -215 OFFCURVE",
+"39 -198 OFFCURVE",
+"13 -198 CURVE SMOOTH",
+"-18 -198 OFFCURVE",
+"-42 -221 OFFCURVE",
+"-42 -256 CURVE SMOOTH",
+"-42 -295 OFFCURVE",
+"-11 -326 OFFCURVE",
+"47 -326 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"99 631 OFFCURVE",
+"129 601 OFFCURVE",
+"165 601 CURVE SMOOTH",
+"201 601 OFFCURVE",
+"231 631 OFFCURVE",
+"231 667 CURVE SMOOTH",
+"231 703 OFFCURVE",
+"201 733 OFFCURVE",
+"165 733 CURVE SMOOTH",
+"129 733 OFFCURVE",
+"99 703 OFFCURVE",
+"99 667 CURVE SMOOTH"
+);
+}
+);
+};
+components = (
+{
+name = jdotless;
+},
+{
+name = dotaccent;
+transform = "{1, 0, 0, 1, 91, -3}";
+}
+);
+layerId = UUID0;
+width = 330;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"156 -322 OFFCURVE",
+"239 -205 OFFCURVE",
+"239 -35 CURVE SMOOTH",
+"239 450 LINE",
+"15 450 LINE",
+"15 420 LINE",
+"101 420 LINE",
+"101 -185 LINE SMOOTH",
+"101 -264 OFFCURVE",
+"81 -285 OFFCURVE",
+"57 -285 CURVE SMOOTH",
+"43 -285 OFFCURVE",
+"36 -278 OFFCURVE",
+"36 -266 CURVE SMOOTH",
+"36 -250 OFFCURVE",
+"50 -245 OFFCURVE",
+"50 -217 CURVE SMOOTH",
+"50 -176 OFFCURVE",
+"21 -159 OFFCURVE",
+"-11 -159 CURVE SMOOTH",
+"-51 -159 OFFCURVE",
+"-80 -186 OFFCURVE",
+"-80 -225 CURVE SMOOTH",
+"-80 -278 OFFCURVE",
+"-26 -322 OFFCURVE",
+"43 -322 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"87 610 OFFCURVE",
+"124 573 OFFCURVE",
+"167 573 CURVE SMOOTH",
+"211 573 OFFCURVE",
+"248 610 OFFCURVE",
+"248 653 CURVE SMOOTH",
+"248 697 OFFCURVE",
+"211 734 OFFCURVE",
+"167 734 CURVE SMOOTH",
+"124 734 OFFCURVE",
+"87 697 OFFCURVE",
+"87 653 CURVE SMOOTH"
+);
+}
+);
+};
+components = (
+{
+name = jdotless;
+},
+{
+name = dotaccent;
+transform = "{1, 0, 0, 1, 71, -7}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 318;
+}
+);
+leftKerningGroup = j;
+rightKerningGroup = j;
+unicode = 006A;
+},
+{
+glyphname = jdotless;
+lastChange = "2016-08-22 12:24:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{165, 0}";
+},
+{
+name = top;
+position = "{165, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"15 416 LINE",
+"114 416 LINE",
+"114 -185 LINE SMOOTH",
+"114 -261 OFFCURVE",
+"95 -281 OFFCURVE",
+"79 -281 CURVE SMOOTH",
+"71 -281 OFFCURVE",
+"61 -276 OFFCURVE",
+"61 -262 CURVE SMOOTH",
+"61 -254 OFFCURVE",
+"64 -239 OFFCURVE",
+"64 -230 CURVE SMOOTH",
+"64 -203 OFFCURVE",
+"39 -186 OFFCURVE",
+"13 -186 CURVE SMOOTH",
+"-18 -186 OFFCURVE",
+"-42 -209 OFFCURVE",
+"-42 -244 CURVE SMOOTH",
+"-42 -283 OFFCURVE",
+"-11 -314 OFFCURVE",
+"47 -314 CURVE SMOOTH",
+"146 -314 OFFCURVE",
+"224 -224 OFFCURVE",
+"224 -35 CURVE SMOOTH",
+"224 441 LINE",
+"15 441 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"146 -326 OFFCURVE",
+"224 -236 OFFCURVE",
+"224 -47 CURVE SMOOTH",
+"224 450 LINE",
+"25 450 LINE",
+"25 425 LINE",
+"114 425 LINE",
+"114 -197 LINE SMOOTH",
+"114 -273 OFFCURVE",
+"95 -293 OFFCURVE",
+"79 -293 CURVE SMOOTH",
+"71 -293 OFFCURVE",
+"61 -288 OFFCURVE",
+"61 -274 CURVE SMOOTH",
+"61 -266 OFFCURVE",
+"64 -251 OFFCURVE",
+"64 -242 CURVE SMOOTH",
+"64 -215 OFFCURVE",
+"39 -198 OFFCURVE",
+"13 -198 CURVE SMOOTH",
+"-18 -198 OFFCURVE",
+"-42 -221 OFFCURVE",
+"-42 -256 CURVE SMOOTH",
+"-42 -295 OFFCURVE",
+"-11 -326 OFFCURVE",
+"47 -326 CURVE SMOOTH",
+"47 -326 LINE SMOOTH"
+);
+}
+);
+width = 330;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{159, 0}";
+},
+{
+name = top;
+position = "{159, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"15 420 LINE",
+"239 420 LINE",
+"239 450 LINE",
+"15 450 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"101 450 LINE",
+"101 -185 LINE SMOOTH",
+"101 -264 OFFCURVE",
+"81 -285 OFFCURVE",
+"57 -285 CURVE SMOOTH",
+"43 -285 OFFCURVE",
+"36 -278 OFFCURVE",
+"36 -266 CURVE SMOOTH",
+"36 -250 OFFCURVE",
+"50 -245 OFFCURVE",
+"50 -217 CURVE SMOOTH",
+"50 -176 OFFCURVE",
+"21 -159 OFFCURVE",
+"-11 -159 CURVE SMOOTH",
+"-51 -159 OFFCURVE",
+"-80 -186 OFFCURVE",
+"-80 -225 CURVE SMOOTH",
+"-80 -278 OFFCURVE",
+"-26 -322 OFFCURVE",
+"43 -322 CURVE SMOOTH",
+"156 -322 OFFCURVE",
+"239 -205 OFFCURVE",
+"239 -35 CURVE SMOOTH",
+"239 450 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"156 -322 OFFCURVE",
+"239 -205 OFFCURVE",
+"239 -35 CURVE SMOOTH",
+"239 450 LINE",
+"15 450 LINE",
+"15 420 LINE",
+"101 420 LINE",
+"101 -185 LINE SMOOTH",
+"101 -264 OFFCURVE",
+"81 -285 OFFCURVE",
+"57 -285 CURVE SMOOTH",
+"43 -285 OFFCURVE",
+"36 -278 OFFCURVE",
+"36 -266 CURVE SMOOTH",
+"36 -250 OFFCURVE",
+"50 -245 OFFCURVE",
+"50 -217 CURVE SMOOTH",
+"50 -176 OFFCURVE",
+"21 -159 OFFCURVE",
+"-11 -159 CURVE SMOOTH",
+"-51 -159 OFFCURVE",
+"-80 -186 OFFCURVE",
+"-80 -225 CURVE SMOOTH",
+"-80 -278 OFFCURVE",
+"-26 -322 OFFCURVE",
+"43 -322 CURVE SMOOTH",
+"43 -322 LINE SMOOTH"
+);
+}
+);
+width = 318;
+}
+);
+unicode = 0237;
+},
+{
+glyphname = jcircumflex;
+lastChange = "2016-08-22 12:24:23 +0000";
+layers = (
+{
+components = (
+{
+name = jdotless;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -125, 0}";
+}
+);
+layerId = UUID0;
+width = 330;
+},
+{
+components = (
+{
+name = jdotless;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -137, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 318;
+}
+);
+leftKerningGroup = j;
+rightKerningGroup = j;
+unicode = 0135;
+},
+{
+glyphname = k;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{261, 0}";
+},
+{
+name = top;
+position = "{261, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"12 729 LINE",
+"201 729 LINE",
+"201 754 LINE",
+"12 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"91 15 LINE",
+"201 15 LINE",
+"201 738 LINE",
+"91 738 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"12 0 LINE",
+"256 0 LINE",
+"256 25 LINE",
+"12 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"318 0 LINE",
+"564 0 LINE",
+"564 25 LINE",
+"318 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"386 15 LINE",
+"529 15 LINE",
+"300 306 LINE",
+"208 249 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"285 425 LINE",
+"517 425 LINE",
+"517 450 LINE",
+"285 450 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"208 249 LINE",
+"251 249 LINE",
+"434 433 LINE",
+"391 433 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"529 15 LINE",
+"300 306 LINE",
+"208 249 LINE",
+"386 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"256 0 LINE",
+"256 25 LINE",
+"12 25 LINE",
+"12 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"564 0 LINE",
+"564 25 LINE",
+"318 25 LINE",
+"318 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"201 15 LINE",
+"201 738 LINE",
+"91 738 LINE",
+"91 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"251 249 LINE",
+"434 433 LINE",
+"391 433 LINE",
+"208 249 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"517 425 LINE",
+"517 450 LINE",
+"285 450 LINE",
+"285 425 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"201 729 LINE",
+"201 754 LINE",
+"12 754 LINE",
+"12 729 LINE"
+);
+}
+);
+width = 522;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{309, 0}";
+},
+{
+name = top;
+position = "{309, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"20 724 LINE",
+"239 724 LINE",
+"239 754 LINE",
+"20 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"101 15 LINE",
+"239 15 LINE",
+"239 738 LINE",
+"101 738 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 0 LINE",
+"304 0 LINE",
+"304 30 LINE",
+"20 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"339 0 LINE",
+"628 0 LINE",
+"628 30 LINE",
+"339 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"413 15 LINE",
+"581 15 LINE",
+"352 321 LINE",
+"235 249 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"332 420 LINE",
+"565 420 LINE",
+"565 450 LINE",
+"332 450 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"235 254 LINE",
+"235 249 LINE",
+"286 249 LINE",
+"492 432 LINE",
+"441 432 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"581 15 LINE",
+"352 321 LINE",
+"247 254 LINE",
+"413 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"304 0 LINE",
+"304 30 LINE",
+"20 30 LINE",
+"20 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"628 0 LINE",
+"628 30 LINE",
+"339 30 LINE",
+"339 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"239 15 LINE",
+"239 738 LINE",
+"101 738 LINE",
+"101 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"492 432 LINE",
+"441 432 LINE",
+"247 254 LINE",
+"286 249 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"239 724 LINE",
+"239 754 LINE",
+"20 754 LINE",
+"20 724 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"565 420 LINE",
+"565 450 LINE",
+"332 450 LINE",
+"332 420 LINE"
+);
+}
+);
+width = 618;
+}
+);
+leftKerningGroup = k;
+rightKerningGroup = k;
+unicode = 006B;
+},
+{
+glyphname = kcommaaccent;
+lastChange = "2016-08-22 12:07:41 +0000";
+layers = (
+{
+components = (
+{
+name = k;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 175, 0}";
+}
+);
+layerId = UUID0;
+width = 522;
+},
+{
+components = (
+{
+name = k;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 216, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 618;
+}
+);
+leftKerningGroup = k;
+rightKerningGroup = k;
+unicode = 0137;
+},
+{
+glyphname = kgreenlandic;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"12 425 LINE",
+"201 425 LINE",
+"201 450 LINE",
+"12 450 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"91 15 LINE",
+"201 15 LINE",
+"201 434 LINE",
+"91 434 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"12 0 LINE",
+"256 0 LINE",
+"256 25 LINE",
+"12 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"318 0 LINE",
+"564 0 LINE",
+"564 25 LINE",
+"318 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"386 15 LINE",
+"529 15 LINE",
+"300 306 LINE",
+"208 249 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"285 425 LINE",
+"517 425 LINE",
+"517 450 LINE",
+"285 450 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"208 249 LINE",
+"251 249 LINE",
+"434 433 LINE",
+"391 433 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"529 15 LINE",
+"300 306 LINE",
+"208 249 LINE",
+"386 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"256 0 LINE",
+"256 25 LINE",
+"12 25 LINE",
+"12 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"201 15 LINE",
+"201 434 LINE",
+"91 434 LINE",
+"91 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"564 0 LINE",
+"564 25 LINE",
+"318 25 LINE",
+"318 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"201 425 LINE",
+"201 450 LINE",
+"12 450 LINE",
+"12 425 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"251 249 LINE",
+"434 433 LINE",
+"391 433 LINE",
+"208 249 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"517 425 LINE",
+"517 450 LINE",
+"285 450 LINE",
+"285 425 LINE"
+);
+}
+);
+width = 522;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"20 420 LINE",
+"239 420 LINE",
+"239 450 LINE",
+"20 450 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"101 15 LINE",
+"239 15 LINE",
+"239 434 LINE",
+"101 434 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 0 LINE",
+"304 0 LINE",
+"304 30 LINE",
+"20 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"339 0 LINE",
+"628 0 LINE",
+"628 30 LINE",
+"339 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"413 15 LINE",
+"581 15 LINE",
+"352 301 LINE",
+"235 229 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"332 420 LINE",
+"565 420 LINE",
+"565 450 LINE",
+"332 450 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"235 234 LINE",
+"235 229 LINE",
+"286 229 LINE",
+"492 432 LINE",
+"441 432 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"581 15 LINE",
+"352 321 LINE",
+"247 254 LINE",
+"413 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"304 0 LINE",
+"304 30 LINE",
+"20 30 LINE",
+"20 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"239 15 LINE",
+"239 434 LINE",
+"101 434 LINE",
+"101 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"628 0 LINE",
+"628 30 LINE",
+"339 30 LINE",
+"339 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"239 420 LINE",
+"239 450 LINE",
+"20 450 LINE",
+"20 420 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"492 432 LINE",
+"441 432 LINE",
+"247 254 LINE",
+"286 249 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"565 420 LINE",
+"565 450 LINE",
+"332 450 LINE",
+"332 420 LINE"
+);
+}
+);
+width = 618;
+}
+);
+rightKerningGroup = k;
+unicode = 0138;
+},
+{
+glyphname = l;
+lastChange = "2016-08-22 12:24:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{148, 0}";
+},
+{
+name = center;
+position = "{148, 225}";
+},
+{
+name = top;
+position = "{148, 450}";
+},
+{
+name = topright;
+position = "{276, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"0 729 LINE",
+"189 729 LINE",
+"189 754 LINE",
+"0 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"79 15 LINE",
+"189 15 LINE",
+"189 738 LINE",
+"79 738 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"0 0 LINE",
+"189 0 LINE",
+"189 25 LINE",
+"0 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"243 22 OFFCURVE",
+"189 80 OFFCURVE",
+"189 210 CURVE",
+"169 58 LINE",
+"193 58 LINE",
+"215 18 OFFCURVE",
+"264 -12 OFFCURVE",
+"326 -12 CURVE SMOOTH",
+"426 -12 OFFCURVE",
+"520 83 OFFCURVE",
+"520 225 CURVE SMOOTH",
+"520 367 OFFCURVE",
+"427 462 OFFCURVE",
+"327 462 CURVE SMOOTH",
+"265 462 OFFCURVE",
+"215 432 OFFCURVE",
+"193 392 CURVE",
+"169 392 LINE",
+"189 240 LINE",
+"189 370 OFFCURVE",
+"242 428 OFFCURVE",
+"314 428 CURVE SMOOTH",
+"370 428 OFFCURVE",
+"392 389 OFFCURVE",
+"392 224 CURVE SMOOTH",
+"392 59 OFFCURVE",
+"371 22 OFFCURVE",
+"315 22 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"202 15 LINE",
+"202 738 LINE",
+"92 738 LINE",
+"92 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"282 0 LINE",
+"282 25 LINE",
+"13 25 LINE",
+"13 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"202 729 LINE",
+"202 754 LINE",
+"13 754 LINE",
+"13 729 LINE"
+);
+}
+);
+width = 296;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{165, 0}";
+},
+{
+name = center;
+position = "{165, 225}";
+},
+{
+name = top;
+position = "{168, 754}";
+},
+{
+name = topright;
+position = "{309, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"217 739 OFFCURVE",
+"145 734 OFFCURVE",
+"128 734 CURVE SMOOTH",
+"117 734 OFFCURVE",
+"96 734 OFFCURVE",
+"80 734 CURVE SMOOTH",
+"64 734 OFFCURVE",
+"46 734 OFFCURVE",
+"40 734 CURVE SMOOTH",
+"35 734 OFFCURVE",
+"27 734 OFFCURVE",
+"22 732 CURVE SMOOTH",
+"11 727 OFFCURVE",
+"8 713 OFFCURVE",
+"16 705 CURVE SMOOTH",
+"19 702 OFFCURVE",
+"22 702 OFFCURVE",
+"48 702 CURVE SMOOTH",
+"64 702 OFFCURVE",
+"80 703 OFFCURVE",
+"83 703 CURVE SMOOTH",
+"92 705 OFFCURVE",
+"95 702 OFFCURVE",
+"97 692 CURVE SMOOTH",
+"97 689 OFFCURVE",
+"97 643 OFFCURVE",
+"97 590 CURVE SMOOTH",
+"97 537 OFFCURVE",
+"97 475 OFFCURVE",
+"97 452 CURVE SMOOTH",
+"97 430 OFFCURVE",
+"97 396 OFFCURVE",
+"97 379 CURVE SMOOTH",
+"97 359 OFFCURVE",
+"97 331 OFFCURVE",
+"97 315 CURVE SMOOTH",
+"97 299 OFFCURVE",
+"97 270 OFFCURVE",
+"97 249 CURVE SMOOTH",
+"97 185 OFFCURVE",
+"97 135 OFFCURVE",
+"97 116 CURVE",
+"99 91 OFFCURVE",
+"96 39 OFFCURVE",
+"93 36 CURVE SMOOTH",
+"91 33 OFFCURVE",
+"85 33 OFFCURVE",
+"61 33 CURVE",
+"35 35 OFFCURVE",
+"30 33 OFFCURVE",
+"25 31 CURVE",
+"14 23 OFFCURVE",
+"17 9 OFFCURVE",
+"30 3 CURVE SMOOTH",
+"36 1 OFFCURVE",
+"40 -1 OFFCURVE",
+"62 1 CURVE SMOOTH",
+"93 3 OFFCURVE",
+"248 3 OFFCURVE",
+"261 1 CURVE",
+"261 1 OFFCURVE",
+"273 -1 OFFCURVE",
+"285 -2 CURVE SMOOTH",
+"303 -4 OFFCURVE",
+"309 -2 OFFCURVE",
+"318 4 CURVE",
+"318 9 OFFCURVE",
+"318 20 OFFCURVE",
+"318 27 CURVE",
+"313 33 LINE",
+"280 33 LINE SMOOTH",
+"262 33 OFFCURVE",
+"246 35 OFFCURVE",
+"245 35 CURVE SMOOTH",
+"243 36 OFFCURVE",
+"243 123 OFFCURVE",
+"243 385 CURVE SMOOTH",
+"243 705 OFFCURVE",
+"243 734 OFFCURVE",
+"240 735 CURVE",
+"238 739 OFFCURVE",
+"222 742 OFFCURVE",
+"221 740 CURVE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"239 15 LINE",
+"239 738 LINE",
+"101 738 LINE",
+"101 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"314 0 LINE",
+"314 30 LINE",
+"20 30 LINE",
+"20 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"239 724 LINE",
+"239 754 LINE",
+"20 754 LINE",
+"20 724 LINE"
+);
+}
+);
+width = 329;
+}
+);
+leftKerningGroup = l;
+rightKerningGroup = l;
+unicode = 006C;
+},
+{
+glyphname = lacute;
+lastChange = "2016-08-22 12:24:52 +0000";
+layers = (
+{
+components = (
+{
+name = l;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -177, 0}";
+}
+);
+layerId = UUID0;
+width = 296;
+},
+{
+components = (
+{
+name = l;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -222, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 329;
+}
+);
+leftKerningGroup = l;
+rightKerningGroup = l;
+unicode = 013A;
+},
+{
+glyphname = lcaron;
+lastChange = "2016-08-22 12:25:20 +0000";
+layers = (
+{
+components = (
+{
+name = l;
+},
+{
+name = caron.alt;
+transform = "{1, 0, 0, 1, 249, -9}";
+}
+);
+layerId = UUID0;
+width = 328;
+},
+{
+components = (
+{
+name = l;
+},
+{
+name = caron.alt;
+transform = "{1, 0, 0, 1, 287, -10}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 388;
+}
+);
+leftKerningGroup = l;
+unicode = 013E;
+},
+{
+glyphname = lcommaaccent;
+lastChange = "2016-08-22 12:07:41 +0000";
+layers = (
+{
+components = (
+{
+name = l;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 62, 0}";
+}
+);
+layerId = UUID0;
+width = 296;
+},
+{
+components = (
+{
+name = l;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 72, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 329;
+}
+);
+leftKerningGroup = l;
+rightKerningGroup = l;
+unicode = 013C;
+},
+{
+glyphname = ldot;
+lastChange = "2016-08-22 12:25:36 +0000";
+layers = (
+{
+components = (
+{
+name = l;
+},
+{
+name = periodcentered;
+transform = "{1, 0, 0, 1, 235, 57}";
+}
+);
+layerId = UUID0;
+width = 372;
+},
+{
+components = (
+{
+name = l;
+},
+{
+name = periodcentered;
+transform = "{1, 0, 0, 1, 246, 52}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 410;
+}
+);
+leftKerningGroup = l;
+unicode = 0140;
+},
+{
+glyphname = lj;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = l;
+},
+{
+name = j;
+transform = "{1, 0, 0, 1, 296, 0}";
+}
+);
+layerId = UUID0;
+width = 626;
+},
+{
+components = (
+{
+name = l;
+},
+{
+name = j;
+transform = "{1, 0, 0, 1, 329, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 647;
+}
+);
+leftKerningGroup = l;
+rightKerningGroup = j;
+unicode = 01C9;
+},
+{
+glyphname = lslash;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+components = (
+{
+name = l;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"298 448 LINE",
+"298 488 LINE",
+"-10 327 LINE",
+"-10 287 LINE"
+);
+}
+);
+width = 296;
+},
+{
+components = (
+{
+name = l;
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"328 448 LINE",
+"328 502 LINE",
+"20 341 LINE",
+"20 287 LINE"
+);
+}
+);
+width = 329;
+}
+);
+unicode = 0142;
+},
+{
+glyphname = m;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{438, 0}";
+},
+{
+name = top;
+position = "{438, 450}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"786 15 LINE",
+"786 353 LINE SMOOTH",
+"786 414 OFFCURVE",
+"731 462 OFFCURVE",
+"654 462 CURVE SMOOTH",
+"579 462 OFFCURVE",
+"532 422 OFFCURVE",
+"505 367 CURVE",
+"481 367 LINE",
+"501 222 LINE",
+"501 339 OFFCURVE",
+"554 428 OFFCURVE",
+"619 428 CURVE SMOOTH",
+"655 428 OFFCURVE",
+"676 403 OFFCURVE",
+"676 353 CURVE SMOOTH",
+"676 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"281 0 LINE",
+"281 25 LINE",
+"27 25 LINE",
+"27 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"216 15 LINE",
+"216 434 LINE",
+"106 434 LINE",
+"106 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"569 0 LINE",
+"569 25 LINE",
+"315 25 LINE",
+"315 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"216 425 LINE",
+"216 450 LINE",
+"27 450 LINE",
+"27 425 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"501 15 LINE",
+"501 353 LINE SMOOTH",
+"501 414 OFFCURVE",
+"446 462 OFFCURVE",
+"369 462 CURVE SMOOTH",
+"294 462 OFFCURVE",
+"247 422 OFFCURVE",
+"220 367 CURVE",
+"196 367 LINE",
+"216 222 LINE",
+"216 339 OFFCURVE",
+"269 428 OFFCURVE",
+"334 428 CURVE SMOOTH",
+"370 428 OFFCURVE",
+"391 403 OFFCURVE",
+"391 353 CURVE SMOOTH",
+"391 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"854 0 LINE",
+"854 25 LINE",
+"600 25 LINE",
+"600 0 LINE"
+);
+}
+);
+width = 876;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{455, 0}";
+},
+{
+name = top;
+position = "{455, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"20 410 LINE",
+"239 410 LINE",
+"239 440 LINE",
+"20 440 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"101 15 LINE",
+"239 15 LINE",
+"239 424 LINE",
+"101 424 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 0 LINE",
+"304 0 LINE",
+"304 30 LINE",
+"20 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"330 0 LINE",
+"599 0 LINE",
+"599 30 LINE",
+"330 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"536 342 LINE SMOOTH",
+"536 403 OFFCURVE",
+"477 451 OFFCURVE",
+"391 451 CURVE SMOOTH",
+"316 451 OFFCURVE",
+"268 415 OFFCURVE",
+"243 356 CURVE",
+"219 356 LINE",
+"239 201 LINE",
+"239 318 OFFCURVE",
+"290 407 OFFCURVE",
+"353 407 CURVE SMOOTH",
+"381 407 OFFCURVE",
+"398 390 OFFCURVE",
+"398 357 CURVE SMOOTH",
+"398 15 LINE",
+"536 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"626 0 LINE",
+"895 0 LINE",
+"895 30 LINE",
+"626 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"832 342 LINE SMOOTH",
+"832 403 OFFCURVE",
+"773 451 OFFCURVE",
+"687 451 CURVE SMOOTH",
+"612 451 OFFCURVE",
+"564 415 OFFCURVE",
+"539 356 CURVE",
+"515 356 LINE",
+"535 201 LINE",
+"535 318 OFFCURVE",
+"586 407 OFFCURVE",
+"649 407 CURVE SMOOTH",
+"677 407 OFFCURVE",
+"694 390 OFFCURVE",
+"694 357 CURVE SMOOTH",
+"694 15 LINE",
+"832 15 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"832 15 LINE",
+"832 353 LINE SMOOTH",
+"832 414 OFFCURVE",
+"773 462 OFFCURVE",
+"687 462 CURVE SMOOTH",
+"612 462 OFFCURVE",
+"564 426 OFFCURVE",
+"539 367 CURVE",
+"515 367 LINE",
+"535 212 LINE",
+"535 329 OFFCURVE",
+"586 418 OFFCURVE",
+"649 418 CURVE SMOOTH",
+"677 418 OFFCURVE",
+"694 401 OFFCURVE",
+"694 368 CURVE SMOOTH",
+"694 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"304 0 LINE",
+"304 30 LINE",
+"20 30 LINE",
+"20 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"239 15 LINE",
+"239 434 LINE",
+"101 434 LINE",
+"101 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"599 0 LINE",
+"599 30 LINE",
+"330 30 LINE",
+"330 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"239 420 LINE",
+"239 450 LINE",
+"20 450 LINE",
+"20 420 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"536 15 LINE",
+"536 353 LINE SMOOTH",
+"536 414 OFFCURVE",
+"477 462 OFFCURVE",
+"391 462 CURVE SMOOTH",
+"316 462 OFFCURVE",
+"268 426 OFFCURVE",
+"243 367 CURVE",
+"219 367 LINE",
+"239 212 LINE",
+"239 329 OFFCURVE",
+"290 418 OFFCURVE",
+"353 418 CURVE SMOOTH",
+"381 418 OFFCURVE",
+"398 401 OFFCURVE",
+"398 368 CURVE SMOOTH",
+"398 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"895 0 LINE",
+"895 30 LINE",
+"626 30 LINE",
+"626 0 LINE"
+);
+}
+);
+width = 910;
+}
+);
+unicode = 006D;
+},
+{
+glyphname = n;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{298, 0}";
+},
+{
+name = top;
+position = "{298, 450}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"508 15 LINE",
+"508 353 LINE SMOOTH",
+"508 414 OFFCURVE",
+"452 462 OFFCURVE",
+"373 462 CURVE SMOOTH",
+"296 462 OFFCURVE",
+"249 422 OFFCURVE",
+"221 367 CURVE",
+"197 367 LINE",
+"217 222 LINE",
+"217 339 OFFCURVE",
+"271 428 OFFCURVE",
+"338 428 CURVE SMOOTH",
+"376 428 OFFCURVE",
+"398 403 OFFCURVE",
+"398 353 CURVE SMOOTH",
+"398 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"282 0 LINE",
+"282 25 LINE",
+"28 25 LINE",
+"28 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"217 15 LINE",
+"217 434 LINE",
+"107 434 LINE",
+"107 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"576 0 LINE",
+"576 25 LINE",
+"322 25 LINE",
+"322 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"217 425 LINE",
+"217 450 LINE",
+"28 450 LINE",
+"28 425 LINE"
+);
+}
+);
+width = 596;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{307, 0}";
+},
+{
+name = top;
+position = "{307, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"20 410 LINE",
+"239 410 LINE",
+"239 440 LINE",
+"20 440 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"101 15 LINE",
+"239 15 LINE",
+"239 424 LINE",
+"101 424 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 0 LINE",
+"304 0 LINE",
+"304 30 LINE",
+"20 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"335 0 LINE",
+"604 0 LINE",
+"604 30 LINE",
+"335 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"541 342 LINE SMOOTH",
+"541 403 OFFCURVE",
+"482 451 OFFCURVE",
+"396 451 CURVE SMOOTH",
+"318 451 OFFCURVE",
+"269 415 OFFCURVE",
+"243 356 CURVE",
+"219 356 LINE",
+"239 201 LINE",
+"239 318 OFFCURVE",
+"292 407 OFFCURVE",
+"358 407 CURVE SMOOTH",
+"386 407 OFFCURVE",
+"403 390 OFFCURVE",
+"403 357 CURVE SMOOTH",
+"403 15 LINE",
+"541 15 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"541 15 LINE",
+"541 353 LINE SMOOTH",
+"541 414 OFFCURVE",
+"482 462 OFFCURVE",
+"396 462 CURVE SMOOTH",
+"318 462 OFFCURVE",
+"269 426 OFFCURVE",
+"243 367 CURVE",
+"219 367 LINE",
+"239 212 LINE",
+"239 329 OFFCURVE",
+"292 418 OFFCURVE",
+"358 418 CURVE SMOOTH",
+"386 418 OFFCURVE",
+"403 401 OFFCURVE",
+"403 368 CURVE SMOOTH",
+"403 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"304 0 LINE",
+"304 30 LINE",
+"20 30 LINE",
+"20 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"239 15 LINE",
+"239 434 LINE",
+"101 434 LINE",
+"101 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"604 0 LINE",
+"604 30 LINE",
+"335 30 LINE",
+"335 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"239 420 LINE",
+"239 450 LINE",
+"20 450 LINE",
+"20 420 LINE"
+);
+}
+);
+width = 614;
+}
+);
+leftKerningGroup = n;
+rightKerningGroup = n;
+unicode = 006E;
+},
+{
+glyphname = nacute;
+lastChange = "2016-08-22 11:53:08 +0000";
+layers = (
+{
+components = (
+{
+name = n;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -27, 0}";
+}
+);
+layerId = UUID0;
+width = 596;
+},
+{
+components = (
+{
+name = n;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -83, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 614;
+}
+);
+leftKerningGroup = n;
+rightKerningGroup = n;
+unicode = 0144;
+},
+{
+glyphname = napostrophe;
+lastChange = "2016-08-22 12:26:02 +0000";
+layers = (
+{
+components = (
+{
+name = n;
+},
+{
+name = quoteright;
+transform = "{1, 0, 0, 1, -60, 13}";
+}
+);
+layerId = UUID0;
+width = 596;
+},
+{
+components = (
+{
+name = n;
+},
+{
+name = quoteright;
+transform = "{1, 0, 0, 1, -47, 80}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 614;
+}
+);
+rightKerningGroup = n;
+unicode = 0149;
+},
+{
+glyphname = ncaron;
+lastChange = "2016-08-22 12:32:08 +0000";
+layers = (
+{
+components = (
+{
+name = n;
+},
+{
+name = caron;
+transform = "{1, 0, 0, 1, 133, -9}";
+}
+);
+layerId = UUID0;
+width = 596;
+},
+{
+components = (
+{
+name = n;
+},
+{
+name = caron;
+transform = "{1, 0, 0, 1, 117, -9}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 614;
+}
+);
+leftKerningGroup = n;
+rightKerningGroup = n;
+unicode = 0148;
+},
+{
+glyphname = ncommaaccent;
+lastChange = "2016-08-22 12:07:41 +0000";
+layers = (
+{
+components = (
+{
+name = n;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 212, 0}";
+}
+);
+layerId = UUID0;
+width = 596;
+},
+{
+components = (
+{
+name = n;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 214, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 614;
+}
+);
+leftKerningGroup = n;
+rightKerningGroup = n;
+unicode = 0146;
+},
+{
+glyphname = ndotaccent;
+lastChange = "2016-08-22 12:07:41 +0000";
+layers = (
+{
+components = (
+{
+name = n;
+},
+{
+name = dotaccent;
+transform = "{1, 0, 0, 1, 224, -3}";
+}
+);
+layerId = UUID0;
+width = 596;
+},
+{
+components = (
+{
+name = n;
+},
+{
+name = dotaccent;
+transform = "{1, 0, 0, 1, 219, -7}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 614;
+}
+);
+leftKerningGroup = n;
+rightKerningGroup = n;
+unicode = 1E45;
+},
+{
+glyphname = eng;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"28 425 LINE",
+"107 425 LINE",
+"107 25 LINE",
+"28 25 LINE",
+"28 0 LINE",
+"282 0 LINE",
+"282 25 LINE",
+"217 25 LINE",
+"217 230 LINE SMOOTH",
+"217 343 OFFCURVE",
+"272 428 OFFCURVE",
+"338 428 CURVE SMOOTH",
+"376 428 OFFCURVE",
+"398 403 OFFCURVE",
+"398 353 CURVE SMOOTH",
+"398 -197 LINE SMOOTH",
+"398 -273 OFFCURVE",
+"379 -293 OFFCURVE",
+"363 -293 CURVE SMOOTH",
+"355 -293 OFFCURVE",
+"345 -288 OFFCURVE",
+"345 -274 CURVE SMOOTH",
+"345 -266 OFFCURVE",
+"348 -251 OFFCURVE",
+"348 -242 CURVE SMOOTH",
+"348 -215 OFFCURVE",
+"323 -198 OFFCURVE",
+"297 -198 CURVE SMOOTH",
+"266 -198 OFFCURVE",
+"242 -221 OFFCURVE",
+"242 -256 CURVE SMOOTH",
+"242 -295 OFFCURVE",
+"273 -326 OFFCURVE",
+"331 -326 CURVE SMOOTH",
+"430 -326 OFFCURVE",
+"508 -236 OFFCURVE",
+"508 -47 CURVE SMOOTH",
+"508 353 LINE SMOOTH",
+"508 414 OFFCURVE",
+"452 462 OFFCURVE",
+"373 462 CURVE SMOOTH",
+"296 462 OFFCURVE",
+"249 422 OFFCURVE",
+"221 367 CURVE",
+"217 367 LINE",
+"217 450 LINE",
+"28 450 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"430 -326 OFFCURVE",
+"508 -236 OFFCURVE",
+"508 -47 CURVE SMOOTH",
+"508 353 LINE SMOOTH",
+"508 414 OFFCURVE",
+"452 462 OFFCURVE",
+"373 462 CURVE SMOOTH",
+"296 462 OFFCURVE",
+"249 422 OFFCURVE",
+"221 367 CURVE",
+"217 367 LINE",
+"217 450 LINE",
+"28 450 LINE",
+"28 425 LINE",
+"107 425 LINE",
+"107 25 LINE",
+"28 25 LINE",
+"28 0 LINE",
+"282 0 LINE",
+"282 25 LINE",
+"217 25 LINE",
+"217 230 LINE SMOOTH",
+"217 343 OFFCURVE",
+"272 428 OFFCURVE",
+"338 428 CURVE SMOOTH",
+"376 428 OFFCURVE",
+"398 403 OFFCURVE",
+"398 353 CURVE SMOOTH",
+"398 -197 LINE SMOOTH",
+"398 -273 OFFCURVE",
+"379 -293 OFFCURVE",
+"363 -293 CURVE SMOOTH",
+"355 -293 OFFCURVE",
+"345 -288 OFFCURVE",
+"345 -274 CURVE SMOOTH",
+"345 -266 OFFCURVE",
+"348 -251 OFFCURVE",
+"348 -242 CURVE SMOOTH",
+"348 -215 OFFCURVE",
+"323 -198 OFFCURVE",
+"297 -198 CURVE SMOOTH",
+"266 -198 OFFCURVE",
+"242 -221 OFFCURVE",
+"242 -256 CURVE SMOOTH",
+"242 -295 OFFCURVE",
+"273 -326 OFFCURVE",
+"331 -326 CURVE SMOOTH"
+);
+}
+);
+width = 607;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"20 420 LINE",
+"101 420 LINE",
+"101 30 LINE",
+"20 30 LINE",
+"20 0 LINE",
+"304 0 LINE",
+"304 30 LINE",
+"239 30 LINE",
+"239 220 LINE SMOOTH",
+"239 333 OFFCURVE",
+"293 418 OFFCURVE",
+"358 418 CURVE SMOOTH",
+"386 418 OFFCURVE",
+"403 401 OFFCURVE",
+"403 368 CURVE SMOOTH",
+"403 -185 LINE SMOOTH",
+"403 -264 OFFCURVE",
+"383 -285 OFFCURVE",
+"359 -285 CURVE SMOOTH",
+"345 -285 OFFCURVE",
+"338 -278 OFFCURVE",
+"338 -266 CURVE SMOOTH",
+"338 -250 OFFCURVE",
+"352 -245 OFFCURVE",
+"352 -217 CURVE SMOOTH",
+"352 -176 OFFCURVE",
+"323 -159 OFFCURVE",
+"291 -159 CURVE SMOOTH",
+"251 -159 OFFCURVE",
+"222 -186 OFFCURVE",
+"222 -225 CURVE SMOOTH",
+"222 -278 OFFCURVE",
+"276 -322 OFFCURVE",
+"345 -322 CURVE SMOOTH",
+"458 -322 OFFCURVE",
+"541 -205 OFFCURVE",
+"541 -35 CURVE SMOOTH",
+"541 353 LINE SMOOTH",
+"541 414 OFFCURVE",
+"482 462 OFFCURVE",
+"396 462 CURVE SMOOTH",
+"318 462 OFFCURVE",
+"269 426 OFFCURVE",
+"243 367 CURVE",
+"239 367 LINE",
+"239 450 LINE",
+"20 450 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"458 -322 OFFCURVE",
+"541 -205 OFFCURVE",
+"541 -35 CURVE SMOOTH",
+"541 353 LINE SMOOTH",
+"541 414 OFFCURVE",
+"482 462 OFFCURVE",
+"396 462 CURVE SMOOTH",
+"318 462 OFFCURVE",
+"269 426 OFFCURVE",
+"243 367 CURVE",
+"239 367 LINE",
+"239 450 LINE",
+"20 450 LINE",
+"20 420 LINE",
+"101 420 LINE",
+"101 30 LINE",
+"20 30 LINE",
+"20 0 LINE",
+"304 0 LINE",
+"304 30 LINE",
+"239 30 LINE",
+"239 220 LINE SMOOTH",
+"239 333 OFFCURVE",
+"293 418 OFFCURVE",
+"358 418 CURVE SMOOTH",
+"386 418 OFFCURVE",
+"403 401 OFFCURVE",
+"403 368 CURVE SMOOTH",
+"403 -185 LINE SMOOTH",
+"403 -264 OFFCURVE",
+"383 -285 OFFCURVE",
+"359 -285 CURVE SMOOTH",
+"345 -285 OFFCURVE",
+"338 -278 OFFCURVE",
+"338 -266 CURVE SMOOTH",
+"338 -250 OFFCURVE",
+"352 -245 OFFCURVE",
+"352 -217 CURVE SMOOTH",
+"352 -176 OFFCURVE",
+"323 -159 OFFCURVE",
+"291 -159 CURVE SMOOTH",
+"251 -159 OFFCURVE",
+"222 -186 OFFCURVE",
+"222 -225 CURVE SMOOTH",
+"222 -278 OFFCURVE",
+"276 -322 OFFCURVE",
+"345 -322 CURVE SMOOTH"
+);
+}
+);
+width = 614;
+}
+);
+leftKerningGroup = n;
+unicode = 014B;
+},
+{
+glyphname = nj;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = n;
+},
+{
+name = j;
+transform = "{1, 0, 0, 1, 596, 0}";
+}
+);
+layerId = UUID0;
+width = 926;
+},
+{
+components = (
+{
+name = n;
+},
+{
+name = j;
+transform = "{1, 0, 0, 1, 614, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 932;
+}
+);
+leftKerningGroup = n;
+rightKerningGroup = j;
+unicode = 01CC;
+},
+{
+glyphname = ntilde;
+lastChange = "2016-08-22 11:53:08 +0000";
+layers = (
+{
+components = (
+{
+name = n;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, 7, 0}";
+}
+);
+layerId = UUID0;
+width = 596;
+},
+{
+components = (
+{
+name = n;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, -6, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 614;
+}
+);
+leftKerningGroup = n;
+rightKerningGroup = n;
+unicode = 00F1;
+},
+{
+glyphname = o;
+lastChange = "2016-08-22 09:33:38 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{281, 0}";
+},
+{
+name = center;
+position = "{281, 225}";
+},
+{
+name = ogonek;
+position = "{506, 10}";
+},
+{
+name = top;
+position = "{281, 450}";
+},
+{
+name = topright;
+position = "{429, 397}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"411 -12 OFFCURVE",
+"516 105 OFFCURVE",
+"516 225 CURVE SMOOTH",
+"516 345 OFFCURVE",
+"411 462 OFFCURVE",
+"281 462 CURVE SMOOTH",
+"151 462 OFFCURVE",
+"46 345 OFFCURVE",
+"46 225 CURVE SMOOTH",
+"46 105 OFFCURVE",
+"151 -12 OFFCURVE",
+"281 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"205 18 OFFCURVE",
+"176 57 OFFCURVE",
+"176 225 CURVE SMOOTH",
+"176 393 OFFCURVE",
+"205 432 OFFCURVE",
+"281 432 CURVE SMOOTH",
+"357 432 OFFCURVE",
+"386 393 OFFCURVE",
+"386 225 CURVE SMOOTH",
+"386 57 OFFCURVE",
+"357 18 OFFCURVE",
+"281 18 CURVE SMOOTH"
+);
+}
+);
+width = 562;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{295, 0}";
+},
+{
+name = center;
+position = "{295, 225}";
+},
+{
+name = ogonek;
+position = "{530, 10}";
+},
+{
+name = top;
+position = "{295, 450}";
+},
+{
+name = topright;
+position = "{341, 395}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"45 82 OFFCURVE",
+"156 -13 OFFCURVE",
+"294 -13 CURVE SMOOTH",
+"432 -13 OFFCURVE",
+"544 82 OFFCURVE",
+"544 220 CURVE SMOOTH",
+"544 358 OFFCURVE",
+"432 454 OFFCURVE",
+"294 454 CURVE SMOOTH",
+"156 454 OFFCURVE",
+"45 358 OFFCURVE",
+"45 220 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"200 383 OFFCURVE",
+"224 419 OFFCURVE",
+"294 419 CURVE SMOOTH",
+"364 419 OFFCURVE",
+"389 383 OFFCURVE",
+"389 220 CURVE SMOOTH",
+"389 57 OFFCURVE",
+"364 22 OFFCURVE",
+"294 22 CURVE SMOOTH",
+"224 22 OFFCURVE",
+"200 57 OFFCURVE",
+"200 220 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"432 -13 OFFCURVE",
+"544 84 OFFCURVE",
+"544 224 CURVE SMOOTH",
+"544 364 OFFCURVE",
+"432 462 OFFCURVE",
+"294 462 CURVE SMOOTH",
+"156 462 OFFCURVE",
+"45 364 OFFCURVE",
+"45 224 CURVE SMOOTH",
+"45 84 OFFCURVE",
+"156 -13 OFFCURVE",
+"294 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"224 22 OFFCURVE",
+"200 58 OFFCURVE",
+"200 224 CURVE SMOOTH",
+"200 390 OFFCURVE",
+"224 427 OFFCURVE",
+"294 427 CURVE SMOOTH",
+"364 427 OFFCURVE",
+"389 390 OFFCURVE",
+"389 224 CURVE SMOOTH",
+"389 58 OFFCURVE",
+"364 22 OFFCURVE",
+"294 22 CURVE SMOOTH"
+);
+}
+);
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 006F;
+},
+{
+glyphname = oacute;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = o;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -44, 0}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = o;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -95, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 00F3;
+},
+{
+glyphname = obreve;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = o;
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, -14, 0}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = o;
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, -3, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 014F;
+},
+{
+glyphname = ocircumflex;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = o;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -9, 0}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = o;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -1, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 00F4;
+},
+{
+glyphname = ocircumflexacute;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = o;
+},
+{
+name = circumflexcomb_acutecomb;
+transform = "{1, 0, 0, 1, -9, 0}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = o;
+},
+{
+name = circumflexcomb_acutecomb;
+transform = "{1, 0, 0, 1, -1, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 1ED1;
+},
+{
+glyphname = ocircumflexdotbelow;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = o;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -3, 0}";
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -9, 0}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = o;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 2, 0}";
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -1, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 1ED9;
+},
+{
+glyphname = ocircumflexgrave;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = o;
+},
+{
+name = circumflexcomb_gravecomb;
+transform = "{1, 0, 0, 1, -9, 0}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = o;
+},
+{
+name = circumflexcomb_gravecomb;
+transform = "{1, 0, 0, 1, -1, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 1ED3;
+},
+{
+glyphname = ocircumflexhookabove;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = o;
+},
+{
+name = circumflexcomb_hookabovecomb;
+transform = "{1, 0, 0, 1, -9, 0}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = o;
+},
+{
+name = circumflexcomb_hookabovecomb;
+transform = "{1, 0, 0, 1, -1, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 1ED5;
+},
+{
+glyphname = ocircumflextilde;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = o;
+},
+{
+name = circumflexcomb_tildecomb;
+transform = "{1, 0, 0, 1, -9, 0}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = o;
+},
+{
+name = circumflexcomb_tildecomb;
+transform = "{1, 0, 0, 1, -1, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 1ED7;
+},
+{
+glyphname = odblgrave;
+lastChange = "2016-08-22 12:07:41 +0000";
+layers = (
+{
+components = (
+{
+name = o;
+},
+{
+name = dblgravecomb;
+transform = "{1, 0, 0, 1, 68, 0}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = o;
+},
+{
+name = dblgravecomb;
+transform = "{1, 0, 0, 1, 61, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 020D;
+},
+{
+glyphname = odieresis;
+lastChange = "2016-08-22 12:32:08 +0000";
+layers = (
+{
+components = (
+{
+name = o;
+},
+{
+name = dieresis;
+transform = "{1, 0, 0, 1, 127, 0}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = o;
+},
+{
+name = dieresis;
+transform = "{1, 0, 0, 1, 133, -2}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 00F6;
+},
+{
+glyphname = odotbelow;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = o;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -3, 0}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = o;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 2, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 1ECD;
+},
+{
+glyphname = ograve;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = o;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, -6, 0}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = o;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 46, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 00F2;
+},
+{
+glyphname = ohookabove;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = o;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, -4, 0}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = o;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 11, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 1ECF;
+},
+{
+glyphname = ohorn;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = o;
+},
+{
+name = horncomb;
+transform = "{1, 0, 0, 1, 117, -53}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = o;
+},
+{
+name = horncomb;
+transform = "{1, 0, 0, 1, 142, -55}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 01A1;
+},
+{
+glyphname = ohornacute;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = ohorn;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -44, 0}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = ohorn;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -95, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 1EDB;
+},
+{
+glyphname = ohorndotbelow;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = ohorn;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -3, 0}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = ohorn;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 2, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 1EE3;
+},
+{
+glyphname = ohorngrave;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = ohorn;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, -6, 0}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = ohorn;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 46, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 1EDD;
+},
+{
+glyphname = ohornhookabove;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = ohorn;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, -4, 0}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = ohorn;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 11, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 1EDF;
+},
+{
+glyphname = ohorntilde;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = ohorn;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, -10, 0}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = ohorn;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, -18, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 1EE1;
+},
+{
+glyphname = ohungarumlaut;
+lastChange = "2016-08-22 12:26:18 +0000";
+layers = (
+{
+components = (
+{
+name = o;
+},
+{
+name = hungarumlaut;
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = o;
+},
+{
+name = hungarumlaut;
+transform = "{1, 0, 0, 1, 138, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 0151;
+},
+{
+glyphname = oinvertedbreve;
+lastChange = "2016-08-22 12:07:41 +0000";
+layers = (
+{
+components = (
+{
+name = o;
+},
+{
+name = breveinvertedcomb;
+transform = "{1, 0, 0, 1, 114, 0}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = o;
+},
+{
+name = breveinvertedcomb;
+transform = "{1, 0, 0, 1, 118, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 020F;
+},
+{
+glyphname = omacron;
+lastChange = "2016-08-22 12:32:08 +0000";
+layers = (
+{
+components = (
+{
+name = o;
+},
+{
+name = macron;
+transform = "{1, 0, 0, 1, 115, 0}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = o;
+},
+{
+name = macron;
+transform = "{1, 0, 0, 1, 121, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 014D;
+},
+{
+glyphname = oogonek;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = o;
+},
+{
+name = ogonek;
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = o;
+},
+{
+name = ogonek;
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 01EB;
+},
+{
+glyphname = oslash;
+lastChange = "2016-08-19 16:44:19 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"411 -12 OFFCURVE",
+"516 105 OFFCURVE",
+"516 225 CURVE SMOOTH",
+"516 345 OFFCURVE",
+"411 462 OFFCURVE",
+"281 462 CURVE SMOOTH",
+"151 462 OFFCURVE",
+"46 345 OFFCURVE",
+"46 225 CURVE SMOOTH",
+"46 105 OFFCURVE",
+"151 -12 OFFCURVE",
+"281 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"117 -53 LINE",
+"504 483 LINE",
+"466 483 LINE",
+"79 -53 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"205 18 OFFCURVE",
+"176 57 OFFCURVE",
+"176 225 CURVE SMOOTH",
+"176 393 OFFCURVE",
+"205 432 OFFCURVE",
+"281 432 CURVE SMOOTH",
+"357 432 OFFCURVE",
+"386 393 OFFCURVE",
+"386 225 CURVE SMOOTH",
+"386 57 OFFCURVE",
+"357 18 OFFCURVE",
+"281 18 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"117 -53 LINE",
+"504 483 LINE",
+"466 483 LINE",
+"79 -53 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"411 -12 OFFCURVE",
+"516 105 OFFCURVE",
+"516 225 CURVE SMOOTH",
+"516 345 OFFCURVE",
+"411 462 OFFCURVE",
+"281 462 CURVE SMOOTH",
+"151 462 OFFCURVE",
+"46 345 OFFCURVE",
+"46 225 CURVE SMOOTH",
+"46 105 OFFCURVE",
+"151 -12 OFFCURVE",
+"281 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"205 18 OFFCURVE",
+"176 57 OFFCURVE",
+"176 225 CURVE SMOOTH",
+"176 393 OFFCURVE",
+"205 432 OFFCURVE",
+"281 432 CURVE SMOOTH",
+"357 432 OFFCURVE",
+"386 393 OFFCURVE",
+"386 225 CURVE SMOOTH",
+"386 57 OFFCURVE",
+"357 18 OFFCURVE",
+"281 18 CURVE SMOOTH"
+);
+}
+);
+width = 562;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"432 -13 OFFCURVE",
+"544 84 OFFCURVE",
+"544 224 CURVE SMOOTH",
+"544 364 OFFCURVE",
+"432 462 OFFCURVE",
+"294 462 CURVE SMOOTH",
+"156 462 OFFCURVE",
+"45 364 OFFCURVE",
+"45 224 CURVE SMOOTH",
+"45 84 OFFCURVE",
+"156 -13 OFFCURVE",
+"294 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"106 -53 LINE",
+"533 483 LINE",
+"475 483 LINE",
+"48 -53 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"224 22 OFFCURVE",
+"200 58 OFFCURVE",
+"200 224 CURVE SMOOTH",
+"200 390 OFFCURVE",
+"224 427 OFFCURVE",
+"294 427 CURVE SMOOTH",
+"364 427 OFFCURVE",
+"389 390 OFFCURVE",
+"389 224 CURVE SMOOTH",
+"389 58 OFFCURVE",
+"364 22 OFFCURVE",
+"294 22 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"106 -53 LINE",
+"533 483 LINE",
+"475 483 LINE",
+"48 -53 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"432 -13 OFFCURVE",
+"544 84 OFFCURVE",
+"544 224 CURVE SMOOTH",
+"544 364 OFFCURVE",
+"432 462 OFFCURVE",
+"294 462 CURVE SMOOTH",
+"156 462 OFFCURVE",
+"45 364 OFFCURVE",
+"45 224 CURVE SMOOTH",
+"45 84 OFFCURVE",
+"156 -13 OFFCURVE",
+"294 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"224 22 OFFCURVE",
+"200 58 OFFCURVE",
+"200 224 CURVE SMOOTH",
+"200 390 OFFCURVE",
+"224 427 OFFCURVE",
+"294 427 CURVE SMOOTH",
+"364 427 OFFCURVE",
+"389 390 OFFCURVE",
+"389 224 CURVE SMOOTH",
+"389 58 OFFCURVE",
+"364 22 OFFCURVE",
+"294 22 CURVE SMOOTH"
+);
+}
+);
+width = 589;
+}
+);
+unicode = 00F8;
+},
+{
+glyphname = oslashacute;
+lastChange = "2016-08-22 12:26:25 +0000";
+layers = (
+{
+components = (
+{
+name = oslash;
+},
+{
+name = acutecomb;
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = oslash;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -93, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+unicode = 01FF;
+},
+{
+glyphname = otilde;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = o;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, -10, 0}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = o;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, -18, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 00F5;
+},
+{
+glyphname = oe;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"46 105 OFFCURVE",
+"151 -12 OFFCURVE",
+"281 -12 CURVE SMOOTH",
+"411 -12 OFFCURVE",
+"516 105 OFFCURVE",
+"516 225 CURVE SMOOTH",
+"516 345 OFFCURVE",
+"411 462 OFFCURVE",
+"281 462 CURVE SMOOTH",
+"151 462 OFFCURVE",
+"46 345 OFFCURVE",
+"46 225 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"176 393 OFFCURVE",
+"205 432 OFFCURVE",
+"281 432 CURVE SMOOTH",
+"357 432 OFFCURVE",
+"386 393 OFFCURVE",
+"386 225 CURVE SMOOTH",
+"386 57 OFFCURVE",
+"357 18 OFFCURVE",
+"281 18 CURVE SMOOTH",
+"205 18 OFFCURVE",
+"176 57 OFFCURVE",
+"176 225 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"693 287 LINE",
+"482 287 LINE",
+"482 262 LINE",
+"809 262 LINE",
+"809 268 LINE SMOOTH",
+"809 382 OFFCURVE",
+"726 462 OFFCURVE",
+"618 462 CURVE SMOOTH",
+"480 462 OFFCURVE",
+"390 347 OFFCURVE",
+"390 225 CURVE SMOOTH",
+"390 103 OFFCURVE",
+"494 -12 OFFCURVE",
+"623 -12 CURVE SMOOTH",
+"714 -12 OFFCURVE",
+"785 45 OFFCURVE",
+"812 139 CURVE",
+"784 139 LINE",
+"748 50 OFFCURVE",
+"696 18 OFFCURVE",
+"626 18 CURVE SMOOTH",
+"547 18 OFFCURVE",
+"520 63 OFFCURVE",
+"520 225 CURVE SMOOTH",
+"520 383 OFFCURVE",
+"546 435 OFFCURVE",
+"613 435 CURVE SMOOTH",
+"666 435 OFFCURVE",
+"693 404 OFFCURVE",
+"693 344 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"411 -12 OFFCURVE",
+"516 105 OFFCURVE",
+"516 225 CURVE SMOOTH",
+"516 345 OFFCURVE",
+"411 462 OFFCURVE",
+"281 462 CURVE SMOOTH",
+"151 462 OFFCURVE",
+"46 345 OFFCURVE",
+"46 225 CURVE SMOOTH",
+"46 105 OFFCURVE",
+"151 -12 OFFCURVE",
+"281 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"205 18 OFFCURVE",
+"176 57 OFFCURVE",
+"176 225 CURVE SMOOTH",
+"176 393 OFFCURVE",
+"205 432 OFFCURVE",
+"281 432 CURVE SMOOTH",
+"357 432 OFFCURVE",
+"386 393 OFFCURVE",
+"386 225 CURVE SMOOTH",
+"386 57 OFFCURVE",
+"357 18 OFFCURVE",
+"281 18 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"714 -12 OFFCURVE",
+"785 45 OFFCURVE",
+"812 139 CURVE",
+"784 139 LINE",
+"748 50 OFFCURVE",
+"696 18 OFFCURVE",
+"626 18 CURVE SMOOTH",
+"547 18 OFFCURVE",
+"520 63 OFFCURVE",
+"520 225 CURVE SMOOTH",
+"520 383 OFFCURVE",
+"546 435 OFFCURVE",
+"613 435 CURVE SMOOTH",
+"666 435 OFFCURVE",
+"693 404 OFFCURVE",
+"693 344 CURVE SMOOTH",
+"693 287 LINE",
+"482 287 LINE",
+"482 262 LINE",
+"809 262 LINE",
+"809 268 LINE SMOOTH",
+"809 382 OFFCURVE",
+"726 462 OFFCURVE",
+"618 462 CURVE SMOOTH",
+"480 462 OFFCURVE",
+"390 347 OFFCURVE",
+"390 225 CURVE SMOOTH",
+"390 103 OFFCURVE",
+"494 -12 OFFCURVE",
+"623 -12 CURVE SMOOTH"
+);
+}
+);
+width = 854;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"45 84 OFFCURVE",
+"156 -12 OFFCURVE",
+"294 -12 CURVE SMOOTH",
+"432 -12 OFFCURVE",
+"540 84 OFFCURVE",
+"540 224 CURVE SMOOTH",
+"540 364 OFFCURVE",
+"432 462 OFFCURVE",
+"294 462 CURVE SMOOTH",
+"156 462 OFFCURVE",
+"45 364 OFFCURVE",
+"45 224 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"200 390 OFFCURVE",
+"224 427 OFFCURVE",
+"294 427 CURVE SMOOTH",
+"364 427 OFFCURVE",
+"389 390 OFFCURVE",
+"389 224 CURVE SMOOTH",
+"389 58 OFFCURVE",
+"364 23 OFFCURVE",
+"294 23 CURVE SMOOTH",
+"224 23 OFFCURVE",
+"200 58 OFFCURVE",
+"200 224 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"702 283 LINE",
+"496 283 LINE",
+"496 253 LINE",
+"843 253 LINE",
+"843 264 LINE SMOOTH",
+"843 386 OFFCURVE",
+"752 462 OFFCURVE",
+"633 462 CURVE SMOOTH",
+"484 462 OFFCURVE",
+"393 344 OFFCURVE",
+"393 228 CURVE SMOOTH",
+"393 103 OFFCURVE",
+"499 -12 OFFCURVE",
+"639 -12 CURVE SMOOTH",
+"739 -12 OFFCURVE",
+"818 46 OFFCURVE",
+"846 138 CURVE",
+"813 138 LINE",
+"774 53 OFFCURVE",
+"714 23 OFFCURVE",
+"644 23 CURVE SMOOTH",
+"568 23 OFFCURVE",
+"544 60 OFFCURVE",
+"544 222 CURVE SMOOTH",
+"544 380 OFFCURVE",
+"567 430 OFFCURVE",
+"630 430 CURVE SMOOTH",
+"678 430 OFFCURVE",
+"702 401 OFFCURVE",
+"702 344 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"432 -12 OFFCURVE",
+"540 84 OFFCURVE",
+"540 224 CURVE SMOOTH",
+"540 364 OFFCURVE",
+"432 462 OFFCURVE",
+"294 462 CURVE SMOOTH",
+"156 462 OFFCURVE",
+"45 364 OFFCURVE",
+"45 224 CURVE SMOOTH",
+"45 84 OFFCURVE",
+"156 -12 OFFCURVE",
+"294 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"224 23 OFFCURVE",
+"200 58 OFFCURVE",
+"200 224 CURVE SMOOTH",
+"200 390 OFFCURVE",
+"224 427 OFFCURVE",
+"294 427 CURVE SMOOTH",
+"364 427 OFFCURVE",
+"389 390 OFFCURVE",
+"389 224 CURVE SMOOTH",
+"389 58 OFFCURVE",
+"364 23 OFFCURVE",
+"294 23 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"739 -12 OFFCURVE",
+"818 46 OFFCURVE",
+"846 138 CURVE",
+"813 138 LINE",
+"774 53 OFFCURVE",
+"714 23 OFFCURVE",
+"644 23 CURVE SMOOTH",
+"568 23 OFFCURVE",
+"544 60 OFFCURVE",
+"544 222 CURVE SMOOTH",
+"544 380 OFFCURVE",
+"567 430 OFFCURVE",
+"630 430 CURVE SMOOTH",
+"678 430 OFFCURVE",
+"702 401 OFFCURVE",
+"702 344 CURVE SMOOTH",
+"702 283 LINE",
+"496 283 LINE",
+"496 253 LINE",
+"843 253 LINE",
+"843 264 LINE SMOOTH",
+"843 386 OFFCURVE",
+"752 462 OFFCURVE",
+"633 462 CURVE SMOOTH",
+"484 462 OFFCURVE",
+"393 344 OFFCURVE",
+"393 228 CURVE SMOOTH",
+"393 103 OFFCURVE",
+"499 -12 OFFCURVE",
+"639 -12 CURVE SMOOTH"
+);
+}
+);
+width = 881;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = e;
+unicode = 0153;
+},
+{
+glyphname = p;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{289, 0}";
+},
+{
+name = top;
+position = "{289, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"0 416 LINE",
+"189 416 LINE",
+"189 441 LINE",
+"0 441 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"79 -299 LINE",
+"189 -299 LINE",
+"189 425 LINE",
+"79 425 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"10 -314 LINE",
+"289 -314 LINE",
+"289 -289 LINE",
+"10 -289 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"243 22 OFFCURVE",
+"189 80 OFFCURVE",
+"189 210 CURVE",
+"169 58 LINE",
+"193 58 LINE",
+"215 18 OFFCURVE",
+"264 -12 OFFCURVE",
+"326 -12 CURVE SMOOTH",
+"426 -12 OFFCURVE",
+"520 78 OFFCURVE",
+"520 220 CURVE SMOOTH",
+"520 362 OFFCURVE",
+"427 452 OFFCURVE",
+"327 452 CURVE SMOOTH",
+"265 452 OFFCURVE",
+"215 422 OFFCURVE",
+"193 382 CURVE",
+"169 382 LINE",
+"189 230 LINE",
+"189 360 OFFCURVE",
+"242 418 OFFCURVE",
+"314 418 CURVE SMOOTH",
+"370 418 OFFCURVE",
+"392 384 OFFCURVE",
+"392 219 CURVE SMOOTH",
+"392 54 OFFCURVE",
+"371 22 OFFCURVE",
+"315 22 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"435 -12 OFFCURVE",
+"529 83 OFFCURVE",
+"529 225 CURVE SMOOTH",
+"529 367 OFFCURVE",
+"436 462 OFFCURVE",
+"336 462 CURVE SMOOTH",
+"274 462 OFFCURVE",
+"224 432 OFFCURVE",
+"202 392 CURVE",
+"178 392 LINE",
+"198 240 LINE",
+"198 370 OFFCURVE",
+"251 428 OFFCURVE",
+"323 428 CURVE SMOOTH",
+"379 428 OFFCURVE",
+"401 389 OFFCURVE",
+"401 224 CURVE SMOOTH",
+"401 59 OFFCURVE",
+"380 22 OFFCURVE",
+"324 22 CURVE SMOOTH",
+"252 22 OFFCURVE",
+"198 80 OFFCURVE",
+"198 210 CURVE",
+"178 58 LINE",
+"202 58 LINE",
+"224 18 OFFCURVE",
+"273 -12 OFFCURVE",
+"335 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"298 -314 LINE",
+"298 -289 LINE",
+"19 -289 LINE",
+"19 -314 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"198 -299 LINE",
+"198 434 LINE",
+"88 434 LINE",
+"88 -299 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"198 425 LINE",
+"198 450 LINE",
+"9 450 LINE",
+"9 425 LINE"
+);
+}
+);
+width = 578;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{318, 0}";
+},
+{
+name = top;
+position = "{318, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"26 -314 LINE",
+"330 -314 LINE",
+"330 -284 LINE",
+"26 -284 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"101 -298 LINE",
+"239 -298 LINE",
+"239 425 LINE",
+"101 425 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 410 LINE",
+"239 410 LINE",
+"239 440 LINE",
+"20 440 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"412 413 OFFCURVE",
+"430 371 OFFCURVE",
+"430 222 CURVE SMOOTH",
+"430 62 OFFCURVE",
+"409 26 OFFCURVE",
+"357 26 CURVE SMOOTH",
+"288 26 OFFCURVE",
+"239 91 OFFCURVE",
+"239 216 CURVE",
+"219 54 LINE",
+"243 54 LINE",
+"264 16 OFFCURVE",
+"301 -14 OFFCURVE",
+"365 -14 CURVE SMOOTH",
+"480 -14 OFFCURVE",
+"585 83 OFFCURVE",
+"585 223 CURVE SMOOTH",
+"585 361 OFFCURVE",
+"484 453 OFFCURVE",
+"376 453 CURVE SMOOTH",
+"312 453 OFFCURVE",
+"267 421 OFFCURVE",
+"243 378 CURVE",
+"219 378 LINE",
+"239 217 LINE",
+"239 345 OFFCURVE",
+"287 413 OFFCURVE",
+"357 413 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"486 -12 OFFCURVE",
+"585 83 OFFCURVE",
+"585 225 CURVE SMOOTH",
+"585 367 OFFCURVE",
+"487 462 OFFCURVE",
+"377 462 CURVE SMOOTH",
+"315 462 OFFCURVE",
+"265 432 OFFCURVE",
+"243 392 CURVE",
+"219 392 LINE",
+"239 240 LINE",
+"239 367 OFFCURVE",
+"288 423 OFFCURVE",
+"354 423 CURVE SMOOTH",
+"408 423 OFFCURVE",
+"430 385 OFFCURVE",
+"430 223 CURVE SMOOTH",
+"430 64 OFFCURVE",
+"409 27 OFFCURVE",
+"355 27 CURVE SMOOTH",
+"289 27 OFFCURVE",
+"239 83 OFFCURVE",
+"239 210 CURVE",
+"219 58 LINE",
+"243 58 LINE",
+"265 18 OFFCURVE",
+"314 -12 OFFCURVE",
+"376 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"339 -314 LINE",
+"339 -284 LINE",
+"27 -284 LINE",
+"27 -314 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"239 -299 LINE",
+"239 434 LINE",
+"101 434 LINE",
+"101 -299 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"239 420 LINE",
+"239 450 LINE",
+"20 450 LINE",
+"20 420 LINE"
+);
+}
+);
+width = 635;
+}
+);
+unicode = 0070;
+},
+{
+glyphname = thorn;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"430 -12 OFFCURVE",
+"524 83 OFFCURVE",
+"524 225 CURVE SMOOTH",
+"524 367 OFFCURVE",
+"431 462 OFFCURVE",
+"331 462 CURVE SMOOTH",
+"269 462 OFFCURVE",
+"219 432 OFFCURVE",
+"197 392 CURVE",
+"193 392 LINE",
+"193 754 LINE",
+"4 754 LINE",
+"4 729 LINE",
+"83 729 LINE",
+"83 -289 LINE",
+"15 -289 LINE",
+"15 -314 LINE",
+"294 -314 LINE",
+"294 -289 LINE",
+"193 -289 LINE",
+"193 58 LINE",
+"197 58 LINE",
+"219 18 OFFCURVE",
+"268 -12 OFFCURVE",
+"330 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"250 22 OFFCURVE",
+"193 77 OFFCURVE",
+"193 200 CURVE SMOOTH",
+"193 249 LINE SMOOTH",
+"193 372 OFFCURVE",
+"249 428 OFFCURVE",
+"318 428 CURVE SMOOTH",
+"374 428 OFFCURVE",
+"396 389 OFFCURVE",
+"396 224 CURVE SMOOTH",
+"396 59 OFFCURVE",
+"375 22 OFFCURVE",
+"319 22 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"294 -314 LINE",
+"294 -289 LINE",
+"193 -289 LINE",
+"193 58 LINE",
+"197 58 LINE",
+"219 18 OFFCURVE",
+"268 -12 OFFCURVE",
+"330 -12 CURVE SMOOTH",
+"430 -12 OFFCURVE",
+"524 83 OFFCURVE",
+"524 225 CURVE SMOOTH",
+"524 367 OFFCURVE",
+"431 462 OFFCURVE",
+"331 462 CURVE SMOOTH",
+"269 462 OFFCURVE",
+"219 432 OFFCURVE",
+"197 392 CURVE",
+"193 392 LINE",
+"193 754 LINE",
+"4 754 LINE",
+"4 729 LINE",
+"83 729 LINE",
+"83 -289 LINE",
+"15 -289 LINE",
+"15 -314 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"250 22 OFFCURVE",
+"193 77 OFFCURVE",
+"193 200 CURVE SMOOTH",
+"193 249 LINE SMOOTH",
+"193 372 OFFCURVE",
+"249 428 OFFCURVE",
+"318 428 CURVE SMOOTH",
+"374 428 OFFCURVE",
+"396 389 OFFCURVE",
+"396 224 CURVE SMOOTH",
+"396 59 OFFCURVE",
+"375 22 OFFCURVE",
+"319 22 CURVE SMOOTH"
+);
+}
+);
+width = 570;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"486 -12 OFFCURVE",
+"585 83 OFFCURVE",
+"585 225 CURVE SMOOTH",
+"585 367 OFFCURVE",
+"487 462 OFFCURVE",
+"377 462 CURVE SMOOTH",
+"315 462 OFFCURVE",
+"265 432 OFFCURVE",
+"243 392 CURVE",
+"239 392 LINE",
+"239 754 LINE",
+"20 754 LINE",
+"20 724 LINE",
+"101 724 LINE",
+"101 -284 LINE",
+"26 -284 LINE",
+"26 -314 LINE",
+"330 -314 LINE",
+"330 -284 LINE",
+"239 -284 LINE",
+"239 58 LINE",
+"243 58 LINE",
+"265 18 OFFCURVE",
+"314 -12 OFFCURVE",
+"376 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"288 27 OFFCURVE",
+"239 85 OFFCURVE",
+"239 210 CURVE SMOOTH",
+"239 249 LINE SMOOTH",
+"241 366 OFFCURVE",
+"288 423 OFFCURVE",
+"353 423 CURVE SMOOTH",
+"405 423 OFFCURVE",
+"430 386 OFFCURVE",
+"430 223 CURVE SMOOTH",
+"430 63 OFFCURVE",
+"406 27 OFFCURVE",
+"354 27 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"330 -314 LINE",
+"330 -284 LINE",
+"239 -284 LINE",
+"239 58 LINE",
+"243 58 LINE",
+"265 18 OFFCURVE",
+"314 -12 OFFCURVE",
+"376 -12 CURVE SMOOTH",
+"486 -12 OFFCURVE",
+"585 83 OFFCURVE",
+"585 225 CURVE SMOOTH",
+"585 367 OFFCURVE",
+"487 462 OFFCURVE",
+"377 462 CURVE SMOOTH",
+"315 462 OFFCURVE",
+"265 432 OFFCURVE",
+"243 392 CURVE",
+"239 392 LINE",
+"239 754 LINE",
+"20 754 LINE",
+"20 724 LINE",
+"101 724 LINE",
+"101 -284 LINE",
+"26 -284 LINE",
+"26 -314 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"288 27 OFFCURVE",
+"239 85 OFFCURVE",
+"239 210 CURVE SMOOTH",
+"239 249 LINE SMOOTH",
+"241 366 OFFCURVE",
+"288 423 OFFCURVE",
+"353 423 CURVE SMOOTH",
+"405 423 OFFCURVE",
+"430 386 OFFCURVE",
+"430 223 CURVE SMOOTH",
+"430 63 OFFCURVE",
+"406 27 OFFCURVE",
+"354 27 CURVE SMOOTH"
+);
+}
+);
+width = 630;
+}
+);
+unicode = 00FE;
+},
+{
+glyphname = q;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{289, 0}";
+},
+{
+name = top;
+position = "{289, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"554 441 LINE",
+"365 441 LINE",
+"365 416 LINE",
+"554 416 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"475 433 LINE",
+"365 433 LINE",
+"365 -299 LINE",
+"475 -299 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"554 -289 LINE",
+"275 -289 LINE",
+"275 -314 LINE",
+"554 -314 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"181 22 OFFCURVE",
+"162 62 OFFCURVE",
+"162 219 CURVE SMOOTH",
+"162 384 OFFCURVE",
+"183 419 OFFCURVE",
+"240 419 CURVE SMOOTH",
+"310 419 OFFCURVE",
+"365 366 OFFCURVE",
+"365 234 CURVE",
+"385 381 LINE",
+"361 381 LINE",
+"339 420 OFFCURVE",
+"296 454 OFFCURVE",
+"233 454 CURVE SMOOTH",
+"128 454 OFFCURVE",
+"34 355 OFFCURVE",
+"34 219 CURVE SMOOTH",
+"34 83 OFFCURVE",
+"129 -13 OFFCURVE",
+"232 -13 CURVE SMOOTH",
+"291 -13 OFFCURVE",
+"338 20 OFFCURVE",
+"361 62 CURVE",
+"385 62 LINE",
+"365 213 LINE",
+"365 88 OFFCURVE",
+"312 22 OFFCURVE",
+"238 22 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"306 -12 OFFCURVE",
+"355 18 OFFCURVE",
+"377 58 CURVE",
+"401 58 LINE",
+"381 210 LINE",
+"381 80 OFFCURVE",
+"327 22 OFFCURVE",
+"255 22 CURVE SMOOTH",
+"199 22 OFFCURVE",
+"178 59 OFFCURVE",
+"178 224 CURVE SMOOTH",
+"178 389 OFFCURVE",
+"200 428 OFFCURVE",
+"256 428 CURVE SMOOTH",
+"328 428 OFFCURVE",
+"381 370 OFFCURVE",
+"381 240 CURVE",
+"401 392 LINE",
+"377 392 LINE",
+"355 432 OFFCURVE",
+"305 462 OFFCURVE",
+"243 462 CURVE SMOOTH",
+"143 462 OFFCURVE",
+"50 367 OFFCURVE",
+"50 225 CURVE SMOOTH",
+"50 83 OFFCURVE",
+"144 -12 OFFCURVE",
+"244 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"570 -314 LINE",
+"570 -289 LINE",
+"291 -289 LINE",
+"291 -314 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"491 -299 LINE",
+"491 442 LINE",
+"381 442 LINE",
+"381 -299 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"570 425 LINE",
+"570 450 LINE",
+"381 450 LINE",
+"381 425 LINE"
+);
+}
+);
+width = 578;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{311, 0}";
+},
+{
+name = top;
+position = "{311, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"611 -284 LINE",
+"298 -284 LINE",
+"298 -314 LINE",
+"611 -314 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"530 425 LINE",
+"392 425 LINE",
+"392 -298 LINE",
+"530 -298 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"611 440 LINE",
+"392 440 LINE",
+"392 410 LINE",
+"611 410 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"218 27 OFFCURVE",
+"200 69 OFFCURVE",
+"200 213 CURVE SMOOTH",
+"200 379 OFFCURVE",
+"224 414 OFFCURVE",
+"275 414 CURVE SMOOTH",
+"344 414 OFFCURVE",
+"392 349 OFFCURVE",
+"392 224 CURVE",
+"412 386 LINE",
+"388 386 LINE",
+"368 420 OFFCURVE",
+"321 454 OFFCURVE",
+"258 454 CURVE SMOOTH",
+"150 454 OFFCURVE",
+"45 354 OFFCURVE",
+"45 216 CURVE SMOOTH",
+"45 79 OFFCURVE",
+"145 -13 OFFCURVE",
+"253 -13 CURVE SMOOTH",
+"317 -13 OFFCURVE",
+"362 19 OFFCURVE",
+"387 62 CURVE",
+"411 62 LINE",
+"392 223 LINE",
+"391 95 OFFCURVE",
+"342 27 OFFCURVE",
+"272 27 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"317 -12 OFFCURVE",
+"366 18 OFFCURVE",
+"388 58 CURVE",
+"412 58 LINE",
+"392 210 LINE",
+"392 83 OFFCURVE",
+"342 27 OFFCURVE",
+"275 27 CURVE SMOOTH",
+"221 27 OFFCURVE",
+"200 64 OFFCURVE",
+"200 223 CURVE SMOOTH",
+"200 385 OFFCURVE",
+"222 423 OFFCURVE",
+"277 423 CURVE SMOOTH",
+"343 423 OFFCURVE",
+"392 367 OFFCURVE",
+"392 240 CURVE",
+"412 392 LINE",
+"388 392 LINE",
+"366 432 OFFCURVE",
+"316 462 OFFCURVE",
+"254 462 CURVE SMOOTH",
+"143 462 OFFCURVE",
+"45 367 OFFCURVE",
+"45 225 CURVE SMOOTH",
+"45 83 OFFCURVE",
+"144 -12 OFFCURVE",
+"255 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"611 -314 LINE",
+"611 -284 LINE",
+"297 -284 LINE",
+"297 -314 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"530 -299 LINE",
+"530 442 LINE",
+"392 442 LINE",
+"392 -299 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"611 420 LINE",
+"611 450 LINE",
+"392 450 LINE",
+"392 420 LINE"
+);
+}
+);
+width = 621;
+}
+);
+unicode = 0071;
+},
+{
+glyphname = r;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{216, 0}";
+},
+{
+name = top;
+position = "{216, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"28 425 LINE",
+"217 425 LINE",
+"217 450 LINE",
+"28 450 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"107 15 LINE",
+"217 15 LINE",
+"217 434 LINE",
+"107 434 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"28 0 LINE",
+"307 0 LINE",
+"307 25 LINE",
+"28 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"217 246 LINE",
+"217 331 OFFCURVE",
+"258 404 OFFCURVE",
+"285 404 CURVE SMOOTH",
+"295 404 OFFCURVE",
+"297 395 OFFCURVE",
+"297 385 CURVE SMOOTH",
+"299 348 OFFCURVE",
+"326 332 OFFCURVE",
+"355 332 CURVE SMOOTH",
+"384 332 OFFCURVE",
+"408 349 OFFCURVE",
+"408 391 CURVE SMOOTH",
+"408 436 OFFCURVE",
+"381 462 OFFCURVE",
+"339 462 CURVE SMOOTH",
+"302 462 OFFCURVE",
+"254 443 OFFCURVE",
+"221 371 CURVE",
+"206 371 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"307 0 LINE",
+"307 25 LINE",
+"217 25 LINE",
+"217 252 LINE SMOOTH",
+"217 335 OFFCURVE",
+"258 404 OFFCURVE",
+"285 404 CURVE SMOOTH",
+"298 404 OFFCURVE",
+"301 398 OFFCURVE",
+"301 391 CURVE SMOOTH",
+"301 384 OFFCURVE",
+"298 379 OFFCURVE",
+"298 371 CURVE SMOOTH",
+"298 346 OFFCURVE",
+"323 331 OFFCURVE",
+"348 331 CURVE SMOOTH",
+"378 331 OFFCURVE",
+"408 350 OFFCURVE",
+"408 391 CURVE SMOOTH",
+"408 436 OFFCURVE",
+"381 462 OFFCURVE",
+"339 462 CURVE SMOOTH",
+"302 462 OFFCURVE",
+"254 443 OFFCURVE",
+"221 371 CURVE",
+"217 371 LINE",
+"217 450 LINE",
+"28 450 LINE",
+"28 425 LINE",
+"107 425 LINE",
+"107 25 LINE",
+"28 25 LINE",
+"28 0 LINE"
+);
+}
+);
+width = 432;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{253, 0}";
+},
+{
+name = top;
+position = "{253, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"239 248 LINE",
+"239 330 OFFCURVE",
+"295 404 OFFCURVE",
+"329 404 CURVE SMOOTH",
+"335 404 OFFCURVE",
+"337 402 OFFCURVE",
+"337 399 CURVE SMOOTH",
+"337 392 OFFCURVE",
+"324 383 OFFCURVE",
+"324 356 CURVE SMOOTH",
+"324 311 OFFCURVE",
+"361 288 OFFCURVE",
+"400 288 CURVE SMOOTH",
+"442 288 OFFCURVE",
+"475 314 OFFCURVE",
+"475 371 CURVE SMOOTH",
+"475 429 OFFCURVE",
+"440 462 OFFCURVE",
+"379 462 CURVE SMOOTH",
+"340 462 OFFCURVE",
+"287 448 OFFCURVE",
+"243 373 CURVE",
+"228 373 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 420 LINE",
+"239 420 LINE",
+"239 450 LINE",
+"20 450 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"101 15 LINE",
+"239 15 LINE",
+"239 434 LINE",
+"101 434 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 0 LINE",
+"304 0 LINE",
+"304 30 LINE",
+"20 30 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"304 0 LINE",
+"304 30 LINE",
+"239 30 LINE",
+"239 254 LINE SMOOTH",
+"239 333 OFFCURVE",
+"296 404 OFFCURVE",
+"329 404 CURVE SMOOTH",
+"335 404 OFFCURVE",
+"337 402 OFFCURVE",
+"337 399 CURVE SMOOTH",
+"337 392 OFFCURVE",
+"324 383 OFFCURVE",
+"324 356 CURVE SMOOTH",
+"324 311 OFFCURVE",
+"361 288 OFFCURVE",
+"400 288 CURVE SMOOTH",
+"442 288 OFFCURVE",
+"475 314 OFFCURVE",
+"475 371 CURVE SMOOTH",
+"475 429 OFFCURVE",
+"440 462 OFFCURVE",
+"379 462 CURVE SMOOTH",
+"340 462 OFFCURVE",
+"287 448 OFFCURVE",
+"243 373 CURVE",
+"239 373 LINE",
+"239 450 LINE",
+"20 450 LINE",
+"20 420 LINE",
+"101 420 LINE",
+"101 30 LINE",
+"20 30 LINE",
+"20 0 LINE"
+);
+}
+);
+width = 506;
+}
+);
+leftKerningGroup = r;
+rightKerningGroup = r;
+unicode = 0072;
+},
+{
+glyphname = racute;
+lastChange = "2016-08-22 11:53:08 +0000";
+layers = (
+{
+components = (
+{
+name = r;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -109, 0}";
+}
+);
+layerId = UUID0;
+width = 432;
+},
+{
+components = (
+{
+name = r;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -137, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 506;
+}
+);
+leftKerningGroup = r;
+rightKerningGroup = r;
+unicode = 0155;
+},
+{
+glyphname = rcaron;
+lastChange = "2016-08-22 12:32:11 +0000";
+layers = (
+{
+components = (
+{
+name = r;
+},
+{
+name = caron;
+transform = "{1, 0, 0, 1, 51, -9}";
+}
+);
+layerId = UUID0;
+width = 432;
+},
+{
+components = (
+{
+name = r;
+},
+{
+name = caron;
+transform = "{1, 0, 0, 1, 63, -9}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 506;
+}
+);
+leftKerningGroup = r;
+rightKerningGroup = r;
+unicode = 0159;
+},
+{
+glyphname = rcommaaccent;
+lastChange = "2016-08-22 12:07:41 +0000";
+layers = (
+{
+components = (
+{
+name = r;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 130, 0}";
+}
+);
+layerId = UUID0;
+width = 432;
+},
+{
+components = (
+{
+name = r;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 160, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 506;
+}
+);
+leftKerningGroup = r;
+rightKerningGroup = r;
+unicode = 0157;
+},
+{
+glyphname = rdblgrave;
+lastChange = "2016-08-22 12:07:41 +0000";
+layers = (
+{
+components = (
+{
+name = r;
+},
+{
+name = dblgravecomb;
+transform = "{1, 0, 0, 1, 3, 0}";
+}
+);
+layerId = UUID0;
+width = 432;
+},
+{
+components = (
+{
+name = r;
+},
+{
+name = dblgravecomb;
+transform = "{1, 0, 0, 1, 19, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 506;
+}
+);
+leftKerningGroup = r;
+rightKerningGroup = r;
+unicode = 0211;
+},
+{
+glyphname = rdotbelow;
+lastChange = "2016-08-22 11:52:49 +0000";
+layers = (
+{
+components = (
+{
+name = r;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -68, 0}";
+}
+);
+layerId = UUID0;
+width = 432;
+},
+{
+components = (
+{
+name = r;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -40, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 506;
+}
+);
+leftKerningGroup = r;
+rightKerningGroup = r;
+unicode = 1E5B;
+},
+{
+glyphname = rinvertedbreve;
+lastChange = "2016-08-22 12:07:41 +0000";
+layers = (
+{
+components = (
+{
+name = r;
+},
+{
+name = breveinvertedcomb;
+transform = "{1, 0, 0, 1, 49, 0}";
+}
+);
+layerId = UUID0;
+width = 432;
+},
+{
+components = (
+{
+name = r;
+},
+{
+name = breveinvertedcomb;
+transform = "{1, 0, 0, 1, 76, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 506;
+}
+);
+leftKerningGroup = r;
+rightKerningGroup = r;
+unicode = 0213;
+},
+{
+glyphname = s;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{219, 0}";
+},
+{
+name = top;
+position = "{219, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"332 -12 OFFCURVE",
+"393 47 OFFCURVE",
+"393 139 CURVE SMOOTH",
+"393 229 OFFCURVE",
+"336 262 OFFCURVE",
+"235 285 CURVE SMOOTH",
+"135 307 OFFCURVE",
+"114 323 OFFCURVE",
+"114 356 CURVE SMOOTH",
+"114 400 OFFCURVE",
+"155 426 OFFCURVE",
+"219 426 CURVE SMOOTH",
+"291 426 OFFCURVE",
+"324 394 OFFCURVE",
+"339 320 CURVE SMOOTH",
+"342 305 LINE",
+"373 305 LINE",
+"373 450 LINE",
+"347 450 LINE",
+"336 417 LINE",
+"319 445 OFFCURVE",
+"274 462 OFFCURVE",
+"217 462 CURVE SMOOTH",
+"116 462 OFFCURVE",
+"59 410 OFFCURVE",
+"59 316 CURVE SMOOTH",
+"59 216 OFFCURVE",
+"122 188 OFFCURVE",
+"218 168 CURVE SMOOTH",
+"293 152 OFFCURVE",
+"338 143 OFFCURVE",
+"338 92 CURVE SMOOTH",
+"338 48 OFFCURVE",
+"304 24 OFFCURVE",
+"238 24 CURVE SMOOTH",
+"156 24 OFFCURVE",
+"109 62 OFFCURVE",
+"90 134 CURVE SMOOTH",
+"85 153 LINE",
+"53 153 LINE",
+"53 0 LINE",
+"82 0 LINE",
+"97 39 LINE",
+"129 8 OFFCURVE",
+"184 -12 OFFCURVE",
+"239 -12 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"332 -12 OFFCURVE",
+"393 47 OFFCURVE",
+"393 139 CURVE SMOOTH",
+"393 229 OFFCURVE",
+"336 262 OFFCURVE",
+"235 285 CURVE SMOOTH",
+"146 305 OFFCURVE",
+"124 323 OFFCURVE",
+"124 356 CURVE SMOOTH",
+"124 400 OFFCURVE",
+"155 426 OFFCURVE",
+"219 426 CURVE SMOOTH",
+"291 426 OFFCURVE",
+"324 394 OFFCURVE",
+"339 320 CURVE SMOOTH",
+"342 305 LINE",
+"373 305 LINE",
+"373 450 LINE",
+"347 450 LINE",
+"336 417 LINE",
+"319 445 OFFCURVE",
+"274 462 OFFCURVE",
+"217 462 CURVE SMOOTH",
+"116 462 OFFCURVE",
+"59 410 OFFCURVE",
+"59 316 CURVE SMOOTH",
+"59 216 OFFCURVE",
+"122 188 OFFCURVE",
+"218 168 CURVE SMOOTH",
+"293 152 OFFCURVE",
+"328 136 OFFCURVE",
+"328 92 CURVE SMOOTH",
+"328 48 OFFCURVE",
+"304 24 OFFCURVE",
+"238 24 CURVE SMOOTH",
+"156 24 OFFCURVE",
+"109 62 OFFCURVE",
+"90 134 CURVE SMOOTH",
+"85 153 LINE",
+"53 153 LINE",
+"53 0 LINE",
+"82 0 LINE",
+"97 39 LINE",
+"129 8 OFFCURVE",
+"184 -12 OFFCURVE",
+"239 -12 CURVE SMOOTH"
+);
+}
+);
+width = 438;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{215, 0}";
+},
+{
+name = top;
+position = "{215, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"328 -12 OFFCURVE",
+"393 43 OFFCURVE",
+"393 147 CURVE SMOOTH",
+"393 256 OFFCURVE",
+"322 280 OFFCURVE",
+"230 300 CURVE SMOOTH",
+"132 321 OFFCURVE",
+"104 328 OFFCURVE",
+"104 362 CURVE SMOOTH",
+"104 404 OFFCURVE",
+"147 426 OFFCURVE",
+"212 426 CURVE SMOOTH",
+"290 426 OFFCURVE",
+"324 394 OFFCURVE",
+"339 320 CURVE SMOOTH",
+"342 305 LINE",
+"373 305 LINE",
+"373 450 LINE",
+"347 450 LINE",
+"336 417 LINE",
+"319 445 OFFCURVE",
+"272 462 OFFCURVE",
+"212 462 CURVE SMOOTH",
+"108 462 OFFCURVE",
+"49 412 OFFCURVE",
+"49 309 CURVE SMOOTH",
+"49 198 OFFCURVE",
+"118 170 OFFCURVE",
+"213 151 CURVE SMOOTH",
+"308 132 OFFCURVE",
+"338 124 OFFCURVE",
+"338 88 CURVE SMOOTH",
+"338 48 OFFCURVE",
+"301 24 OFFCURVE",
+"231 24 CURVE SMOOTH",
+"134 24 OFFCURVE",
+"86 71 OFFCURVE",
+"73 134 CURVE SMOOTH",
+"67 163 LINE",
+"35 163 LINE",
+"35 0 LINE",
+"64 0 LINE",
+"79 39 LINE",
+"113 8 OFFCURVE",
+"170 -12 OFFCURVE",
+"229 -12 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"328 -12 OFFCURVE",
+"393 40 OFFCURVE",
+"393 144 CURVE SMOOTH",
+"393 243 OFFCURVE",
+"322 277 OFFCURVE",
+"230 297 CURVE SMOOTH",
+"136 317 OFFCURVE",
+"119 337 OFFCURVE",
+"119 367 CURVE SMOOTH",
+"119 402 OFFCURVE",
+"150 426 OFFCURVE",
+"212 426 CURVE SMOOTH",
+"290 426 OFFCURVE",
+"320 394 OFFCURVE",
+"335 320 CURVE SMOOTH",
+"338 305 LINE",
+"373 305 LINE",
+"373 450 LINE",
+"347 450 LINE",
+"336 417 LINE",
+"319 445 OFFCURVE",
+"272 462 OFFCURVE",
+"212 462 CURVE SMOOTH",
+"108 462 OFFCURVE",
+"49 409 OFFCURVE",
+"49 306 CURVE SMOOTH",
+"49 205 OFFCURVE",
+"118 170 OFFCURVE",
+"213 152 CURVE SMOOTH",
+"304 135 OFFCURVE",
+"324 114 OFFCURVE",
+"324 82 CURVE SMOOTH",
+"324 43 OFFCURVE",
+"294 24 OFFCURVE",
+"231 24 CURVE SMOOTH",
+"134 24 OFFCURVE",
+"87 71 OFFCURVE",
+"74 134 CURVE SMOOTH",
+"68 163 LINE",
+"35 163 LINE",
+"35 0 LINE",
+"64 0 LINE",
+"79 39 LINE",
+"113 8 OFFCURVE",
+"170 -12 OFFCURVE",
+"229 -12 CURVE SMOOTH"
+);
+}
+);
+width = 429;
+}
+);
+leftKerningGroup = s;
+rightKerningGroup = s;
+unicode = 0073;
+},
+{
+glyphname = sacute;
+lastChange = "2016-08-22 11:52:49 +0000";
+layers = (
+{
+components = (
+{
+name = s;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -106, 0}";
+}
+);
+layerId = UUID0;
+width = 438;
+},
+{
+components = (
+{
+name = s;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -175, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 429;
+}
+);
+leftKerningGroup = s;
+rightKerningGroup = s;
+unicode = 015B;
+},
+{
+glyphname = scaron;
+lastChange = "2016-08-22 12:32:11 +0000";
+layers = (
+{
+components = (
+{
+name = s;
+},
+{
+name = caron;
+transform = "{1, 0, 0, 1, 54, -9}";
+}
+);
+layerId = UUID0;
+width = 438;
+},
+{
+components = (
+{
+name = s;
+},
+{
+name = caron;
+transform = "{1, 0, 0, 1, 25, -9}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 429;
+}
+);
+leftKerningGroup = s;
+rightKerningGroup = s;
+unicode = 0161;
+},
+{
+glyphname = scedilla;
+lastChange = "2016-08-22 12:07:41 +0000";
+layers = (
+{
+components = (
+{
+name = s;
+},
+{
+name = cedilla;
+transform = "{1, 0, 0, 1, 114, 6}";
+}
+);
+layerId = UUID0;
+width = 438;
+},
+{
+components = (
+{
+name = s;
+},
+{
+name = cedilla;
+transform = "{1, 0, 0, 1, 98, 13}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 429;
+}
+);
+leftKerningGroup = s;
+rightKerningGroup = s;
+unicode = 015F;
+},
+{
+glyphname = scircumflex;
+lastChange = "2016-08-22 11:52:49 +0000";
+layers = (
+{
+components = (
+{
+name = s;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -71, 0}";
+}
+);
+layerId = UUID0;
+width = 438;
+},
+{
+components = (
+{
+name = s;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -81, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 429;
+}
+);
+leftKerningGroup = s;
+rightKerningGroup = s;
+unicode = 015D;
+},
+{
+glyphname = scommaaccent;
+lastChange = "2016-08-22 12:07:41 +0000";
+layers = (
+{
+components = (
+{
+name = s;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 133, 0}";
+}
+);
+layerId = UUID0;
+width = 438;
+},
+{
+components = (
+{
+name = s;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 122, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 429;
+}
+);
+leftKerningGroup = s;
+rightKerningGroup = s;
+unicode = 0219;
+},
+{
+glyphname = sdotbelow;
+lastChange = "2016-08-22 11:52:49 +0000";
+layers = (
+{
+components = (
+{
+name = s;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -65, 0}";
+}
+);
+layerId = UUID0;
+width = 438;
+},
+{
+components = (
+{
+name = s;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -78, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 429;
+}
+);
+leftKerningGroup = s;
+rightKerningGroup = s;
+unicode = 1E63;
+},
+{
+glyphname = germandbls;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"435 -6 OFFCURVE",
+"526 80 OFFCURVE",
+"526 218 CURVE SMOOTH",
+"526 350 OFFCURVE",
+"443 427 OFFCURVE",
+"345 435 CURVE",
+"345 439 LINE",
+"418 457 OFFCURVE",
+"481 499 OFFCURVE",
+"481 596 CURVE SMOOTH",
+"481 704 OFFCURVE",
+"404 763 OFFCURVE",
+"288 763 CURVE SMOOTH",
+"157 763 OFFCURVE",
+"92 687 OFFCURVE",
+"92 550 CURVE SMOOTH",
+"92 25 LINE",
+"7 25 LINE",
+"7 0 LINE",
+"202 0 LINE",
+"202 615 LINE SMOOTH",
+"202 694 OFFCURVE",
+"220 736 OFFCURVE",
+"290 736 CURVE SMOOTH",
+"342 736 OFFCURVE",
+"371 714 OFFCURVE",
+"371 599 CURVE SMOOTH",
+"371 482 OFFCURVE",
+"341 448 OFFCURVE",
+"287 448 CURVE SMOOTH",
+"249 448 LINE",
+"249 422 LINE",
+"286 422 LINE SMOOTH",
+"360 422 OFFCURVE",
+"397 379 OFFCURVE",
+"397 216 CURVE SMOOTH",
+"397 59 OFFCURVE",
+"363 19 OFFCURVE",
+"336 19 CURVE SMOOTH",
+"325 19 OFFCURVE",
+"311 25 OFFCURVE",
+"311 35 CURVE SMOOTH",
+"311 49 OFFCURVE",
+"339 46 OFFCURVE",
+"339 80 CURVE SMOOTH",
+"339 111 OFFCURVE",
+"317 125 OFFCURVE",
+"291 125 CURVE SMOOTH",
+"259 125 OFFCURVE",
+"238 104 OFFCURVE",
+"238 72 CURVE SMOOTH",
+"238 29 OFFCURVE",
+"278 -6 OFFCURVE",
+"339 -6 CURVE SMOOTH"
+);
+}
+);
+width = 561;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"521 -6 OFFCURVE",
+"623 80 OFFCURVE",
+"623 221 CURVE SMOOTH",
+"623 345 OFFCURVE",
+"543 427 OFFCURVE",
+"442 435 CURVE",
+"442 439 LINE",
+"515 457 OFFCURVE",
+"578 500 OFFCURVE",
+"578 595 CURVE SMOOTH",
+"578 704 OFFCURVE",
+"495 763 OFFCURVE",
+"355 763 CURVE SMOOTH",
+"197 763 OFFCURVE",
+"115 687 OFFCURVE",
+"115 550 CURVE SMOOTH",
+"115 30 LINE",
+"20 30 LINE",
+"20 0 LINE",
+"273 0 LINE",
+"273 615 LINE SMOOTH",
+"273 693 OFFCURVE",
+"291 731 OFFCURVE",
+"362 731 CURVE SMOOTH",
+"413 731 OFFCURVE",
+"442 711 OFFCURVE",
+"442 599 CURVE SMOOTH",
+"442 484 OFFCURVE",
+"412 450 OFFCURVE",
+"358 450 CURVE SMOOTH",
+"320 450 LINE",
+"320 418 LINE",
+"357 418 LINE SMOOTH",
+"431 418 OFFCURVE",
+"468 375 OFFCURVE",
+"468 216 CURVE SMOOTH",
+"468 61 OFFCURVE",
+"434 24 OFFCURVE",
+"406 24 CURVE SMOOTH",
+"396 24 OFFCURVE",
+"382 29 OFFCURVE",
+"382 40 CURVE SMOOTH",
+"382 55 OFFCURVE",
+"410 60 OFFCURVE",
+"410 92 CURVE SMOOTH",
+"410 121 OFFCURVE",
+"388 135 OFFCURVE",
+"363 135 CURVE SMOOTH",
+"330 135 OFFCURVE",
+"309 112 OFFCURVE",
+"309 78 CURVE SMOOTH",
+"309 33 OFFCURVE",
+"345 -6 OFFCURVE",
+"416 -6 CURVE SMOOTH"
+);
+}
+);
+width = 669;
+}
+);
+unicode = 00DF;
+},
+{
+glyphname = t;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{177, 0}";
+},
+{
+name = center;
+position = "{177, 225}";
+},
+{
+name = top;
+position = "{177, 450}";
+},
+{
+name = topright;
+position = "{334, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"312 95 LINE",
+"287 48 OFFCURVE",
+"259 34 OFFCURVE",
+"232 34 CURVE SMOOTH",
+"206 34 OFFCURVE",
+"188 47 OFFCURVE",
+"188 79 CURVE SMOOTH",
+"188 603 LINE",
+"78 563 LINE",
+"78 62 LINE SMOOTH",
+"78 19 OFFCURVE",
+"119 -12 OFFCURVE",
+"187 -12 CURVE SMOOTH",
+"256 -12 OFFCURVE",
+"302 20 OFFCURVE",
+"332 84 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"-3 425 LINE",
+"297 425 LINE",
+"297 450 LINE",
+"-3 450 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"263 -13 OFFCURVE",
+"301 12 OFFCURVE",
+"335 85 CURVE",
+"315 96 LINE",
+"289 51 OFFCURVE",
+"268 33 OFFCURVE",
+"240 33 CURVE SMOOTH",
+"215 33 OFFCURVE",
+"203 47 OFFCURVE",
+"203 78 CURVE SMOOTH",
+"203 424 LINE",
+"318 424 LINE",
+"318 449 LINE",
+"203 449 LINE",
+"203 622 LINE",
+"175 622 LINE",
+"142 532 OFFCURVE",
+"81 455 OFFCURVE",
+"12 449 CURVE",
+"12 424 LINE",
+"93 424 LINE",
+"93 71 LINE SMOOTH",
+"93 15 OFFCURVE",
+"126 -13 OFFCURVE",
+"196 -13 CURVE SMOOTH"
+);
+}
+);
+width = 354;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{177, 0}";
+},
+{
+name = center;
+position = "{177, 225}";
+},
+{
+name = top;
+position = "{177, 450}";
+},
+{
+name = topright;
+position = "{334, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"325 99 LINE",
+"305 64 OFFCURVE",
+"282 53 OFFCURVE",
+"260 53 CURVE SMOOTH",
+"244 53 OFFCURVE",
+"229 63 OFFCURVE",
+"229 88 CURVE SMOOTH",
+"229 563 LINE",
+"91 563 LINE",
+"91 61 LINE SMOOTH",
+"91 18 OFFCURVE",
+"132 -13 OFFCURVE",
+"200 -13 CURVE SMOOTH",
+"269 -13 OFFCURVE",
+"315 19 OFFCURVE",
+"345 83 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 416 LINE",
+"323 416 LINE",
+"323 441 LINE",
+"20 441 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"281 -13 OFFCURVE",
+"325 12 OFFCURVE",
+"361 85 CURVE",
+"337 99 LINE",
+"312 58 OFFCURVE",
+"294 43 OFFCURVE",
+"267 43 CURVE SMOOTH",
+"241 43 OFFCURVE",
+"229 57 OFFCURVE",
+"229 88 CURVE SMOOTH",
+"229 419 LINE",
+"344 419 LINE",
+"344 450 LINE",
+"229 450 LINE",
+"229 622 LINE",
+"188 622 LINE",
+"152 532 OFFCURVE",
+"85 456 OFFCURVE",
+"10 450 CURVE",
+"10 419 LINE",
+"91 419 LINE",
+"91 71 LINE SMOOTH",
+"91 16 OFFCURVE",
+"126 -13 OFFCURVE",
+"206 -13 CURVE SMOOTH"
+);
+}
+);
+width = 354;
+}
+);
+leftKerningGroup = t;
+rightKerningGroup = t;
+unicode = 0074;
+},
+{
+glyphname = tbar;
+lastChange = "2016-08-22 12:27:05 +0000";
+layers = (
+{
+components = (
+{
+name = t;
+},
+{
+alignment = -1;
+name = strokeshortcomb;
+transform = "{1, 0, 0, 1, 367, 269}";
+}
+);
+layerId = UUID0;
+width = 354;
+},
+{
+components = (
+{
+name = t;
+},
+{
+alignment = -1;
+name = strokeshortcomb;
+transform = "{1, 0, 0, 1, -77, 262}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 354;
+}
+);
+unicode = 0167;
+},
+{
+glyphname = tcaron;
+lastChange = "2016-08-22 12:27:25 +0000";
+layers = (
+{
+components = (
+{
+name = t;
+},
+{
+name = caron.alt;
+transform = "{1, 0, 0, 1, 236, -10}";
+}
+);
+layerId = UUID0;
+width = 366;
+},
+{
+components = (
+{
+name = t;
+},
+{
+name = caron.alt;
+transform = "{1, 0, 0, 1, 265, 8}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 379;
+}
+);
+leftKerningGroup = t;
+unicode = 0165;
+},
+{
+glyphname = tcedilla;
+lastChange = "2016-08-22 12:32:11 +0000";
+layers = (
+{
+components = (
+{
+name = t;
+},
+{
+name = cedilla;
+transform = "{1, 0, 0, 1, 72, 6}";
+}
+);
+layerId = UUID0;
+width = 354;
+},
+{
+components = (
+{
+name = t;
+},
+{
+name = cedilla;
+transform = "{1, 0, 0, 1, 60, 13}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 354;
+}
+);
+leftKerningGroup = t;
+rightKerningGroup = t;
+unicode = 0163;
+},
+{
+glyphname = tcommaaccent;
+lastChange = "2016-08-22 12:32:11 +0000";
+layers = (
+{
+components = (
+{
+name = t;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 91, 0}";
+}
+);
+layerId = UUID0;
+width = 354;
+},
+{
+components = (
+{
+name = t;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 84, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 354;
+}
+);
+leftKerningGroup = t;
+rightKerningGroup = t;
+unicode = 021B;
+},
+{
+glyphname = tdotbelow;
+lastChange = "2016-08-22 11:52:50 +0000";
+layers = (
+{
+components = (
+{
+name = t;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -107, 0}";
+}
+);
+layerId = UUID0;
+width = 354;
+},
+{
+components = (
+{
+name = t;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -116, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 354;
+}
+);
+leftKerningGroup = t;
+rightKerningGroup = t;
+unicode = 1E6D;
+},
+{
+glyphname = u;
+lastChange = "2016-08-22 09:33:30 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{285, 0}";
+},
+{
+name = ogonek;
+position = "{513, 10}";
+},
+{
+name = top;
+position = "{285, 450}";
+},
+{
+name = topright;
+position = "{517, 396}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"290 -12 OFFCURVE",
+"335 26 OFFCURVE",
+"364 78 CURVE",
+"388 78 LINE",
+"368 228 LINE",
+"368 114 OFFCURVE",
+"312 25 OFFCURVE",
+"251 25 CURVE SMOOTH",
+"216 25 OFFCURVE",
+"195 50 OFFCURVE",
+"195 100 CURVE SMOOTH",
+"195 435 LINE",
+"85 435 LINE",
+"85 97 LINE SMOOTH",
+"85 36 OFFCURVE",
+"139 -12 OFFCURVE",
+"216 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"557 0 LINE",
+"557 25 LINE",
+"368 25 LINE",
+"368 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"195 425 LINE",
+"195 450 LINE",
+"7 450 LINE",
+"7 425 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"478 16 LINE",
+"478 435 LINE",
+"368 435 LINE",
+"368 16 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"478 425 LINE",
+"478 450 LINE",
+"286 450 LINE",
+"286 425 LINE"
+);
+}
+);
+width = 570;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{307, 0}";
+},
+{
+name = ogonek;
+position = "{552, 10}";
+},
+{
+name = top;
+position = "{307, 450}";
+},
+{
+name = topright;
+position = "{453, 391}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"603 30 LINE",
+"386 30 LINE",
+"386 0 LINE",
+"603 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"524 425 LINE",
+"386 425 LINE",
+"386 15 LINE",
+"524 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"524 440 LINE",
+"304 440 LINE",
+"304 410 LINE",
+"524 410 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"226 440 LINE",
+"10 440 LINE",
+"10 410 LINE",
+"226 410 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"88 98 LINE SMOOTH",
+"88 37 OFFCURVE",
+"140 -13 OFFCURVE",
+"222 -13 CURVE SMOOTH",
+"292 -13 OFFCURVE",
+"358 24 OFFCURVE",
+"382 79 CURVE",
+"406 79 LINE",
+"386 229 LINE",
+"386 120 OFFCURVE",
+"340 36 OFFCURVE",
+"273 36 CURVE SMOOTH",
+"241 36 OFFCURVE",
+"226 56 OFFCURVE",
+"226 111 CURVE SMOOTH",
+"226 425 LINE",
+"88 425 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"292 -13 OFFCURVE",
+"358 24 OFFCURVE",
+"382 79 CURVE",
+"406 79 LINE",
+"386 229 LINE",
+"386 120 OFFCURVE",
+"340 36 OFFCURVE",
+"273 36 CURVE SMOOTH",
+"241 36 OFFCURVE",
+"226 56 OFFCURVE",
+"226 111 CURVE SMOOTH",
+"226 435 LINE",
+"88 435 LINE",
+"88 98 LINE SMOOTH",
+"88 37 OFFCURVE",
+"140 -13 OFFCURVE",
+"222 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"603 0 LINE",
+"603 30 LINE",
+"386 30 LINE",
+"386 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"226 420 LINE",
+"226 450 LINE",
+"10 450 LINE",
+"10 420 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"524 15 LINE",
+"524 435 LINE",
+"386 435 LINE",
+"386 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"524 420 LINE",
+"524 450 LINE",
+"304 450 LINE",
+"304 420 LINE"
+);
+}
+);
+width = 613;
+}
+);
+leftKerningGroup = u;
+rightKerningGroup = u;
+unicode = 0075;
+},
+{
+glyphname = uacute;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = u;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -40, 0}";
+}
+);
+layerId = UUID0;
+width = 570;
+},
+{
+components = (
+{
+name = u;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -83, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 613;
+}
+);
+leftKerningGroup = u;
+rightKerningGroup = u;
+unicode = 00FA;
+},
+{
+glyphname = ubreve;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = u;
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, -10, 0}";
+}
+);
+layerId = UUID0;
+width = 570;
+},
+{
+components = (
+{
+name = u;
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, 9, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 613;
+}
+);
+leftKerningGroup = u;
+rightKerningGroup = u;
+unicode = 016D;
+},
+{
+glyphname = ucircumflex;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = u;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -5, 0}";
+}
+);
+layerId = UUID0;
+width = 570;
+},
+{
+components = (
+{
+name = u;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 11, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 613;
+}
+);
+leftKerningGroup = u;
+rightKerningGroup = u;
+unicode = 00FB;
+},
+{
+glyphname = udblgrave;
+lastChange = "2016-08-22 12:32:11 +0000";
+layers = (
+{
+components = (
+{
+name = u;
+},
+{
+name = dblgravecomb;
+transform = "{1, 0, 0, 1, 72, 0}";
+}
+);
+layerId = UUID0;
+width = 570;
+},
+{
+components = (
+{
+name = u;
+},
+{
+name = dblgravecomb;
+transform = "{1, 0, 0, 1, 73, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 613;
+}
+);
+leftKerningGroup = u;
+rightKerningGroup = u;
+unicode = 0215;
+},
+{
+glyphname = udieresis;
+lastChange = "2016-08-22 12:32:11 +0000";
+layers = (
+{
+components = (
+{
+name = u;
+},
+{
+name = dieresis;
+transform = "{1, 0, 0, 1, 131, 0}";
+}
+);
+layerId = UUID0;
+width = 570;
+},
+{
+components = (
+{
+name = u;
+},
+{
+name = dieresis;
+transform = "{1, 0, 0, 1, 145, -2}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 613;
+}
+);
+leftKerningGroup = u;
+rightKerningGroup = u;
+unicode = 00FC;
+},
+{
+glyphname = udotbelow;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = u;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 1, 0}";
+}
+);
+layerId = UUID0;
+width = 570;
+},
+{
+components = (
+{
+name = u;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 14, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 613;
+}
+);
+leftKerningGroup = u;
+rightKerningGroup = u;
+unicode = 1EE5;
+},
+{
+glyphname = ugrave;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = u;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, -2, 0}";
+}
+);
+layerId = UUID0;
+width = 570;
+},
+{
+components = (
+{
+name = u;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 58, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 613;
+}
+);
+leftKerningGroup = u;
+rightKerningGroup = u;
+unicode = 00F9;
+},
+{
+glyphname = uhookabove;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = u;
+},
+{
+name = hookabovecomb;
+}
+);
+layerId = UUID0;
+width = 570;
+},
+{
+components = (
+{
+name = u;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 23, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 613;
+}
+);
+leftKerningGroup = u;
+rightKerningGroup = u;
+unicode = 1EE7;
+},
+{
+glyphname = uhorn;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = u;
+},
+{
+name = horncomb;
+transform = "{1, 0, 0, 1, 205, -54}";
+}
+);
+layerId = UUID0;
+width = 570;
+},
+{
+components = (
+{
+name = u;
+},
+{
+name = horncomb;
+transform = "{1, 0, 0, 1, 254, -59}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 613;
+}
+);
+leftKerningGroup = u;
+rightKerningGroup = u;
+unicode = 01B0;
+},
+{
+glyphname = uhornacute;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = uhorn;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -40, 0}";
+}
+);
+layerId = UUID0;
+width = 570;
+},
+{
+components = (
+{
+name = uhorn;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -83, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 613;
+}
+);
+leftKerningGroup = u;
+rightKerningGroup = u;
+unicode = 1EE9;
+},
+{
+glyphname = uhorndotbelow;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = uhorn;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 1, 0}";
+}
+);
+layerId = UUID0;
+width = 570;
+},
+{
+components = (
+{
+name = uhorn;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 14, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 613;
+}
+);
+leftKerningGroup = u;
+rightKerningGroup = u;
+unicode = 1EF1;
+},
+{
+glyphname = uhorngrave;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = uhorn;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, -2, 0}";
+}
+);
+layerId = UUID0;
+width = 570;
+},
+{
+components = (
+{
+name = uhorn;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 58, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 613;
+}
+);
+leftKerningGroup = u;
+rightKerningGroup = u;
+unicode = 1EEB;
+},
+{
+glyphname = uhornhookabove;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = uhorn;
+},
+{
+name = hookabovecomb;
+}
+);
+layerId = UUID0;
+width = 570;
+},
+{
+components = (
+{
+name = uhorn;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 23, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 613;
+}
+);
+leftKerningGroup = u;
+rightKerningGroup = u;
+unicode = 1EED;
+},
+{
+glyphname = uhorntilde;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = uhorn;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, -6, 0}";
+}
+);
+layerId = UUID0;
+width = 570;
+},
+{
+components = (
+{
+name = uhorn;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, -6, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 613;
+}
+);
+leftKerningGroup = u;
+rightKerningGroup = u;
+unicode = 1EEF;
+},
+{
+glyphname = uhungarumlaut;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = u;
+},
+{
+name = hungarumlaut;
+}
+);
+layerId = UUID0;
+width = 570;
+},
+{
+components = (
+{
+name = u;
+},
+{
+name = hungarumlaut;
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 613;
+}
+);
+leftKerningGroup = u;
+rightKerningGroup = u;
+unicode = 0171;
+},
+{
+glyphname = uinvertedbreve;
+lastChange = "2016-08-22 12:32:11 +0000";
+layers = (
+{
+components = (
+{
+name = u;
+},
+{
+name = breveinvertedcomb;
+transform = "{1, 0, 0, 1, 118, 0}";
+}
+);
+layerId = UUID0;
+width = 570;
+},
+{
+components = (
+{
+name = u;
+},
+{
+name = breveinvertedcomb;
+transform = "{1, 0, 0, 1, 130, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 613;
+}
+);
+leftKerningGroup = u;
+rightKerningGroup = u;
+unicode = 0217;
+},
+{
+glyphname = umacron;
+lastChange = "2016-08-22 12:32:11 +0000";
+layers = (
+{
+components = (
+{
+name = u;
+},
+{
+name = macron;
+transform = "{1, 0, 0, 1, 119, 0}";
+}
+);
+layerId = UUID0;
+width = 570;
+},
+{
+components = (
+{
+name = u;
+},
+{
+name = macron;
+transform = "{1, 0, 0, 1, 133, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 613;
+}
+);
+leftKerningGroup = u;
+rightKerningGroup = u;
+unicode = 016B;
+},
+{
+glyphname = uogonek;
+lastChange = "2016-08-22 12:28:01 +0000";
+layers = (
+{
+components = (
+{
+name = u;
+},
+{
+name = ogonek;
+transform = "{1, 0, 0, 1, 290, 0}";
+}
+);
+layerId = UUID0;
+width = 570;
+},
+{
+components = (
+{
+name = u;
+},
+{
+name = ogonek;
+transform = "{1, 0, 0, 1, 322, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 613;
+}
+);
+leftKerningGroup = u;
+rightKerningGroup = u;
+unicode = 0173;
+},
+{
+glyphname = uring;
+lastChange = "2016-08-22 12:28:13 +0000";
+layers = (
+{
+components = (
+{
+name = u;
+},
+{
+name = ring;
+transform = "{1, 0, 0, 1, 164, 0}";
+}
+);
+layerId = UUID0;
+width = 570;
+},
+{
+components = (
+{
+name = u;
+},
+{
+name = ring;
+transform = "{1, 0, 0, 1, 184, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 613;
+}
+);
+leftKerningGroup = u;
+rightKerningGroup = u;
+unicode = 016F;
+},
+{
+glyphname = utilde;
+lastChange = "2016-08-22 11:52:11 +0000";
+layers = (
+{
+components = (
+{
+name = u;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, -6, 0}";
+}
+);
+layerId = UUID0;
+width = 570;
+},
+{
+components = (
+{
+name = u;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, -6, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 613;
+}
+);
+leftKerningGroup = u;
+rightKerningGroup = u;
+unicode = 0169;
+},
+{
+glyphname = v;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{249, 0}";
+},
+{
+name = top;
+position = "{249, 450}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"294 135 LINE",
+"289 135 LINE",
+"162 447 LINE",
+"41 441 LINE",
+"241 -12 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"231 425 LINE",
+"231 450 LINE",
+"-13 450 LINE",
+"-13 425 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"270 -12 LINE",
+"435 433 LINE",
+"399 433 LINE",
+"241 -12 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"506 425 LINE",
+"506 450 LINE",
+"327 450 LINE",
+"327 425 LINE"
+);
+}
+);
+width = 498;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{246, 0}";
+},
+{
+name = top;
+position = "{246, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"-15 411 LINE",
+"253 411 LINE",
+"253 441 LINE",
+"-15 441 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"234 -13 LINE",
+"309 167 LINE",
+"304 167 LINE",
+"187 431 LINE",
+"31 431 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"323 411 LINE",
+"511 411 LINE",
+"511 441 LINE",
+"323 441 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"234 -13 LINE",
+"263 -13 LINE",
+"450 423 LINE",
+"414 423 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"309 167 LINE",
+"304 167 LINE",
+"187 440 LINE",
+"31 440 LINE",
+"234 -13 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"263 -13 LINE",
+"450 432 LINE",
+"414 432 LINE",
+"234 -13 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"253 420 LINE",
+"253 450 LINE",
+"-15 450 LINE",
+"-15 420 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"511 420 LINE",
+"511 450 LINE",
+"323 450 LINE",
+"323 420 LINE"
+);
+}
+);
+width = 491;
+}
+);
+unicode = 0076;
+},
+{
+glyphname = w;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{343, 0}";
+},
+{
+name = top;
+position = "{343, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"-12 425 LINE",
+"230 425 LINE",
+"230 450 LINE",
+"-12 450 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"204 -12 LINE",
+"233 -12 LINE",
+"407 450 LINE",
+"369 450 LINE",
+"265 156 LINE",
+"261 156 LINE",
+"166 446 LINE",
+"45 440 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"349 293 LINE",
+"353 293 LINE",
+"461 -12 LINE",
+"490 -12 LINE",
+"650 450 LINE",
+"614 450 LINE",
+"517 156 LINE",
+"513 156 LINE",
+"407 450 LINE",
+"338 334 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"532 425 LINE",
+"713 425 LINE",
+"713 450 LINE",
+"532 450 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"233 -12 LINE",
+"348 295 LINE",
+"352 295 LINE",
+"461 -12 LINE",
+"490 -12 LINE",
+"641 425 LINE",
+"713 425 LINE",
+"713 450 LINE",
+"532 450 LINE",
+"532 425 LINE",
+"606 425 LINE",
+"517 156 LINE",
+"513 156 LINE",
+"407 450 LINE",
+"369 450 LINE",
+"265 156 LINE",
+"261 156 LINE",
+"173 425 LINE",
+"230 425 LINE",
+"230 450 LINE",
+"-12 450 LINE",
+"-12 425 LINE",
+"50 425 LINE",
+"204 -12 LINE"
+);
+}
+);
+width = 686;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{345, 0}";
+},
+{
+name = top;
+position = "{345, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"-15 420 LINE",
+"253 420 LINE",
+"253 450 LINE",
+"-15 450 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"205 -13 LINE",
+"280 187 LINE",
+"275 187 LINE",
+"187 441 LINE",
+"31 441 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"205 -13 LINE",
+"234 -13 LINE",
+"411 450 LINE",
+"375 450 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"522 420 LINE",
+"710 420 LINE",
+"710 450 LINE",
+"522 450 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"458 -13 LINE",
+"487 -13 LINE",
+"642 433 LINE",
+"606 433 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"458 -13 LINE",
+"526 187 LINE",
+"521 187 LINE",
+"411 450 LINE",
+"340 266 LINE",
+"344 266 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"234 -13 LINE",
+"340 266 LINE",
+"344 266 LINE",
+"458 -13 LINE",
+"487 -13 LINE",
+"637 420 LINE",
+"710 420 LINE",
+"710 450 LINE",
+"522 450 LINE",
+"522 420 LINE",
+"601 420 LINE",
+"524 187 LINE",
+"520 187 LINE",
+"411 450 LINE",
+"375 450 LINE",
+"278 187 LINE",
+"274 187 LINE",
+"194 420 LINE",
+"253 420 LINE",
+"253 450 LINE",
+"-15 450 LINE",
+"-15 420 LINE",
+"39 420 LINE",
+"205 -13 LINE"
+);
+}
+);
+width = 690;
+}
+);
+leftKerningGroup = w;
+rightKerningGroup = w;
+unicode = 0077;
+},
+{
+glyphname = wacute;
+lastChange = "2016-08-22 11:52:50 +0000";
+layers = (
+{
+components = (
+{
+name = w;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 18, 0}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = w;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -45, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 690;
+}
+);
+leftKerningGroup = w;
+rightKerningGroup = w;
+unicode = 1E83;
+},
+{
+glyphname = wcircumflex;
+lastChange = "2016-08-22 11:52:50 +0000";
+layers = (
+{
+components = (
+{
+name = w;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 53, 0}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = w;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 49, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 690;
+}
+);
+leftKerningGroup = w;
+rightKerningGroup = w;
+unicode = 0175;
+},
+{
+glyphname = wdieresis;
+lastChange = "2016-08-22 12:32:11 +0000";
+layers = (
+{
+components = (
+{
+name = w;
+},
+{
+name = dieresis;
+transform = "{1, 0, 0, 1, 189, 0}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = w;
+},
+{
+name = dieresis;
+transform = "{1, 0, 0, 1, 183, -2}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 690;
+}
+);
+leftKerningGroup = w;
+rightKerningGroup = w;
+unicode = 1E85;
+},
+{
+glyphname = wgrave;
+lastChange = "2016-08-22 11:52:50 +0000";
+layers = (
+{
+components = (
+{
+name = w;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 56, 0}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = w;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 96, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 690;
+}
+);
+leftKerningGroup = w;
+rightKerningGroup = w;
+unicode = 1E81;
+},
+{
+glyphname = x;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{253, 0}";
+},
+{
+name = top;
+position = "{253, 450}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"477 15 LINE",
+"166 440 LINE",
+"33 440 LINE",
+"340 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"189 0 LINE",
+"189 25 LINE",
+"-9 25 LINE",
+"-9 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"103 18 LINE",
+"235 202 LINE",
+"217 226 LINE",
+"67 18 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"522 0 LINE",
+"522 25 LINE",
+"274 25 LINE",
+"274 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"237 425 LINE",
+"237 450 LINE",
+"-11 450 LINE",
+"-11 425 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"416 432 LINE",
+"380 432 LINE",
+"248 249 LINE",
+"269 228 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"497 425 LINE",
+"497 450 LINE",
+"309 450 LINE",
+"309 425 LINE"
+);
+}
+);
+width = 506;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{289, 0}";
+},
+{
+name = top;
+position = "{289, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"350 410 LINE",
+"538 410 LINE",
+"538 440 LINE",
+"350 440 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"277 243 LINE",
+"298 222 LINE",
+"479 421 LINE",
+"443 421 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"205 30 LINE",
+"7 30 LINE",
+"7 0 LINE",
+"205 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"256 177 LINE",
+"238 201 LINE",
+"68 18 LINE",
+"104 18 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"5 410 LINE",
+"283 410 LINE",
+"283 440 LINE",
+"5 440 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"285 0 LINE",
+"573 0 LINE",
+"573 30 LINE",
+"285 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"361 15 LINE",
+"531 15 LINE",
+"212 430 LINE",
+"39 430 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"531 15 LINE",
+"222 440 LINE",
+"49 440 LINE",
+"361 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"205 0 LINE",
+"205 30 LINE",
+"7 30 LINE",
+"7 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"104 18 LINE",
+"266 182 LINE",
+"248 206 LINE",
+"68 18 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"573 0 LINE",
+"573 30 LINE",
+"285 30 LINE",
+"285 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"293 420 LINE",
+"293 450 LINE",
+"15 450 LINE",
+"15 420 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"499 431 LINE",
+"463 431 LINE",
+"287 248 LINE",
+"308 227 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"558 420 LINE",
+"558 450 LINE",
+"370 450 LINE",
+"370 420 LINE"
+);
+}
+);
+width = 578;
+}
+);
+unicode = 0078;
+},
+{
+glyphname = y;
+lastChange = "2016-08-22 09:54:01 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{243, 0}";
+},
+{
+name = top;
+position = "{243, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"-11 425 LINE",
+"237 425 LINE",
+"237 450 LINE",
+"-11 450 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"238 15 LINE",
+"303 124 LINE",
+"162 446 LINE",
+"41 440 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"309 425 LINE",
+"497 425 LINE",
+"497 450 LINE",
+"309 450 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"149 -228 LINE SMOOTH",
+"145 -240 OFFCURVE",
+"139 -251 OFFCURVE",
+"129 -251 CURVE SMOOTH",
+"110 -251 OFFCURVE",
+"103 -213 OFFCURVE",
+"63 -213 CURVE SMOOTH",
+"34 -213 OFFCURVE",
+"12 -234 OFFCURVE",
+"12 -266 CURVE SMOOTH",
+"12 -291 OFFCURVE",
+"26 -326 OFFCURVE",
+"76 -326 CURVE SMOOTH",
+"112 -326 OFFCURVE",
+"148 -306 OFFCURVE",
+"182 -216 CURVE SMOOTH",
+"422 432 LINE",
+"386 432 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"112 -326 OFFCURVE",
+"148 -306 OFFCURVE",
+"182 -216 CURVE SMOOTH",
+"422 432 LINE",
+"386 432 LINE",
+"149 -228 LINE SMOOTH",
+"145 -240 OFFCURVE",
+"139 -251 OFFCURVE",
+"129 -251 CURVE SMOOTH",
+"110 -251 OFFCURVE",
+"103 -213 OFFCURVE",
+"63 -213 CURVE SMOOTH",
+"34 -213 OFFCURVE",
+"12 -234 OFFCURVE",
+"12 -266 CURVE SMOOTH",
+"12 -291 OFFCURVE",
+"26 -326 OFFCURVE",
+"76 -326 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"291 159 LINE",
+"285 159 LINE",
+"162 446 LINE",
+"41 440 LINE",
+"238 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"237 425 LINE",
+"237 450 LINE",
+"-11 450 LINE",
+"-11 425 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"497 425 LINE",
+"497 450 LINE",
+"309 450 LINE",
+"309 425 LINE"
+);
+}
+);
+width = 486;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{251, 0}";
+},
+{
+name = top;
+position = "{251, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"-15 410 LINE",
+"253 410 LINE",
+"253 440 LINE",
+"-15 440 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"244 -3 LINE",
+"314 176 LINE",
+"309 176 LINE",
+"187 430 LINE",
+"28 430 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"323 410 LINE",
+"511 410 LINE",
+"511 440 LINE",
+"323 440 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"156 -205 LINE SMOOTH",
+"148 -223 OFFCURVE",
+"142 -230 OFFCURVE",
+"131 -230 CURVE SMOOTH",
+"104 -230 OFFCURVE",
+"99 -190 OFFCURVE",
+"54 -190 CURVE SMOOTH",
+"19 -190 OFFCURVE",
+"-7 -215 OFFCURVE",
+"-7 -252 CURVE SMOOTH",
+"-7 -283 OFFCURVE",
+"11 -323 OFFCURVE",
+"70 -323 CURVE SMOOTH",
+"109 -323 OFFCURVE",
+"146 -306 OFFCURVE",
+"181 -223 CURVE SMOOTH",
+"456 423 LINE",
+"415 423 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"109 -323 OFFCURVE",
+"147 -305 OFFCURVE",
+"181 -223 CURVE SMOOTH",
+"456 433 LINE",
+"415 433 LINE",
+"156 -205 LINE SMOOTH",
+"148 -223 OFFCURVE",
+"142 -230 OFFCURVE",
+"131 -230 CURVE SMOOTH",
+"104 -230 OFFCURVE",
+"99 -190 OFFCURVE",
+"54 -190 CURVE SMOOTH",
+"19 -190 OFFCURVE",
+"-7 -215 OFFCURVE",
+"-7 -252 CURVE SMOOTH",
+"-7 -283 OFFCURVE",
+"11 -323 OFFCURVE",
+"70 -323 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"313 176 LINE",
+"308 176 LINE",
+"187 440 LINE",
+"28 440 LINE",
+"244 -3 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"276 420 LINE",
+"276 450 LINE",
+"-15 450 LINE",
+"-15 420 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"511 420 LINE",
+"511 450 LINE",
+"336 450 LINE",
+"336 420 LINE"
+);
+}
+);
+width = 501;
+}
+);
+leftKerningGroup = y;
+rightKerningGroup = y;
+unicode = 0079;
+},
+{
+glyphname = yacute;
+lastChange = "2016-08-22 11:52:12 +0000";
+layers = (
+{
+components = (
+{
+name = y;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -82, 0}";
+}
+);
+layerId = UUID0;
+width = 486;
+},
+{
+components = (
+{
+name = y;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -139, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 501;
+}
+);
+leftKerningGroup = y;
+rightKerningGroup = y;
+unicode = 00FD;
+},
+{
+glyphname = ycircumflex;
+lastChange = "2016-08-22 11:52:12 +0000";
+layers = (
+{
+components = (
+{
+name = y;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -47, 0}";
+}
+);
+layerId = UUID0;
+width = 486;
+},
+{
+components = (
+{
+name = y;
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -45, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 501;
+}
+);
+leftKerningGroup = y;
+rightKerningGroup = y;
+unicode = 0177;
+},
+{
+glyphname = ydieresis;
+lastChange = "2016-08-22 12:32:11 +0000";
+layers = (
+{
+components = (
+{
+name = y;
+},
+{
+name = dieresis;
+transform = "{1, 0, 0, 1, 89, 0}";
+}
+);
+layerId = UUID0;
+width = 486;
+},
+{
+components = (
+{
+name = y;
+},
+{
+name = dieresis;
+transform = "{1, 0, 0, 1, 89, -2}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 501;
+}
+);
+leftKerningGroup = y;
+rightKerningGroup = y;
+unicode = 00FF;
+},
+{
+glyphname = ydotbelow;
+lastChange = "2016-08-22 12:28:30 +0000";
+layers = (
+{
+components = (
+{
+name = y;
+},
+{
+alignment = -1;
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 41, 0}";
+}
+);
+layerId = UUID0;
+width = 486;
+},
+{
+components = (
+{
+name = y;
+},
+{
+alignment = -1;
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 81, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 501;
+}
+);
+leftKerningGroup = y;
+rightKerningGroup = y;
+unicode = 1EF5;
+},
+{
+glyphname = ygrave;
+lastChange = "2016-08-22 11:52:12 +0000";
+layers = (
+{
+components = (
+{
+name = y;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, -44, 0}";
+}
+);
+layerId = UUID0;
+width = 486;
+},
+{
+components = (
+{
+name = y;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 2, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 501;
+}
+);
+leftKerningGroup = y;
+rightKerningGroup = y;
+unicode = 1EF3;
+},
+{
+glyphname = yhookabove;
+lastChange = "2016-08-22 11:52:12 +0000";
+layers = (
+{
+components = (
+{
+name = y;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, -42, 0}";
+}
+);
+layerId = UUID0;
+width = 486;
+},
+{
+components = (
+{
+name = y;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, -33, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 501;
+}
+);
+leftKerningGroup = y;
+rightKerningGroup = y;
+unicode = 1EF7;
+},
+{
+glyphname = ytilde;
+lastChange = "2016-08-22 11:52:12 +0000";
+layers = (
+{
+components = (
+{
+name = y;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, -48, 0}";
+}
+);
+layerId = UUID0;
+width = 486;
+},
+{
+components = (
+{
+name = y;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, -62, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 501;
+}
+);
+leftKerningGroup = y;
+rightKerningGroup = y;
+unicode = 1EF9;
+},
+{
+glyphname = z;
+lastChange = "2016-08-22 11:52:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{240, 0}";
+},
+{
+name = top;
+position = "{240, 450}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"161 15 LINE",
+"422 415 LINE",
+"408 440 LINE",
+"314 440 LINE",
+"46 35 LINE",
+"49 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"431 0 LINE",
+"431 185 LINE",
+"406 185 LINE",
+"405 169 LINE SMOOTH",
+"401 73 OFFCURVE",
+"342 25 OFFCURVE",
+"268 25 CURVE SMOOTH",
+"54 25 LINE",
+"46 35 LINE",
+"46 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"93 275 LINE",
+"95 357 OFFCURVE",
+"144 425 OFFCURVE",
+"231 425 CURVE SMOOTH",
+"414 425 LINE",
+"422 415 LINE",
+"422 450 LINE",
+"68 450 LINE",
+"68 275 LINE"
+);
+}
+);
+width = 480;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{238, 0}";
+},
+{
+name = top;
+position = "{238, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"446 406 LINE",
+"432 431 LINE",
+"303 431 LINE",
+"25 35 LINE",
+"28 15 LINE",
+"175 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"57 265 LINE",
+"87 265 LINE",
+"89 344 OFFCURVE",
+"138 410 OFFCURVE",
+"225 410 CURVE SMOOTH",
+"438 410 LINE",
+"446 406 LINE",
+"446 440 LINE",
+"57 440 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"440 185 LINE",
+"410 185 LINE",
+"409 169 LINE SMOOTH",
+"405 76 OFFCURVE",
+"346 30 OFFCURVE",
+"272 30 CURVE SMOOTH",
+"33 30 LINE",
+"25 35 LINE",
+"25 0 LINE",
+"440 0 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"175 15 LINE",
+"446 416 LINE",
+"432 441 LINE",
+"303 441 LINE",
+"25 35 LINE",
+"28 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"440 0 LINE",
+"440 185 LINE",
+"410 185 LINE",
+"409 169 LINE SMOOTH",
+"405 76 OFFCURVE",
+"346 30 OFFCURVE",
+"272 30 CURVE SMOOTH",
+"33 30 LINE",
+"25 35 LINE",
+"25 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"87 275 LINE",
+"89 354 OFFCURVE",
+"138 420 OFFCURVE",
+"225 420 CURVE SMOOTH",
+"438 420 LINE",
+"446 416 LINE",
+"446 450 LINE",
+"57 450 LINE",
+"57 275 LINE"
+);
+}
+);
+width = 476;
+}
+);
+leftKerningGroup = z;
+rightKerningGroup = z;
+unicode = 007A;
+},
+{
+glyphname = zacute;
+lastChange = "2016-08-22 11:52:50 +0000";
+layers = (
+{
+components = (
+{
+name = z;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -85, 0}";
+}
+);
+layerId = UUID0;
+width = 480;
+},
+{
+components = (
+{
+name = z;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -152, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 476;
+}
+);
+leftKerningGroup = z;
+rightKerningGroup = z;
+unicode = 017A;
+},
+{
+glyphname = zcaron;
+lastChange = "2016-08-22 12:32:11 +0000";
+layers = (
+{
+components = (
+{
+name = z;
+},
+{
+name = caron;
+transform = "{1, 0, 0, 1, 75, -9}";
+}
+);
+layerId = UUID0;
+width = 480;
+},
+{
+components = (
+{
+name = z;
+},
+{
+name = caron;
+transform = "{1, 0, 0, 1, 48, -9}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 476;
+}
+);
+leftKerningGroup = z;
+rightKerningGroup = z;
+unicode = 017E;
+},
+{
+glyphname = zdotaccent;
+lastChange = "2016-08-22 12:32:11 +0000";
+layers = (
+{
+components = (
+{
+name = z;
+},
+{
+name = dotaccent;
+transform = "{1, 0, 0, 1, 166, -3}";
+}
+);
+layerId = UUID0;
+width = 480;
+},
+{
+components = (
+{
+name = z;
+},
+{
+name = dotaccent;
+transform = "{1, 0, 0, 1, 150, -7}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 476;
+}
+);
+leftKerningGroup = z;
+rightKerningGroup = z;
+unicode = 017C;
+},
+{
+glyphname = zdotbelow;
+lastChange = "2016-08-22 11:52:50 +0000";
+layers = (
+{
+components = (
+{
+name = z;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -44, 0}";
+}
+);
+layerId = UUID0;
+width = 480;
+},
+{
+components = (
+{
+name = z;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -55, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 476;
+}
+);
+leftKerningGroup = z;
+rightKerningGroup = z;
+unicode = 1E93;
+},
+{
+glyphname = odotbelow.001;
+lastChange = "2016-08-22 11:52:12 +0000";
+layers = (
+{
+components = (
+{
+name = o;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -3, 0}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = o;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 2, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+},
+{
+glyphname = f_f;
+lastChange = "2016-08-19 17:28:22 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"116 0 LINE",
+"226 0 LINE",
+"226 585 LINE SMOOTH",
+"226 671 OFFCURVE",
+"242 705 OFFCURVE",
+"282 705 CURVE SMOOTH",
+"298 705 OFFCURVE",
+"305 700 OFFCURVE",
+"305 688 CURVE SMOOTH",
+"305 671 OFFCURVE",
+"291 665 OFFCURVE",
+"291 641 CURVE SMOOTH",
+"291 613 OFFCURVE",
+"311 594 OFFCURVE",
+"341 594 CURVE SMOOTH",
+"374 594 OFFCURVE",
+"397 617 OFFCURVE",
+"397 652 CURVE SMOOTH",
+"397 700 OFFCURVE",
+"355 732 OFFCURVE",
+"287 732 CURVE SMOOTH",
+"171 732 OFFCURVE",
+"116 639 OFFCURVE",
+"116 445 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"400 0 LINE",
+"510 0 LINE",
+"510 618 LINE SMOOTH",
+"510 704 OFFCURVE",
+"526 738 OFFCURVE",
+"566 738 CURVE SMOOTH",
+"582 738 OFFCURVE",
+"589 733 OFFCURVE",
+"589 721 CURVE SMOOTH",
+"589 704 OFFCURVE",
+"575 698 OFFCURVE",
+"575 674 CURVE SMOOTH",
+"575 646 OFFCURVE",
+"595 627 OFFCURVE",
+"625 627 CURVE SMOOTH",
+"658 627 OFFCURVE",
+"681 650 OFFCURVE",
+"681 685 CURVE SMOOTH",
+"681 733 OFFCURVE",
+"639 765 OFFCURVE",
+"571 765 CURVE SMOOTH",
+"455 765 OFFCURVE",
+"400 672 OFFCURVE",
+"400 478 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"19 0 LINE",
+"289 0 LINE",
+"289 25 LINE",
+"19 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"343 0 LINE",
+"623 0 LINE",
+"623 25 LINE",
+"343 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"19 425 LINE",
+"633 425 LINE",
+"633 450 LINE",
+"19 450 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"510 0 LINE",
+"510 618 LINE SMOOTH",
+"510 704 OFFCURVE",
+"526 738 OFFCURVE",
+"566 738 CURVE SMOOTH",
+"582 738 OFFCURVE",
+"589 733 OFFCURVE",
+"589 721 CURVE SMOOTH",
+"589 704 OFFCURVE",
+"575 698 OFFCURVE",
+"575 674 CURVE SMOOTH",
+"575 646 OFFCURVE",
+"595 627 OFFCURVE",
+"625 627 CURVE SMOOTH",
+"658 627 OFFCURVE",
+"681 650 OFFCURVE",
+"681 685 CURVE SMOOTH",
+"681 733 OFFCURVE",
+"639 765 OFFCURVE",
+"571 765 CURVE SMOOTH",
+"455 765 OFFCURVE",
+"400 672 OFFCURVE",
+"400 478 CURVE SMOOTH",
+"400 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"289 0 LINE",
+"289 25 LINE",
+"19 25 LINE",
+"19 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"623 0 LINE",
+"623 25 LINE",
+"343 25 LINE",
+"343 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"226 0 LINE",
+"226 585 LINE SMOOTH",
+"226 671 OFFCURVE",
+"242 705 OFFCURVE",
+"282 705 CURVE SMOOTH",
+"298 705 OFFCURVE",
+"305 700 OFFCURVE",
+"305 688 CURVE SMOOTH",
+"305 671 OFFCURVE",
+"291 665 OFFCURVE",
+"291 641 CURVE SMOOTH",
+"291 613 OFFCURVE",
+"311 594 OFFCURVE",
+"341 594 CURVE SMOOTH",
+"374 594 OFFCURVE",
+"397 617 OFFCURVE",
+"397 652 CURVE SMOOTH",
+"397 700 OFFCURVE",
+"355 732 OFFCURVE",
+"287 732 CURVE SMOOTH",
+"171 732 OFFCURVE",
+"116 639 OFFCURVE",
+"116 445 CURVE SMOOTH",
+"116 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"633 425 LINE",
+"633 450 LINE",
+"19 450 LINE",
+"19 425 LINE"
+);
+}
+);
+width = 646;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"241 0 LINE",
+"241 596 LINE SMOOTH",
+"241 679 OFFCURVE",
+"276 701 OFFCURVE",
+"317 701 CURVE SMOOTH",
+"340 701 OFFCURVE",
+"350 694 OFFCURVE",
+"350 682 CURVE SMOOTH",
+"350 664 OFFCURVE",
+"326 660 OFFCURVE",
+"326 626 CURVE SMOOTH",
+"326 588 OFFCURVE",
+"355 570 OFFCURVE",
+"387 570 CURVE SMOOTH",
+"427 570 OFFCURVE",
+"456 597 OFFCURVE",
+"456 637 CURVE SMOOTH",
+"456 689 OFFCURVE",
+"405 733 OFFCURVE",
+"323 733 CURVE SMOOTH",
+"188 733 OFFCURVE",
+"103 616 OFFCURVE",
+"103 446 CURVE SMOOTH",
+"103 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"553 0 LINE",
+"553 629 LINE SMOOTH",
+"553 712 OFFCURVE",
+"588 734 OFFCURVE",
+"629 734 CURVE SMOOTH",
+"652 734 OFFCURVE",
+"662 727 OFFCURVE",
+"662 715 CURVE SMOOTH",
+"662 697 OFFCURVE",
+"638 693 OFFCURVE",
+"638 659 CURVE SMOOTH",
+"638 621 OFFCURVE",
+"667 603 OFFCURVE",
+"699 603 CURVE SMOOTH",
+"739 603 OFFCURVE",
+"768 630 OFFCURVE",
+"768 670 CURVE SMOOTH",
+"768 722 OFFCURVE",
+"717 766 OFFCURVE",
+"635 766 CURVE SMOOTH",
+"500 766 OFFCURVE",
+"415 649 OFFCURVE",
+"415 479 CURVE SMOOTH",
+"415 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"23 0 LINE",
+"314 0 LINE",
+"314 30 LINE",
+"23 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"338 0 LINE",
+"654 0 LINE",
+"654 30 LINE",
+"338 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 420 LINE",
+"661 420 LINE",
+"661 450 LINE",
+"20 450 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"553 0 LINE",
+"553 629 LINE SMOOTH",
+"553 712 OFFCURVE",
+"588 734 OFFCURVE",
+"629 734 CURVE SMOOTH",
+"652 734 OFFCURVE",
+"662 727 OFFCURVE",
+"662 715 CURVE SMOOTH",
+"662 697 OFFCURVE",
+"638 693 OFFCURVE",
+"638 659 CURVE SMOOTH",
+"638 621 OFFCURVE",
+"667 603 OFFCURVE",
+"699 603 CURVE SMOOTH",
+"739 603 OFFCURVE",
+"768 630 OFFCURVE",
+"768 670 CURVE SMOOTH",
+"768 722 OFFCURVE",
+"717 766 OFFCURVE",
+"635 766 CURVE SMOOTH",
+"500 766 OFFCURVE",
+"415 649 OFFCURVE",
+"415 479 CURVE SMOOTH",
+"415 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"314 0 LINE",
+"314 30 LINE",
+"23 30 LINE",
+"23 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"654 0 LINE",
+"654 30 LINE",
+"338 30 LINE",
+"338 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"241 0 LINE",
+"241 596 LINE SMOOTH",
+"241 679 OFFCURVE",
+"276 701 OFFCURVE",
+"317 701 CURVE SMOOTH",
+"340 701 OFFCURVE",
+"350 694 OFFCURVE",
+"350 682 CURVE SMOOTH",
+"350 664 OFFCURVE",
+"326 660 OFFCURVE",
+"326 626 CURVE SMOOTH",
+"326 588 OFFCURVE",
+"355 570 OFFCURVE",
+"387 570 CURVE SMOOTH",
+"427 570 OFFCURVE",
+"456 597 OFFCURVE",
+"456 637 CURVE SMOOTH",
+"456 689 OFFCURVE",
+"405 733 OFFCURVE",
+"323 733 CURVE SMOOTH",
+"188 733 OFFCURVE",
+"103 616 OFFCURVE",
+"103 446 CURVE SMOOTH",
+"103 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"661 420 LINE",
+"661 450 LINE",
+"20 450 LINE",
+"20 420 LINE"
+);
+}
+);
+width = 658;
+}
+);
+leftKerningGroup = f;
+rightKerningGroup = f;
+},
+{
+glyphname = f_f_i;
+lastChange = "2016-08-19 17:28:22 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"116 10 LINE",
+"226 10 LINE",
+"226 565 LINE SMOOTH",
+"226 666 OFFCURVE",
+"245 705 OFFCURVE",
+"292 705 CURVE SMOOTH",
+"314 705 OFFCURVE",
+"325 697 OFFCURVE",
+"325 680 CURVE SMOOTH",
+"325 660 OFFCURVE",
+"311 655 OFFCURVE",
+"311 631 CURVE SMOOTH",
+"311 603 OFFCURVE",
+"331 584 OFFCURVE",
+"361 584 CURVE SMOOTH",
+"394 584 OFFCURVE",
+"417 606 OFFCURVE",
+"417 643 CURVE SMOOTH",
+"417 695 OFFCURVE",
+"372 732 OFFCURVE",
+"297 732 CURVE SMOOTH",
+"174 732 OFFCURVE",
+"116 633 OFFCURVE",
+"116 425 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"19 0 LINE",
+"299 0 LINE",
+"299 25 LINE",
+"19 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"19 425 LINE",
+"791 425 LINE",
+"791 450 LINE",
+"19 450 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"400 10 LINE",
+"510 10 LINE",
+"510 588 LINE SMOOTH",
+"510 696 OFFCURVE",
+"541 738 OFFCURVE",
+"618 738 CURVE SMOOTH",
+"658 738 OFFCURVE",
+"679 727 OFFCURVE",
+"679 703 CURVE SMOOTH",
+"679 683 OFFCURVE",
+"665 678 OFFCURVE",
+"665 654 CURVE SMOOTH",
+"665 626 OFFCURVE",
+"685 607 OFFCURVE",
+"715 607 CURVE SMOOTH",
+"748 607 OFFCURVE",
+"771 630 OFFCURVE",
+"771 666 CURVE SMOOTH",
+"771 724 OFFCURVE",
+"713 765 OFFCURVE",
+"622 765 CURVE SMOOTH",
+"479 765 OFFCURVE",
+"400 663 OFFCURVE",
+"400 448 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"333 0 LINE",
+"574 0 LINE",
+"574 25 LINE",
+"333 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"681 15 LINE",
+"791 15 LINE",
+"791 435 LINE",
+"681 435 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"612 0 LINE",
+"871 0 LINE",
+"871 25 LINE",
+"612 25 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"510 10 LINE",
+"510 588 LINE SMOOTH",
+"510 696 OFFCURVE",
+"541 738 OFFCURVE",
+"618 738 CURVE SMOOTH",
+"658 738 OFFCURVE",
+"679 727 OFFCURVE",
+"679 703 CURVE SMOOTH",
+"679 683 OFFCURVE",
+"665 678 OFFCURVE",
+"665 654 CURVE SMOOTH",
+"665 626 OFFCURVE",
+"685 607 OFFCURVE",
+"715 607 CURVE SMOOTH",
+"748 607 OFFCURVE",
+"771 630 OFFCURVE",
+"771 666 CURVE SMOOTH",
+"771 724 OFFCURVE",
+"713 765 OFFCURVE",
+"622 765 CURVE SMOOTH",
+"479 765 OFFCURVE",
+"400 663 OFFCURVE",
+"400 448 CURVE SMOOTH",
+"400 10 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"299 0 LINE",
+"299 25 LINE",
+"19 25 LINE",
+"19 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"574 0 LINE",
+"574 25 LINE",
+"333 25 LINE",
+"333 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"226 10 LINE",
+"226 565 LINE SMOOTH",
+"226 666 OFFCURVE",
+"245 705 OFFCURVE",
+"292 705 CURVE SMOOTH",
+"314 705 OFFCURVE",
+"325 697 OFFCURVE",
+"325 680 CURVE SMOOTH",
+"325 660 OFFCURVE",
+"311 655 OFFCURVE",
+"311 631 CURVE SMOOTH",
+"311 603 OFFCURVE",
+"331 584 OFFCURVE",
+"361 584 CURVE SMOOTH",
+"394 584 OFFCURVE",
+"417 606 OFFCURVE",
+"417 643 CURVE SMOOTH",
+"417 695 OFFCURVE",
+"372 732 OFFCURVE",
+"297 732 CURVE SMOOTH",
+"174 732 OFFCURVE",
+"116 633 OFFCURVE",
+"116 425 CURVE SMOOTH",
+"116 10 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"871 0 LINE",
+"871 25 LINE",
+"612 25 LINE",
+"612 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"791 425 LINE",
+"791 450 LINE",
+"19 450 LINE",
+"19 425 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"791 15 LINE",
+"791 435 LINE",
+"681 435 LINE",
+"681 15 LINE"
+);
+}
+);
+width = 897;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"103 10 LINE",
+"241 10 LINE",
+"241 596 LINE SMOOTH",
+"241 679 OFFCURVE",
+"276 701 OFFCURVE",
+"317 701 CURVE SMOOTH",
+"340 701 OFFCURVE",
+"350 694 OFFCURVE",
+"350 682 CURVE SMOOTH",
+"350 664 OFFCURVE",
+"326 660 OFFCURVE",
+"326 626 CURVE SMOOTH",
+"326 588 OFFCURVE",
+"355 570 OFFCURVE",
+"387 570 CURVE SMOOTH",
+"427 570 OFFCURVE",
+"456 597 OFFCURVE",
+"456 637 CURVE SMOOTH",
+"456 689 OFFCURVE",
+"405 733 OFFCURVE",
+"323 733 CURVE SMOOTH",
+"188 733 OFFCURVE",
+"103 616 OFFCURVE",
+"103 446 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"23 0 LINE",
+"312 0 LINE",
+"312 30 LINE",
+"23 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"415 10 LINE",
+"553 10 LINE",
+"553 609 LINE SMOOTH",
+"553 709 OFFCURVE",
+"603 734 OFFCURVE",
+"660 734 CURVE SMOOTH",
+"700 734 OFFCURVE",
+"719 722 OFFCURVE",
+"719 703 CURVE SMOOTH",
+"719 683 OFFCURVE",
+"698 680 OFFCURVE",
+"698 647 CURVE SMOOTH",
+"698 608 OFFCURVE",
+"727 590 OFFCURVE",
+"759 590 CURVE SMOOTH",
+"799 590 OFFCURVE",
+"828 617 OFFCURVE",
+"828 657 CURVE SMOOTH",
+"828 717 OFFCURVE",
+"765 766 OFFCURVE",
+"665 766 CURVE SMOOTH",
+"512 766 OFFCURVE",
+"415 649 OFFCURVE",
+"415 479 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"341 0 LINE",
+"618 0 LINE",
+"618 30 LINE",
+"341 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 420 LINE",
+"845 420 LINE",
+"845 450 LINE",
+"20 450 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"707 15 LINE",
+"845 15 LINE",
+"845 434 LINE",
+"707 434 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"650 0 LINE",
+"910 0 LINE",
+"910 30 LINE",
+"650 30 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"553 10 LINE",
+"553 609 LINE SMOOTH",
+"553 709 OFFCURVE",
+"603 734 OFFCURVE",
+"660 734 CURVE SMOOTH",
+"700 734 OFFCURVE",
+"719 722 OFFCURVE",
+"719 703 CURVE SMOOTH",
+"719 683 OFFCURVE",
+"698 680 OFFCURVE",
+"698 647 CURVE SMOOTH",
+"698 608 OFFCURVE",
+"727 590 OFFCURVE",
+"759 590 CURVE SMOOTH",
+"799 590 OFFCURVE",
+"828 617 OFFCURVE",
+"828 657 CURVE SMOOTH",
+"828 717 OFFCURVE",
+"765 766 OFFCURVE",
+"665 766 CURVE SMOOTH",
+"512 766 OFFCURVE",
+"415 649 OFFCURVE",
+"415 479 CURVE SMOOTH",
+"415 10 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"312 0 LINE",
+"312 30 LINE",
+"23 30 LINE",
+"23 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"618 0 LINE",
+"618 30 LINE",
+"341 30 LINE",
+"341 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"241 10 LINE",
+"241 596 LINE SMOOTH",
+"241 679 OFFCURVE",
+"276 701 OFFCURVE",
+"317 701 CURVE SMOOTH",
+"340 701 OFFCURVE",
+"350 694 OFFCURVE",
+"350 682 CURVE SMOOTH",
+"350 664 OFFCURVE",
+"326 660 OFFCURVE",
+"326 626 CURVE SMOOTH",
+"326 588 OFFCURVE",
+"355 570 OFFCURVE",
+"387 570 CURVE SMOOTH",
+"427 570 OFFCURVE",
+"456 597 OFFCURVE",
+"456 637 CURVE SMOOTH",
+"456 689 OFFCURVE",
+"405 733 OFFCURVE",
+"323 733 CURVE SMOOTH",
+"188 733 OFFCURVE",
+"103 616 OFFCURVE",
+"103 446 CURVE SMOOTH",
+"103 10 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"910 0 LINE",
+"910 30 LINE",
+"650 30 LINE",
+"650 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"845 420 LINE",
+"845 450 LINE",
+"20 450 LINE",
+"20 420 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"845 15 LINE",
+"845 434 LINE",
+"707 434 LINE",
+"707 15 LINE"
+);
+}
+);
+width = 925;
+}
+);
+leftKerningGroup = f;
+rightKerningGroup = i;
+},
+{
+glyphname = f_f_l;
+lastChange = "2016-08-19 17:28:22 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"116 0 LINE",
+"226 0 LINE",
+"226 565 LINE SMOOTH",
+"226 665 OFFCURVE",
+"245 705 OFFCURVE",
+"292 705 CURVE SMOOTH",
+"315 705 OFFCURVE",
+"325 697 OFFCURVE",
+"325 678 CURVE SMOOTH",
+"325 661 OFFCURVE",
+"311 655 OFFCURVE",
+"311 631 CURVE SMOOTH",
+"311 603 OFFCURVE",
+"331 584 OFFCURVE",
+"361 584 CURVE SMOOTH",
+"394 584 OFFCURVE",
+"417 607 OFFCURVE",
+"417 642 CURVE SMOOTH",
+"417 696 OFFCURVE",
+"371 732 OFFCURVE",
+"297 732 CURVE SMOOTH",
+"174 732 OFFCURVE",
+"116 633 OFFCURVE",
+"116 425 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"400 0 LINE",
+"510 0 LINE",
+"510 588 LINE SMOOTH",
+"510 695 OFFCURVE",
+"538 738 OFFCURVE",
+"606 738 CURVE SMOOTH",
+"641 738 OFFCURVE",
+"659 727 OFFCURVE",
+"659 703 CURVE SMOOTH",
+"659 682 OFFCURVE",
+"645 679 OFFCURVE",
+"645 655 CURVE SMOOTH",
+"645 626 OFFCURVE",
+"665 607 OFFCURVE",
+"695 607 CURVE SMOOTH",
+"728 607 OFFCURVE",
+"751 629 OFFCURVE",
+"751 667 CURVE SMOOTH",
+"751 724 OFFCURVE",
+"697 765 OFFCURVE",
+"612 765 CURVE SMOOTH",
+"477 765 OFFCURVE",
+"400 663 OFFCURVE",
+"400 448 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"681 15 LINE",
+"791 15 LINE",
+"791 766 LINE",
+"681 718 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"19 425 LINE",
+"633 425 LINE",
+"633 450 LINE",
+"19 450 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"19 0 LINE",
+"304 0 LINE",
+"304 25 LINE",
+"19 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"318 0 LINE",
+"581 0 LINE",
+"581 25 LINE",
+"318 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"600 0 LINE",
+"871 0 LINE",
+"871 25 LINE",
+"600 25 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"510 0 LINE",
+"510 588 LINE SMOOTH",
+"510 695 OFFCURVE",
+"538 738 OFFCURVE",
+"606 738 CURVE SMOOTH",
+"641 738 OFFCURVE",
+"659 727 OFFCURVE",
+"659 703 CURVE SMOOTH",
+"659 682 OFFCURVE",
+"645 679 OFFCURVE",
+"645 655 CURVE SMOOTH",
+"645 626 OFFCURVE",
+"665 607 OFFCURVE",
+"695 607 CURVE SMOOTH",
+"728 607 OFFCURVE",
+"751 629 OFFCURVE",
+"751 667 CURVE SMOOTH",
+"751 724 OFFCURVE",
+"697 765 OFFCURVE",
+"612 765 CURVE SMOOTH",
+"477 765 OFFCURVE",
+"400 663 OFFCURVE",
+"400 448 CURVE SMOOTH",
+"400 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"304 0 LINE",
+"304 25 LINE",
+"19 25 LINE",
+"19 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"581 0 LINE",
+"581 25 LINE",
+"318 25 LINE",
+"318 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"226 0 LINE",
+"226 565 LINE SMOOTH",
+"226 665 OFFCURVE",
+"245 705 OFFCURVE",
+"292 705 CURVE SMOOTH",
+"315 705 OFFCURVE",
+"325 697 OFFCURVE",
+"325 678 CURVE SMOOTH",
+"325 661 OFFCURVE",
+"311 655 OFFCURVE",
+"311 631 CURVE SMOOTH",
+"311 603 OFFCURVE",
+"331 584 OFFCURVE",
+"361 584 CURVE SMOOTH",
+"394 584 OFFCURVE",
+"417 607 OFFCURVE",
+"417 642 CURVE SMOOTH",
+"417 696 OFFCURVE",
+"371 732 OFFCURVE",
+"297 732 CURVE SMOOTH",
+"174 732 OFFCURVE",
+"116 633 OFFCURVE",
+"116 425 CURVE SMOOTH",
+"116 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"871 0 LINE",
+"871 25 LINE",
+"600 25 LINE",
+"600 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"633 425 LINE",
+"633 450 LINE",
+"19 450 LINE",
+"19 425 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"791 15 LINE",
+"791 766 LINE",
+"681 718 LINE",
+"681 15 LINE"
+);
+}
+);
+width = 885;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"103 0 LINE",
+"241 0 LINE",
+"241 596 LINE SMOOTH",
+"241 679 OFFCURVE",
+"276 701 OFFCURVE",
+"317 701 CURVE SMOOTH",
+"340 701 OFFCURVE",
+"350 694 OFFCURVE",
+"350 682 CURVE SMOOTH",
+"350 664 OFFCURVE",
+"326 660 OFFCURVE",
+"326 626 CURVE SMOOTH",
+"326 588 OFFCURVE",
+"355 570 OFFCURVE",
+"387 570 CURVE SMOOTH",
+"427 570 OFFCURVE",
+"456 597 OFFCURVE",
+"456 637 CURVE SMOOTH",
+"456 689 OFFCURVE",
+"405 733 OFFCURVE",
+"323 733 CURVE SMOOTH",
+"188 733 OFFCURVE",
+"103 616 OFFCURVE",
+"103 446 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"23 0 LINE",
+"312 0 LINE",
+"312 30 LINE",
+"23 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"413 0 LINE",
+"551 0 LINE",
+"551 628 LINE SMOOTH",
+"551 711 OFFCURVE",
+"591 733 OFFCURVE",
+"637 733 CURVE SMOOTH",
+"667 733 OFFCURVE",
+"680 726 OFFCURVE",
+"680 714 CURVE SMOOTH",
+"680 696 OFFCURVE",
+"656 692 OFFCURVE",
+"656 658 CURVE SMOOTH",
+"656 620 OFFCURVE",
+"685 602 OFFCURVE",
+"717 602 CURVE SMOOTH",
+"757 602 OFFCURVE",
+"786 629 OFFCURVE",
+"786 669 CURVE SMOOTH",
+"786 721 OFFCURVE",
+"731 765 OFFCURVE",
+"643 765 CURVE SMOOTH",
+"502 765 OFFCURVE",
+"413 648 OFFCURVE",
+"413 478 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"333 0 LINE",
+"624 0 LINE",
+"624 30 LINE",
+"333 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 420 LINE",
+"791 420 LINE",
+"791 450 LINE",
+"20 450 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"716 15 LINE",
+"854 15 LINE",
+"854 754 LINE",
+"716 730 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"645 0 LINE",
+"929 0 LINE",
+"929 30 LINE",
+"645 30 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"551 0 LINE",
+"551 628 LINE SMOOTH",
+"551 711 OFFCURVE",
+"591 733 OFFCURVE",
+"637 733 CURVE SMOOTH",
+"667 733 OFFCURVE",
+"680 726 OFFCURVE",
+"680 714 CURVE SMOOTH",
+"680 696 OFFCURVE",
+"656 692 OFFCURVE",
+"656 658 CURVE SMOOTH",
+"656 620 OFFCURVE",
+"685 602 OFFCURVE",
+"717 602 CURVE SMOOTH",
+"757 602 OFFCURVE",
+"786 629 OFFCURVE",
+"786 669 CURVE SMOOTH",
+"786 721 OFFCURVE",
+"731 765 OFFCURVE",
+"643 765 CURVE SMOOTH",
+"502 765 OFFCURVE",
+"413 648 OFFCURVE",
+"413 478 CURVE SMOOTH",
+"413 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"312 0 LINE",
+"312 30 LINE",
+"23 30 LINE",
+"23 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"624 0 LINE",
+"624 30 LINE",
+"333 30 LINE",
+"333 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"241 0 LINE",
+"241 596 LINE SMOOTH",
+"241 679 OFFCURVE",
+"276 701 OFFCURVE",
+"317 701 CURVE SMOOTH",
+"340 701 OFFCURVE",
+"350 694 OFFCURVE",
+"350 682 CURVE SMOOTH",
+"350 664 OFFCURVE",
+"326 660 OFFCURVE",
+"326 626 CURVE SMOOTH",
+"326 588 OFFCURVE",
+"355 570 OFFCURVE",
+"387 570 CURVE SMOOTH",
+"427 570 OFFCURVE",
+"456 597 OFFCURVE",
+"456 637 CURVE SMOOTH",
+"456 689 OFFCURVE",
+"405 733 OFFCURVE",
+"323 733 CURVE SMOOTH",
+"188 733 OFFCURVE",
+"103 616 OFFCURVE",
+"103 446 CURVE SMOOTH",
+"103 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"929 0 LINE",
+"929 30 LINE",
+"645 30 LINE",
+"645 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"791 420 LINE",
+"791 450 LINE",
+"20 450 LINE",
+"20 420 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"854 15 LINE",
+"854 754 LINE",
+"716 730 LINE",
+"716 15 LINE"
+);
+}
+);
+width = 944;
+}
+);
+leftKerningGroup = f;
+rightKerningGroup = l;
+},
+{
+glyphname = f_i;
+lastChange = "2016-08-19 17:28:22 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"116 0 LINE",
+"226 0 LINE",
+"226 588 LINE SMOOTH",
+"226 696 OFFCURVE",
+"257 738 OFFCURVE",
+"334 738 CURVE SMOOTH",
+"374 738 OFFCURVE",
+"395 727 OFFCURVE",
+"395 703 CURVE SMOOTH",
+"395 683 OFFCURVE",
+"381 678 OFFCURVE",
+"381 654 CURVE SMOOTH",
+"381 626 OFFCURVE",
+"401 607 OFFCURVE",
+"431 607 CURVE SMOOTH",
+"464 607 OFFCURVE",
+"487 630 OFFCURVE",
+"487 666 CURVE SMOOTH",
+"487 724 OFFCURVE",
+"429 765 OFFCURVE",
+"338 765 CURVE SMOOTH",
+"195 765 OFFCURVE",
+"116 663 OFFCURVE",
+"116 448 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"19 0 LINE",
+"280 0 LINE",
+"280 25 LINE",
+"19 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"19 425 LINE",
+"507 425 LINE",
+"507 450 LINE",
+"19 450 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"397 15 LINE",
+"507 15 LINE",
+"507 435 LINE",
+"397 435 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"318 0 LINE",
+"587 0 LINE",
+"587 25 LINE",
+"318 25 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"226 0 LINE",
+"226 588 LINE SMOOTH",
+"226 696 OFFCURVE",
+"257 738 OFFCURVE",
+"334 738 CURVE SMOOTH",
+"374 738 OFFCURVE",
+"395 727 OFFCURVE",
+"395 703 CURVE SMOOTH",
+"395 683 OFFCURVE",
+"381 678 OFFCURVE",
+"381 654 CURVE SMOOTH",
+"381 626 OFFCURVE",
+"401 607 OFFCURVE",
+"431 607 CURVE SMOOTH",
+"464 607 OFFCURVE",
+"487 630 OFFCURVE",
+"487 666 CURVE SMOOTH",
+"487 724 OFFCURVE",
+"429 765 OFFCURVE",
+"338 765 CURVE SMOOTH",
+"195 765 OFFCURVE",
+"116 663 OFFCURVE",
+"116 448 CURVE SMOOTH",
+"116 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"280 0 LINE",
+"280 25 LINE",
+"19 25 LINE",
+"19 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"587 0 LINE",
+"587 25 LINE",
+"318 25 LINE",
+"318 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"507 15 LINE",
+"507 435 LINE",
+"397 435 LINE",
+"397 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"507 425 LINE",
+"507 450 LINE",
+"19 450 LINE",
+"19 425 LINE"
+);
+}
+);
+width = 613;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"241 0 LINE",
+"241 609 LINE SMOOTH",
+"241 709 OFFCURVE",
+"291 734 OFFCURVE",
+"348 734 CURVE SMOOTH",
+"388 734 OFFCURVE",
+"407 722 OFFCURVE",
+"407 703 CURVE SMOOTH",
+"407 683 OFFCURVE",
+"386 680 OFFCURVE",
+"386 647 CURVE SMOOTH",
+"386 608 OFFCURVE",
+"415 590 OFFCURVE",
+"447 590 CURVE SMOOTH",
+"487 590 OFFCURVE",
+"516 617 OFFCURVE",
+"516 657 CURVE SMOOTH",
+"516 717 OFFCURVE",
+"453 766 OFFCURVE",
+"353 766 CURVE SMOOTH",
+"200 766 OFFCURVE",
+"103 649 OFFCURVE",
+"103 479 CURVE SMOOTH",
+"103 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"23 0 LINE",
+"302 0 LINE",
+"302 30 LINE",
+"23 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 420 LINE",
+"533 420 LINE",
+"533 450 LINE",
+"20 450 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"395 15 LINE",
+"533 15 LINE",
+"533 434 LINE",
+"395 434 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"334 0 LINE",
+"598 0 LINE",
+"598 30 LINE",
+"334 30 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"241 10 LINE",
+"241 609 LINE SMOOTH",
+"241 709 OFFCURVE",
+"291 734 OFFCURVE",
+"348 734 CURVE SMOOTH",
+"388 734 OFFCURVE",
+"407 722 OFFCURVE",
+"407 703 CURVE SMOOTH",
+"407 683 OFFCURVE",
+"386 680 OFFCURVE",
+"386 647 CURVE SMOOTH",
+"386 608 OFFCURVE",
+"415 590 OFFCURVE",
+"447 590 CURVE SMOOTH",
+"487 590 OFFCURVE",
+"516 617 OFFCURVE",
+"516 657 CURVE SMOOTH",
+"516 717 OFFCURVE",
+"453 766 OFFCURVE",
+"353 766 CURVE SMOOTH",
+"200 766 OFFCURVE",
+"103 649 OFFCURVE",
+"103 479 CURVE SMOOTH",
+"103 10 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"302 0 LINE",
+"302 30 LINE",
+"23 30 LINE",
+"23 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"598 0 LINE",
+"598 30 LINE",
+"334 30 LINE",
+"334 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"533 15 LINE",
+"533 434 LINE",
+"395 434 LINE",
+"395 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"533 420 LINE",
+"533 450 LINE",
+"20 450 LINE",
+"20 420 LINE"
+);
+}
+);
+width = 613;
+}
+);
+leftKerningGroup = f;
+rightKerningGroup = i;
+},
+{
+glyphname = f_l;
+lastChange = "2016-08-19 17:28:22 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"116 0 LINE",
+"226 0 LINE",
+"226 588 LINE SMOOTH",
+"226 695 OFFCURVE",
+"254 738 OFFCURVE",
+"322 738 CURVE SMOOTH",
+"357 738 OFFCURVE",
+"375 727 OFFCURVE",
+"375 703 CURVE SMOOTH",
+"375 682 OFFCURVE",
+"361 679 OFFCURVE",
+"361 655 CURVE SMOOTH",
+"361 626 OFFCURVE",
+"381 607 OFFCURVE",
+"411 607 CURVE SMOOTH",
+"444 607 OFFCURVE",
+"467 629 OFFCURVE",
+"467 667 CURVE SMOOTH",
+"467 724 OFFCURVE",
+"413 765 OFFCURVE",
+"328 765 CURVE SMOOTH",
+"193 765 OFFCURVE",
+"116 663 OFFCURVE",
+"116 448 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"19 0 LINE",
+"280 0 LINE",
+"280 25 LINE",
+"19 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"19 425 LINE",
+"349 425 LINE",
+"349 450 LINE",
+"19 450 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"397 15 LINE",
+"507 15 LINE",
+"507 766 LINE",
+"397 718 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"318 0 LINE",
+"587 0 LINE",
+"587 25 LINE",
+"318 25 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"226 0 LINE",
+"226 588 LINE SMOOTH",
+"226 695 OFFCURVE",
+"254 738 OFFCURVE",
+"322 738 CURVE SMOOTH",
+"357 738 OFFCURVE",
+"375 727 OFFCURVE",
+"375 703 CURVE SMOOTH",
+"375 682 OFFCURVE",
+"361 679 OFFCURVE",
+"361 655 CURVE SMOOTH",
+"361 626 OFFCURVE",
+"381 607 OFFCURVE",
+"411 607 CURVE SMOOTH",
+"444 607 OFFCURVE",
+"467 629 OFFCURVE",
+"467 667 CURVE SMOOTH",
+"467 724 OFFCURVE",
+"413 765 OFFCURVE",
+"328 765 CURVE SMOOTH",
+"193 765 OFFCURVE",
+"116 663 OFFCURVE",
+"116 448 CURVE SMOOTH",
+"116 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"280 0 LINE",
+"280 25 LINE",
+"19 25 LINE",
+"19 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"587 0 LINE",
+"587 25 LINE",
+"318 25 LINE",
+"318 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"349 425 LINE",
+"349 450 LINE",
+"19 450 LINE",
+"19 425 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"507 15 LINE",
+"507 766 LINE",
+"397 718 LINE",
+"397 15 LINE"
+);
+}
+);
+width = 601;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"241 0 LINE",
+"241 576 LINE SMOOTH",
+"241 700 OFFCURVE",
+"286 731 OFFCURVE",
+"340 731 CURVE SMOOTH",
+"371 731 OFFCURVE",
+"385 724 OFFCURVE",
+"385 711 CURVE SMOOTH",
+"385 695 OFFCURVE",
+"361 689 OFFCURVE",
+"361 656 CURVE SMOOTH",
+"361 618 OFFCURVE",
+"392 600 OFFCURVE",
+"426 600 CURVE SMOOTH",
+"467 600 OFFCURVE",
+"496 627 OFFCURVE",
+"496 665 CURVE SMOOTH",
+"496 719 OFFCURVE",
+"437 763 OFFCURVE",
+"345 763 CURVE SMOOTH",
+"195 763 OFFCURVE",
+"103 646 OFFCURVE",
+"103 476 CURVE SMOOTH",
+"103 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"29 0 LINE",
+"312 0 LINE",
+"312 30 LINE",
+"29 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 410 LINE",
+"429 410 LINE",
+"429 440 LINE",
+"20 440 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"406 15 LINE",
+"544 15 LINE",
+"544 754 LINE",
+"406 730 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"335 0 LINE",
+"619 0 LINE",
+"619 30 LINE",
+"335 30 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"241 0 LINE",
+"241 628 LINE SMOOTH",
+"241 711 OFFCURVE",
+"281 733 OFFCURVE",
+"327 733 CURVE SMOOTH",
+"357 733 OFFCURVE",
+"370 726 OFFCURVE",
+"370 714 CURVE SMOOTH",
+"370 696 OFFCURVE",
+"346 692 OFFCURVE",
+"346 658 CURVE SMOOTH",
+"346 620 OFFCURVE",
+"375 602 OFFCURVE",
+"407 602 CURVE SMOOTH",
+"447 602 OFFCURVE",
+"476 629 OFFCURVE",
+"476 669 CURVE SMOOTH",
+"476 721 OFFCURVE",
+"421 765 OFFCURVE",
+"333 765 CURVE SMOOTH",
+"192 765 OFFCURVE",
+"103 648 OFFCURVE",
+"103 478 CURVE SMOOTH",
+"103 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"314 0 LINE",
+"314 30 LINE",
+"23 30 LINE",
+"23 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"619 0 LINE",
+"619 30 LINE",
+"335 30 LINE",
+"335 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"481 420 LINE",
+"481 450 LINE",
+"20 450 LINE",
+"20 420 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"544 15 LINE",
+"544 754 LINE",
+"406 730 LINE",
+"406 15 LINE"
+);
+}
+);
+width = 634;
+}
+);
+leftKerningGroup = f;
+rightKerningGroup = l;
+},
+{
+glyphname = ordfeminine;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"133 458 OFFCURVE",
+"174 478 OFFCURVE",
+"191 507 CURVE",
+"195 507 LINE",
+"201 478 OFFCURVE",
+"220 458 OFFCURVE",
+"251 458 CURVE SMOOTH",
+"278 458 OFFCURVE",
+"300 469 OFFCURVE",
+"321 492 CURVE",
+"308 509 LINE",
+"300 499 OFFCURVE",
+"295 497 OFFCURVE",
+"289 497 CURVE SMOOTH",
+"282 497 OFFCURVE",
+"274 501 OFFCURVE",
+"274 510 CURVE SMOOTH",
+"274 691 LINE SMOOTH",
+"274 735 OFFCURVE",
+"228 764 OFFCURVE",
+"157 764 CURVE SMOOTH",
+"81 764 OFFCURVE",
+"36 725 OFFCURVE",
+"36 685 CURVE SMOOTH",
+"36 667 OFFCURVE",
+"49 651 OFFCURVE",
+"71 651 CURVE SMOOTH",
+"90 651 OFFCURVE",
+"107 663 OFFCURVE",
+"107 683 CURVE SMOOTH",
+"107 697 OFFCURVE",
+"98 702 OFFCURVE",
+"98 711 CURVE SMOOTH",
+"98 723 OFFCURVE",
+"113 735 OFFCURVE",
+"143 735 CURVE SMOOTH",
+"174 735 OFFCURVE",
+"191 727 OFFCURVE",
+"191 712 CURVE SMOOTH",
+"191 634 LINE",
+"74 634 OFFCURVE",
+"15 590 OFFCURVE",
+"15 532 CURVE SMOOTH",
+"15 486 OFFCURVE",
+"50 458 OFFCURVE",
+"95 458 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"116 505 OFFCURVE",
+"101 521 OFFCURVE",
+"101 550 CURVE SMOOTH",
+"101 584 OFFCURVE",
+"126 607 OFFCURVE",
+"191 607 CURVE",
+"191 563 LINE SMOOTH",
+"191 524 OFFCURVE",
+"166 505 OFFCURVE",
+"140 505 CURVE SMOOTH"
+);
+}
+);
+width = 336;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"131 458 OFFCURVE",
+"170 478 OFFCURVE",
+"186 507 CURVE",
+"190 507 LINE",
+"197 478 OFFCURVE",
+"217 458 OFFCURVE",
+"251 458 CURVE SMOOTH",
+"280 458 OFFCURVE",
+"303 469 OFFCURVE",
+"326 492 CURVE",
+"313 514 LINE",
+"305 504 OFFCURVE",
+"300 502 OFFCURVE",
+"294 502 CURVE SMOOTH",
+"287 502 OFFCURVE",
+"279 505 OFFCURVE",
+"279 515 CURVE SMOOTH",
+"279 691 LINE SMOOTH",
+"279 735 OFFCURVE",
+"231 764 OFFCURVE",
+"157 764 CURVE SMOOTH",
+"78 764 OFFCURVE",
+"31 725 OFFCURVE",
+"31 685 CURVE SMOOTH",
+"31 664 OFFCURVE",
+"46 646 OFFCURVE",
+"71 646 CURVE SMOOTH",
+"93 646 OFFCURVE",
+"112 660 OFFCURVE",
+"112 683 CURVE SMOOTH",
+"112 697 OFFCURVE",
+"103 702 OFFCURVE",
+"103 711 CURVE SMOOTH",
+"103 723 OFFCURVE",
+"116 735 OFFCURVE",
+"143 735 CURVE SMOOTH",
+"171 735 OFFCURVE",
+"186 727 OFFCURVE",
+"186 712 CURVE SMOOTH",
+"186 634 LINE",
+"69 634 OFFCURVE",
+"10 590 OFFCURVE",
+"10 532 CURVE SMOOTH",
+"10 486 OFFCURVE",
+"47 458 OFFCURVE",
+"95 458 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"121 505 OFFCURVE",
+"106 521 OFFCURVE",
+"106 550 CURVE SMOOTH",
+"106 584 OFFCURVE",
+"129 607 OFFCURVE",
+"186 607 CURVE",
+"186 563 LINE SMOOTH",
+"186 524 OFFCURVE",
+"165 505 OFFCURVE",
+"145 505 CURVE SMOOTH"
+);
+}
+);
+width = 336;
+}
+);
+unicode = 00AA;
+},
+{
+glyphname = ordmasculine;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"254 457 OFFCURVE",
+"323 533 OFFCURVE",
+"323 611 CURVE SMOOTH",
+"323 688 OFFCURVE",
+"254 764 OFFCURVE",
+"168 764 CURVE SMOOTH",
+"83 764 OFFCURVE",
+"15 688 OFFCURVE",
+"15 611 CURVE SMOOTH",
+"15 533 OFFCURVE",
+"83 457 OFFCURVE",
+"168 457 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"125 487 OFFCURVE",
+"110 509 OFFCURVE",
+"110 611 CURVE SMOOTH",
+"110 712 OFFCURVE",
+"125 735 OFFCURVE",
+"168 735 CURVE SMOOTH",
+"212 735 OFFCURVE",
+"227 712 OFFCURVE",
+"227 611 CURVE SMOOTH",
+"227 509 OFFCURVE",
+"212 487 OFFCURVE",
+"168 487 CURVE SMOOTH"
+);
+}
+);
+width = 338;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"257 457 OFFCURVE",
+"328 533 OFFCURVE",
+"328 611 CURVE SMOOTH",
+"328 688 OFFCURVE",
+"257 764 OFFCURVE",
+"168 764 CURVE SMOOTH",
+"80 764 OFFCURVE",
+"10 688 OFFCURVE",
+"10 611 CURVE SMOOTH",
+"10 533 OFFCURVE",
+"80 457 OFFCURVE",
+"168 457 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"129 487 OFFCURVE",
+"115 509 OFFCURVE",
+"115 611 CURVE SMOOTH",
+"115 712 OFFCURVE",
+"129 735 OFFCURVE",
+"168 735 CURVE SMOOTH",
+"208 735 OFFCURVE",
+"222 712 OFFCURVE",
+"222 611 CURVE SMOOTH",
+"222 509 OFFCURVE",
+"208 487 OFFCURVE",
+"168 487 CURVE SMOOTH"
+);
+}
+);
+width = 338;
+}
+);
+unicode = 00BA;
+},
+{
+glyphname = Delta;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"645 0 LINE",
+"645 37 LINE",
+"363 729 LINE",
+"306 715 LINE",
+"35 37 LINE",
+"35 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"283 570 LINE",
+"482 37 LINE",
+"71 37 LINE"
+);
+}
+);
+width = 680;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"689 0 LINE",
+"689 43 LINE",
+"392 733 LINE",
+"322 716 LINE",
+"37 43 LINE",
+"37 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"304 527 LINE",
+"495 73 LINE",
+"119 73 LINE"
+);
+}
+);
+width = 727;
+}
+);
+unicode = 0394;
+},
+{
+glyphname = Omega;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"332 0 LINE",
+"342 23 LINE",
+"254 156 OFFCURVE",
+"219 257 OFFCURVE",
+"219 412 CURVE SMOOTH",
+"219 636 OFFCURVE",
+"292 702 OFFCURVE",
+"377 702 CURVE SMOOTH",
+"468 702 OFFCURVE",
+"542 625 OFFCURVE",
+"542 408 CURVE SMOOTH",
+"542 267 OFFCURVE",
+"511 160 OFFCURVE",
+"418 23 CURVE",
+"427 0 LINE",
+"698 0 LINE",
+"727 174 LINE",
+"704 174 LINE",
+"683 109 OFFCURVE",
+"669 95 OFFCURVE",
+"627 95 CURVE SMOOTH",
+"505 95 LINE",
+"604 187 OFFCURVE",
+"691 269 OFFCURVE",
+"691 421 CURVE SMOOTH",
+"691 607 OFFCURVE",
+"562 733 OFFCURVE",
+"384 733 CURVE SMOOTH",
+"205 733 OFFCURVE",
+"69 606 OFFCURVE",
+"69 412 CURVE SMOOTH",
+"69 249 OFFCURVE",
+"165 165 OFFCURVE",
+"248 96 CURVE",
+"141 96 LINE SMOOTH",
+"97 96 OFFCURVE",
+"81 112 OFFCURVE",
+"59 174 CURVE",
+"35 174 LINE",
+"60 0 LINE"
+);
+}
+);
+width = 762;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"353 0 LINE",
+"363 26 LINE",
+"314 132 OFFCURVE",
+"251 268 OFFCURVE",
+"251 399 CURVE SMOOTH",
+"251 626 OFFCURVE",
+"311 694 OFFCURVE",
+"403 694 CURVE SMOOTH",
+"494 694 OFFCURVE",
+"560 615 OFFCURVE",
+"560 402 CURVE SMOOTH",
+"560 267 OFFCURVE",
+"488 123 OFFCURVE",
+"446 26 CURVE",
+"456 0 LINE",
+"744 0 LINE",
+"776 189 LINE",
+"735 189 LINE",
+"712 127 OFFCURVE",
+"697 116 OFFCURVE",
+"653 116 CURVE SMOOTH",
+"540 116 LINE",
+"632 188 OFFCURVE",
+"739 274 OFFCURVE",
+"739 414 CURVE SMOOTH",
+"739 612 OFFCURVE",
+"603 733 OFFCURVE",
+"407 733 CURVE SMOOTH",
+"214 733 OFFCURVE",
+"71 609 OFFCURVE",
+"71 408 CURVE SMOOTH",
+"71 253 OFFCURVE",
+"183 171 OFFCURVE",
+"262 116 CURVE",
+"164 116 LINE SMOOTH",
+"115 116 OFFCURVE",
+"99 128 OFFCURVE",
+"75 189 CURVE",
+"36 189 LINE",
+"63 0 LINE"
+);
+}
+);
+width = 812;
+}
+);
+unicode = 03A9;
+},
+{
+glyphname = mu;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"541 25 LINE",
+"352 25 LINE",
+"352 0 LINE",
+"541 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"462 426 LINE",
+"352 426 LINE",
+"352 16 LINE",
+"462 16 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"462 441 LINE",
+"270 441 LINE",
+"270 416 LINE",
+"462 416 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"179 441 LINE",
+"-9 441 LINE",
+"-9 416 LINE",
+"179 416 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"69 99 LINE SMOOTH",
+"69 38 OFFCURVE",
+"123 -10 OFFCURVE",
+"200 -10 CURVE SMOOTH",
+"274 -10 OFFCURVE",
+"319 28 OFFCURVE",
+"348 80 CURVE",
+"372 80 LINE",
+"352 230 LINE",
+"352 116 OFFCURVE",
+"296 27 OFFCURVE",
+"235 27 CURVE SMOOTH",
+"200 27 OFFCURVE",
+"179 52 OFFCURVE",
+"179 102 CURVE SMOOTH",
+"179 426 LINE",
+"69 426 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"69 101 LINE",
+"64 -72 OFFCURVE",
+"35 -124 OFFCURVE",
+"35 -190 CURVE SMOOTH",
+"35 -230 OFFCURVE",
+"51 -254 OFFCURVE",
+"86 -254 CURVE SMOOTH",
+"122 -254 OFFCURVE",
+"139 -227 OFFCURVE",
+"139 -188 CURVE SMOOTH",
+"139 -140 OFFCURVE",
+"103 -103 OFFCURVE",
+"95 28 CURVE",
+"99 28 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"290 -12 OFFCURVE",
+"335 26 OFFCURVE",
+"364 78 CURVE",
+"388 78 LINE",
+"368 228 LINE",
+"368 114 OFFCURVE",
+"312 25 OFFCURVE",
+"251 25 CURVE SMOOTH",
+"216 25 OFFCURVE",
+"195 50 OFFCURVE",
+"195 100 CURVE SMOOTH",
+"195 435 LINE",
+"85 435 LINE",
+"85 97 LINE SMOOTH",
+"85 36 OFFCURVE",
+"139 -12 OFFCURVE",
+"216 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"136 -254 OFFCURVE",
+"153 -227 OFFCURVE",
+"153 -188 CURVE SMOOTH",
+"153 -140 OFFCURVE",
+"117 -103 OFFCURVE",
+"109 28 CURVE",
+"113 28 LINE",
+"85 101 LINE",
+"80 -72 OFFCURVE",
+"49 -124 OFFCURVE",
+"49 -190 CURVE SMOOTH",
+"49 -230 OFFCURVE",
+"65 -254 OFFCURVE",
+"100 -254 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"557 0 LINE",
+"557 25 LINE",
+"368 25 LINE",
+"368 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"195 425 LINE",
+"195 450 LINE",
+"7 450 LINE",
+"7 425 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"478 16 LINE",
+"478 435 LINE",
+"368 435 LINE",
+"368 16 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"478 425 LINE",
+"478 450 LINE",
+"286 450 LINE",
+"286 425 LINE"
+);
+}
+);
+width = 570;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"603 30 LINE",
+"386 30 LINE",
+"386 0 LINE",
+"603 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"524 425 LINE",
+"386 425 LINE",
+"386 15 LINE",
+"524 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"524 440 LINE",
+"304 440 LINE",
+"304 410 LINE",
+"524 410 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"226 440 LINE",
+"10 440 LINE",
+"10 410 LINE",
+"226 410 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"88 98 LINE SMOOTH",
+"88 37 OFFCURVE",
+"140 -13 OFFCURVE",
+"222 -13 CURVE SMOOTH",
+"292 -13 OFFCURVE",
+"358 24 OFFCURVE",
+"382 79 CURVE",
+"406 79 LINE",
+"386 229 LINE",
+"386 120 OFFCURVE",
+"340 36 OFFCURVE",
+"273 36 CURVE SMOOTH",
+"241 36 OFFCURVE",
+"226 56 OFFCURVE",
+"226 111 CURVE SMOOTH",
+"226 425 LINE",
+"88 425 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"88 101 LINE",
+"83 -78 OFFCURVE",
+"54 -140 OFFCURVE",
+"54 -198 CURVE SMOOTH",
+"54 -251 OFFCURVE",
+"78 -277 OFFCURVE",
+"114 -277 CURVE SMOOTH",
+"153 -277 OFFCURVE",
+"178 -246 OFFCURVE",
+"178 -203 CURVE SMOOTH",
+"178 -152 OFFCURVE",
+"152 -119 OFFCURVE",
+"134 10 CURVE",
+"138 10 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"292 -13 OFFCURVE",
+"358 24 OFFCURVE",
+"382 79 CURVE",
+"406 79 LINE",
+"386 229 LINE",
+"386 120 OFFCURVE",
+"340 36 OFFCURVE",
+"273 36 CURVE SMOOTH",
+"241 36 OFFCURVE",
+"226 56 OFFCURVE",
+"226 111 CURVE SMOOTH",
+"226 435 LINE",
+"88 435 LINE",
+"88 98 LINE SMOOTH",
+"88 37 OFFCURVE",
+"140 -13 OFFCURVE",
+"222 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"153 -277 OFFCURVE",
+"178 -246 OFFCURVE",
+"178 -203 CURVE SMOOTH",
+"178 -152 OFFCURVE",
+"152 -119 OFFCURVE",
+"134 10 CURVE",
+"138 10 LINE",
+"88 101 LINE",
+"83 -78 OFFCURVE",
+"54 -140 OFFCURVE",
+"54 -198 CURVE SMOOTH",
+"54 -251 OFFCURVE",
+"78 -277 OFFCURVE",
+"114 -277 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"603 0 LINE",
+"603 30 LINE",
+"386 30 LINE",
+"386 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"226 420 LINE",
+"226 450 LINE",
+"10 450 LINE",
+"10 420 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"524 15 LINE",
+"524 435 LINE",
+"386 435 LINE",
+"386 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"524 420 LINE",
+"524 450 LINE",
+"304 450 LINE",
+"304 420 LINE"
+);
+}
+);
+width = 613;
+}
+);
+unicode = 03BC;
+},
+{
+glyphname = pi;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"98 -12 OFFCURVE",
+"126 -5 OFFCURVE",
+"151 6 CURVE",
+"168 29 OFFCURVE",
+"220 117 OFFCURVE",
+"220 365 CURVE SMOOTH",
+"220 377 LINE",
+"353 377 LINE",
+"350 331 OFFCURVE",
+"343 218 OFFCURVE",
+"343 155 CURVE SMOOTH",
+"343 40 OFFCURVE",
+"366 -13 OFFCURVE",
+"447 -13 CURVE SMOOTH",
+"507 -13 OFFCURVE",
+"544 16 OFFCURVE",
+"572 62 CURVE",
+"563 80 LINE",
+"546 64 OFFCURVE",
+"530 57 OFFCURVE",
+"515 57 CURVE SMOOTH",
+"483 57 OFFCURVE",
+"471 89 OFFCURVE",
+"471 214 CURVE SMOOTH",
+"471 270 OFFCURVE",
+"471 324 OFFCURVE",
+"476 377 CURVE",
+"531 377 LINE",
+"582 490 LINE",
+"567 496 LINE",
+"550 472 OFFCURVE",
+"534 465 OFFCURVE",
+"489 465 CURVE SMOOTH",
+"395 465 OFFCURVE",
+"302 465 OFFCURVE",
+"208 465 CURVE SMOOTH",
+"124 465 OFFCURVE",
+"79 438 OFFCURVE",
+"19 362 CURVE",
+"36 340 LINE",
+"80 369 OFFCURVE",
+"105 377 OFFCURVE",
+"168 377 CURVE",
+"168 272 OFFCURVE",
+"145 116 OFFCURVE",
+"70 9 CURVE",
+"78 -13 LINE"
+);
+}
+);
+width = 602;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"109 -12 OFFCURVE",
+"137 -6 OFFCURVE",
+"167 6 CURVE",
+"185 28 OFFCURVE",
+"238 111 OFFCURVE",
+"238 353 CURVE SMOOTH",
+"238 363 LINE",
+"365 363 LINE",
+"359 295 OFFCURVE",
+"355 206 OFFCURVE",
+"355 163 CURVE SMOOTH",
+"355 17 OFFCURVE",
+"401 -14 OFFCURVE",
+"465 -14 CURVE SMOOTH",
+"535 -14 OFFCURVE",
+"584 24 OFFCURVE",
+"612 64 CURVE",
+"598 96 LINE",
+"581 83 OFFCURVE",
+"569 77 OFFCURVE",
+"554 77 CURVE SMOOTH",
+"528 77 OFFCURVE",
+"509 96 OFFCURVE",
+"509 166 CURVE SMOOTH",
+"509 239 OFFCURVE",
+"509 295 OFFCURVE",
+"515 363 CURVE",
+"583 363 LINE",
+"626 500 LINE",
+"592 509 LINE",
+"572 476 OFFCURVE",
+"559 474 OFFCURVE",
+"511 474 CURVE SMOOTH",
+"452 474 OFFCURVE",
+"285 477 OFFCURVE",
+"242 477 CURVE SMOOTH",
+"126 477 OFFCURVE",
+"94 455 OFFCURVE",
+"22 361 CURVE",
+"41 325 LINE",
+"90 354 OFFCURVE",
+"118 363 OFFCURVE",
+"180 363 CURVE",
+"180 266 OFFCURVE",
+"153 118 OFFCURVE",
+"77 12 CURVE",
+"86 -14 LINE"
+);
+}
+);
+width = 652;
+}
+);
+unicode = 03C0;
+},
+{
+glyphname = zero;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"47 152 OFFCURVE",
+"169 -12 OFFCURVE",
+"331 -12 CURVE SMOOTH",
+"494 -12 OFFCURVE",
+"616 152 OFFCURVE",
+"616 360 CURVE SMOOTH",
+"616 567 OFFCURVE",
+"494 732 OFFCURVE",
+"331 732 CURVE SMOOTH",
+"169 732 OFFCURVE",
+"47 567 OFFCURVE",
+"47 360 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"197 638 OFFCURVE",
+"228 702 OFFCURVE",
+"331 702 CURVE SMOOTH",
+"433 702 OFFCURVE",
+"466 638 OFFCURVE",
+"466 360 CURVE SMOOTH",
+"466 81 OFFCURVE",
+"433 18 OFFCURVE",
+"331 18 CURVE SMOOTH",
+"228 18 OFFCURVE",
+"197 81 OFFCURVE",
+"197 360 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"494 -12 OFFCURVE",
+"616 152 OFFCURVE",
+"616 360 CURVE SMOOTH",
+"616 567 OFFCURVE",
+"494 732 OFFCURVE",
+"331 732 CURVE SMOOTH",
+"169 732 OFFCURVE",
+"47 567 OFFCURVE",
+"47 360 CURVE SMOOTH",
+"47 152 OFFCURVE",
+"169 -12 OFFCURVE",
+"331 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"228 18 OFFCURVE",
+"197 81 OFFCURVE",
+"197 360 CURVE SMOOTH",
+"197 638 OFFCURVE",
+"228 702 OFFCURVE",
+"331 702 CURVE SMOOTH",
+"433 702 OFFCURVE",
+"466 638 OFFCURVE",
+"466 360 CURVE SMOOTH",
+"466 81 OFFCURVE",
+"433 18 OFFCURVE",
+"331 18 CURVE SMOOTH"
+);
+}
+);
+width = 663;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"44 142 OFFCURVE",
+"182 -13 OFFCURVE",
+"363 -13 CURVE SMOOTH",
+"544 -13 OFFCURVE",
+"683 142 OFFCURVE",
+"683 360 CURVE SMOOTH",
+"683 577 OFFCURVE",
+"544 733 OFFCURVE",
+"363 733 CURVE SMOOTH",
+"182 733 OFFCURVE",
+"44 577 OFFCURVE",
+"44 360 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"224 634 OFFCURVE",
+"256 698 OFFCURVE",
+"363 698 CURVE SMOOTH",
+"465 698 OFFCURVE",
+"503 634 OFFCURVE",
+"503 360 CURVE SMOOTH",
+"503 85 OFFCURVE",
+"465 22 OFFCURVE",
+"363 22 CURVE SMOOTH",
+"256 22 OFFCURVE",
+"224 85 OFFCURVE",
+"224 360 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"544 -12 OFFCURVE",
+"683 142 OFFCURVE",
+"683 360 CURVE SMOOTH",
+"683 577 OFFCURVE",
+"544 733 OFFCURVE",
+"363 733 CURVE SMOOTH",
+"182 733 OFFCURVE",
+"44 577 OFFCURVE",
+"44 360 CURVE SMOOTH",
+"44 142 OFFCURVE",
+"182 -12 OFFCURVE",
+"363 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"256 23 OFFCURVE",
+"224 85 OFFCURVE",
+"224 360 CURVE SMOOTH",
+"224 634 OFFCURVE",
+"256 698 OFFCURVE",
+"363 698 CURVE SMOOTH",
+"465 698 OFFCURVE",
+"503 634 OFFCURVE",
+"503 360 CURVE SMOOTH",
+"503 85 OFFCURVE",
+"465 23 OFFCURVE",
+"363 23 CURVE SMOOTH"
+);
+}
+);
+width = 727;
+}
+);
+unicode = 0030;
+},
+{
+glyphname = one;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"11 691 LINE",
+"161 691 LINE",
+"161 25 LINE",
+"11 25 LINE",
+"11 0 LINE",
+"420 0 LINE",
+"420 25 LINE",
+"280 25 LINE",
+"280 716 LINE",
+"11 716 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"420 0 LINE",
+"420 25 LINE",
+"280 25 LINE",
+"280 716 LINE",
+"11 716 LINE",
+"11 691 LINE",
+"161 691 LINE",
+"161 25 LINE",
+"11 25 LINE",
+"11 0 LINE"
+);
+}
+);
+width = 431;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"8 694 LINE",
+"166 694 LINE",
+"166 30 LINE",
+"8 30 LINE",
+"8 0 LINE",
+"472 0 LINE",
+"472 30 LINE",
+"324 30 LINE",
+"324 724 LINE",
+"8 724 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"472 0 LINE",
+"472 30 LINE",
+"324 30 LINE",
+"324 716 LINE",
+"8 716 LINE",
+"8 686 LINE",
+"166 686 LINE",
+"166 30 LINE",
+"8 30 LINE",
+"8 0 LINE"
+);
+}
+);
+width = 480;
+}
+);
+unicode = 0031;
+},
+{
+glyphname = two;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"490 200 LINE",
+"490 105 OFFCURVE",
+"476 96 OFFCURVE",
+"429 96 CURVE SMOOTH",
+"124 96 LINE",
+"124 100 LINE",
+"409 355 LINE SMOOTH",
+"498 435 OFFCURVE",
+"515 495 OFFCURVE",
+"515 543 CURVE SMOOTH",
+"515 673 OFFCURVE",
+"395 732 OFFCURVE",
+"283 732 CURVE SMOOTH",
+"166 732 OFFCURVE",
+"54 668 OFFCURVE",
+"54 555 CURVE SMOOTH",
+"54 499 OFFCURVE",
+"81 449 OFFCURVE",
+"142 449 CURVE SMOOTH",
+"179 449 OFFCURVE",
+"210 467 OFFCURVE",
+"210 512 CURVE SMOOTH",
+"210 551 OFFCURVE",
+"187 569 OFFCURVE",
+"154 569 CURVE SMOOTH",
+"128 569 OFFCURVE",
+"116 557 OFFCURVE",
+"103 557 CURVE SMOOTH",
+"95 557 OFFCURVE",
+"90 561 OFFCURVE",
+"90 576 CURVE SMOOTH",
+"90 631 OFFCURVE",
+"160 687 OFFCURVE",
+"242 687 CURVE SMOOTH",
+"332 687 OFFCURVE",
+"381 619 OFFCURVE",
+"381 509 CURVE SMOOTH",
+"381 425 OFFCURVE",
+"352 372 OFFCURVE",
+"250 277 CURVE SMOOTH",
+"35 77 LINE",
+"35 0 LINE",
+"515 0 LINE",
+"515 200 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"515 0 LINE",
+"515 200 LINE",
+"490 200 LINE",
+"490 105 OFFCURVE",
+"476 96 OFFCURVE",
+"429 96 CURVE SMOOTH",
+"124 96 LINE",
+"124 100 LINE",
+"409 355 LINE SMOOTH",
+"498 435 OFFCURVE",
+"515 495 OFFCURVE",
+"515 543 CURVE SMOOTH",
+"515 673 OFFCURVE",
+"395 732 OFFCURVE",
+"283 732 CURVE SMOOTH",
+"166 732 OFFCURVE",
+"54 668 OFFCURVE",
+"54 555 CURVE SMOOTH",
+"54 499 OFFCURVE",
+"81 449 OFFCURVE",
+"142 449 CURVE SMOOTH",
+"179 449 OFFCURVE",
+"210 467 OFFCURVE",
+"210 512 CURVE SMOOTH",
+"210 551 OFFCURVE",
+"187 569 OFFCURVE",
+"154 569 CURVE SMOOTH",
+"128 569 OFFCURVE",
+"116 557 OFFCURVE",
+"103 557 CURVE SMOOTH",
+"95 557 OFFCURVE",
+"90 561 OFFCURVE",
+"90 576 CURVE SMOOTH",
+"90 631 OFFCURVE",
+"160 687 OFFCURVE",
+"242 687 CURVE SMOOTH",
+"332 687 OFFCURVE",
+"381 619 OFFCURVE",
+"381 509 CURVE SMOOTH",
+"381 425 OFFCURVE",
+"352 372 OFFCURVE",
+"250 277 CURVE SMOOTH",
+"35 77 LINE",
+"35 0 LINE"
+);
+}
+);
+width = 570;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"542 245 LINE",
+"542 148 OFFCURVE",
+"528 139 OFFCURVE",
+"481 139 CURVE SMOOTH",
+"155 139 LINE",
+"155 143 LINE",
+"442 339 LINE SMOOTH",
+"541 406 OFFCURVE",
+"572 472 OFFCURVE",
+"572 539 CURVE SMOOTH",
+"572 676 OFFCURVE",
+"442 733 OFFCURVE",
+"319 733 CURVE SMOOTH",
+"189 733 OFFCURVE",
+"61 670 OFFCURVE",
+"61 551 CURVE SMOOTH",
+"61 494 OFFCURVE",
+"91 434 OFFCURVE",
+"162 434 CURVE SMOOTH",
+"207 434 OFFCURVE",
+"247 458 OFFCURVE",
+"247 515 CURVE SMOOTH",
+"247 556 OFFCURVE",
+"226 584 OFFCURVE",
+"182 584 CURVE SMOOTH",
+"154 584 OFFCURVE",
+"142 572 OFFCURVE",
+"131 572 CURVE SMOOTH",
+"123 572 OFFCURVE",
+"117 578 OFFCURVE",
+"117 592 CURVE SMOOTH",
+"117 636 OFFCURVE",
+"181 688 OFFCURVE",
+"256 688 CURVE SMOOTH",
+"344 688 OFFCURVE",
+"398 618 OFFCURVE",
+"398 503 CURVE SMOOTH",
+"398 422 OFFCURVE",
+"371 365 OFFCURVE",
+"264 280 CURVE SMOOTH",
+"32 97 LINE",
+"32 0 LINE",
+"572 0 LINE",
+"572 245 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"572 0 LINE",
+"572 245 LINE",
+"542 245 LINE",
+"542 148 OFFCURVE",
+"528 139 OFFCURVE",
+"481 139 CURVE SMOOTH",
+"155 139 LINE",
+"155 143 LINE",
+"442 339 LINE SMOOTH",
+"541 406 OFFCURVE",
+"572 472 OFFCURVE",
+"572 539 CURVE SMOOTH",
+"572 676 OFFCURVE",
+"442 732 OFFCURVE",
+"319 732 CURVE SMOOTH",
+"189 732 OFFCURVE",
+"61 670 OFFCURVE",
+"61 551 CURVE SMOOTH",
+"61 494 OFFCURVE",
+"91 434 OFFCURVE",
+"162 434 CURVE SMOOTH",
+"207 434 OFFCURVE",
+"247 458 OFFCURVE",
+"247 515 CURVE SMOOTH",
+"247 556 OFFCURVE",
+"226 584 OFFCURVE",
+"182 584 CURVE SMOOTH",
+"154 584 OFFCURVE",
+"142 572 OFFCURVE",
+"131 572 CURVE SMOOTH",
+"123 572 OFFCURVE",
+"117 578 OFFCURVE",
+"117 592 CURVE SMOOTH",
+"117 636 OFFCURVE",
+"181 687 OFFCURVE",
+"256 687 CURVE SMOOTH",
+"344 687 OFFCURVE",
+"398 618 OFFCURVE",
+"398 503 CURVE SMOOTH",
+"398 422 OFFCURVE",
+"371 365 OFFCURVE",
+"264 280 CURVE SMOOTH",
+"32 97 LINE",
+"32 0 LINE"
+);
+}
+);
+width = 625;
+}
+);
+unicode = 0032;
+},
+{
+glyphname = three;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"209 371 LINE",
+"328 371 OFFCURVE",
+"374 311 OFFCURVE",
+"374 200 CURVE SMOOTH",
+"374 83 OFFCURVE",
+"322 18 OFFCURVE",
+"229 18 CURVE SMOOTH",
+"187 18 OFFCURVE",
+"116 31 OFFCURVE",
+"116 67 CURVE SMOOTH",
+"116 95 OFFCURVE",
+"158 91 OFFCURVE",
+"158 135 CURVE SMOOTH",
+"158 170 OFFCURVE",
+"130 195 OFFCURVE",
+"94 195 CURVE SMOOTH",
+"56 195 OFFCURVE",
+"29 167 OFFCURVE",
+"29 123 CURVE SMOOTH",
+"29 44 OFFCURVE",
+"115 -12 OFFCURVE",
+"241 -12 CURVE SMOOTH",
+"413 -12 OFFCURVE",
+"514 91 OFFCURVE",
+"514 200 CURVE SMOOTH",
+"514 299 OFFCURVE",
+"431 379 OFFCURVE",
+"307 394 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"131 371 LINE",
+"307 371 LINE",
+"307 401 LINE",
+"131 401 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"248 390 LINE",
+"384 404 OFFCURVE",
+"471 480 OFFCURVE",
+"471 570 CURVE SMOOTH",
+"471 654 OFFCURVE",
+"393 732 OFFCURVE",
+"259 732 CURVE SMOOTH",
+"137 732 OFFCURVE",
+"67 666 OFFCURVE",
+"67 609 CURVE SMOOTH",
+"67 574 OFFCURVE",
+"94 547 OFFCURVE",
+"127 547 CURVE SMOOTH",
+"153 547 OFFCURVE",
+"181 563 OFFCURVE",
+"181 598 CURVE SMOOTH",
+"181 636 OFFCURVE",
+"149 639 OFFCURVE",
+"149 661 CURVE SMOOTH",
+"149 686 OFFCURVE",
+"187 702 OFFCURVE",
+"236 702 CURVE SMOOTH",
+"302 702 OFFCURVE",
+"341 674 OFFCURVE",
+"341 572 CURVE SMOOTH",
+"341 465 OFFCURVE",
+"298 401 OFFCURVE",
+"190 401 CURVE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"410 -12 OFFCURVE",
+"511 91 OFFCURVE",
+"511 200 CURVE SMOOTH",
+"511 299 OFFCURVE",
+"428 379 OFFCURVE",
+"304 394 CURVE",
+"206 371 LINE",
+"325 371 OFFCURVE",
+"371 311 OFFCURVE",
+"371 200 CURVE SMOOTH",
+"371 83 OFFCURVE",
+"319 18 OFFCURVE",
+"226 18 CURVE SMOOTH",
+"184 18 OFFCURVE",
+"113 31 OFFCURVE",
+"113 67 CURVE SMOOTH",
+"113 95 OFFCURVE",
+"155 91 OFFCURVE",
+"155 135 CURVE SMOOTH",
+"155 170 OFFCURVE",
+"127 195 OFFCURVE",
+"91 195 CURVE SMOOTH",
+"53 195 OFFCURVE",
+"26 167 OFFCURVE",
+"26 123 CURVE SMOOTH",
+"26 44 OFFCURVE",
+"112 -12 OFFCURVE",
+"238 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"304 371 LINE",
+"304 401 LINE",
+"128 401 LINE",
+"128 371 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"381 404 OFFCURVE",
+"468 480 OFFCURVE",
+"468 570 CURVE SMOOTH",
+"468 654 OFFCURVE",
+"390 732 OFFCURVE",
+"256 732 CURVE SMOOTH",
+"134 732 OFFCURVE",
+"64 666 OFFCURVE",
+"64 609 CURVE SMOOTH",
+"64 574 OFFCURVE",
+"91 547 OFFCURVE",
+"124 547 CURVE SMOOTH",
+"150 547 OFFCURVE",
+"178 563 OFFCURVE",
+"178 598 CURVE SMOOTH",
+"178 636 OFFCURVE",
+"146 639 OFFCURVE",
+"146 661 CURVE SMOOTH",
+"146 686 OFFCURVE",
+"184 702 OFFCURVE",
+"233 702 CURVE SMOOTH",
+"299 702 OFFCURVE",
+"338 674 OFFCURVE",
+"338 572 CURVE SMOOTH",
+"338 465 OFFCURVE",
+"295 401 OFFCURVE",
+"187 401 CURVE",
+"245 390 LINE"
+);
+}
+);
+width = 552;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"206 371 LINE",
+"333 371 OFFCURVE",
+"381 311 OFFCURVE",
+"381 198 CURVE SMOOTH",
+"381 86 OFFCURVE",
+"334 22 OFFCURVE",
+"242 22 CURVE SMOOTH",
+"206 22 OFFCURVE",
+"133 32 OFFCURVE",
+"133 61 CURVE SMOOTH",
+"133 88 OFFCURVE",
+"195 88 OFFCURVE",
+"195 154 CURVE SMOOTH",
+"195 211 OFFCURVE",
+"148 229 OFFCURVE",
+"113 229 CURVE SMOOTH",
+"57 229 OFFCURVE",
+"26 183 OFFCURVE",
+"26 131 CURVE SMOOTH",
+"26 43 OFFCURVE",
+"113 -13 OFFCURVE",
+"255 -13 CURVE SMOOTH",
+"448 -13 OFFCURVE",
+"567 91 OFFCURVE",
+"567 204 CURVE SMOOTH",
+"567 323 OFFCURVE",
+"458 388 OFFCURVE",
+"314 396 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"139 371 LINE",
+"314 371 LINE",
+"314 403 LINE",
+"139 406 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"254 395 LINE",
+"447 409 OFFCURVE",
+"532 476 OFFCURVE",
+"532 568 CURVE SMOOTH",
+"532 664 OFFCURVE",
+"440 733 OFFCURVE",
+"288 733 CURVE SMOOTH",
+"133 733 OFFCURVE",
+"68 662 OFFCURVE",
+"68 594 CURVE SMOOTH",
+"68 547 OFFCURVE",
+"100 518 OFFCURVE",
+"145 518 CURVE SMOOTH",
+"183 518 OFFCURVE",
+"227 538 OFFCURVE",
+"227 584 CURVE SMOOTH",
+"227 633 OFFCURVE",
+"175 640 OFFCURVE",
+"175 665 CURVE SMOOTH",
+"175 688 OFFCURVE",
+"218 698 OFFCURVE",
+"258 698 CURVE SMOOTH",
+"319 698 OFFCURVE",
+"357 674 OFFCURVE",
+"357 576 CURVE SMOOTH",
+"357 468 OFFCURVE",
+"310 405 OFFCURVE",
+"186 405 CURVE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"446 -12 OFFCURVE",
+"565 91 OFFCURVE",
+"565 204 CURVE SMOOTH",
+"565 323 OFFCURVE",
+"456 388 OFFCURVE",
+"312 396 CURVE",
+"204 371 LINE",
+"331 371 OFFCURVE",
+"379 311 OFFCURVE",
+"379 198 CURVE SMOOTH",
+"379 86 OFFCURVE",
+"332 23 OFFCURVE",
+"240 23 CURVE SMOOTH",
+"204 23 OFFCURVE",
+"131 32 OFFCURVE",
+"131 61 CURVE SMOOTH",
+"131 88 OFFCURVE",
+"193 89 OFFCURVE",
+"193 155 CURVE SMOOTH",
+"193 212 OFFCURVE",
+"146 230 OFFCURVE",
+"111 230 CURVE SMOOTH",
+"55 230 OFFCURVE",
+"24 184 OFFCURVE",
+"24 132 CURVE SMOOTH",
+"24 44 OFFCURVE",
+"111 -12 OFFCURVE",
+"253 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"312 371 LINE",
+"312 406 LINE",
+"137 406 LINE",
+"137 371 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"445 409 OFFCURVE",
+"530 476 OFFCURVE",
+"530 568 CURVE SMOOTH",
+"530 664 OFFCURVE",
+"438 732 OFFCURVE",
+"286 732 CURVE SMOOTH",
+"131 732 OFFCURVE",
+"66 662 OFFCURVE",
+"66 594 CURVE SMOOTH",
+"66 547 OFFCURVE",
+"98 518 OFFCURVE",
+"143 518 CURVE SMOOTH",
+"181 518 OFFCURVE",
+"225 538 OFFCURVE",
+"225 584 CURVE SMOOTH",
+"225 633 OFFCURVE",
+"173 640 OFFCURVE",
+"173 665 CURVE SMOOTH",
+"173 688 OFFCURVE",
+"216 697 OFFCURVE",
+"256 697 CURVE SMOOTH",
+"317 697 OFFCURVE",
+"355 674 OFFCURVE",
+"355 576 CURVE SMOOTH",
+"355 468 OFFCURVE",
+"308 406 OFFCURVE",
+"184 406 CURVE",
+"252 395 LINE"
+);
+}
+);
+width = 602;
+}
+);
+unicode = 0033;
+},
+{
+glyphname = four;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"56 227 LINE",
+"56 231 LINE",
+"308 599 LINE",
+"312 599 LINE",
+"312 227 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"539 200 LINE",
+"539 118 LINE",
+"565 118 LINE",
+"565 306 LINE",
+"539 306 LINE",
+"539 227 LINE",
+"431 227 LINE",
+"431 732 LINE",
+"358 732 LINE",
+"18 228 LINE",
+"18 200 LINE",
+"313 200 LINE",
+"313 25 LINE",
+"214 25 LINE",
+"214 0 LINE",
+"517 0 LINE",
+"517 25 LINE",
+"432 25 LINE",
+"432 200 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"517 0 LINE",
+"517 25 LINE",
+"432 25 LINE",
+"432 200 LINE",
+"539 200 LINE",
+"539 118 LINE",
+"565 118 LINE",
+"565 306 LINE",
+"539 306 LINE",
+"539 227 LINE",
+"431 227 LINE",
+"431 732 LINE",
+"358 732 LINE",
+"18 228 LINE",
+"18 200 LINE",
+"313 200 LINE",
+"313 25 LINE",
+"214 25 LINE",
+"214 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"56 231 LINE",
+"308 599 LINE",
+"312 599 LINE",
+"312 227 LINE",
+"56 227 LINE"
+);
+}
+);
+width = 595;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"61 232 LINE",
+"61 236 LINE",
+"315 580 LINE",
+"319 580 LINE",
+"319 232 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"602 200 LINE",
+"602 118 LINE",
+"633 118 LINE",
+"633 311 LINE",
+"602 311 LINE",
+"602 232 LINE",
+"477 232 LINE",
+"477 723 LINE",
+"375 723 LINE",
+"15 233 LINE",
+"15 200 LINE",
+"319 200 LINE",
+"319 30 LINE",
+"211 30 LINE",
+"211 0 LINE",
+"573 0 LINE",
+"573 30 LINE",
+"477 30 LINE",
+"477 200 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"573 0 LINE",
+"573 30 LINE",
+"477 30 LINE",
+"477 200 LINE",
+"602 200 LINE",
+"602 118 LINE",
+"633 118 LINE",
+"633 311 LINE",
+"602 311 LINE",
+"602 232 LINE",
+"477 232 LINE",
+"477 732 LINE",
+"375 732 LINE",
+"15 233 LINE",
+"15 200 LINE",
+"319 200 LINE",
+"319 30 LINE",
+"211 30 LINE",
+"211 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"61 236 LINE",
+"315 588 LINE",
+"319 588 LINE",
+"319 232 LINE",
+"61 232 LINE"
+);
+}
+);
+width = 670;
+}
+);
+unicode = 0034;
+},
+{
+glyphname = five;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"127 620 LINE",
+"429 620 LINE",
+"465 748 LINE",
+"440 748 LINE",
+"426 722 OFFCURVE",
+"412 716 OFFCURVE",
+"368 716 CURVE SMOOTH",
+"102 716 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"83 387 LINE",
+"99 377 LINE",
+"118 396 LINE",
+"137 716 LINE",
+"102 716 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"169 437 OFFCURVE",
+"120 423 OFFCURVE",
+"106 415 CURVE",
+"99 377 LINE",
+"124 394 OFFCURVE",
+"172 406 OFFCURVE",
+"214 406 CURVE SMOOTH",
+"310 406 OFFCURVE",
+"379 345 OFFCURVE",
+"379 208 CURVE SMOOTH",
+"379 81 OFFCURVE",
+"319 18 OFFCURVE",
+"218 18 CURVE SMOOTH",
+"164 18 OFFCURVE",
+"114 35 OFFCURVE",
+"114 66 CURVE SMOOTH",
+"114 97 OFFCURVE",
+"161 96 OFFCURVE",
+"161 141 CURVE SMOOTH",
+"161 176 OFFCURVE",
+"133 197 OFFCURVE",
+"97 197 CURVE SMOOTH",
+"59 197 OFFCURVE",
+"32 167 OFFCURVE",
+"32 123 CURVE SMOOTH",
+"32 42 OFFCURVE",
+"123 -12 OFFCURVE",
+"239 -12 CURVE SMOOTH",
+"393 -12 OFFCURVE",
+"517 87 OFFCURVE",
+"517 222 CURVE SMOOTH",
+"517 346 OFFCURVE",
+"412 437 OFFCURVE",
+"237 437 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"393 -12 OFFCURVE",
+"517 87 OFFCURVE",
+"517 222 CURVE SMOOTH",
+"517 346 OFFCURVE",
+"412 437 OFFCURVE",
+"237 437 CURVE SMOOTH",
+"169 437 OFFCURVE",
+"120 423 OFFCURVE",
+"106 415 CURVE",
+"99 377 LINE",
+"124 394 OFFCURVE",
+"172 406 OFFCURVE",
+"214 406 CURVE SMOOTH",
+"310 406 OFFCURVE",
+"379 345 OFFCURVE",
+"379 208 CURVE SMOOTH",
+"379 81 OFFCURVE",
+"319 18 OFFCURVE",
+"218 18 CURVE SMOOTH",
+"164 18 OFFCURVE",
+"114 35 OFFCURVE",
+"114 66 CURVE SMOOTH",
+"114 97 OFFCURVE",
+"161 96 OFFCURVE",
+"161 141 CURVE SMOOTH",
+"161 176 OFFCURVE",
+"133 197 OFFCURVE",
+"97 197 CURVE SMOOTH",
+"59 197 OFFCURVE",
+"32 167 OFFCURVE",
+"32 123 CURVE SMOOTH",
+"32 42 OFFCURVE",
+"123 -12 OFFCURVE",
+"239 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"118 396 LINE",
+"155 716 LINE",
+"120 716 LINE",
+"83 387 LINE",
+"99 377 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"447 620 LINE",
+"483 748 LINE",
+"458 748 LINE",
+"444 722 OFFCURVE",
+"430 716 OFFCURVE",
+"386 716 CURVE SMOOTH",
+"120 716 LINE",
+"145 620 LINE"
+);
+}
+);
+width = 551;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"135 594 LINE",
+"507 594 LINE",
+"543 773 LINE",
+"513 773 LINE",
+"500 741 OFFCURVE",
+"487 733 OFFCURVE",
+"446 733 CURVE SMOOTH",
+"110 733 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"85 382 LINE",
+"102 371 LINE",
+"126 410 LINE",
+"145 733 LINE",
+"105 733 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"214 447 OFFCURVE",
+"131 430 OFFCURVE",
+"113 420 CURVE",
+"102 371 LINE",
+"123 388 OFFCURVE",
+"182 401 OFFCURVE",
+"230 401 CURVE SMOOTH",
+"330 401 OFFCURVE",
+"401 343 OFFCURVE",
+"401 206 CURVE SMOOTH",
+"401 83 OFFCURVE",
+"344 27 OFFCURVE",
+"241 27 CURVE SMOOTH",
+"198 27 OFFCURVE",
+"141 37 OFFCURVE",
+"141 61 CURVE SMOOTH",
+"141 86 OFFCURVE",
+"203 86 OFFCURVE",
+"203 150 CURVE SMOOTH",
+"203 202 OFFCURVE",
+"161 224 OFFCURVE",
+"119 224 CURVE SMOOTH",
+"66 224 OFFCURVE",
+"29 187 OFFCURVE",
+"29 133 CURVE SMOOTH",
+"29 51 OFFCURVE",
+"116 -8 OFFCURVE",
+"266 -8 CURVE SMOOTH",
+"445 -8 OFFCURVE",
+"589 76 OFFCURVE",
+"589 224 CURVE SMOOTH",
+"589 345 OFFCURVE",
+"494 447 OFFCURVE",
+"295 447 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"445 -12 OFFCURVE",
+"589 76 OFFCURVE",
+"589 224 CURVE SMOOTH",
+"589 345 OFFCURVE",
+"494 447 OFFCURVE",
+"295 447 CURVE SMOOTH",
+"214 447 OFFCURVE",
+"131 430 OFFCURVE",
+"113 420 CURVE",
+"102 371 LINE",
+"123 388 OFFCURVE",
+"182 401 OFFCURVE",
+"230 401 CURVE SMOOTH",
+"330 401 OFFCURVE",
+"401 343 OFFCURVE",
+"401 206 CURVE SMOOTH",
+"401 83 OFFCURVE",
+"344 23 OFFCURVE",
+"241 23 CURVE SMOOTH",
+"198 23 OFFCURVE",
+"141 33 OFFCURVE",
+"141 57 CURVE SMOOTH",
+"141 82 OFFCURVE",
+"203 82 OFFCURVE",
+"203 146 CURVE SMOOTH",
+"203 198 OFFCURVE",
+"161 220 OFFCURVE",
+"119 220 CURVE SMOOTH",
+"66 220 OFFCURVE",
+"29 183 OFFCURVE",
+"29 129 CURVE SMOOTH",
+"29 47 OFFCURVE",
+"116 -12 OFFCURVE",
+"266 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"126 410 LINE",
+"154 716 LINE",
+"114 716 LINE",
+"85 382 LINE",
+"102 371 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"516 577 LINE",
+"552 754 LINE",
+"522 754 LINE",
+"509 722 OFFCURVE",
+"496 716 OFFCURVE",
+"455 716 CURVE SMOOTH",
+"119 716 LINE",
+"144 577 LINE"
+);
+}
+);
+width = 620;
+}
+);
+unicode = 0035;
+},
+{
+glyphname = six;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"508 752 LINE",
+"265 743 OFFCURVE",
+"43 544 OFFCURVE",
+"43 290 CURVE SMOOTH",
+"43 107 OFFCURVE",
+"158 -12 OFFCURVE",
+"304 -12 CURVE SMOOTH",
+"442 -12 OFFCURVE",
+"570 93 OFFCURVE",
+"570 238 CURVE SMOOTH",
+"570 371 OFFCURVE",
+"461 474 OFFCURVE",
+"328 474 CURVE SMOOTH",
+"274 474 OFFCURVE",
+"234 457 OFFCURVE",
+"198 425 CURVE",
+"195 426 LINE",
+"218 593 OFFCURVE",
+"336 710 OFFCURVE",
+"508 723 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"181 262 OFFCURVE",
+"183 320 OFFCURVE",
+"191 368 CURVE",
+"219 413 OFFCURVE",
+"265 444 OFFCURVE",
+"326 444 CURVE SMOOTH",
+"395 444 OFFCURVE",
+"425 404 OFFCURVE",
+"425 231 CURVE SMOOTH",
+"425 59 OFFCURVE",
+"395 18 OFFCURVE",
+"302 18 CURVE SMOOTH",
+"213 18 OFFCURVE",
+"181 55 OFFCURVE",
+"181 221 CURVE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"448 -12 OFFCURVE",
+"576 93 OFFCURVE",
+"576 238 CURVE SMOOTH",
+"576 371 OFFCURVE",
+"467 474 OFFCURVE",
+"334 474 CURVE SMOOTH",
+"280 474 OFFCURVE",
+"240 457 OFFCURVE",
+"204 425 CURVE",
+"201 426 LINE",
+"224 593 OFFCURVE",
+"342 710 OFFCURVE",
+"514 723 CURVE",
+"514 752 LINE",
+"271 743 OFFCURVE",
+"49 544 OFFCURVE",
+"49 290 CURVE SMOOTH",
+"49 107 OFFCURVE",
+"164 -12 OFFCURVE",
+"310 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"219 18 OFFCURVE",
+"187 55 OFFCURVE",
+"187 221 CURVE",
+"187 262 OFFCURVE",
+"189 320 OFFCURVE",
+"197 368 CURVE",
+"225 413 OFFCURVE",
+"271 444 OFFCURVE",
+"332 444 CURVE SMOOTH",
+"401 444 OFFCURVE",
+"431 404 OFFCURVE",
+"431 231 CURVE SMOOTH",
+"431 59 OFFCURVE",
+"401 18 OFFCURVE",
+"308 18 CURVE SMOOTH"
+);
+}
+);
+width = 606;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"525 733 LINE",
+"272 724 OFFCURVE",
+"40 530 OFFCURVE",
+"40 291 CURVE SMOOTH",
+"40 107 OFFCURVE",
+"164 -13 OFFCURVE",
+"319 -13 CURVE SMOOTH",
+"464 -13 OFFCURVE",
+"597 93 OFFCURVE",
+"597 236 CURVE SMOOTH",
+"597 365 OFFCURVE",
+"490 464 OFFCURVE",
+"357 464 CURVE SMOOTH",
+"303 464 OFFCURVE",
+"265 448 OFFCURVE",
+"230 420 CURVE",
+"227 421 LINE",
+"249 574 OFFCURVE",
+"361 682 OFFCURVE",
+"525 699 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"208 258 OFFCURVE",
+"208 310 OFFCURVE",
+"218 353 CURVE",
+"240 392 OFFCURVE",
+"278 424 OFFCURVE",
+"333 424 CURVE SMOOTH",
+"391 424 OFFCURVE",
+"422 388 OFFCURVE",
+"422 224 CURVE SMOOTH",
+"422 73 OFFCURVE",
+"396 22 OFFCURVE",
+"316 22 CURVE SMOOTH",
+"237 22 OFFCURVE",
+"208 71 OFFCURVE",
+"208 221 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"470 -12 OFFCURVE",
+"603 93 OFFCURVE",
+"603 236 CURVE SMOOTH",
+"603 365 OFFCURVE",
+"496 464 OFFCURVE",
+"363 464 CURVE SMOOTH",
+"309 464 OFFCURVE",
+"271 448 OFFCURVE",
+"236 420 CURVE",
+"233 421 LINE",
+"255 574 OFFCURVE",
+"359 703 OFFCURVE",
+"523 720 CURVE",
+"523 754 LINE",
+"270 745 OFFCURVE",
+"46 530 OFFCURVE",
+"46 291 CURVE SMOOTH",
+"46 107 OFFCURVE",
+"170 -12 OFFCURVE",
+"325 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"243 23 OFFCURVE",
+"214 71 OFFCURVE",
+"214 221 CURVE SMOOTH",
+"214 258 OFFCURVE",
+"214 310 OFFCURVE",
+"224 353 CURVE",
+"246 392 OFFCURVE",
+"284 424 OFFCURVE",
+"339 424 CURVE SMOOTH",
+"397 424 OFFCURVE",
+"428 388 OFFCURVE",
+"428 224 CURVE SMOOTH",
+"428 73 OFFCURVE",
+"402 23 OFFCURVE",
+"322 23 CURVE SMOOTH"
+);
+}
+);
+width = 630;
+}
+);
+unicode = 0036;
+},
+{
+glyphname = seven;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"23 518 LINE",
+"48 518 LINE",
+"80 606 OFFCURVE",
+"98 620 OFFCURVE",
+"153 620 CURVE SMOOTH",
+"409 620 LINE",
+"244 276 LINE SMOOTH",
+"183 149 OFFCURVE",
+"175 112 OFFCURVE",
+"175 76 CURVE SMOOTH",
+"175 15 OFFCURVE",
+"205 -12 OFFCURVE",
+"252 -12 CURVE SMOOTH",
+"294 -12 OFFCURVE",
+"322 10 OFFCURVE",
+"322 56 CURVE SMOOTH",
+"322 106 OFFCURVE",
+"290 113 OFFCURVE",
+"290 197 CURVE SMOOTH",
+"290 250 OFFCURVE",
+"300 313 OFFCURVE",
+"345 408 CURVE SMOOTH",
+"486 704 LINE",
+"486 716 LINE",
+"69 716 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"311 -12 OFFCURVE",
+"339 10 OFFCURVE",
+"339 56 CURVE SMOOTH",
+"339 106 OFFCURVE",
+"307 113 OFFCURVE",
+"307 197 CURVE SMOOTH",
+"307 250 OFFCURVE",
+"318 312 OFFCURVE",
+"362 408 CURVE SMOOTH",
+"497 704 LINE",
+"497 716 LINE",
+"86 716 LINE",
+"40 518 LINE",
+"65 518 LINE",
+"97 606 OFFCURVE",
+"115 620 OFFCURVE",
+"170 620 CURVE SMOOTH",
+"420 620 LINE",
+"261 276 LINE SMOOTH",
+"202 147 OFFCURVE",
+"192 112 OFFCURVE",
+"192 76 CURVE SMOOTH",
+"192 15 OFFCURVE",
+"222 -12 OFFCURVE",
+"269 -12 CURVE SMOOTH"
+);
+}
+);
+width = 504;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"36 485 LINE",
+"71 485 LINE",
+"103 579 OFFCURVE",
+"114 594 OFFCURVE",
+"145 594 CURVE SMOOTH",
+"479 594 LINE",
+"295 286 LINE SMOOTH",
+"227 172 OFFCURVE",
+"201 126 OFFCURVE",
+"201 77 CURVE SMOOTH",
+"201 22 OFFCURVE",
+"233 -13 OFFCURVE",
+"296 -13 CURVE SMOOTH",
+"352 -13 OFFCURVE",
+"398 14 OFFCURVE",
+"398 72 CURVE SMOOTH",
+"398 121 OFFCURVE",
+"366 167 OFFCURVE",
+"366 238 CURVE SMOOTH",
+"366 284 OFFCURVE",
+"382 341 OFFCURVE",
+"429 418 CURVE SMOOTH",
+"591 683 LINE",
+"591 733 LINE",
+"112 733 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"352 -12 OFFCURVE",
+"398 14 OFFCURVE",
+"398 72 CURVE SMOOTH",
+"398 121 OFFCURVE",
+"366 167 OFFCURVE",
+"366 238 CURVE SMOOTH",
+"366 284 OFFCURVE",
+"384 340 OFFCURVE",
+"429 418 CURVE SMOOTH",
+"573 666 LINE",
+"573 716 LINE",
+"104 716 LINE",
+"38 468 LINE",
+"73 468 LINE",
+"105 562 OFFCURVE",
+"106 577 OFFCURVE",
+"137 577 CURVE SMOOTH",
+"465 577 LINE",
+"295 286 LINE SMOOTH",
+"228 172 OFFCURVE",
+"201 126 OFFCURVE",
+"201 77 CURVE SMOOTH",
+"201 22 OFFCURVE",
+"233 -12 OFFCURVE",
+"296 -12 CURVE SMOOTH"
+);
+}
+);
+width = 590;
+}
+);
+unicode = 0037;
+},
+{
+glyphname = eight;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"184 300 OFFCURVE",
+"217 361 OFFCURVE",
+"308 361 CURVE SMOOTH",
+"399 361 OFFCURVE",
+"433 300 OFFCURVE",
+"433 190 CURVE SMOOTH",
+"433 67 OFFCURVE",
+"399 18 OFFCURVE",
+"308 18 CURVE SMOOTH",
+"217 18 OFFCURVE",
+"184 67 OFFCURVE",
+"184 190 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"543 653 OFFCURVE",
+"465 732 OFFCURVE",
+"309 732 CURVE SMOOTH",
+"153 732 OFFCURVE",
+"74 653 OFFCURVE",
+"74 555 CURVE SMOOTH",
+"74 443 OFFCURVE",
+"179 371 OFFCURVE",
+"309 371 CURVE SMOOTH",
+"439 371 OFFCURVE",
+"543 443 OFFCURVE",
+"543 555 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"413 445 OFFCURVE",
+"385 386 OFFCURVE",
+"309 386 CURVE SMOOTH",
+"233 386 OFFCURVE",
+"204 445 OFFCURVE",
+"204 550 CURVE SMOOTH",
+"204 659 OFFCURVE",
+"233 702 OFFCURVE",
+"309 702 CURVE SMOOTH",
+"385 702 OFFCURVE",
+"413 659 OFFCURVE",
+"413 550 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"44 77 OFFCURVE",
+"130 -12 OFFCURVE",
+"308 -12 CURVE SMOOTH",
+"486 -12 OFFCURVE",
+"573 77 OFFCURVE",
+"573 190 CURVE SMOOTH",
+"573 270 OFFCURVE",
+"490 350 OFFCURVE",
+"376 374 CURVE",
+"376 378 LINE",
+"242 378 LINE",
+"242 374 LINE",
+"127 351 OFFCURVE",
+"44 270 OFFCURVE",
+"44 190 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"484 -12 OFFCURVE",
+"571 77 OFFCURVE",
+"571 190 CURVE SMOOTH",
+"571 270 OFFCURVE",
+"488 350 OFFCURVE",
+"374 374 CURVE",
+"374 378 LINE",
+"240 378 LINE",
+"240 374 LINE",
+"125 351 OFFCURVE",
+"42 270 OFFCURVE",
+"42 190 CURVE SMOOTH",
+"42 77 OFFCURVE",
+"128 -12 OFFCURVE",
+"306 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"215 18 OFFCURVE",
+"182 67 OFFCURVE",
+"182 190 CURVE SMOOTH",
+"182 300 OFFCURVE",
+"215 361 OFFCURVE",
+"306 361 CURVE SMOOTH",
+"397 361 OFFCURVE",
+"431 300 OFFCURVE",
+"431 190 CURVE SMOOTH",
+"431 67 OFFCURVE",
+"397 18 OFFCURVE",
+"306 18 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"231 386 OFFCURVE",
+"202 445 OFFCURVE",
+"202 550 CURVE SMOOTH",
+"202 659 OFFCURVE",
+"231 702 OFFCURVE",
+"307 702 CURVE SMOOTH",
+"383 702 OFFCURVE",
+"411 659 OFFCURVE",
+"411 550 CURVE SMOOTH",
+"411 445 OFFCURVE",
+"383 386 OFFCURVE",
+"307 386 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"437 371 OFFCURVE",
+"541 443 OFFCURVE",
+"541 555 CURVE SMOOTH",
+"541 653 OFFCURVE",
+"463 732 OFFCURVE",
+"307 732 CURVE SMOOTH",
+"151 732 OFFCURVE",
+"72 653 OFFCURVE",
+"72 555 CURVE SMOOTH",
+"72 443 OFFCURVE",
+"177 371 OFFCURVE",
+"307 371 CURVE SMOOTH"
+);
+}
+);
+width = 613;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"211 298 OFFCURVE",
+"239 356 OFFCURVE",
+"320 356 CURVE SMOOTH",
+"402 356 OFFCURVE",
+"430 296 OFFCURVE",
+"430 185 CURVE SMOOTH",
+"430 66 OFFCURVE",
+"398 17 OFFCURVE",
+"320 17 CURVE SMOOTH",
+"242 17 OFFCURVE",
+"211 66 OFFCURVE",
+"211 185 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"575 649 OFFCURVE",
+"493 733 OFFCURVE",
+"320 733 CURVE SMOOTH",
+"151 733 OFFCURVE",
+"66 653 OFFCURVE",
+"66 555 CURVE SMOOTH",
+"66 443 OFFCURVE",
+"179 371 OFFCURVE",
+"321 371 CURVE SMOOTH",
+"463 371 OFFCURVE",
+"575 443 OFFCURVE",
+"575 554 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"410 448 OFFCURVE",
+"387 391 OFFCURVE",
+"321 391 CURVE SMOOTH",
+"255 391 OFFCURVE",
+"231 448 OFFCURVE",
+"231 551 CURVE SMOOTH",
+"231 654 OFFCURVE",
+"255 698 OFFCURVE",
+"321 698 CURVE SMOOTH",
+"387 698 OFFCURVE",
+"410 654 OFFCURVE",
+"410 551 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"36 73 OFFCURVE",
+"128 -13 OFFCURVE",
+"320 -13 CURVE SMOOTH",
+"512 -13 OFFCURVE",
+"605 73 OFFCURVE",
+"605 180 CURVE SMOOTH",
+"605 285 OFFCURVE",
+"514 349 OFFCURVE",
+"388 374 CURVE",
+"388 378 LINE",
+"254 378 LINE",
+"254 374 LINE",
+"127 350 OFFCURVE",
+"36 285 OFFCURVE",
+"36 180 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"510 -12 OFFCURVE",
+"603 73 OFFCURVE",
+"603 180 CURVE SMOOTH",
+"603 285 OFFCURVE",
+"512 349 OFFCURVE",
+"386 374 CURVE",
+"386 378 LINE",
+"252 378 LINE",
+"252 374 LINE",
+"125 350 OFFCURVE",
+"34 285 OFFCURVE",
+"34 180 CURVE SMOOTH",
+"34 73 OFFCURVE",
+"126 -12 OFFCURVE",
+"318 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"240 18 OFFCURVE",
+"209 66 OFFCURVE",
+"209 185 CURVE SMOOTH",
+"209 298 OFFCURVE",
+"237 356 OFFCURVE",
+"318 356 CURVE SMOOTH",
+"400 356 OFFCURVE",
+"428 296 OFFCURVE",
+"428 185 CURVE SMOOTH",
+"428 66 OFFCURVE",
+"396 18 OFFCURVE",
+"318 18 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"253 391 OFFCURVE",
+"229 448 OFFCURVE",
+"229 551 CURVE SMOOTH",
+"229 654 OFFCURVE",
+"253 697 OFFCURVE",
+"319 697 CURVE SMOOTH",
+"385 697 OFFCURVE",
+"408 654 OFFCURVE",
+"408 551 CURVE SMOOTH",
+"408 448 OFFCURVE",
+"385 391 OFFCURVE",
+"319 391 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"461 371 OFFCURVE",
+"573 443 OFFCURVE",
+"573 554 CURVE SMOOTH",
+"573 649 OFFCURVE",
+"491 732 OFFCURVE",
+"318 732 CURVE SMOOTH",
+"149 732 OFFCURVE",
+"64 653 OFFCURVE",
+"64 555 CURVE SMOOTH",
+"64 443 OFFCURVE",
+"177 371 OFFCURVE",
+"319 371 CURVE SMOOTH"
+);
+}
+);
+width = 637;
+}
+);
+unicode = 0038;
+},
+{
+glyphname = nine;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"97 -32 LINE",
+"340 -23 OFFCURVE",
+"562 176 OFFCURVE",
+"562 430 CURVE SMOOTH",
+"562 613 OFFCURVE",
+"447 732 OFFCURVE",
+"301 732 CURVE SMOOTH",
+"163 732 OFFCURVE",
+"35 627 OFFCURVE",
+"35 482 CURVE SMOOTH",
+"35 349 OFFCURVE",
+"144 246 OFFCURVE",
+"277 246 CURVE SMOOTH",
+"331 246 OFFCURVE",
+"371 263 OFFCURVE",
+"407 295 CURVE",
+"410 294 LINE",
+"387 127 OFFCURVE",
+"269 11 OFFCURVE",
+"97 -3 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"424 458 OFFCURVE",
+"422 400 OFFCURVE",
+"414 352 CURVE",
+"386 307 OFFCURVE",
+"340 276 OFFCURVE",
+"279 276 CURVE SMOOTH",
+"210 276 OFFCURVE",
+"180 316 OFFCURVE",
+"180 489 CURVE SMOOTH",
+"180 661 OFFCURVE",
+"210 702 OFFCURVE",
+"303 702 CURVE SMOOTH",
+"392 702 OFFCURVE",
+"424 665 OFFCURVE",
+"424 499 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"349 -23 OFFCURVE",
+"571 176 OFFCURVE",
+"571 430 CURVE SMOOTH",
+"571 613 OFFCURVE",
+"456 732 OFFCURVE",
+"310 732 CURVE SMOOTH",
+"172 732 OFFCURVE",
+"44 627 OFFCURVE",
+"44 482 CURVE SMOOTH",
+"44 349 OFFCURVE",
+"153 246 OFFCURVE",
+"286 246 CURVE SMOOTH",
+"340 246 OFFCURVE",
+"380 263 OFFCURVE",
+"416 295 CURVE",
+"419 294 LINE",
+"396 127 OFFCURVE",
+"278 11 OFFCURVE",
+"106 -3 CURVE",
+"106 -32 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"219 276 OFFCURVE",
+"189 316 OFFCURVE",
+"189 489 CURVE SMOOTH",
+"189 661 OFFCURVE",
+"219 702 OFFCURVE",
+"312 702 CURVE SMOOTH",
+"401 702 OFFCURVE",
+"433 665 OFFCURVE",
+"433 499 CURVE SMOOTH",
+"433 458 OFFCURVE",
+"431 400 OFFCURVE",
+"423 352 CURVE",
+"395 307 OFFCURVE",
+"349 276 OFFCURVE",
+"288 276 CURVE SMOOTH"
+);
+}
+);
+width = 606;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"104 -11 LINE",
+"357 -2 OFFCURVE",
+"589 188 OFFCURVE",
+"589 430 CURVE SMOOTH",
+"589 614 OFFCURVE",
+"465 734 OFFCURVE",
+"310 734 CURVE SMOOTH",
+"165 734 OFFCURVE",
+"32 628 OFFCURVE",
+"32 485 CURVE SMOOTH",
+"32 356 OFFCURVE",
+"139 257 OFFCURVE",
+"272 257 CURVE SMOOTH",
+"326 257 OFFCURVE",
+"364 273 OFFCURVE",
+"399 301 CURVE",
+"402 300 LINE",
+"380 145 OFFCURVE",
+"268 39 OFFCURVE",
+"104 23 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"421 463 OFFCURVE",
+"421 411 OFFCURVE",
+"411 368 CURVE",
+"389 329 OFFCURVE",
+"351 297 OFFCURVE",
+"296 297 CURVE SMOOTH",
+"238 297 OFFCURVE",
+"207 333 OFFCURVE",
+"207 497 CURVE SMOOTH",
+"207 648 OFFCURVE",
+"233 699 OFFCURVE",
+"313 699 CURVE SMOOTH",
+"392 699 OFFCURVE",
+"421 650 OFFCURVE",
+"421 500 CURVE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"357 -2 OFFCURVE",
+"589 188 OFFCURVE",
+"589 430 CURVE SMOOTH",
+"589 614 OFFCURVE",
+"465 734 OFFCURVE",
+"310 734 CURVE SMOOTH",
+"165 734 OFFCURVE",
+"32 628 OFFCURVE",
+"32 485 CURVE SMOOTH",
+"32 356 OFFCURVE",
+"139 257 OFFCURVE",
+"272 257 CURVE SMOOTH",
+"326 257 OFFCURVE",
+"364 273 OFFCURVE",
+"399 301 CURVE",
+"402 300 LINE",
+"380 145 OFFCURVE",
+"268 39 OFFCURVE",
+"104 23 CURVE",
+"104 -11 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"238 297 OFFCURVE",
+"207 333 OFFCURVE",
+"207 497 CURVE SMOOTH",
+"207 648 OFFCURVE",
+"233 699 OFFCURVE",
+"313 699 CURVE SMOOTH",
+"392 699 OFFCURVE",
+"421 650 OFFCURVE",
+"421 500 CURVE",
+"421 463 OFFCURVE",
+"421 411 OFFCURVE",
+"411 368 CURVE",
+"389 329 OFFCURVE",
+"351 297 OFFCURVE",
+"296 297 CURVE SMOOTH"
+);
+}
+);
+width = 630;
+}
+);
+unicode = 0039;
+},
+{
+glyphname = zero.denominator;
+lastChange = "2016-08-19 17:28:22 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"305 -8 OFFCURVE",
+"383 75 OFFCURVE",
+"383 197 CURVE SMOOTH",
+"383 319 OFFCURVE",
+"305 403 OFFCURVE",
+"203 403 CURVE SMOOTH",
+"101 403 OFFCURVE",
+"24 319 OFFCURVE",
+"24 197 CURVE SMOOTH",
+"24 75 OFFCURVE",
+"101 -8 OFFCURVE",
+"203 -8 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"144 13 OFFCURVE",
+"126 47 OFFCURVE",
+"126 197 CURVE SMOOTH",
+"126 348 OFFCURVE",
+"144 383 OFFCURVE",
+"203 383 CURVE SMOOTH",
+"259 383 OFFCURVE",
+"280 348 OFFCURVE",
+"280 197 CURVE SMOOTH",
+"280 47 OFFCURVE",
+"259 13 OFFCURVE",
+"203 13 CURVE SMOOTH"
+);
+}
+);
+width = 407;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"24 434 OFFCURVE",
+"101 351 OFFCURVE",
+"203 351 CURVE SMOOTH",
+"305 351 OFFCURVE",
+"383 434 OFFCURVE",
+"383 556 CURVE SMOOTH",
+"383 678 OFFCURVE",
+"305 762 OFFCURVE",
+"203 762 CURVE SMOOTH",
+"101 762 OFFCURVE",
+"24 678 OFFCURVE",
+"24 556 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"126 707 OFFCURVE",
+"144 742 OFFCURVE",
+"203 742 CURVE SMOOTH",
+"259 742 OFFCURVE",
+"280 707 OFFCURVE",
+"280 556 CURVE SMOOTH",
+"280 406 OFFCURVE",
+"259 372 OFFCURVE",
+"203 372 CURVE SMOOTH",
+"144 372 OFFCURVE",
+"126 406 OFFCURVE",
+"126 556 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"314 -8 OFFCURVE",
+"396 74 OFFCURVE",
+"396 197 CURVE SMOOTH",
+"396 319 OFFCURVE",
+"314 403 OFFCURVE",
+"209 403 CURVE SMOOTH",
+"104 403 OFFCURVE",
+"23 319 OFFCURVE",
+"23 197 CURVE SMOOTH",
+"23 74 OFFCURVE",
+"104 -8 OFFCURVE",
+"209 -8 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"149 13 OFFCURVE",
+"131 46 OFFCURVE",
+"131 197 CURVE SMOOTH",
+"131 347 OFFCURVE",
+"149 382 OFFCURVE",
+"209 382 CURVE SMOOTH",
+"265 382 OFFCURVE",
+"287 347 OFFCURVE",
+"287 197 CURVE SMOOTH",
+"287 46 OFFCURVE",
+"265 13 OFFCURVE",
+"209 13 CURVE SMOOTH"
+);
+}
+);
+width = 419;
+}
+);
+},
+{
+glyphname = one.denominator;
+lastChange = "2016-08-19 17:28:22 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"266 0 LINE",
+"266 17 LINE",
+"184 17 LINE",
+"184 395 LINE",
+"4 395 LINE",
+"4 377 LINE",
+"91 377 LINE",
+"91 17 LINE",
+"4 17 LINE",
+"4 0 LINE"
+);
+}
+);
+width = 270;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"275 0 LINE",
+"275 18 LINE",
+"192 18 LINE",
+"192 395 LINE",
+"3 395 LINE",
+"3 377 LINE",
+"92 377 LINE",
+"92 18 LINE",
+"3 18 LINE",
+"3 0 LINE"
+);
+}
+);
+width = 279;
+}
+);
+},
+{
+glyphname = two.denominator;
+lastChange = "2016-08-19 17:28:22 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"321 0 LINE",
+"321 143 LINE",
+"304 143 LINE",
+"304 90 OFFCURVE",
+"296 85 OFFCURVE",
+"271 85 CURVE SMOOTH",
+"89 85 LINE",
+"89 89 LINE",
+"247 184 LINE SMOOTH",
+"303 217 OFFCURVE",
+"321 256 OFFCURVE",
+"321 296 CURVE SMOOTH",
+"321 373 OFFCURVE",
+"249 403 OFFCURVE",
+"180 403 CURVE SMOOTH",
+"107 403 OFFCURVE",
+"34 370 OFFCURVE",
+"34 303 CURVE SMOOTH",
+"34 271 OFFCURVE",
+"51 236 OFFCURVE",
+"92 236 CURVE SMOOTH",
+"117 236 OFFCURVE",
+"141 251 OFFCURVE",
+"141 284 CURVE SMOOTH",
+"141 307 OFFCURVE",
+"129 325 OFFCURVE",
+"104 325 CURVE SMOOTH",
+"88 325 OFFCURVE",
+"82 318 OFFCURVE",
+"76 318 CURVE SMOOTH",
+"71 318 OFFCURVE",
+"68 322 OFFCURVE",
+"68 329 CURVE SMOOTH",
+"68 351 OFFCURVE",
+"102 379 OFFCURVE",
+"142 379 CURVE SMOOTH",
+"190 379 OFFCURVE",
+"220 340 OFFCURVE",
+"220 276 CURVE SMOOTH",
+"220 232 OFFCURVE",
+"206 200 OFFCURVE",
+"146 155 CURVE SMOOTH",
+"17 57 LINE",
+"17 0 LINE"
+);
+}
+);
+width = 350;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"332 0 LINE",
+"332 147 LINE",
+"314 147 LINE",
+"314 93 OFFCURVE",
+"306 88 OFFCURVE",
+"280 88 CURVE SMOOTH",
+"95 88 LINE",
+"95 92 LINE",
+"252 183 LINE SMOOTH",
+"309 216 OFFCURVE",
+"332 254 OFFCURVE",
+"332 296 CURVE SMOOTH",
+"332 374 OFFCURVE",
+"257 403 OFFCURVE",
+"186 403 CURVE SMOOTH",
+"111 403 OFFCURVE",
+"36 369 OFFCURVE",
+"36 302 CURVE SMOOTH",
+"36 270 OFFCURVE",
+"53 235 OFFCURVE",
+"95 235 CURVE SMOOTH",
+"123 235 OFFCURVE",
+"147 249 OFFCURVE",
+"147 284 CURVE SMOOTH",
+"147 307 OFFCURVE",
+"137 325 OFFCURVE",
+"109 325 CURVE SMOOTH",
+"93 325 OFFCURVE",
+"86 318 OFFCURVE",
+"81 318 CURVE SMOOTH",
+"77 318 OFFCURVE",
+"73 322 OFFCURVE",
+"73 330 CURVE SMOOTH",
+"73 351 OFFCURVE",
+"106 378 OFFCURVE",
+"144 378 CURVE SMOOTH",
+"192 378 OFFCURVE",
+"223 341 OFFCURVE",
+"223 276 CURVE SMOOTH",
+"223 232 OFFCURVE",
+"210 199 OFFCURVE",
+"149 155 CURVE SMOOTH",
+"16 59 LINE",
+"16 0 LINE"
+);
+}
+);
+width = 360;
+}
+);
+},
+{
+glyphname = three.denominator;
+lastChange = "2016-08-19 17:28:22 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"249 -8 OFFCURVE",
+"317 50 OFFCURVE",
+"317 113 CURVE SMOOTH",
+"317 183 OFFCURVE",
+"253 216 OFFCURVE",
+"172 219 CURVE",
+"111 204 LINE",
+"182 204 OFFCURVE",
+"208 171 OFFCURVE",
+"208 109 CURVE SMOOTH",
+"208 48 OFFCURVE",
+"183 13 OFFCURVE",
+"133 13 CURVE SMOOTH",
+"115 13 OFFCURVE",
+"74 17 OFFCURVE",
+"74 31 CURVE SMOOTH",
+"74 46 OFFCURVE",
+"111 48 OFFCURVE",
+"111 88 CURVE SMOOTH",
+"111 124 OFFCURVE",
+"83 132 OFFCURVE",
+"64 132 CURVE SMOOTH",
+"30 132 OFFCURVE",
+"13 104 OFFCURVE",
+"13 73 CURVE SMOOTH",
+"13 23 OFFCURVE",
+"61 -8 OFFCURVE",
+"141 -8 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"172 204 LINE",
+"172 225 LINE",
+"76 225 LINE",
+"76 204 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"253 226 OFFCURVE",
+"299 262 OFFCURVE",
+"299 313 CURVE SMOOTH",
+"299 368 OFFCURVE",
+"247 403 OFFCURVE",
+"161 403 CURVE SMOOTH",
+"71 403 OFFCURVE",
+"36 364 OFFCURVE",
+"36 325 CURVE SMOOTH",
+"36 296 OFFCURVE",
+"55 280 OFFCURVE",
+"81 280 CURVE SMOOTH",
+"104 280 OFFCURVE",
+"130 292 OFFCURVE",
+"130 319 CURVE SMOOTH",
+"130 348 OFFCURVE",
+"99 353 OFFCURVE",
+"99 367 CURVE SMOOTH",
+"99 380 OFFCURVE",
+"123 383 OFFCURVE",
+"143 383 CURVE SMOOTH",
+"176 383 OFFCURVE",
+"197 371 OFFCURVE",
+"197 318 CURVE SMOOTH",
+"197 258 OFFCURVE",
+"170 225 OFFCURVE",
+"100 225 CURVE",
+"139 219 LINE"
+);
+}
+);
+width = 337;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"256 -8 OFFCURVE",
+"327 49 OFFCURVE",
+"327 113 CURVE SMOOTH",
+"327 183 OFFCURVE",
+"258 215 OFFCURVE",
+"173 218 CURVE",
+"111 204 LINE",
+"183 204 OFFCURVE",
+"210 171 OFFCURVE",
+"210 108 CURVE SMOOTH",
+"210 47 OFFCURVE",
+"186 13 OFFCURVE",
+"136 13 CURVE SMOOTH",
+"118 13 OFFCURVE",
+"78 17 OFFCURVE",
+"78 31 CURVE SMOOTH",
+"78 46 OFFCURVE",
+"118 48 OFFCURVE",
+"118 90 CURVE SMOOTH",
+"118 127 OFFCURVE",
+"86 135 OFFCURVE",
+"67 135 CURVE SMOOTH",
+"31 135 OFFCURVE",
+"12 105 OFFCURVE",
+"12 74 CURVE SMOOTH",
+"12 23 OFFCURVE",
+"60 -8 OFFCURVE",
+"143 -8 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"173 204 LINE",
+"173 224 LINE",
+"78 224 LINE",
+"78 204 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"265 226 OFFCURVE",
+"310 261 OFFCURVE",
+"310 312 CURVE SMOOTH",
+"310 368 OFFCURVE",
+"255 403 OFFCURVE",
+"166 403 CURVE SMOOTH",
+"70 403 OFFCURVE",
+"37 363 OFFCURVE",
+"37 323 CURVE SMOOTH",
+"37 294 OFFCURVE",
+"56 277 OFFCURVE",
+"85 277 CURVE SMOOTH",
+"109 277 OFFCURVE",
+"139 289 OFFCURVE",
+"139 318 CURVE SMOOTH",
+"139 347 OFFCURVE",
+"104 352 OFFCURVE",
+"104 367 CURVE SMOOTH",
+"104 379 OFFCURVE",
+"129 382 OFFCURVE",
+"148 382 CURVE SMOOTH",
+"179 382 OFFCURVE",
+"200 371 OFFCURVE",
+"200 318 CURVE SMOOTH",
+"200 258 OFFCURVE",
+"173 224 OFFCURVE",
+"99 224 CURVE",
+"140 218 LINE"
+);
+}
+);
+width = 346;
+}
+);
+},
+{
+glyphname = four.denominator;
+lastChange = "2016-08-19 17:28:22 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"322 0 LINE",
+"322 17 LINE",
+"267 17 LINE",
+"267 110 LINE",
+"338 110 LINE",
+"338 65 LINE",
+"356 65 LINE",
+"356 172 LINE",
+"338 172 LINE",
+"338 129 LINE",
+"268 129 LINE",
+"268 403 LINE",
+"208 403 LINE",
+"8 129 LINE",
+"8 110 LINE",
+"175 110 LINE",
+"175 17 LINE",
+"115 17 LINE",
+"115 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"36 133 LINE",
+"171 320 LINE",
+"175 320 LINE",
+"175 129 LINE",
+"36 129 LINE"
+);
+}
+);
+width = 377;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"332 0 LINE",
+"332 18 LINE",
+"276 18 LINE",
+"276 110 LINE",
+"350 110 LINE",
+"350 65 LINE",
+"369 65 LINE",
+"369 173 LINE",
+"350 173 LINE",
+"350 129 LINE",
+"276 129 LINE",
+"276 403 LINE",
+"210 403 LINE",
+"7 130 LINE",
+"7 110 LINE",
+"176 110 LINE",
+"176 18 LINE",
+"114 18 LINE",
+"114 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"34 133 LINE",
+"172 318 LINE",
+"176 318 LINE",
+"176 129 LINE",
+"34 129 LINE"
+);
+}
+);
+width = 391;
+}
+);
+},
+{
+glyphname = five.denominator;
+lastChange = "2016-08-19 17:28:22 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"251 -8 OFFCURVE",
+"333 39 OFFCURVE",
+"333 123 CURVE SMOOTH",
+"333 189 OFFCURVE",
+"282 247 OFFCURVE",
+"170 247 CURVE SMOOTH",
+"124 247 OFFCURVE",
+"73 237 OFFCURVE",
+"63 231 CURVE",
+"56 202 LINE",
+"67 212 OFFCURVE",
+"101 219 OFFCURVE",
+"128 219 CURVE SMOOTH",
+"183 219 OFFCURVE",
+"222 188 OFFCURVE",
+"222 112 CURVE SMOOTH",
+"222 45 OFFCURVE",
+"192 13 OFFCURVE",
+"135 13 CURVE SMOOTH",
+"113 13 OFFCURVE",
+"81 17 OFFCURVE",
+"81 29 CURVE SMOOTH",
+"81 41 OFFCURVE",
+"117 42 OFFCURVE",
+"117 80 CURVE SMOOTH",
+"117 112 OFFCURVE",
+"92 125 OFFCURVE",
+"68 125 CURVE SMOOTH",
+"37 125 OFFCURVE",
+"15 103 OFFCURVE",
+"15 71 CURVE SMOOTH",
+"15 26 OFFCURVE",
+"62 -8 OFFCURVE",
+"149 -8 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"70 228 LINE",
+"84 395 LINE",
+"61 395 LINE",
+"47 209 LINE",
+"56 202 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"292 310 LINE",
+"312 417 LINE",
+"295 417 LINE",
+"288 398 OFFCURVE",
+"281 395 OFFCURVE",
+"259 395 CURVE SMOOTH",
+"65 395 LINE",
+"79 310 LINE"
+);
+}
+);
+width = 349;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"261 -8 OFFCURVE",
+"346 38 OFFCURVE",
+"346 123 CURVE SMOOTH",
+"346 189 OFFCURVE",
+"298 248 OFFCURVE",
+"181 248 CURVE SMOOTH",
+"132 248 OFFCURVE",
+"75 238 OFFCURVE",
+"64 232 CURVE",
+"57 202 LINE",
+"67 211 OFFCURVE",
+"103 219 OFFCURVE",
+"131 219 CURVE SMOOTH",
+"187 219 OFFCURVE",
+"226 188 OFFCURVE",
+"226 112 CURVE SMOOTH",
+"226 45 OFFCURVE",
+"196 13 OFFCURVE",
+"139 13 CURVE SMOOTH",
+"120 13 OFFCURVE",
+"86 17 OFFCURVE",
+"86 28 CURVE SMOOTH",
+"86 40 OFFCURVE",
+"125 41 OFFCURVE",
+"125 81 CURVE SMOOTH",
+"125 114 OFFCURVE",
+"97 126 OFFCURVE",
+"72 126 CURVE SMOOTH",
+"38 126 OFFCURVE",
+"15 104 OFFCURVE",
+"15 72 CURVE SMOOTH",
+"15 26 OFFCURVE",
+"61 -8 OFFCURVE",
+"154 -8 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"71 229 LINE",
+"84 395 LINE",
+"60 395 LINE",
+"47 208 LINE",
+"57 202 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"305 306 LINE",
+"325 418 LINE",
+"307 418 LINE",
+"300 398 OFFCURVE",
+"293 395 OFFCURVE",
+"272 395 CURVE SMOOTH",
+"65 395 LINE",
+"78 306 LINE"
+);
+}
+);
+width = 362;
+}
+);
+},
+{
+glyphname = six.denominator;
+lastChange = "2016-08-19 17:28:22 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"260 -8 OFFCURVE",
+"334 50 OFFCURVE",
+"334 129 CURVE SMOOTH",
+"334 199 OFFCURVE",
+"275 253 OFFCURVE",
+"203 253 CURVE SMOOTH",
+"173 253 OFFCURVE",
+"153 244 OFFCURVE",
+"136 230 CURVE",
+"132 230 LINE",
+"144 312 OFFCURVE",
+"199 385 OFFCURVE",
+"287 395 CURVE",
+"287 415 LINE",
+"147 410 OFFCURVE",
+"25 288 OFFCURVE",
+"25 160 CURVE SMOOTH",
+"25 58 OFFCURVE",
+"94 -8 OFFCURVE",
+"180 -8 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"136 13 OFFCURVE",
+"121 41 OFFCURVE",
+"121 121 CURVE SMOOTH",
+"121 140 OFFCURVE",
+"121 168 OFFCURVE",
+"126 191 CURVE",
+"138 211 OFFCURVE",
+"157 229 OFFCURVE",
+"186 229 CURVE SMOOTH",
+"216 229 OFFCURVE",
+"233 210 OFFCURVE",
+"233 121 CURVE SMOOTH",
+"233 42 OFFCURVE",
+"220 13 OFFCURVE",
+"178 13 CURVE SMOOTH"
+);
+}
+);
+width = 348;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"264 -8 OFFCURVE",
+"338 50 OFFCURVE",
+"338 129 CURVE SMOOTH",
+"338 199 OFFCURVE",
+"281 252 OFFCURVE",
+"208 252 CURVE SMOOTH",
+"179 252 OFFCURVE",
+"159 243 OFFCURVE",
+"141 228 CURVE",
+"138 230 LINE",
+"150 311 OFFCURVE",
+"202 385 OFFCURVE",
+"288 395 CURVE",
+"288 416 LINE",
+"147 411 OFFCURVE",
+"24 288 OFFCURVE",
+"24 160 CURVE SMOOTH",
+"24 58 OFFCURVE",
+"95 -8 OFFCURVE",
+"182 -8 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"141 13 OFFCURVE",
+"126 42 OFFCURVE",
+"126 121 CURVE SMOOTH",
+"126 140 OFFCURVE",
+"126 167 OFFCURVE",
+"131 190 CURVE",
+"141 210 OFFCURVE",
+"159 228 OFFCURVE",
+"187 228 CURVE SMOOTH",
+"215 228 OFFCURVE",
+"233 209 OFFCURVE",
+"233 121 CURVE SMOOTH",
+"233 43 OFFCURVE",
+"220 13 OFFCURVE",
+"181 13 CURVE SMOOTH"
+);
+}
+);
+width = 352;
+}
+);
+},
+{
+glyphname = seven.denominator;
+lastChange = "2016-08-19 17:28:22 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"199 -8 OFFCURVE",
+"226 7 OFFCURVE",
+"226 42 CURVE SMOOTH",
+"226 69 OFFCURVE",
+"209 101 OFFCURVE",
+"209 138 CURVE SMOOTH",
+"209 162 OFFCURVE",
+"220 192 OFFCURVE",
+"245 231 CURVE SMOOTH",
+"325 359 LINE",
+"325 395 LINE",
+"60 395 LINE",
+"20 248 LINE",
+"41 248 LINE",
+"59 300 OFFCURVE",
+"57 309 OFFCURVE",
+"70 309 CURVE SMOOTH",
+"261 309 LINE",
+"166 159 LINE SMOOTH",
+"127 98 OFFCURVE",
+"111 71 OFFCURVE",
+"111 42 CURVE SMOOTH",
+"111 12 OFFCURVE",
+"129 -8 OFFCURVE",
+"166 -8 CURVE SMOOTH"
+);
+}
+);
+width = 335;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"206 -8 OFFCURVE",
+"237 8 OFFCURVE",
+"237 43 CURVE SMOOTH",
+"237 70 OFFCURVE",
+"220 105 OFFCURVE",
+"220 141 CURVE SMOOTH",
+"220 165 OFFCURVE",
+"232 194 OFFCURVE",
+"257 232 CURVE SMOOTH",
+"339 357 LINE",
+"339 395 LINE",
+"63 395 LINE",
+"20 244 LINE",
+"43 244 LINE",
+"60 298 OFFCURVE",
+"66 306 OFFCURVE",
+"75 306 CURVE SMOOTH",
+"269 306 LINE",
+"173 159 LINE SMOOTH",
+"134 99 OFFCURVE",
+"113 72 OFFCURVE",
+"113 42 CURVE SMOOTH",
+"113 13 OFFCURVE",
+"131 -8 OFFCURVE",
+"171 -8 CURVE SMOOTH"
+);
+}
+);
+width = 351;
+}
+);
+},
+{
+glyphname = eight.denominator;
+lastChange = "2016-08-19 17:28:22 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"283 -8 OFFCURVE",
+"334 38 OFFCURVE",
+"334 96 CURVE SMOOTH",
+"334 159 OFFCURVE",
+"283 191 OFFCURVE",
+"213 205 CURVE",
+"213 209 LINE",
+"140 209 LINE",
+"140 205 LINE",
+"68 192 OFFCURVE",
+"17 159 OFFCURVE",
+"17 96 CURVE SMOOTH",
+"17 38 OFFCURVE",
+"69 -8 OFFCURVE",
+"176 -8 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"135 9 OFFCURVE",
+"118 35 OFFCURVE",
+"118 100 CURVE SMOOTH",
+"118 163 OFFCURVE",
+"133 195 OFFCURVE",
+"176 195 CURVE SMOOTH",
+"219 195 OFFCURVE",
+"233 161 OFFCURVE",
+"233 100 CURVE SMOOTH",
+"233 35 OFFCURVE",
+"216 9 OFFCURVE",
+"176 9 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"142 216 OFFCURVE",
+"129 246 OFFCURVE",
+"129 303 CURVE SMOOTH",
+"129 359 OFFCURVE",
+"142 383 OFFCURVE",
+"176 383 CURVE SMOOTH",
+"211 383 OFFCURVE",
+"223 359 OFFCURVE",
+"223 303 CURVE SMOOTH",
+"223 246 OFFCURVE",
+"211 216 OFFCURVE",
+"176 216 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"256 205 OFFCURVE",
+"318 243 OFFCURVE",
+"318 304 CURVE SMOOTH",
+"318 356 OFFCURVE",
+"273 403 OFFCURVE",
+"175 403 CURVE SMOOTH",
+"81 403 OFFCURVE",
+"34 359 OFFCURVE",
+"34 305 CURVE SMOOTH",
+"34 243 OFFCURVE",
+"97 205 OFFCURVE",
+"176 205 CURVE SMOOTH"
+);
+}
+);
+width = 352;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"287 -8 OFFCURVE",
+"340 38 OFFCURVE",
+"340 96 CURVE SMOOTH",
+"340 160 OFFCURVE",
+"288 190 OFFCURVE",
+"215 204 CURVE",
+"215 210 LINE",
+"142 210 LINE",
+"142 204 LINE",
+"68 191 OFFCURVE",
+"16 160 OFFCURVE",
+"16 96 CURVE SMOOTH",
+"16 38 OFFCURVE",
+"68 -8 OFFCURVE",
+"178 -8 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"140 9 OFFCURVE",
+"123 35 OFFCURVE",
+"123 100 CURVE SMOOTH",
+"123 163 OFFCURVE",
+"137 194 OFFCURVE",
+"178 194 CURVE SMOOTH",
+"219 194 OFFCURVE",
+"233 161 OFFCURVE",
+"233 100 CURVE SMOOTH",
+"233 35 OFFCURVE",
+"216 9 OFFCURVE",
+"178 9 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"146 216 OFFCURVE",
+"134 247 OFFCURVE",
+"134 303 CURVE SMOOTH",
+"134 359 OFFCURVE",
+"146 382 OFFCURVE",
+"178 382 CURVE SMOOTH",
+"211 382 OFFCURVE",
+"222 359 OFFCURVE",
+"222 303 CURVE SMOOTH",
+"222 247 OFFCURVE",
+"211 216 OFFCURVE",
+"178 216 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"260 205 OFFCURVE",
+"324 243 OFFCURVE",
+"324 304 CURVE SMOOTH",
+"324 356 OFFCURVE",
+"278 403 OFFCURVE",
+"177 403 CURVE SMOOTH",
+"81 403 OFFCURVE",
+"32 359 OFFCURVE",
+"32 305 CURVE SMOOTH",
+"32 243 OFFCURVE",
+"97 205 OFFCURVE",
+"178 205 CURVE SMOOTH"
+);
+}
+);
+width = 356;
+}
+);
+},
+{
+glyphname = nine.denominator;
+lastChange = "2016-08-19 17:28:22 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"196 1 OFFCURVE",
+"325 104 OFFCURVE",
+"325 235 CURVE SMOOTH",
+"325 337 OFFCURVE",
+"256 403 OFFCURVE",
+"169 403 CURVE SMOOTH",
+"89 403 OFFCURVE",
+"16 344 OFFCURVE",
+"16 266 CURVE SMOOTH",
+"16 196 OFFCURVE",
+"74 142 OFFCURVE",
+"147 142 CURVE SMOOTH",
+"176 142 OFFCURVE",
+"195 149 OFFCURVE",
+"213 164 CURVE",
+"217 164 LINE",
+"205 81 OFFCURVE",
+"145 25 OFFCURVE",
+"57 16 CURVE",
+"57 -4 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"133 166 OFFCURVE",
+"116 185 OFFCURVE",
+"116 273 CURVE SMOOTH",
+"116 353 OFFCURVE",
+"129 383 OFFCURVE",
+"171 383 CURVE SMOOTH",
+"213 383 OFFCURVE",
+"228 353 OFFCURVE",
+"228 274 CURVE SMOOTH",
+"228 254 OFFCURVE",
+"228 227 OFFCURVE",
+"223 204 CURVE",
+"212 183 OFFCURVE",
+"192 166 OFFCURVE",
+"163 166 CURVE SMOOTH"
+);
+}
+);
+width = 348;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"198 2 OFFCURVE",
+"328 105 OFFCURVE",
+"328 235 CURVE SMOOTH",
+"328 337 OFFCURVE",
+"257 403 OFFCURVE",
+"169 403 CURVE SMOOTH",
+"88 403 OFFCURVE",
+"13 345 OFFCURVE",
+"13 266 CURVE SMOOTH",
+"13 196 OFFCURVE",
+"71 143 OFFCURVE",
+"144 143 CURVE SMOOTH",
+"173 143 OFFCURVE",
+"192 152 OFFCURVE",
+"211 167 CURVE",
+"214 165 LINE",
+"202 83 OFFCURVE",
+"143 27 OFFCURVE",
+"56 17 CURVE",
+"56 -3 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"136 167 OFFCURVE",
+"119 186 OFFCURVE",
+"119 274 CURVE SMOOTH",
+"119 352 OFFCURVE",
+"132 383 OFFCURVE",
+"171 383 CURVE SMOOTH",
+"211 383 OFFCURVE",
+"226 353 OFFCURVE",
+"226 274 CURVE SMOOTH",
+"226 255 OFFCURVE",
+"225 228 OFFCURVE",
+"220 205 CURVE",
+"210 185 OFFCURVE",
+"192 167 OFFCURVE",
+"164 167 CURVE SMOOTH"
+);
+}
+);
+width = 352;
+}
+);
+},
+{
+glyphname = zero.numerator;
+lastChange = "2016-08-19 17:28:22 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"305 351 OFFCURVE",
+"383 434 OFFCURVE",
+"383 556 CURVE SMOOTH",
+"383 678 OFFCURVE",
+"305 762 OFFCURVE",
+"203 762 CURVE SMOOTH",
+"101 762 OFFCURVE",
+"24 678 OFFCURVE",
+"24 556 CURVE SMOOTH",
+"24 434 OFFCURVE",
+"101 351 OFFCURVE",
+"203 351 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"144 372 OFFCURVE",
+"126 406 OFFCURVE",
+"126 556 CURVE SMOOTH",
+"126 707 OFFCURVE",
+"144 742 OFFCURVE",
+"203 742 CURVE SMOOTH",
+"259 742 OFFCURVE",
+"280 707 OFFCURVE",
+"280 556 CURVE SMOOTH",
+"280 406 OFFCURVE",
+"259 372 OFFCURVE",
+"203 372 CURVE SMOOTH"
+);
+}
+);
+width = 407;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"24 434 OFFCURVE",
+"101 351 OFFCURVE",
+"203 351 CURVE SMOOTH",
+"305 351 OFFCURVE",
+"383 434 OFFCURVE",
+"383 556 CURVE SMOOTH",
+"383 678 OFFCURVE",
+"305 762 OFFCURVE",
+"203 762 CURVE SMOOTH",
+"101 762 OFFCURVE",
+"24 678 OFFCURVE",
+"24 556 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"126 707 OFFCURVE",
+"144 742 OFFCURVE",
+"203 742 CURVE SMOOTH",
+"259 742 OFFCURVE",
+"280 707 OFFCURVE",
+"280 556 CURVE SMOOTH",
+"280 406 OFFCURVE",
+"259 372 OFFCURVE",
+"203 372 CURVE SMOOTH",
+"144 372 OFFCURVE",
+"126 406 OFFCURVE",
+"126 556 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"314 351 OFFCURVE",
+"396 433 OFFCURVE",
+"396 556 CURVE SMOOTH",
+"396 678 OFFCURVE",
+"314 762 OFFCURVE",
+"209 762 CURVE SMOOTH",
+"104 762 OFFCURVE",
+"23 678 OFFCURVE",
+"23 556 CURVE SMOOTH",
+"23 433 OFFCURVE",
+"104 351 OFFCURVE",
+"209 351 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"149 372 OFFCURVE",
+"131 405 OFFCURVE",
+"131 556 CURVE SMOOTH",
+"131 706 OFFCURVE",
+"149 741 OFFCURVE",
+"209 741 CURVE SMOOTH",
+"265 741 OFFCURVE",
+"287 706 OFFCURVE",
+"287 556 CURVE SMOOTH",
+"287 405 OFFCURVE",
+"265 372 OFFCURVE",
+"209 372 CURVE SMOOTH"
+);
+}
+);
+width = 419;
+}
+);
+},
+{
+glyphname = one.numerator;
+lastChange = "2016-08-19 17:28:22 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"266 359 LINE",
+"266 376 LINE",
+"184 376 LINE",
+"184 754 LINE",
+"4 754 LINE",
+"4 736 LINE",
+"91 736 LINE",
+"91 376 LINE",
+"4 376 LINE",
+"4 359 LINE"
+);
+}
+);
+width = 270;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"275 359 LINE",
+"275 377 LINE",
+"192 377 LINE",
+"192 754 LINE",
+"3 754 LINE",
+"3 736 LINE",
+"92 736 LINE",
+"92 377 LINE",
+"3 377 LINE",
+"3 359 LINE"
+);
+}
+);
+width = 279;
+}
+);
+},
+{
+glyphname = two.numerator;
+lastChange = "2016-08-19 17:28:22 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"321 359 LINE",
+"321 502 LINE",
+"304 502 LINE",
+"304 449 OFFCURVE",
+"296 444 OFFCURVE",
+"271 444 CURVE SMOOTH",
+"89 444 LINE",
+"89 448 LINE",
+"247 543 LINE SMOOTH",
+"303 576 OFFCURVE",
+"321 615 OFFCURVE",
+"321 655 CURVE SMOOTH",
+"321 732 OFFCURVE",
+"249 762 OFFCURVE",
+"180 762 CURVE SMOOTH",
+"107 762 OFFCURVE",
+"34 729 OFFCURVE",
+"34 662 CURVE SMOOTH",
+"34 630 OFFCURVE",
+"51 595 OFFCURVE",
+"92 595 CURVE SMOOTH",
+"117 595 OFFCURVE",
+"141 610 OFFCURVE",
+"141 643 CURVE SMOOTH",
+"141 666 OFFCURVE",
+"129 684 OFFCURVE",
+"104 684 CURVE SMOOTH",
+"88 684 OFFCURVE",
+"82 677 OFFCURVE",
+"76 677 CURVE SMOOTH",
+"71 677 OFFCURVE",
+"68 681 OFFCURVE",
+"68 688 CURVE SMOOTH",
+"68 710 OFFCURVE",
+"102 738 OFFCURVE",
+"142 738 CURVE SMOOTH",
+"190 738 OFFCURVE",
+"220 699 OFFCURVE",
+"220 635 CURVE SMOOTH",
+"220 591 OFFCURVE",
+"206 559 OFFCURVE",
+"146 514 CURVE SMOOTH",
+"17 416 LINE",
+"17 359 LINE"
+);
+}
+);
+width = 350;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"332 359 LINE",
+"332 506 LINE",
+"314 506 LINE",
+"314 452 OFFCURVE",
+"306 447 OFFCURVE",
+"280 447 CURVE SMOOTH",
+"95 447 LINE",
+"95 451 LINE",
+"252 542 LINE SMOOTH",
+"309 575 OFFCURVE",
+"332 613 OFFCURVE",
+"332 655 CURVE SMOOTH",
+"332 733 OFFCURVE",
+"257 762 OFFCURVE",
+"186 762 CURVE SMOOTH",
+"111 762 OFFCURVE",
+"36 728 OFFCURVE",
+"36 661 CURVE SMOOTH",
+"36 629 OFFCURVE",
+"53 594 OFFCURVE",
+"95 594 CURVE SMOOTH",
+"123 594 OFFCURVE",
+"147 608 OFFCURVE",
+"147 643 CURVE SMOOTH",
+"147 666 OFFCURVE",
+"137 684 OFFCURVE",
+"109 684 CURVE SMOOTH",
+"93 684 OFFCURVE",
+"86 677 OFFCURVE",
+"81 677 CURVE SMOOTH",
+"77 677 OFFCURVE",
+"73 681 OFFCURVE",
+"73 689 CURVE SMOOTH",
+"73 710 OFFCURVE",
+"106 737 OFFCURVE",
+"144 737 CURVE SMOOTH",
+"192 737 OFFCURVE",
+"223 700 OFFCURVE",
+"223 635 CURVE SMOOTH",
+"223 591 OFFCURVE",
+"210 558 OFFCURVE",
+"149 514 CURVE SMOOTH",
+"16 418 LINE",
+"16 359 LINE"
+);
+}
+);
+width = 360;
+}
+);
+},
+{
+glyphname = three.numerator;
+lastChange = "2016-08-19 17:28:22 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"249 351 OFFCURVE",
+"317 409 OFFCURVE",
+"317 472 CURVE SMOOTH",
+"317 542 OFFCURVE",
+"253 575 OFFCURVE",
+"172 578 CURVE",
+"111 563 LINE",
+"182 563 OFFCURVE",
+"208 530 OFFCURVE",
+"208 468 CURVE SMOOTH",
+"208 407 OFFCURVE",
+"183 372 OFFCURVE",
+"133 372 CURVE SMOOTH",
+"115 372 OFFCURVE",
+"74 376 OFFCURVE",
+"74 390 CURVE SMOOTH",
+"74 405 OFFCURVE",
+"111 407 OFFCURVE",
+"111 447 CURVE SMOOTH",
+"111 483 OFFCURVE",
+"83 491 OFFCURVE",
+"64 491 CURVE SMOOTH",
+"30 491 OFFCURVE",
+"13 463 OFFCURVE",
+"13 432 CURVE SMOOTH",
+"13 382 OFFCURVE",
+"61 351 OFFCURVE",
+"141 351 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"172 563 LINE",
+"172 584 LINE",
+"76 584 LINE",
+"76 563 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"253 585 OFFCURVE",
+"299 621 OFFCURVE",
+"299 672 CURVE SMOOTH",
+"299 727 OFFCURVE",
+"247 762 OFFCURVE",
+"161 762 CURVE SMOOTH",
+"71 762 OFFCURVE",
+"36 723 OFFCURVE",
+"36 684 CURVE SMOOTH",
+"36 655 OFFCURVE",
+"55 639 OFFCURVE",
+"81 639 CURVE SMOOTH",
+"104 639 OFFCURVE",
+"130 651 OFFCURVE",
+"130 678 CURVE SMOOTH",
+"130 707 OFFCURVE",
+"99 712 OFFCURVE",
+"99 726 CURVE SMOOTH",
+"99 739 OFFCURVE",
+"123 742 OFFCURVE",
+"143 742 CURVE SMOOTH",
+"176 742 OFFCURVE",
+"197 730 OFFCURVE",
+"197 677 CURVE SMOOTH",
+"197 617 OFFCURVE",
+"170 584 OFFCURVE",
+"100 584 CURVE",
+"139 578 LINE"
+);
+}
+);
+width = 337;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"256 351 OFFCURVE",
+"327 408 OFFCURVE",
+"327 472 CURVE SMOOTH",
+"327 542 OFFCURVE",
+"258 574 OFFCURVE",
+"173 577 CURVE",
+"111 563 LINE",
+"183 563 OFFCURVE",
+"210 530 OFFCURVE",
+"210 467 CURVE SMOOTH",
+"210 406 OFFCURVE",
+"186 372 OFFCURVE",
+"136 372 CURVE SMOOTH",
+"118 372 OFFCURVE",
+"78 376 OFFCURVE",
+"78 390 CURVE SMOOTH",
+"78 405 OFFCURVE",
+"118 407 OFFCURVE",
+"118 449 CURVE SMOOTH",
+"118 486 OFFCURVE",
+"86 494 OFFCURVE",
+"67 494 CURVE SMOOTH",
+"31 494 OFFCURVE",
+"12 464 OFFCURVE",
+"12 433 CURVE SMOOTH",
+"12 382 OFFCURVE",
+"60 351 OFFCURVE",
+"143 351 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"173 563 LINE",
+"173 583 LINE",
+"78 583 LINE",
+"78 563 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"265 585 OFFCURVE",
+"310 620 OFFCURVE",
+"310 671 CURVE SMOOTH",
+"310 727 OFFCURVE",
+"255 762 OFFCURVE",
+"166 762 CURVE SMOOTH",
+"70 762 OFFCURVE",
+"37 722 OFFCURVE",
+"37 682 CURVE SMOOTH",
+"37 653 OFFCURVE",
+"56 636 OFFCURVE",
+"85 636 CURVE SMOOTH",
+"109 636 OFFCURVE",
+"139 648 OFFCURVE",
+"139 677 CURVE SMOOTH",
+"139 706 OFFCURVE",
+"104 711 OFFCURVE",
+"104 726 CURVE SMOOTH",
+"104 738 OFFCURVE",
+"129 741 OFFCURVE",
+"148 741 CURVE SMOOTH",
+"179 741 OFFCURVE",
+"200 730 OFFCURVE",
+"200 677 CURVE SMOOTH",
+"200 617 OFFCURVE",
+"173 583 OFFCURVE",
+"99 583 CURVE",
+"140 577 LINE"
+);
+}
+);
+width = 346;
+}
+);
+},
+{
+glyphname = four.numerator;
+lastChange = "2016-08-19 17:28:22 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"322 359 LINE",
+"322 376 LINE",
+"267 376 LINE",
+"267 469 LINE",
+"338 469 LINE",
+"338 424 LINE",
+"356 424 LINE",
+"356 531 LINE",
+"338 531 LINE",
+"338 488 LINE",
+"268 488 LINE",
+"268 762 LINE",
+"208 762 LINE",
+"8 488 LINE",
+"8 469 LINE",
+"175 469 LINE",
+"175 376 LINE",
+"115 376 LINE",
+"115 359 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"36 492 LINE",
+"171 679 LINE",
+"175 679 LINE",
+"175 488 LINE",
+"36 488 LINE"
+);
+}
+);
+width = 377;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"332 359 LINE",
+"332 377 LINE",
+"276 377 LINE",
+"276 469 LINE",
+"350 469 LINE",
+"350 424 LINE",
+"369 424 LINE",
+"369 532 LINE",
+"350 532 LINE",
+"350 488 LINE",
+"276 488 LINE",
+"276 762 LINE",
+"210 762 LINE",
+"7 489 LINE",
+"7 469 LINE",
+"176 469 LINE",
+"176 377 LINE",
+"114 377 LINE",
+"114 359 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"34 492 LINE",
+"172 677 LINE",
+"176 677 LINE",
+"176 488 LINE",
+"34 488 LINE"
+);
+}
+);
+width = 391;
+}
+);
+},
+{
+glyphname = five.numerator;
+lastChange = "2016-08-19 17:28:22 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"251 351 OFFCURVE",
+"333 398 OFFCURVE",
+"333 482 CURVE SMOOTH",
+"333 548 OFFCURVE",
+"282 606 OFFCURVE",
+"170 606 CURVE SMOOTH",
+"124 606 OFFCURVE",
+"73 596 OFFCURVE",
+"63 590 CURVE",
+"56 561 LINE",
+"67 571 OFFCURVE",
+"101 578 OFFCURVE",
+"128 578 CURVE SMOOTH",
+"183 578 OFFCURVE",
+"222 547 OFFCURVE",
+"222 471 CURVE SMOOTH",
+"222 404 OFFCURVE",
+"192 372 OFFCURVE",
+"135 372 CURVE SMOOTH",
+"113 372 OFFCURVE",
+"81 376 OFFCURVE",
+"81 388 CURVE SMOOTH",
+"81 400 OFFCURVE",
+"117 401 OFFCURVE",
+"117 439 CURVE SMOOTH",
+"117 471 OFFCURVE",
+"92 484 OFFCURVE",
+"68 484 CURVE SMOOTH",
+"37 484 OFFCURVE",
+"15 462 OFFCURVE",
+"15 430 CURVE SMOOTH",
+"15 385 OFFCURVE",
+"62 351 OFFCURVE",
+"149 351 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"70 587 LINE",
+"84 754 LINE",
+"61 754 LINE",
+"47 568 LINE",
+"56 561 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"292 669 LINE",
+"312 776 LINE",
+"295 776 LINE",
+"288 757 OFFCURVE",
+"281 754 OFFCURVE",
+"259 754 CURVE SMOOTH",
+"65 754 LINE",
+"79 669 LINE"
+);
+}
+);
+width = 349;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"261 351 OFFCURVE",
+"346 397 OFFCURVE",
+"346 482 CURVE SMOOTH",
+"346 548 OFFCURVE",
+"298 607 OFFCURVE",
+"181 607 CURVE SMOOTH",
+"132 607 OFFCURVE",
+"75 597 OFFCURVE",
+"64 591 CURVE",
+"57 561 LINE",
+"67 570 OFFCURVE",
+"103 578 OFFCURVE",
+"131 578 CURVE SMOOTH",
+"187 578 OFFCURVE",
+"226 547 OFFCURVE",
+"226 471 CURVE SMOOTH",
+"226 404 OFFCURVE",
+"196 372 OFFCURVE",
+"139 372 CURVE SMOOTH",
+"120 372 OFFCURVE",
+"86 376 OFFCURVE",
+"86 387 CURVE SMOOTH",
+"86 399 OFFCURVE",
+"125 400 OFFCURVE",
+"125 440 CURVE SMOOTH",
+"125 473 OFFCURVE",
+"97 485 OFFCURVE",
+"72 485 CURVE SMOOTH",
+"38 485 OFFCURVE",
+"15 463 OFFCURVE",
+"15 431 CURVE SMOOTH",
+"15 385 OFFCURVE",
+"61 351 OFFCURVE",
+"154 351 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"71 588 LINE",
+"84 754 LINE",
+"60 754 LINE",
+"47 567 LINE",
+"57 561 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"305 665 LINE",
+"325 777 LINE",
+"307 777 LINE",
+"300 757 OFFCURVE",
+"293 754 OFFCURVE",
+"272 754 CURVE SMOOTH",
+"65 754 LINE",
+"78 665 LINE"
+);
+}
+);
+width = 362;
+}
+);
+},
+{
+glyphname = six.numerator;
+lastChange = "2016-08-19 17:28:22 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"260 351 OFFCURVE",
+"334 409 OFFCURVE",
+"334 488 CURVE SMOOTH",
+"334 558 OFFCURVE",
+"275 612 OFFCURVE",
+"203 612 CURVE SMOOTH",
+"173 612 OFFCURVE",
+"153 603 OFFCURVE",
+"136 589 CURVE",
+"132 589 LINE",
+"144 671 OFFCURVE",
+"199 744 OFFCURVE",
+"287 754 CURVE",
+"287 774 LINE",
+"147 769 OFFCURVE",
+"25 647 OFFCURVE",
+"25 519 CURVE SMOOTH",
+"25 417 OFFCURVE",
+"94 351 OFFCURVE",
+"180 351 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"136 372 OFFCURVE",
+"121 400 OFFCURVE",
+"121 480 CURVE SMOOTH",
+"121 499 OFFCURVE",
+"121 527 OFFCURVE",
+"126 550 CURVE",
+"138 570 OFFCURVE",
+"157 588 OFFCURVE",
+"186 588 CURVE SMOOTH",
+"216 588 OFFCURVE",
+"233 569 OFFCURVE",
+"233 480 CURVE SMOOTH",
+"233 401 OFFCURVE",
+"220 372 OFFCURVE",
+"178 372 CURVE SMOOTH"
+);
+}
+);
+width = 348;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"264 351 OFFCURVE",
+"338 409 OFFCURVE",
+"338 488 CURVE SMOOTH",
+"338 558 OFFCURVE",
+"281 611 OFFCURVE",
+"208 611 CURVE SMOOTH",
+"179 611 OFFCURVE",
+"159 602 OFFCURVE",
+"141 587 CURVE",
+"138 589 LINE",
+"150 670 OFFCURVE",
+"202 744 OFFCURVE",
+"288 754 CURVE",
+"288 775 LINE",
+"147 770 OFFCURVE",
+"24 647 OFFCURVE",
+"24 519 CURVE SMOOTH",
+"24 417 OFFCURVE",
+"95 351 OFFCURVE",
+"182 351 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"141 372 OFFCURVE",
+"126 401 OFFCURVE",
+"126 480 CURVE SMOOTH",
+"126 499 OFFCURVE",
+"126 526 OFFCURVE",
+"131 549 CURVE",
+"141 569 OFFCURVE",
+"159 587 OFFCURVE",
+"187 587 CURVE SMOOTH",
+"215 587 OFFCURVE",
+"233 568 OFFCURVE",
+"233 480 CURVE SMOOTH",
+"233 402 OFFCURVE",
+"220 372 OFFCURVE",
+"181 372 CURVE SMOOTH"
+);
+}
+);
+width = 352;
+}
+);
+},
+{
+glyphname = seven.numerator;
+lastChange = "2016-08-19 17:28:22 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"199 351 OFFCURVE",
+"226 366 OFFCURVE",
+"226 401 CURVE SMOOTH",
+"226 428 OFFCURVE",
+"209 460 OFFCURVE",
+"209 497 CURVE SMOOTH",
+"209 521 OFFCURVE",
+"220 551 OFFCURVE",
+"245 590 CURVE SMOOTH",
+"325 718 LINE",
+"325 754 LINE",
+"60 754 LINE",
+"20 607 LINE",
+"41 607 LINE",
+"59 659 OFFCURVE",
+"57 668 OFFCURVE",
+"70 668 CURVE SMOOTH",
+"261 668 LINE",
+"166 518 LINE SMOOTH",
+"127 457 OFFCURVE",
+"111 430 OFFCURVE",
+"111 401 CURVE SMOOTH",
+"111 371 OFFCURVE",
+"129 351 OFFCURVE",
+"166 351 CURVE SMOOTH"
+);
+}
+);
+width = 335;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"206 351 OFFCURVE",
+"237 367 OFFCURVE",
+"237 402 CURVE SMOOTH",
+"237 429 OFFCURVE",
+"220 464 OFFCURVE",
+"220 500 CURVE SMOOTH",
+"220 524 OFFCURVE",
+"232 553 OFFCURVE",
+"257 591 CURVE SMOOTH",
+"339 716 LINE",
+"339 754 LINE",
+"63 754 LINE",
+"20 603 LINE",
+"43 603 LINE",
+"60 657 OFFCURVE",
+"66 665 OFFCURVE",
+"75 665 CURVE SMOOTH",
+"269 665 LINE",
+"173 518 LINE SMOOTH",
+"134 458 OFFCURVE",
+"113 431 OFFCURVE",
+"113 401 CURVE SMOOTH",
+"113 372 OFFCURVE",
+"131 351 OFFCURVE",
+"171 351 CURVE SMOOTH"
+);
+}
+);
+width = 351;
+}
+);
+},
+{
+glyphname = eight.numerator;
+lastChange = "2016-08-19 17:28:22 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"283 351 OFFCURVE",
+"334 397 OFFCURVE",
+"334 455 CURVE SMOOTH",
+"334 518 OFFCURVE",
+"283 550 OFFCURVE",
+"213 564 CURVE",
+"213 568 LINE",
+"140 568 LINE",
+"140 564 LINE",
+"68 551 OFFCURVE",
+"17 518 OFFCURVE",
+"17 455 CURVE SMOOTH",
+"17 397 OFFCURVE",
+"69 351 OFFCURVE",
+"176 351 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"135 368 OFFCURVE",
+"118 394 OFFCURVE",
+"118 459 CURVE SMOOTH",
+"118 522 OFFCURVE",
+"133 554 OFFCURVE",
+"176 554 CURVE SMOOTH",
+"219 554 OFFCURVE",
+"233 520 OFFCURVE",
+"233 459 CURVE SMOOTH",
+"233 394 OFFCURVE",
+"216 368 OFFCURVE",
+"176 368 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"142 575 OFFCURVE",
+"129 605 OFFCURVE",
+"129 662 CURVE SMOOTH",
+"129 718 OFFCURVE",
+"142 742 OFFCURVE",
+"176 742 CURVE SMOOTH",
+"211 742 OFFCURVE",
+"223 718 OFFCURVE",
+"223 662 CURVE SMOOTH",
+"223 605 OFFCURVE",
+"211 575 OFFCURVE",
+"176 575 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"256 564 OFFCURVE",
+"318 602 OFFCURVE",
+"318 663 CURVE SMOOTH",
+"318 715 OFFCURVE",
+"273 762 OFFCURVE",
+"175 762 CURVE SMOOTH",
+"81 762 OFFCURVE",
+"34 718 OFFCURVE",
+"34 664 CURVE SMOOTH",
+"34 602 OFFCURVE",
+"97 564 OFFCURVE",
+"176 564 CURVE SMOOTH"
+);
+}
+);
+width = 352;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"287 351 OFFCURVE",
+"340 397 OFFCURVE",
+"340 455 CURVE SMOOTH",
+"340 519 OFFCURVE",
+"288 549 OFFCURVE",
+"215 563 CURVE",
+"215 569 LINE",
+"142 569 LINE",
+"142 563 LINE",
+"68 550 OFFCURVE",
+"16 519 OFFCURVE",
+"16 455 CURVE SMOOTH",
+"16 397 OFFCURVE",
+"68 351 OFFCURVE",
+"178 351 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"140 368 OFFCURVE",
+"123 394 OFFCURVE",
+"123 459 CURVE SMOOTH",
+"123 522 OFFCURVE",
+"137 553 OFFCURVE",
+"178 553 CURVE SMOOTH",
+"219 553 OFFCURVE",
+"233 520 OFFCURVE",
+"233 459 CURVE SMOOTH",
+"233 394 OFFCURVE",
+"216 368 OFFCURVE",
+"178 368 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"146 575 OFFCURVE",
+"134 606 OFFCURVE",
+"134 662 CURVE SMOOTH",
+"134 718 OFFCURVE",
+"146 741 OFFCURVE",
+"178 741 CURVE SMOOTH",
+"211 741 OFFCURVE",
+"222 718 OFFCURVE",
+"222 662 CURVE SMOOTH",
+"222 606 OFFCURVE",
+"211 575 OFFCURVE",
+"178 575 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"260 564 OFFCURVE",
+"324 602 OFFCURVE",
+"324 663 CURVE SMOOTH",
+"324 715 OFFCURVE",
+"278 762 OFFCURVE",
+"177 762 CURVE SMOOTH",
+"81 762 OFFCURVE",
+"32 718 OFFCURVE",
+"32 664 CURVE SMOOTH",
+"32 602 OFFCURVE",
+"97 564 OFFCURVE",
+"178 564 CURVE SMOOTH"
+);
+}
+);
+width = 356;
+}
+);
+},
+{
+glyphname = nine.numerator;
+lastChange = "2016-08-19 17:28:22 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"196 360 OFFCURVE",
+"325 463 OFFCURVE",
+"325 594 CURVE SMOOTH",
+"325 696 OFFCURVE",
+"256 762 OFFCURVE",
+"169 762 CURVE SMOOTH",
+"89 762 OFFCURVE",
+"16 703 OFFCURVE",
+"16 625 CURVE SMOOTH",
+"16 555 OFFCURVE",
+"74 501 OFFCURVE",
+"147 501 CURVE SMOOTH",
+"176 501 OFFCURVE",
+"195 508 OFFCURVE",
+"213 523 CURVE",
+"217 523 LINE",
+"205 440 OFFCURVE",
+"145 384 OFFCURVE",
+"57 375 CURVE",
+"57 355 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"133 525 OFFCURVE",
+"116 544 OFFCURVE",
+"116 632 CURVE SMOOTH",
+"116 712 OFFCURVE",
+"129 742 OFFCURVE",
+"171 742 CURVE SMOOTH",
+"213 742 OFFCURVE",
+"228 712 OFFCURVE",
+"228 633 CURVE SMOOTH",
+"228 613 OFFCURVE",
+"228 586 OFFCURVE",
+"223 563 CURVE",
+"212 542 OFFCURVE",
+"192 525 OFFCURVE",
+"163 525 CURVE SMOOTH"
+);
+}
+);
+width = 348;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"198 361 OFFCURVE",
+"328 464 OFFCURVE",
+"328 594 CURVE SMOOTH",
+"328 696 OFFCURVE",
+"257 762 OFFCURVE",
+"169 762 CURVE SMOOTH",
+"88 762 OFFCURVE",
+"13 704 OFFCURVE",
+"13 625 CURVE SMOOTH",
+"13 555 OFFCURVE",
+"71 502 OFFCURVE",
+"144 502 CURVE SMOOTH",
+"173 502 OFFCURVE",
+"192 511 OFFCURVE",
+"211 526 CURVE",
+"214 524 LINE",
+"202 442 OFFCURVE",
+"143 386 OFFCURVE",
+"56 376 CURVE",
+"56 356 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"136 526 OFFCURVE",
+"119 545 OFFCURVE",
+"119 633 CURVE SMOOTH",
+"119 711 OFFCURVE",
+"132 742 OFFCURVE",
+"171 742 CURVE SMOOTH",
+"211 742 OFFCURVE",
+"226 712 OFFCURVE",
+"226 633 CURVE SMOOTH",
+"226 614 OFFCURVE",
+"225 587 OFFCURVE",
+"220 564 CURVE",
+"210 544 OFFCURVE",
+"192 526 OFFCURVE",
+"164 526 CURVE SMOOTH"
+);
+}
+);
+width = 352;
+}
+);
+},
+{
+glyphname = zeroinferior;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"305 -108 OFFCURVE",
+"383 -25 OFFCURVE",
+"383 97 CURVE SMOOTH",
+"383 219 OFFCURVE",
+"305 303 OFFCURVE",
+"203 303 CURVE SMOOTH",
+"101 303 OFFCURVE",
+"24 219 OFFCURVE",
+"24 97 CURVE SMOOTH",
+"24 -25 OFFCURVE",
+"101 -108 OFFCURVE",
+"203 -108 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"144 -87 OFFCURVE",
+"126 -53 OFFCURVE",
+"126 97 CURVE SMOOTH",
+"126 248 OFFCURVE",
+"144 283 OFFCURVE",
+"203 283 CURVE SMOOTH",
+"259 283 OFFCURVE",
+"280 248 OFFCURVE",
+"280 97 CURVE SMOOTH",
+"280 -53 OFFCURVE",
+"259 -87 OFFCURVE",
+"203 -87 CURVE SMOOTH"
+);
+}
+);
+width = 407;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"24 434 OFFCURVE",
+"101 351 OFFCURVE",
+"203 351 CURVE SMOOTH",
+"305 351 OFFCURVE",
+"383 434 OFFCURVE",
+"383 556 CURVE SMOOTH",
+"383 678 OFFCURVE",
+"305 762 OFFCURVE",
+"203 762 CURVE SMOOTH",
+"101 762 OFFCURVE",
+"24 678 OFFCURVE",
+"24 556 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"126 707 OFFCURVE",
+"144 742 OFFCURVE",
+"203 742 CURVE SMOOTH",
+"259 742 OFFCURVE",
+"280 707 OFFCURVE",
+"280 556 CURVE SMOOTH",
+"280 406 OFFCURVE",
+"259 372 OFFCURVE",
+"203 372 CURVE SMOOTH",
+"144 372 OFFCURVE",
+"126 406 OFFCURVE",
+"126 556 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"314 -108 OFFCURVE",
+"396 -26 OFFCURVE",
+"396 97 CURVE SMOOTH",
+"396 219 OFFCURVE",
+"314 303 OFFCURVE",
+"209 303 CURVE SMOOTH",
+"104 303 OFFCURVE",
+"23 219 OFFCURVE",
+"23 97 CURVE SMOOTH",
+"23 -26 OFFCURVE",
+"104 -108 OFFCURVE",
+"209 -108 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"149 -87 OFFCURVE",
+"131 -54 OFFCURVE",
+"131 97 CURVE SMOOTH",
+"131 247 OFFCURVE",
+"149 282 OFFCURVE",
+"209 282 CURVE SMOOTH",
+"265 282 OFFCURVE",
+"287 247 OFFCURVE",
+"287 97 CURVE SMOOTH",
+"287 -54 OFFCURVE",
+"265 -87 OFFCURVE",
+"209 -87 CURVE SMOOTH"
+);
+}
+);
+width = 419;
+}
+);
+unicode = 2080;
+},
+{
+glyphname = oneinferior;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"266 -100 LINE",
+"266 -83 LINE",
+"184 -83 LINE",
+"184 295 LINE",
+"4 295 LINE",
+"4 277 LINE",
+"91 277 LINE",
+"91 -83 LINE",
+"4 -83 LINE",
+"4 -100 LINE"
+);
+}
+);
+width = 270;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"275 -100 LINE",
+"275 -82 LINE",
+"192 -82 LINE",
+"192 295 LINE",
+"3 295 LINE",
+"3 277 LINE",
+"92 277 LINE",
+"92 -82 LINE",
+"3 -82 LINE",
+"3 -100 LINE"
+);
+}
+);
+width = 279;
+}
+);
+unicode = 2081;
+},
+{
+glyphname = twoinferior;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"321 -100 LINE",
+"321 43 LINE",
+"304 43 LINE",
+"304 -10 OFFCURVE",
+"296 -15 OFFCURVE",
+"271 -15 CURVE SMOOTH",
+"89 -15 LINE",
+"89 -11 LINE",
+"247 84 LINE SMOOTH",
+"303 117 OFFCURVE",
+"321 156 OFFCURVE",
+"321 196 CURVE SMOOTH",
+"321 273 OFFCURVE",
+"249 303 OFFCURVE",
+"180 303 CURVE SMOOTH",
+"107 303 OFFCURVE",
+"34 270 OFFCURVE",
+"34 203 CURVE SMOOTH",
+"34 171 OFFCURVE",
+"51 136 OFFCURVE",
+"92 136 CURVE SMOOTH",
+"117 136 OFFCURVE",
+"141 151 OFFCURVE",
+"141 184 CURVE SMOOTH",
+"141 207 OFFCURVE",
+"129 225 OFFCURVE",
+"104 225 CURVE SMOOTH",
+"88 225 OFFCURVE",
+"82 218 OFFCURVE",
+"76 218 CURVE SMOOTH",
+"71 218 OFFCURVE",
+"68 222 OFFCURVE",
+"68 229 CURVE SMOOTH",
+"68 251 OFFCURVE",
+"102 279 OFFCURVE",
+"142 279 CURVE SMOOTH",
+"190 279 OFFCURVE",
+"220 240 OFFCURVE",
+"220 176 CURVE SMOOTH",
+"220 132 OFFCURVE",
+"206 100 OFFCURVE",
+"146 55 CURVE SMOOTH",
+"17 -43 LINE",
+"17 -100 LINE"
+);
+}
+);
+width = 350;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"332 -100 LINE",
+"332 47 LINE",
+"314 47 LINE",
+"314 -7 OFFCURVE",
+"306 -12 OFFCURVE",
+"280 -12 CURVE SMOOTH",
+"95 -12 LINE",
+"95 -8 LINE",
+"252 83 LINE SMOOTH",
+"309 116 OFFCURVE",
+"332 154 OFFCURVE",
+"332 196 CURVE SMOOTH",
+"332 274 OFFCURVE",
+"257 303 OFFCURVE",
+"186 303 CURVE SMOOTH",
+"111 303 OFFCURVE",
+"36 269 OFFCURVE",
+"36 202 CURVE SMOOTH",
+"36 170 OFFCURVE",
+"53 135 OFFCURVE",
+"95 135 CURVE SMOOTH",
+"123 135 OFFCURVE",
+"147 149 OFFCURVE",
+"147 184 CURVE SMOOTH",
+"147 207 OFFCURVE",
+"137 225 OFFCURVE",
+"109 225 CURVE SMOOTH",
+"93 225 OFFCURVE",
+"86 218 OFFCURVE",
+"81 218 CURVE SMOOTH",
+"77 218 OFFCURVE",
+"73 222 OFFCURVE",
+"73 230 CURVE SMOOTH",
+"73 251 OFFCURVE",
+"106 278 OFFCURVE",
+"144 278 CURVE SMOOTH",
+"192 278 OFFCURVE",
+"223 241 OFFCURVE",
+"223 176 CURVE SMOOTH",
+"223 132 OFFCURVE",
+"210 99 OFFCURVE",
+"149 55 CURVE SMOOTH",
+"16 -41 LINE",
+"16 -100 LINE"
+);
+}
+);
+width = 360;
+}
+);
+unicode = 2082;
+},
+{
+glyphname = threeinferior;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"249 -108 OFFCURVE",
+"317 -50 OFFCURVE",
+"317 13 CURVE SMOOTH",
+"317 83 OFFCURVE",
+"253 116 OFFCURVE",
+"172 119 CURVE",
+"111 104 LINE",
+"182 104 OFFCURVE",
+"208 71 OFFCURVE",
+"208 9 CURVE SMOOTH",
+"208 -52 OFFCURVE",
+"183 -87 OFFCURVE",
+"133 -87 CURVE SMOOTH",
+"115 -87 OFFCURVE",
+"74 -83 OFFCURVE",
+"74 -69 CURVE SMOOTH",
+"74 -54 OFFCURVE",
+"111 -52 OFFCURVE",
+"111 -12 CURVE SMOOTH",
+"111 24 OFFCURVE",
+"83 32 OFFCURVE",
+"64 32 CURVE SMOOTH",
+"30 32 OFFCURVE",
+"13 4 OFFCURVE",
+"13 -27 CURVE SMOOTH",
+"13 -77 OFFCURVE",
+"61 -108 OFFCURVE",
+"141 -108 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"172 104 LINE",
+"172 125 LINE",
+"76 125 LINE",
+"76 104 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"253 126 OFFCURVE",
+"299 162 OFFCURVE",
+"299 213 CURVE SMOOTH",
+"299 268 OFFCURVE",
+"247 303 OFFCURVE",
+"161 303 CURVE SMOOTH",
+"71 303 OFFCURVE",
+"36 264 OFFCURVE",
+"36 225 CURVE SMOOTH",
+"36 196 OFFCURVE",
+"55 180 OFFCURVE",
+"81 180 CURVE SMOOTH",
+"104 180 OFFCURVE",
+"130 192 OFFCURVE",
+"130 219 CURVE SMOOTH",
+"130 248 OFFCURVE",
+"99 253 OFFCURVE",
+"99 267 CURVE SMOOTH",
+"99 280 OFFCURVE",
+"123 283 OFFCURVE",
+"143 283 CURVE SMOOTH",
+"176 283 OFFCURVE",
+"197 271 OFFCURVE",
+"197 218 CURVE SMOOTH",
+"197 158 OFFCURVE",
+"170 125 OFFCURVE",
+"100 125 CURVE",
+"139 119 LINE"
+);
+}
+);
+width = 337;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"256 -108 OFFCURVE",
+"327 -51 OFFCURVE",
+"327 13 CURVE SMOOTH",
+"327 83 OFFCURVE",
+"258 115 OFFCURVE",
+"173 118 CURVE",
+"111 104 LINE",
+"183 104 OFFCURVE",
+"210 71 OFFCURVE",
+"210 8 CURVE SMOOTH",
+"210 -53 OFFCURVE",
+"186 -87 OFFCURVE",
+"136 -87 CURVE SMOOTH",
+"118 -87 OFFCURVE",
+"78 -83 OFFCURVE",
+"78 -69 CURVE SMOOTH",
+"78 -54 OFFCURVE",
+"118 -52 OFFCURVE",
+"118 -10 CURVE SMOOTH",
+"118 27 OFFCURVE",
+"86 35 OFFCURVE",
+"67 35 CURVE SMOOTH",
+"31 35 OFFCURVE",
+"12 5 OFFCURVE",
+"12 -26 CURVE SMOOTH",
+"12 -77 OFFCURVE",
+"60 -108 OFFCURVE",
+"143 -108 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"173 104 LINE",
+"173 124 LINE",
+"78 124 LINE",
+"78 104 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"265 126 OFFCURVE",
+"310 161 OFFCURVE",
+"310 212 CURVE SMOOTH",
+"310 268 OFFCURVE",
+"255 303 OFFCURVE",
+"166 303 CURVE SMOOTH",
+"70 303 OFFCURVE",
+"37 263 OFFCURVE",
+"37 223 CURVE SMOOTH",
+"37 194 OFFCURVE",
+"56 177 OFFCURVE",
+"85 177 CURVE SMOOTH",
+"109 177 OFFCURVE",
+"139 189 OFFCURVE",
+"139 218 CURVE SMOOTH",
+"139 247 OFFCURVE",
+"104 252 OFFCURVE",
+"104 267 CURVE SMOOTH",
+"104 279 OFFCURVE",
+"129 282 OFFCURVE",
+"148 282 CURVE SMOOTH",
+"179 282 OFFCURVE",
+"200 271 OFFCURVE",
+"200 218 CURVE SMOOTH",
+"200 158 OFFCURVE",
+"173 124 OFFCURVE",
+"99 124 CURVE",
+"140 118 LINE"
+);
+}
+);
+width = 346;
+}
+);
+unicode = 2083;
+},
+{
+glyphname = fourinferior;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"322 -100 LINE",
+"322 -83 LINE",
+"267 -83 LINE",
+"267 10 LINE",
+"338 10 LINE",
+"338 -35 LINE",
+"356 -35 LINE",
+"356 72 LINE",
+"338 72 LINE",
+"338 29 LINE",
+"268 29 LINE",
+"268 303 LINE",
+"208 303 LINE",
+"8 29 LINE",
+"8 10 LINE",
+"175 10 LINE",
+"175 -83 LINE",
+"115 -83 LINE",
+"115 -100 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"36 33 LINE",
+"171 220 LINE",
+"175 220 LINE",
+"175 29 LINE",
+"36 29 LINE"
+);
+}
+);
+width = 377;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"332 -100 LINE",
+"332 -82 LINE",
+"276 -82 LINE",
+"276 10 LINE",
+"350 10 LINE",
+"350 -35 LINE",
+"369 -35 LINE",
+"369 73 LINE",
+"350 73 LINE",
+"350 29 LINE",
+"276 29 LINE",
+"276 303 LINE",
+"210 303 LINE",
+"7 30 LINE",
+"7 10 LINE",
+"176 10 LINE",
+"176 -82 LINE",
+"114 -82 LINE",
+"114 -100 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"34 33 LINE",
+"172 218 LINE",
+"176 218 LINE",
+"176 29 LINE",
+"34 29 LINE"
+);
+}
+);
+width = 391;
+}
+);
+unicode = 2084;
+},
+{
+glyphname = fiveinferior;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"251 -108 OFFCURVE",
+"333 -61 OFFCURVE",
+"333 23 CURVE SMOOTH",
+"333 89 OFFCURVE",
+"282 147 OFFCURVE",
+"170 147 CURVE SMOOTH",
+"124 147 OFFCURVE",
+"73 137 OFFCURVE",
+"63 131 CURVE",
+"56 102 LINE",
+"67 112 OFFCURVE",
+"101 119 OFFCURVE",
+"128 119 CURVE SMOOTH",
+"183 119 OFFCURVE",
+"222 88 OFFCURVE",
+"222 12 CURVE SMOOTH",
+"222 -55 OFFCURVE",
+"192 -87 OFFCURVE",
+"135 -87 CURVE SMOOTH",
+"113 -87 OFFCURVE",
+"81 -83 OFFCURVE",
+"81 -71 CURVE SMOOTH",
+"81 -59 OFFCURVE",
+"117 -58 OFFCURVE",
+"117 -20 CURVE SMOOTH",
+"117 12 OFFCURVE",
+"92 25 OFFCURVE",
+"68 25 CURVE SMOOTH",
+"37 25 OFFCURVE",
+"15 3 OFFCURVE",
+"15 -29 CURVE SMOOTH",
+"15 -74 OFFCURVE",
+"62 -108 OFFCURVE",
+"149 -108 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"70 128 LINE",
+"84 295 LINE",
+"61 295 LINE",
+"47 109 LINE",
+"56 102 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"292 210 LINE",
+"312 317 LINE",
+"295 317 LINE",
+"288 298 OFFCURVE",
+"281 295 OFFCURVE",
+"259 295 CURVE SMOOTH",
+"65 295 LINE",
+"79 210 LINE"
+);
+}
+);
+width = 349;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"261 -108 OFFCURVE",
+"346 -62 OFFCURVE",
+"346 23 CURVE SMOOTH",
+"346 89 OFFCURVE",
+"298 148 OFFCURVE",
+"181 148 CURVE SMOOTH",
+"132 148 OFFCURVE",
+"75 138 OFFCURVE",
+"64 132 CURVE",
+"57 102 LINE",
+"67 111 OFFCURVE",
+"103 119 OFFCURVE",
+"131 119 CURVE SMOOTH",
+"187 119 OFFCURVE",
+"226 88 OFFCURVE",
+"226 12 CURVE SMOOTH",
+"226 -55 OFFCURVE",
+"196 -87 OFFCURVE",
+"139 -87 CURVE SMOOTH",
+"120 -87 OFFCURVE",
+"86 -83 OFFCURVE",
+"86 -72 CURVE SMOOTH",
+"86 -60 OFFCURVE",
+"125 -59 OFFCURVE",
+"125 -19 CURVE SMOOTH",
+"125 14 OFFCURVE",
+"97 26 OFFCURVE",
+"72 26 CURVE SMOOTH",
+"38 26 OFFCURVE",
+"15 4 OFFCURVE",
+"15 -28 CURVE SMOOTH",
+"15 -74 OFFCURVE",
+"61 -108 OFFCURVE",
+"154 -108 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"71 129 LINE",
+"84 295 LINE",
+"60 295 LINE",
+"47 108 LINE",
+"57 102 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"305 206 LINE",
+"325 318 LINE",
+"307 318 LINE",
+"300 298 OFFCURVE",
+"293 295 OFFCURVE",
+"272 295 CURVE SMOOTH",
+"65 295 LINE",
+"78 206 LINE"
+);
+}
+);
+width = 362;
+}
+);
+unicode = 2085;
+},
+{
+glyphname = sixinferior;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"260 -108 OFFCURVE",
+"334 -50 OFFCURVE",
+"334 29 CURVE SMOOTH",
+"334 99 OFFCURVE",
+"275 153 OFFCURVE",
+"203 153 CURVE SMOOTH",
+"173 153 OFFCURVE",
+"153 144 OFFCURVE",
+"136 130 CURVE",
+"132 130 LINE",
+"144 212 OFFCURVE",
+"199 285 OFFCURVE",
+"287 295 CURVE",
+"287 315 LINE",
+"147 310 OFFCURVE",
+"25 188 OFFCURVE",
+"25 60 CURVE SMOOTH",
+"25 -42 OFFCURVE",
+"94 -108 OFFCURVE",
+"180 -108 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"136 -87 OFFCURVE",
+"121 -59 OFFCURVE",
+"121 21 CURVE SMOOTH",
+"121 40 OFFCURVE",
+"121 68 OFFCURVE",
+"126 91 CURVE",
+"138 111 OFFCURVE",
+"157 129 OFFCURVE",
+"186 129 CURVE SMOOTH",
+"216 129 OFFCURVE",
+"233 110 OFFCURVE",
+"233 21 CURVE SMOOTH",
+"233 -58 OFFCURVE",
+"220 -87 OFFCURVE",
+"178 -87 CURVE SMOOTH"
+);
+}
+);
+width = 348;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"264 -108 OFFCURVE",
+"338 -50 OFFCURVE",
+"338 29 CURVE SMOOTH",
+"338 99 OFFCURVE",
+"281 152 OFFCURVE",
+"208 152 CURVE SMOOTH",
+"179 152 OFFCURVE",
+"159 143 OFFCURVE",
+"141 128 CURVE",
+"138 130 LINE",
+"150 211 OFFCURVE",
+"202 285 OFFCURVE",
+"288 295 CURVE",
+"288 316 LINE",
+"147 311 OFFCURVE",
+"24 188 OFFCURVE",
+"24 60 CURVE SMOOTH",
+"24 -42 OFFCURVE",
+"95 -108 OFFCURVE",
+"182 -108 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"141 -87 OFFCURVE",
+"126 -58 OFFCURVE",
+"126 21 CURVE SMOOTH",
+"126 40 OFFCURVE",
+"126 67 OFFCURVE",
+"131 90 CURVE",
+"141 110 OFFCURVE",
+"159 128 OFFCURVE",
+"187 128 CURVE SMOOTH",
+"215 128 OFFCURVE",
+"233 109 OFFCURVE",
+"233 21 CURVE SMOOTH",
+"233 -57 OFFCURVE",
+"220 -87 OFFCURVE",
+"181 -87 CURVE SMOOTH"
+);
+}
+);
+width = 352;
+}
+);
+unicode = 2086;
+},
+{
+glyphname = seveninferior;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"199 -108 OFFCURVE",
+"226 -93 OFFCURVE",
+"226 -58 CURVE SMOOTH",
+"226 -31 OFFCURVE",
+"209 1 OFFCURVE",
+"209 38 CURVE SMOOTH",
+"209 62 OFFCURVE",
+"220 92 OFFCURVE",
+"245 131 CURVE SMOOTH",
+"325 259 LINE",
+"325 295 LINE",
+"60 295 LINE",
+"20 148 LINE",
+"41 148 LINE",
+"59 200 OFFCURVE",
+"57 209 OFFCURVE",
+"70 209 CURVE SMOOTH",
+"261 209 LINE",
+"166 59 LINE SMOOTH",
+"127 -2 OFFCURVE",
+"111 -29 OFFCURVE",
+"111 -58 CURVE SMOOTH",
+"111 -88 OFFCURVE",
+"129 -108 OFFCURVE",
+"166 -108 CURVE SMOOTH"
+);
+}
+);
+width = 335;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"206 -108 OFFCURVE",
+"237 -92 OFFCURVE",
+"237 -57 CURVE SMOOTH",
+"237 -30 OFFCURVE",
+"220 5 OFFCURVE",
+"220 41 CURVE SMOOTH",
+"220 65 OFFCURVE",
+"232 94 OFFCURVE",
+"257 132 CURVE SMOOTH",
+"339 257 LINE",
+"339 295 LINE",
+"63 295 LINE",
+"20 144 LINE",
+"43 144 LINE",
+"60 198 OFFCURVE",
+"66 206 OFFCURVE",
+"75 206 CURVE SMOOTH",
+"269 206 LINE",
+"173 59 LINE SMOOTH",
+"134 -1 OFFCURVE",
+"113 -28 OFFCURVE",
+"113 -58 CURVE SMOOTH",
+"113 -87 OFFCURVE",
+"131 -108 OFFCURVE",
+"171 -108 CURVE SMOOTH"
+);
+}
+);
+width = 351;
+}
+);
+unicode = 2087;
+},
+{
+glyphname = eightinferior;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"283 -108 OFFCURVE",
+"334 -62 OFFCURVE",
+"334 -4 CURVE SMOOTH",
+"334 59 OFFCURVE",
+"283 91 OFFCURVE",
+"213 105 CURVE",
+"213 109 LINE",
+"140 109 LINE",
+"140 105 LINE",
+"68 92 OFFCURVE",
+"17 59 OFFCURVE",
+"17 -4 CURVE SMOOTH",
+"17 -62 OFFCURVE",
+"69 -108 OFFCURVE",
+"176 -108 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"135 -91 OFFCURVE",
+"118 -65 OFFCURVE",
+"118 0 CURVE SMOOTH",
+"118 63 OFFCURVE",
+"133 95 OFFCURVE",
+"176 95 CURVE SMOOTH",
+"219 95 OFFCURVE",
+"233 61 OFFCURVE",
+"233 0 CURVE SMOOTH",
+"233 -65 OFFCURVE",
+"216 -91 OFFCURVE",
+"176 -91 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"142 116 OFFCURVE",
+"129 146 OFFCURVE",
+"129 203 CURVE SMOOTH",
+"129 259 OFFCURVE",
+"142 283 OFFCURVE",
+"176 283 CURVE SMOOTH",
+"211 283 OFFCURVE",
+"223 259 OFFCURVE",
+"223 203 CURVE SMOOTH",
+"223 146 OFFCURVE",
+"211 116 OFFCURVE",
+"176 116 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"256 105 OFFCURVE",
+"318 143 OFFCURVE",
+"318 204 CURVE SMOOTH",
+"318 256 OFFCURVE",
+"273 303 OFFCURVE",
+"175 303 CURVE SMOOTH",
+"81 303 OFFCURVE",
+"34 259 OFFCURVE",
+"34 205 CURVE SMOOTH",
+"34 143 OFFCURVE",
+"97 105 OFFCURVE",
+"176 105 CURVE SMOOTH"
+);
+}
+);
+width = 352;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"287 -108 OFFCURVE",
+"340 -62 OFFCURVE",
+"340 -4 CURVE SMOOTH",
+"340 60 OFFCURVE",
+"288 90 OFFCURVE",
+"215 104 CURVE",
+"215 110 LINE",
+"142 110 LINE",
+"142 104 LINE",
+"68 91 OFFCURVE",
+"16 60 OFFCURVE",
+"16 -4 CURVE SMOOTH",
+"16 -62 OFFCURVE",
+"68 -108 OFFCURVE",
+"178 -108 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"140 -91 OFFCURVE",
+"123 -65 OFFCURVE",
+"123 0 CURVE SMOOTH",
+"123 63 OFFCURVE",
+"137 94 OFFCURVE",
+"178 94 CURVE SMOOTH",
+"219 94 OFFCURVE",
+"233 61 OFFCURVE",
+"233 0 CURVE SMOOTH",
+"233 -65 OFFCURVE",
+"216 -91 OFFCURVE",
+"178 -91 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"146 116 OFFCURVE",
+"134 147 OFFCURVE",
+"134 203 CURVE SMOOTH",
+"134 259 OFFCURVE",
+"146 282 OFFCURVE",
+"178 282 CURVE SMOOTH",
+"211 282 OFFCURVE",
+"222 259 OFFCURVE",
+"222 203 CURVE SMOOTH",
+"222 147 OFFCURVE",
+"211 116 OFFCURVE",
+"178 116 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"260 105 OFFCURVE",
+"324 143 OFFCURVE",
+"324 204 CURVE SMOOTH",
+"324 256 OFFCURVE",
+"278 303 OFFCURVE",
+"177 303 CURVE SMOOTH",
+"81 303 OFFCURVE",
+"32 259 OFFCURVE",
+"32 205 CURVE SMOOTH",
+"32 143 OFFCURVE",
+"97 105 OFFCURVE",
+"178 105 CURVE SMOOTH"
+);
+}
+);
+width = 356;
+}
+);
+unicode = 2088;
+},
+{
+glyphname = nineinferior;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"196 -99 OFFCURVE",
+"325 4 OFFCURVE",
+"325 135 CURVE SMOOTH",
+"325 237 OFFCURVE",
+"256 303 OFFCURVE",
+"169 303 CURVE SMOOTH",
+"89 303 OFFCURVE",
+"16 244 OFFCURVE",
+"16 166 CURVE SMOOTH",
+"16 96 OFFCURVE",
+"74 42 OFFCURVE",
+"147 42 CURVE SMOOTH",
+"176 42 OFFCURVE",
+"195 49 OFFCURVE",
+"213 64 CURVE",
+"217 64 LINE",
+"205 -19 OFFCURVE",
+"145 -75 OFFCURVE",
+"57 -84 CURVE",
+"57 -104 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"133 66 OFFCURVE",
+"116 85 OFFCURVE",
+"116 173 CURVE SMOOTH",
+"116 253 OFFCURVE",
+"129 283 OFFCURVE",
+"171 283 CURVE SMOOTH",
+"213 283 OFFCURVE",
+"228 253 OFFCURVE",
+"228 174 CURVE SMOOTH",
+"228 154 OFFCURVE",
+"228 127 OFFCURVE",
+"223 104 CURVE",
+"212 83 OFFCURVE",
+"192 66 OFFCURVE",
+"163 66 CURVE SMOOTH"
+);
+}
+);
+width = 348;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"198 -98 OFFCURVE",
+"328 5 OFFCURVE",
+"328 135 CURVE SMOOTH",
+"328 237 OFFCURVE",
+"257 303 OFFCURVE",
+"169 303 CURVE SMOOTH",
+"88 303 OFFCURVE",
+"13 245 OFFCURVE",
+"13 166 CURVE SMOOTH",
+"13 96 OFFCURVE",
+"71 43 OFFCURVE",
+"144 43 CURVE SMOOTH",
+"173 43 OFFCURVE",
+"192 52 OFFCURVE",
+"211 67 CURVE",
+"214 65 LINE",
+"202 -17 OFFCURVE",
+"143 -73 OFFCURVE",
+"56 -83 CURVE",
+"56 -103 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"136 67 OFFCURVE",
+"119 86 OFFCURVE",
+"119 174 CURVE SMOOTH",
+"119 252 OFFCURVE",
+"132 283 OFFCURVE",
+"171 283 CURVE SMOOTH",
+"211 283 OFFCURVE",
+"226 253 OFFCURVE",
+"226 174 CURVE SMOOTH",
+"226 155 OFFCURVE",
+"225 128 OFFCURVE",
+"220 105 CURVE",
+"210 85 OFFCURVE",
+"192 67 OFFCURVE",
+"164 67 CURVE SMOOTH"
+);
+}
+);
+width = 352;
+}
+);
+unicode = 2089;
+},
+{
+glyphname = zerosuperior;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"305 451 OFFCURVE",
+"383 534 OFFCURVE",
+"383 656 CURVE SMOOTH",
+"383 778 OFFCURVE",
+"305 862 OFFCURVE",
+"203 862 CURVE SMOOTH",
+"101 862 OFFCURVE",
+"24 778 OFFCURVE",
+"24 656 CURVE SMOOTH",
+"24 534 OFFCURVE",
+"101 451 OFFCURVE",
+"203 451 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"144 472 OFFCURVE",
+"126 506 OFFCURVE",
+"126 656 CURVE SMOOTH",
+"126 807 OFFCURVE",
+"144 842 OFFCURVE",
+"203 842 CURVE SMOOTH",
+"259 842 OFFCURVE",
+"280 807 OFFCURVE",
+"280 656 CURVE SMOOTH",
+"280 506 OFFCURVE",
+"259 472 OFFCURVE",
+"203 472 CURVE SMOOTH"
+);
+}
+);
+width = 407;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"24 434 OFFCURVE",
+"101 351 OFFCURVE",
+"203 351 CURVE SMOOTH",
+"305 351 OFFCURVE",
+"383 434 OFFCURVE",
+"383 556 CURVE SMOOTH",
+"383 678 OFFCURVE",
+"305 762 OFFCURVE",
+"203 762 CURVE SMOOTH",
+"101 762 OFFCURVE",
+"24 678 OFFCURVE",
+"24 556 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"126 707 OFFCURVE",
+"144 742 OFFCURVE",
+"203 742 CURVE SMOOTH",
+"259 742 OFFCURVE",
+"280 707 OFFCURVE",
+"280 556 CURVE SMOOTH",
+"280 406 OFFCURVE",
+"259 372 OFFCURVE",
+"203 372 CURVE SMOOTH",
+"144 372 OFFCURVE",
+"126 406 OFFCURVE",
+"126 556 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"314 451 OFFCURVE",
+"396 533 OFFCURVE",
+"396 656 CURVE SMOOTH",
+"396 778 OFFCURVE",
+"314 862 OFFCURVE",
+"209 862 CURVE SMOOTH",
+"104 862 OFFCURVE",
+"23 778 OFFCURVE",
+"23 656 CURVE SMOOTH",
+"23 533 OFFCURVE",
+"104 451 OFFCURVE",
+"209 451 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"149 472 OFFCURVE",
+"131 505 OFFCURVE",
+"131 656 CURVE SMOOTH",
+"131 806 OFFCURVE",
+"149 841 OFFCURVE",
+"209 841 CURVE SMOOTH",
+"265 841 OFFCURVE",
+"287 806 OFFCURVE",
+"287 656 CURVE SMOOTH",
+"287 505 OFFCURVE",
+"265 472 OFFCURVE",
+"209 472 CURVE SMOOTH"
+);
+}
+);
+width = 419;
+}
+);
+unicode = 2070;
+},
+{
+glyphname = onesuperior;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"266 459 LINE",
+"266 476 LINE",
+"184 476 LINE",
+"184 854 LINE",
+"4 854 LINE",
+"4 836 LINE",
+"91 836 LINE",
+"91 476 LINE",
+"4 476 LINE",
+"4 459 LINE"
+);
+}
+);
+width = 270;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"275 459 LINE",
+"275 477 LINE",
+"192 477 LINE",
+"192 854 LINE",
+"3 854 LINE",
+"3 836 LINE",
+"92 836 LINE",
+"92 477 LINE",
+"3 477 LINE",
+"3 459 LINE"
+);
+}
+);
+width = 279;
+}
+);
+unicode = 00B9;
+},
+{
+glyphname = twosuperior;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"321 459 LINE",
+"321 602 LINE",
+"304 602 LINE",
+"304 549 OFFCURVE",
+"296 544 OFFCURVE",
+"271 544 CURVE SMOOTH",
+"89 544 LINE",
+"89 548 LINE",
+"247 643 LINE SMOOTH",
+"303 676 OFFCURVE",
+"321 715 OFFCURVE",
+"321 755 CURVE SMOOTH",
+"321 832 OFFCURVE",
+"249 862 OFFCURVE",
+"180 862 CURVE SMOOTH",
+"107 862 OFFCURVE",
+"34 829 OFFCURVE",
+"34 762 CURVE SMOOTH",
+"34 730 OFFCURVE",
+"51 695 OFFCURVE",
+"92 695 CURVE SMOOTH",
+"117 695 OFFCURVE",
+"141 710 OFFCURVE",
+"141 743 CURVE SMOOTH",
+"141 766 OFFCURVE",
+"129 784 OFFCURVE",
+"104 784 CURVE SMOOTH",
+"88 784 OFFCURVE",
+"82 777 OFFCURVE",
+"76 777 CURVE SMOOTH",
+"71 777 OFFCURVE",
+"68 781 OFFCURVE",
+"68 788 CURVE SMOOTH",
+"68 810 OFFCURVE",
+"102 838 OFFCURVE",
+"142 838 CURVE SMOOTH",
+"190 838 OFFCURVE",
+"220 799 OFFCURVE",
+"220 735 CURVE SMOOTH",
+"220 691 OFFCURVE",
+"206 659 OFFCURVE",
+"146 614 CURVE SMOOTH",
+"17 516 LINE",
+"17 459 LINE"
+);
+}
+);
+width = 350;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"332 459 LINE",
+"332 606 LINE",
+"314 606 LINE",
+"314 552 OFFCURVE",
+"306 547 OFFCURVE",
+"280 547 CURVE SMOOTH",
+"95 547 LINE",
+"95 551 LINE",
+"252 642 LINE SMOOTH",
+"309 675 OFFCURVE",
+"332 713 OFFCURVE",
+"332 755 CURVE SMOOTH",
+"332 833 OFFCURVE",
+"257 862 OFFCURVE",
+"186 862 CURVE SMOOTH",
+"111 862 OFFCURVE",
+"36 828 OFFCURVE",
+"36 761 CURVE SMOOTH",
+"36 729 OFFCURVE",
+"53 694 OFFCURVE",
+"95 694 CURVE SMOOTH",
+"123 694 OFFCURVE",
+"147 708 OFFCURVE",
+"147 743 CURVE SMOOTH",
+"147 766 OFFCURVE",
+"137 784 OFFCURVE",
+"109 784 CURVE SMOOTH",
+"93 784 OFFCURVE",
+"86 777 OFFCURVE",
+"81 777 CURVE SMOOTH",
+"77 777 OFFCURVE",
+"73 781 OFFCURVE",
+"73 789 CURVE SMOOTH",
+"73 810 OFFCURVE",
+"106 837 OFFCURVE",
+"144 837 CURVE SMOOTH",
+"192 837 OFFCURVE",
+"223 800 OFFCURVE",
+"223 735 CURVE SMOOTH",
+"223 691 OFFCURVE",
+"210 658 OFFCURVE",
+"149 614 CURVE SMOOTH",
+"16 518 LINE",
+"16 459 LINE"
+);
+}
+);
+width = 360;
+}
+);
+unicode = 00B2;
+},
+{
+glyphname = threesuperior;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"249 451 OFFCURVE",
+"317 509 OFFCURVE",
+"317 572 CURVE SMOOTH",
+"317 642 OFFCURVE",
+"253 675 OFFCURVE",
+"172 678 CURVE",
+"111 663 LINE",
+"182 663 OFFCURVE",
+"208 630 OFFCURVE",
+"208 568 CURVE SMOOTH",
+"208 507 OFFCURVE",
+"183 472 OFFCURVE",
+"133 472 CURVE SMOOTH",
+"115 472 OFFCURVE",
+"74 476 OFFCURVE",
+"74 490 CURVE SMOOTH",
+"74 505 OFFCURVE",
+"111 507 OFFCURVE",
+"111 547 CURVE SMOOTH",
+"111 583 OFFCURVE",
+"83 591 OFFCURVE",
+"64 591 CURVE SMOOTH",
+"30 591 OFFCURVE",
+"13 563 OFFCURVE",
+"13 532 CURVE SMOOTH",
+"13 482 OFFCURVE",
+"61 451 OFFCURVE",
+"141 451 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"172 663 LINE",
+"172 684 LINE",
+"76 684 LINE",
+"76 663 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"253 685 OFFCURVE",
+"299 721 OFFCURVE",
+"299 772 CURVE SMOOTH",
+"299 827 OFFCURVE",
+"247 862 OFFCURVE",
+"161 862 CURVE SMOOTH",
+"71 862 OFFCURVE",
+"36 823 OFFCURVE",
+"36 784 CURVE SMOOTH",
+"36 755 OFFCURVE",
+"55 739 OFFCURVE",
+"81 739 CURVE SMOOTH",
+"104 739 OFFCURVE",
+"130 751 OFFCURVE",
+"130 778 CURVE SMOOTH",
+"130 807 OFFCURVE",
+"99 812 OFFCURVE",
+"99 826 CURVE SMOOTH",
+"99 839 OFFCURVE",
+"123 842 OFFCURVE",
+"143 842 CURVE SMOOTH",
+"176 842 OFFCURVE",
+"197 830 OFFCURVE",
+"197 777 CURVE SMOOTH",
+"197 717 OFFCURVE",
+"170 684 OFFCURVE",
+"100 684 CURVE",
+"139 678 LINE"
+);
+}
+);
+width = 337;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"256 451 OFFCURVE",
+"327 508 OFFCURVE",
+"327 572 CURVE SMOOTH",
+"327 642 OFFCURVE",
+"258 674 OFFCURVE",
+"173 677 CURVE",
+"111 663 LINE",
+"183 663 OFFCURVE",
+"210 630 OFFCURVE",
+"210 567 CURVE SMOOTH",
+"210 506 OFFCURVE",
+"186 472 OFFCURVE",
+"136 472 CURVE SMOOTH",
+"118 472 OFFCURVE",
+"78 476 OFFCURVE",
+"78 490 CURVE SMOOTH",
+"78 505 OFFCURVE",
+"118 507 OFFCURVE",
+"118 549 CURVE SMOOTH",
+"118 586 OFFCURVE",
+"86 594 OFFCURVE",
+"67 594 CURVE SMOOTH",
+"31 594 OFFCURVE",
+"12 564 OFFCURVE",
+"12 533 CURVE SMOOTH",
+"12 482 OFFCURVE",
+"60 451 OFFCURVE",
+"143 451 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"173 663 LINE",
+"173 683 LINE",
+"78 683 LINE",
+"78 663 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"265 685 OFFCURVE",
+"310 720 OFFCURVE",
+"310 771 CURVE SMOOTH",
+"310 827 OFFCURVE",
+"255 862 OFFCURVE",
+"166 862 CURVE SMOOTH",
+"70 862 OFFCURVE",
+"37 822 OFFCURVE",
+"37 782 CURVE SMOOTH",
+"37 753 OFFCURVE",
+"56 736 OFFCURVE",
+"85 736 CURVE SMOOTH",
+"109 736 OFFCURVE",
+"139 748 OFFCURVE",
+"139 777 CURVE SMOOTH",
+"139 806 OFFCURVE",
+"104 811 OFFCURVE",
+"104 826 CURVE SMOOTH",
+"104 838 OFFCURVE",
+"129 841 OFFCURVE",
+"148 841 CURVE SMOOTH",
+"179 841 OFFCURVE",
+"200 830 OFFCURVE",
+"200 777 CURVE SMOOTH",
+"200 717 OFFCURVE",
+"173 683 OFFCURVE",
+"99 683 CURVE",
+"140 677 LINE"
+);
+}
+);
+width = 346;
+}
+);
+unicode = 00B3;
+},
+{
+glyphname = foursuperior;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"322 459 LINE",
+"322 476 LINE",
+"267 476 LINE",
+"267 569 LINE",
+"338 569 LINE",
+"338 524 LINE",
+"356 524 LINE",
+"356 631 LINE",
+"338 631 LINE",
+"338 588 LINE",
+"268 588 LINE",
+"268 862 LINE",
+"208 862 LINE",
+"8 588 LINE",
+"8 569 LINE",
+"175 569 LINE",
+"175 476 LINE",
+"115 476 LINE",
+"115 459 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"36 592 LINE",
+"171 779 LINE",
+"175 779 LINE",
+"175 588 LINE",
+"36 588 LINE"
+);
+}
+);
+width = 377;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"332 459 LINE",
+"332 477 LINE",
+"276 477 LINE",
+"276 569 LINE",
+"350 569 LINE",
+"350 524 LINE",
+"369 524 LINE",
+"369 632 LINE",
+"350 632 LINE",
+"350 588 LINE",
+"276 588 LINE",
+"276 862 LINE",
+"210 862 LINE",
+"7 589 LINE",
+"7 569 LINE",
+"176 569 LINE",
+"176 477 LINE",
+"114 477 LINE",
+"114 459 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"34 592 LINE",
+"172 777 LINE",
+"176 777 LINE",
+"176 588 LINE",
+"34 588 LINE"
+);
+}
+);
+width = 391;
+}
+);
+unicode = 2074;
+},
+{
+glyphname = fivesuperior;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"251 451 OFFCURVE",
+"333 498 OFFCURVE",
+"333 582 CURVE SMOOTH",
+"333 648 OFFCURVE",
+"282 706 OFFCURVE",
+"170 706 CURVE SMOOTH",
+"124 706 OFFCURVE",
+"73 696 OFFCURVE",
+"63 690 CURVE",
+"56 661 LINE",
+"67 671 OFFCURVE",
+"101 678 OFFCURVE",
+"128 678 CURVE SMOOTH",
+"183 678 OFFCURVE",
+"222 647 OFFCURVE",
+"222 571 CURVE SMOOTH",
+"222 504 OFFCURVE",
+"192 472 OFFCURVE",
+"135 472 CURVE SMOOTH",
+"113 472 OFFCURVE",
+"81 476 OFFCURVE",
+"81 488 CURVE SMOOTH",
+"81 500 OFFCURVE",
+"117 501 OFFCURVE",
+"117 539 CURVE SMOOTH",
+"117 571 OFFCURVE",
+"92 584 OFFCURVE",
+"68 584 CURVE SMOOTH",
+"37 584 OFFCURVE",
+"15 562 OFFCURVE",
+"15 530 CURVE SMOOTH",
+"15 485 OFFCURVE",
+"62 451 OFFCURVE",
+"149 451 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"70 687 LINE",
+"84 854 LINE",
+"61 854 LINE",
+"47 668 LINE",
+"56 661 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"292 769 LINE",
+"312 876 LINE",
+"295 876 LINE",
+"288 857 OFFCURVE",
+"281 854 OFFCURVE",
+"259 854 CURVE SMOOTH",
+"65 854 LINE",
+"79 769 LINE"
+);
+}
+);
+width = 349;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"261 451 OFFCURVE",
+"346 497 OFFCURVE",
+"346 582 CURVE SMOOTH",
+"346 648 OFFCURVE",
+"298 707 OFFCURVE",
+"181 707 CURVE SMOOTH",
+"132 707 OFFCURVE",
+"75 697 OFFCURVE",
+"64 691 CURVE",
+"57 661 LINE",
+"67 670 OFFCURVE",
+"103 678 OFFCURVE",
+"131 678 CURVE SMOOTH",
+"187 678 OFFCURVE",
+"226 647 OFFCURVE",
+"226 571 CURVE SMOOTH",
+"226 504 OFFCURVE",
+"196 472 OFFCURVE",
+"139 472 CURVE SMOOTH",
+"120 472 OFFCURVE",
+"86 476 OFFCURVE",
+"86 487 CURVE SMOOTH",
+"86 499 OFFCURVE",
+"125 500 OFFCURVE",
+"125 540 CURVE SMOOTH",
+"125 573 OFFCURVE",
+"97 585 OFFCURVE",
+"72 585 CURVE SMOOTH",
+"38 585 OFFCURVE",
+"15 563 OFFCURVE",
+"15 531 CURVE SMOOTH",
+"15 485 OFFCURVE",
+"61 451 OFFCURVE",
+"154 451 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"71 688 LINE",
+"84 854 LINE",
+"60 854 LINE",
+"47 667 LINE",
+"57 661 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"305 765 LINE",
+"325 877 LINE",
+"307 877 LINE",
+"300 857 OFFCURVE",
+"293 854 OFFCURVE",
+"272 854 CURVE SMOOTH",
+"65 854 LINE",
+"78 765 LINE"
+);
+}
+);
+width = 362;
+}
+);
+unicode = 2075;
+},
+{
+glyphname = sixsuperior;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"260 451 OFFCURVE",
+"334 509 OFFCURVE",
+"334 588 CURVE SMOOTH",
+"334 658 OFFCURVE",
+"275 712 OFFCURVE",
+"203 712 CURVE SMOOTH",
+"173 712 OFFCURVE",
+"153 703 OFFCURVE",
+"136 689 CURVE",
+"132 689 LINE",
+"144 771 OFFCURVE",
+"199 844 OFFCURVE",
+"287 854 CURVE",
+"287 874 LINE",
+"147 869 OFFCURVE",
+"25 747 OFFCURVE",
+"25 619 CURVE SMOOTH",
+"25 517 OFFCURVE",
+"94 451 OFFCURVE",
+"180 451 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"136 472 OFFCURVE",
+"121 500 OFFCURVE",
+"121 580 CURVE SMOOTH",
+"121 599 OFFCURVE",
+"121 627 OFFCURVE",
+"126 650 CURVE",
+"138 670 OFFCURVE",
+"157 688 OFFCURVE",
+"186 688 CURVE SMOOTH",
+"216 688 OFFCURVE",
+"233 669 OFFCURVE",
+"233 580 CURVE SMOOTH",
+"233 501 OFFCURVE",
+"220 472 OFFCURVE",
+"178 472 CURVE SMOOTH"
+);
+}
+);
+width = 348;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"264 451 OFFCURVE",
+"338 509 OFFCURVE",
+"338 588 CURVE SMOOTH",
+"338 658 OFFCURVE",
+"281 711 OFFCURVE",
+"208 711 CURVE SMOOTH",
+"179 711 OFFCURVE",
+"159 702 OFFCURVE",
+"141 687 CURVE",
+"138 689 LINE",
+"150 770 OFFCURVE",
+"202 844 OFFCURVE",
+"288 854 CURVE",
+"288 875 LINE",
+"147 870 OFFCURVE",
+"24 747 OFFCURVE",
+"24 619 CURVE SMOOTH",
+"24 517 OFFCURVE",
+"95 451 OFFCURVE",
+"182 451 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"141 472 OFFCURVE",
+"126 501 OFFCURVE",
+"126 580 CURVE SMOOTH",
+"126 599 OFFCURVE",
+"126 626 OFFCURVE",
+"131 649 CURVE",
+"141 669 OFFCURVE",
+"159 687 OFFCURVE",
+"187 687 CURVE SMOOTH",
+"215 687 OFFCURVE",
+"233 668 OFFCURVE",
+"233 580 CURVE SMOOTH",
+"233 502 OFFCURVE",
+"220 472 OFFCURVE",
+"181 472 CURVE SMOOTH"
+);
+}
+);
+width = 352;
+}
+);
+unicode = 2076;
+},
+{
+glyphname = sevensuperior;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"199 451 OFFCURVE",
+"226 466 OFFCURVE",
+"226 501 CURVE SMOOTH",
+"226 528 OFFCURVE",
+"209 560 OFFCURVE",
+"209 597 CURVE SMOOTH",
+"209 621 OFFCURVE",
+"220 651 OFFCURVE",
+"245 690 CURVE SMOOTH",
+"325 818 LINE",
+"325 854 LINE",
+"60 854 LINE",
+"20 707 LINE",
+"41 707 LINE",
+"59 759 OFFCURVE",
+"57 768 OFFCURVE",
+"70 768 CURVE SMOOTH",
+"261 768 LINE",
+"166 618 LINE SMOOTH",
+"127 557 OFFCURVE",
+"111 530 OFFCURVE",
+"111 501 CURVE SMOOTH",
+"111 471 OFFCURVE",
+"129 451 OFFCURVE",
+"166 451 CURVE SMOOTH"
+);
+}
+);
+width = 335;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"206 451 OFFCURVE",
+"237 467 OFFCURVE",
+"237 502 CURVE SMOOTH",
+"237 529 OFFCURVE",
+"220 564 OFFCURVE",
+"220 600 CURVE SMOOTH",
+"220 624 OFFCURVE",
+"232 653 OFFCURVE",
+"257 691 CURVE SMOOTH",
+"339 816 LINE",
+"339 854 LINE",
+"63 854 LINE",
+"20 703 LINE",
+"43 703 LINE",
+"60 757 OFFCURVE",
+"66 765 OFFCURVE",
+"75 765 CURVE SMOOTH",
+"269 765 LINE",
+"173 618 LINE SMOOTH",
+"134 558 OFFCURVE",
+"113 531 OFFCURVE",
+"113 501 CURVE SMOOTH",
+"113 472 OFFCURVE",
+"131 451 OFFCURVE",
+"171 451 CURVE SMOOTH"
+);
+}
+);
+width = 351;
+}
+);
+unicode = 2077;
+},
+{
+glyphname = eightsuperior;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"283 451 OFFCURVE",
+"334 497 OFFCURVE",
+"334 555 CURVE SMOOTH",
+"334 618 OFFCURVE",
+"283 650 OFFCURVE",
+"213 664 CURVE",
+"213 668 LINE",
+"140 668 LINE",
+"140 664 LINE",
+"68 651 OFFCURVE",
+"17 618 OFFCURVE",
+"17 555 CURVE SMOOTH",
+"17 497 OFFCURVE",
+"69 451 OFFCURVE",
+"176 451 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"135 468 OFFCURVE",
+"118 494 OFFCURVE",
+"118 559 CURVE SMOOTH",
+"118 622 OFFCURVE",
+"133 654 OFFCURVE",
+"176 654 CURVE SMOOTH",
+"219 654 OFFCURVE",
+"233 620 OFFCURVE",
+"233 559 CURVE SMOOTH",
+"233 494 OFFCURVE",
+"216 468 OFFCURVE",
+"176 468 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"142 675 OFFCURVE",
+"129 705 OFFCURVE",
+"129 762 CURVE SMOOTH",
+"129 818 OFFCURVE",
+"142 842 OFFCURVE",
+"176 842 CURVE SMOOTH",
+"211 842 OFFCURVE",
+"223 818 OFFCURVE",
+"223 762 CURVE SMOOTH",
+"223 705 OFFCURVE",
+"211 675 OFFCURVE",
+"176 675 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"256 664 OFFCURVE",
+"318 702 OFFCURVE",
+"318 763 CURVE SMOOTH",
+"318 815 OFFCURVE",
+"273 862 OFFCURVE",
+"175 862 CURVE SMOOTH",
+"81 862 OFFCURVE",
+"34 818 OFFCURVE",
+"34 764 CURVE SMOOTH",
+"34 702 OFFCURVE",
+"97 664 OFFCURVE",
+"176 664 CURVE SMOOTH"
+);
+}
+);
+width = 352;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"287 451 OFFCURVE",
+"340 497 OFFCURVE",
+"340 555 CURVE SMOOTH",
+"340 619 OFFCURVE",
+"288 649 OFFCURVE",
+"215 663 CURVE",
+"215 669 LINE",
+"142 669 LINE",
+"142 663 LINE",
+"68 650 OFFCURVE",
+"16 619 OFFCURVE",
+"16 555 CURVE SMOOTH",
+"16 497 OFFCURVE",
+"68 451 OFFCURVE",
+"178 451 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"140 468 OFFCURVE",
+"123 494 OFFCURVE",
+"123 559 CURVE SMOOTH",
+"123 622 OFFCURVE",
+"137 653 OFFCURVE",
+"178 653 CURVE SMOOTH",
+"219 653 OFFCURVE",
+"233 620 OFFCURVE",
+"233 559 CURVE SMOOTH",
+"233 494 OFFCURVE",
+"216 468 OFFCURVE",
+"178 468 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"146 675 OFFCURVE",
+"134 706 OFFCURVE",
+"134 762 CURVE SMOOTH",
+"134 818 OFFCURVE",
+"146 841 OFFCURVE",
+"178 841 CURVE SMOOTH",
+"211 841 OFFCURVE",
+"222 818 OFFCURVE",
+"222 762 CURVE SMOOTH",
+"222 706 OFFCURVE",
+"211 675 OFFCURVE",
+"178 675 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"260 664 OFFCURVE",
+"324 702 OFFCURVE",
+"324 763 CURVE SMOOTH",
+"324 815 OFFCURVE",
+"278 862 OFFCURVE",
+"177 862 CURVE SMOOTH",
+"81 862 OFFCURVE",
+"32 818 OFFCURVE",
+"32 764 CURVE SMOOTH",
+"32 702 OFFCURVE",
+"97 664 OFFCURVE",
+"178 664 CURVE SMOOTH"
+);
+}
+);
+width = 356;
+}
+);
+unicode = 2078;
+},
+{
+glyphname = ninesuperior;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"196 460 OFFCURVE",
+"325 563 OFFCURVE",
+"325 694 CURVE SMOOTH",
+"325 796 OFFCURVE",
+"256 862 OFFCURVE",
+"169 862 CURVE SMOOTH",
+"89 862 OFFCURVE",
+"16 803 OFFCURVE",
+"16 725 CURVE SMOOTH",
+"16 655 OFFCURVE",
+"74 601 OFFCURVE",
+"147 601 CURVE SMOOTH",
+"176 601 OFFCURVE",
+"195 608 OFFCURVE",
+"213 623 CURVE",
+"217 623 LINE",
+"205 540 OFFCURVE",
+"145 484 OFFCURVE",
+"57 475 CURVE",
+"57 455 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"133 625 OFFCURVE",
+"116 644 OFFCURVE",
+"116 732 CURVE SMOOTH",
+"116 812 OFFCURVE",
+"129 842 OFFCURVE",
+"171 842 CURVE SMOOTH",
+"213 842 OFFCURVE",
+"228 812 OFFCURVE",
+"228 733 CURVE SMOOTH",
+"228 713 OFFCURVE",
+"228 686 OFFCURVE",
+"223 663 CURVE",
+"212 642 OFFCURVE",
+"192 625 OFFCURVE",
+"163 625 CURVE SMOOTH"
+);
+}
+);
+width = 348;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"198 461 OFFCURVE",
+"328 564 OFFCURVE",
+"328 694 CURVE SMOOTH",
+"328 796 OFFCURVE",
+"257 862 OFFCURVE",
+"169 862 CURVE SMOOTH",
+"88 862 OFFCURVE",
+"13 804 OFFCURVE",
+"13 725 CURVE SMOOTH",
+"13 655 OFFCURVE",
+"71 602 OFFCURVE",
+"144 602 CURVE SMOOTH",
+"173 602 OFFCURVE",
+"192 611 OFFCURVE",
+"211 626 CURVE",
+"214 624 LINE",
+"202 542 OFFCURVE",
+"143 486 OFFCURVE",
+"56 476 CURVE",
+"56 456 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"136 626 OFFCURVE",
+"119 645 OFFCURVE",
+"119 733 CURVE SMOOTH",
+"119 811 OFFCURVE",
+"132 842 OFFCURVE",
+"171 842 CURVE SMOOTH",
+"211 842 OFFCURVE",
+"226 812 OFFCURVE",
+"226 733 CURVE SMOOTH",
+"226 714 OFFCURVE",
+"225 687 OFFCURVE",
+"220 664 CURVE",
+"210 644 OFFCURVE",
+"192 626 OFFCURVE",
+"164 626 CURVE SMOOTH"
+);
+}
+);
+width = 352;
+}
+);
+unicode = 2079;
+},
+{
+glyphname = fraction;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"59 0 LINE",
+"489 753 LINE",
+"430 753 LINE",
+"0 0 LINE"
+);
+}
+);
+width = 489;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"79 0 LINE",
+"489 753 LINE",
+"410 753 LINE",
+"0 0 LINE"
+);
+}
+);
+width = 489;
+}
+);
+unicode = 2044;
+},
+{
+glyphname = onehalf;
+lastChange = "2016-08-19 16:52:41 +0000";
+layers = (
+{
+components = (
+{
+alignment = -1;
+name = fraction;
+transform = "{1, 0, 0, 1, 215, 0}";
+},
+{
+name = one.numerator;
+transform = "{1, 0, 0, 1, 71, 0}";
+},
+{
+name = two.denominator;
+transform = "{1, 0, 0, 1, 506, 0}";
+}
+);
+layerId = UUID0;
+width = 913;
+},
+{
+components = (
+{
+alignment = -1;
+name = fraction;
+transform = "{1, 0, 0, 1, 220, 0}";
+},
+{
+name = one.numerator;
+transform = "{1, 0, 0, 1, 71, 0}";
+},
+{
+name = two.denominator;
+transform = "{1, 0, 0, 1, 506, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 913;
+}
+);
+unicode = 00BD;
+},
+{
+glyphname = onethird;
+lastChange = "2016-08-16 11:12:00 +0000";
+layers = (
+{
+components = (
+{
+name = three.denominator;
+transform = "{1, 0, 0, 1, 502, 0}";
+},
+{
+name = one.numerator;
+transform = "{1, 0, 0, 1, 71, 0}";
+},
+{
+name = fraction;
+transform = "{1, 0, 0, 1, 194, 0}";
+}
+);
+layerId = UUID0;
+width = 913;
+},
+{
+components = (
+{
+name = three.denominator;
+transform = "{1, 0, 0, 1, 502, 0}";
+},
+{
+name = one.numerator;
+transform = "{1, 0, 0, 1, 71, 0}";
+},
+{
+name = fraction;
+transform = "{1, 0, 0, 1, 194, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 913;
+}
+);
+unicode = 2153;
+},
+{
+glyphname = twothirds;
+lastChange = "2016-08-16 11:12:00 +0000";
+layers = (
+{
+components = (
+{
+name = two.numerator;
+transform = "{1, 0, 0, 1, 43, 0}";
+},
+{
+name = three.denominator;
+transform = "{1, 0, 0, 1, 502, 0}";
+},
+{
+name = fraction;
+transform = "{1, 0, 0, 1, 215, 0}";
+}
+);
+layerId = UUID0;
+width = 913;
+},
+{
+components = (
+{
+name = two.numerator;
+transform = "{1, 0, 0, 1, 43, 0}";
+},
+{
+name = three.denominator;
+transform = "{1, 0, 0, 1, 502, 0}";
+},
+{
+name = fraction;
+transform = "{1, 0, 0, 1, 221, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 913;
+}
+);
+unicode = 2154;
+},
+{
+glyphname = onequarter;
+lastChange = "2016-08-16 11:12:00 +0000";
+layers = (
+{
+components = (
+{
+name = four.denominator;
+transform = "{1, 0, 0, 1, 469, 0}";
+},
+{
+name = one.numerator;
+transform = "{1, 0, 0, 1, 71, 0}";
+},
+{
+name = fraction;
+transform = "{1, 0, 0, 1, 220, 0}";
+}
+);
+layerId = UUID0;
+width = 913;
+},
+{
+components = (
+{
+name = four.denominator;
+transform = "{1, 0, 0, 1, 469, 0}";
+},
+{
+name = one.numerator;
+transform = "{1, 0, 0, 1, 71, 0}";
+},
+{
+name = fraction;
+transform = "{1, 0, 0, 1, 220, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 913;
+}
+);
+unicode = 00BC;
+},
+{
+glyphname = threequarters;
+lastChange = "2016-08-16 11:12:00 +0000";
+layers = (
+{
+components = (
+{
+name = three.numerator;
+transform = "{1, 0, 0, 1, 61, 0}";
+},
+{
+name = fraction;
+transform = "{1, 0, 0, 1, 220, 0}";
+},
+{
+name = four.denominator;
+transform = "{1, 0, 0, 1, 469, 0}";
+}
+);
+layerId = UUID0;
+width = 913;
+},
+{
+components = (
+{
+name = three.numerator;
+transform = "{1, 0, 0, 1, 61, 0}";
+},
+{
+name = fraction;
+transform = "{1, 0, 0, 1, 226, 0}";
+},
+{
+name = four.denominator;
+transform = "{1, 0, 0, 1, 469, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 913;
+}
+);
+unicode = 00BE;
+},
+{
+glyphname = oneeighth;
+lastChange = "2016-08-16 11:12:00 +0000";
+layers = (
+{
+components = (
+{
+name = eight.denominator;
+transform = "{1, 0, 0, 1, 493, 0}";
+},
+{
+name = one.numerator;
+transform = "{1, 0, 0, 1, 71, 0}";
+},
+{
+name = fraction;
+transform = "{1, 0, 0, 1, 194, 0}";
+}
+);
+layerId = UUID0;
+width = 913;
+},
+{
+components = (
+{
+name = eight.denominator;
+transform = "{1, 0, 0, 1, 493, 0}";
+},
+{
+name = one.numerator;
+transform = "{1, 0, 0, 1, 71, 0}";
+},
+{
+name = fraction;
+transform = "{1, 0, 0, 1, 194, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 913;
+}
+);
+unicode = 215B;
+},
+{
+glyphname = threeeighths;
+lastChange = "2016-08-16 11:12:00 +0000";
+layers = (
+{
+components = (
+{
+name = eight.denominator;
+transform = "{1, 0, 0, 1, 513, 0}";
+},
+{
+name = three.numerator;
+transform = "{1, 0, 0, 1, 61, 0}";
+},
+{
+name = fraction;
+transform = "{1, 0, 0, 1, 214, 0}";
+}
+);
+layerId = UUID0;
+width = 913;
+},
+{
+components = (
+{
+name = eight.denominator;
+transform = "{1, 0, 0, 1, 513, 0}";
+},
+{
+name = three.numerator;
+transform = "{1, 0, 0, 1, 61, 0}";
+},
+{
+name = fraction;
+transform = "{1, 0, 0, 1, 216, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 913;
+}
+);
+unicode = 215C;
+},
+{
+glyphname = fiveeighths;
+lastChange = "2016-08-16 11:12:00 +0000";
+layers = (
+{
+components = (
+{
+name = five.numerator;
+transform = "{1, 0, 0, 1, 57, 0}";
+},
+{
+name = fraction;
+transform = "{1, 0, 0, 1, 214, 0}";
+},
+{
+name = eight.denominator;
+transform = "{1, 0, 0, 1, 513, 0}";
+}
+);
+layerId = UUID0;
+width = 913;
+},
+{
+components = (
+{
+name = five.numerator;
+transform = "{1, 0, 0, 1, 57, 0}";
+},
+{
+name = fraction;
+transform = "{1, 0, 0, 1, 218, 0}";
+},
+{
+name = eight.denominator;
+transform = "{1, 0, 0, 1, 513, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 913;
+}
+);
+unicode = 215D;
+},
+{
+glyphname = seveneighths;
+lastChange = "2016-08-16 11:12:00 +0000";
+layers = (
+{
+components = (
+{
+name = seven.numerator;
+transform = "{1, 0, 0, 1, 63, 0}";
+},
+{
+name = fraction;
+transform = "{1, 0, 0, 1, 205, 0}";
+},
+{
+name = eight.denominator;
+transform = "{1, 0, 0, 1, 513, 0}";
+}
+);
+layerId = UUID0;
+width = 913;
+},
+{
+components = (
+{
+name = seven.numerator;
+transform = "{1, 0, 0, 1, 63, 0}";
+},
+{
+name = fraction;
+transform = "{1, 0, 0, 1, 205, 0}";
+},
+{
+name = eight.denominator;
+transform = "{1, 0, 0, 1, 513, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 913;
+}
+);
+unicode = 215E;
+},
+{
+glyphname = asterisk;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"254 336 OFFCURVE",
+"269 361 OFFCURVE",
+"269 390 CURVE SMOOTH",
+"269 427 OFFCURVE",
+"244 457 OFFCURVE",
+"238 520 CURVE",
+"241 522 LINE",
+"305 482 OFFCURVE",
+"317 419 OFFCURVE",
+"366 419 CURVE SMOOTH",
+"399 419 OFFCURVE",
+"413 447 OFFCURVE",
+"413 467 CURVE SMOOTH",
+"413 485 OFFCURVE",
+"401 500 OFFCURVE",
+"384 510 CURVE SMOOTH",
+"351 529 OFFCURVE",
+"315 521 OFFCURVE",
+"258 547 CURVE",
+"258 551 LINE",
+"315 577 OFFCURVE",
+"351 569 OFFCURVE",
+"384 588 CURVE SMOOTH",
+"401 598 OFFCURVE",
+"413 613 OFFCURVE",
+"413 631 CURVE SMOOTH",
+"413 651 OFFCURVE",
+"399 679 OFFCURVE",
+"366 679 CURVE SMOOTH",
+"317 679 OFFCURVE",
+"305 616 OFFCURVE",
+"241 576 CURVE",
+"238 578 LINE",
+"244 643 OFFCURVE",
+"269 671 OFFCURVE",
+"269 709 CURVE SMOOTH",
+"269 738 OFFCURVE",
+"254 763 OFFCURVE",
+"221 763 CURVE SMOOTH",
+"190 763 OFFCURVE",
+"175 741 OFFCURVE",
+"175 711 CURVE SMOOTH",
+"175 672 OFFCURVE",
+"201 643 OFFCURVE",
+"206 578 CURVE",
+"203 576 LINE",
+"135 618 OFFCURVE",
+"126 679 OFFCURVE",
+"76 679 CURVE SMOOTH",
+"44 679 OFFCURVE",
+"30 655 OFFCURVE",
+"30 633 CURVE SMOOTH",
+"30 614 OFFCURVE",
+"41 600 OFFCURVE",
+"59 590 CURVE SMOOTH",
+"96 568 OFFCURVE",
+"129 578 OFFCURVE",
+"187 551 CURVE",
+"187 547 LINE",
+"129 520 OFFCURVE",
+"96 530 OFFCURVE",
+"59 508 CURVE SMOOTH",
+"41 498 OFFCURVE",
+"30 484 OFFCURVE",
+"30 465 CURVE SMOOTH",
+"30 443 OFFCURVE",
+"44 419 OFFCURVE",
+"76 419 CURVE SMOOTH",
+"127 419 OFFCURVE",
+"135 480 OFFCURVE",
+"203 522 CURVE",
+"206 520 LINE",
+"200 455 OFFCURVE",
+"175 426 OFFCURVE",
+"175 388 CURVE SMOOTH",
+"175 358 OFFCURVE",
+"190 336 OFFCURVE",
+"221 336 CURVE SMOOTH"
+);
+}
+);
+width = 443;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"261 336 OFFCURVE",
+"279 364 OFFCURVE",
+"279 393 CURVE SMOOTH",
+"279 433 OFFCURVE",
+"246 458 OFFCURVE",
+"238 520 CURVE",
+"241 522 LINE",
+"307 477 OFFCURVE",
+"315 409 OFFCURVE",
+"368 409 CURVE SMOOTH",
+"405 409 OFFCURVE",
+"423 443 OFFCURVE",
+"423 466 CURVE SMOOTH",
+"423 488 OFFCURVE",
+"406 510 OFFCURVE",
+"384 520 CURVE SMOOTH",
+"354 534 OFFCURVE",
+"315 522 OFFCURVE",
+"258 547 CURVE",
+"258 551 LINE",
+"315 575 OFFCURVE",
+"354 564 OFFCURVE",
+"384 578 CURVE SMOOTH",
+"406 588 OFFCURVE",
+"423 610 OFFCURVE",
+"423 632 CURVE SMOOTH",
+"423 655 OFFCURVE",
+"405 689 OFFCURVE",
+"368 689 CURVE SMOOTH",
+"315 689 OFFCURVE",
+"307 621 OFFCURVE",
+"241 576 CURVE",
+"238 578 LINE",
+"246 642 OFFCURVE",
+"279 665 OFFCURVE",
+"279 705 CURVE SMOOTH",
+"279 735 OFFCURVE",
+"261 763 OFFCURVE",
+"221 763 CURVE SMOOTH",
+"183 763 OFFCURVE",
+"165 738 OFFCURVE",
+"165 708 CURVE SMOOTH",
+"165 666 OFFCURVE",
+"199 642 OFFCURVE",
+"206 578 CURVE",
+"203 576 LINE",
+"133 623 OFFCURVE",
+"128 689 OFFCURVE",
+"74 689 CURVE SMOOTH",
+"39 689 OFFCURVE",
+"20 661 OFFCURVE",
+"20 635 CURVE SMOOTH",
+"20 611 OFFCURVE",
+"35 591 OFFCURVE",
+"59 580 CURVE SMOOTH",
+"94 564 OFFCURVE",
+"129 577 OFFCURVE",
+"187 551 CURVE",
+"187 547 LINE",
+"129 520 OFFCURVE",
+"94 534 OFFCURVE",
+"59 518 CURVE SMOOTH",
+"35 507 OFFCURVE",
+"20 487 OFFCURVE",
+"20 464 CURVE SMOOTH",
+"20 438 OFFCURVE",
+"38 409 OFFCURVE",
+"74 409 CURVE SMOOTH",
+"129 409 OFFCURVE",
+"134 475 OFFCURVE",
+"203 522 CURVE",
+"206 520 LINE",
+"198 456 OFFCURVE",
+"165 432 OFFCURVE",
+"165 391 CURVE SMOOTH",
+"165 361 OFFCURVE",
+"183 336 OFFCURVE",
+"221 336 CURVE SMOOTH"
+);
+}
+);
+width = 443;
+}
+);
+unicode = 002A;
+},
+{
+glyphname = backslash;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"209 0 LINE",
+"-1 753 LINE",
+"-60 753 LINE",
+"150 0 LINE"
+);
+}
+);
+width = 149;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"209 0 LINE",
+"19 753 LINE",
+"-60 753 LINE",
+"130 0 LINE"
+);
+}
+);
+width = 149;
+}
+);
+unicode = 005C;
+},
+{
+glyphname = periodcentered;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"123 177 OFFCURVE",
+"156 210 OFFCURVE",
+"156 250 CURVE SMOOTH",
+"156 290 OFFCURVE",
+"123 323 OFFCURVE",
+"83 323 CURVE SMOOTH",
+"43 323 OFFCURVE",
+"10 290 OFFCURVE",
+"10 250 CURVE SMOOTH",
+"10 210 OFFCURVE",
+"43 177 OFFCURVE",
+"83 177 CURVE SMOOTH"
+);
+}
+);
+width = 166;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"185 167 OFFCURVE",
+"224 206 OFFCURVE",
+"224 254 CURVE SMOOTH",
+"224 302 OFFCURVE",
+"185 341 OFFCURVE",
+"137 341 CURVE SMOOTH",
+"89 341 OFFCURVE",
+"50 302 OFFCURVE",
+"50 254 CURVE SMOOTH",
+"50 206 OFFCURVE",
+"89 167 OFFCURVE",
+"137 167 CURVE SMOOTH"
+);
+}
+);
+width = 274;
+}
+);
+unicode = 00B7;
+},
+{
+glyphname = bullet;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"275 265 OFFCURVE",
+"320 317 OFFCURVE",
+"320 380 CURVE SMOOTH",
+"320 443 OFFCURVE",
+"275 495 OFFCURVE",
+"205 495 CURVE SMOOTH",
+"135 495 OFFCURVE",
+"90 443 OFFCURVE",
+"90 380 CURVE SMOOTH",
+"90 317 OFFCURVE",
+"135 265 OFFCURVE",
+"205 265 CURVE SMOOTH"
+);
+}
+);
+width = 410;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"275 265 OFFCURVE",
+"320 317 OFFCURVE",
+"320 380 CURVE SMOOTH",
+"320 443 OFFCURVE",
+"275 495 OFFCURVE",
+"205 495 CURVE SMOOTH",
+"135 495 OFFCURVE",
+"90 443 OFFCURVE",
+"90 380 CURVE SMOOTH",
+"90 317 OFFCURVE",
+"135 265 OFFCURVE",
+"205 265 CURVE SMOOTH"
+);
+}
+);
+width = 410;
+}
+);
+unicode = 2022;
+},
+{
+glyphname = colon;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"40 21 OFFCURVE",
+"73 -12 OFFCURVE",
+"113 -12 CURVE SMOOTH",
+"153 -12 OFFCURVE",
+"186 21 OFFCURVE",
+"186 61 CURVE SMOOTH",
+"186 101 OFFCURVE",
+"153 134 OFFCURVE",
+"113 134 CURVE SMOOTH",
+"73 134 OFFCURVE",
+"40 101 OFFCURVE",
+"40 61 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"40 318 OFFCURVE",
+"73 285 OFFCURVE",
+"113 285 CURVE SMOOTH",
+"153 285 OFFCURVE",
+"186 318 OFFCURVE",
+"186 358 CURVE SMOOTH",
+"186 398 OFFCURVE",
+"153 431 OFFCURVE",
+"113 431 CURVE SMOOTH",
+"73 431 OFFCURVE",
+"40 398 OFFCURVE",
+"40 358 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"153 285 OFFCURVE",
+"186 318 OFFCURVE",
+"186 358 CURVE SMOOTH",
+"186 398 OFFCURVE",
+"153 431 OFFCURVE",
+"113 431 CURVE SMOOTH",
+"73 431 OFFCURVE",
+"40 398 OFFCURVE",
+"40 358 CURVE SMOOTH",
+"40 318 OFFCURVE",
+"73 285 OFFCURVE",
+"113 285 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"153 -12 OFFCURVE",
+"186 21 OFFCURVE",
+"186 61 CURVE SMOOTH",
+"186 101 OFFCURVE",
+"153 134 OFFCURVE",
+"113 134 CURVE SMOOTH",
+"73 134 OFFCURVE",
+"40 101 OFFCURVE",
+"40 61 CURVE SMOOTH",
+"40 21 OFFCURVE",
+"73 -12 OFFCURVE",
+"113 -12 CURVE SMOOTH"
+);
+}
+);
+width = 226;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"50 319 OFFCURVE",
+"89 280 OFFCURVE",
+"137 280 CURVE SMOOTH",
+"185 280 OFFCURVE",
+"224 319 OFFCURVE",
+"224 367 CURVE SMOOTH",
+"224 415 OFFCURVE",
+"185 454 OFFCURVE",
+"137 454 CURVE SMOOTH",
+"89 454 OFFCURVE",
+"50 415 OFFCURVE",
+"50 367 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"50 26 OFFCURVE",
+"89 -13 OFFCURVE",
+"137 -13 CURVE SMOOTH",
+"185 -13 OFFCURVE",
+"224 26 OFFCURVE",
+"224 74 CURVE SMOOTH",
+"224 122 OFFCURVE",
+"185 161 OFFCURVE",
+"137 161 CURVE SMOOTH",
+"89 161 OFFCURVE",
+"50 122 OFFCURVE",
+"50 74 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"185 280 OFFCURVE",
+"224 319 OFFCURVE",
+"224 367 CURVE SMOOTH",
+"224 415 OFFCURVE",
+"185 454 OFFCURVE",
+"137 454 CURVE SMOOTH",
+"89 454 OFFCURVE",
+"50 415 OFFCURVE",
+"50 367 CURVE SMOOTH",
+"50 319 OFFCURVE",
+"89 280 OFFCURVE",
+"137 280 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"185 -13 OFFCURVE",
+"224 26 OFFCURVE",
+"224 74 CURVE SMOOTH",
+"224 122 OFFCURVE",
+"185 161 OFFCURVE",
+"137 161 CURVE SMOOTH",
+"89 161 OFFCURVE",
+"50 122 OFFCURVE",
+"50 74 CURVE SMOOTH",
+"50 26 OFFCURVE",
+"89 -13 OFFCURVE",
+"137 -13 CURVE SMOOTH"
+);
+}
+);
+width = 274;
+}
+);
+unicode = 003A;
+},
+{
+glyphname = comma;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"55 -165 LINE",
+"144 -128 OFFCURVE",
+"198 -57 OFFCURVE",
+"198 22 CURVE SMOOTH",
+"198 86 OFFCURVE",
+"163 125 OFFCURVE",
+"106 125 CURVE SMOOTH",
+"61 125 OFFCURVE",
+"34 101 OFFCURVE",
+"34 60 CURVE SMOOTH",
+"34 22 OFFCURVE",
+"57 -3 OFFCURVE",
+"94 -3 CURVE SMOOTH",
+"137 -3 OFFCURVE",
+"130 32 OFFCURVE",
+"151 32 CURVE SMOOTH",
+"162 32 OFFCURVE",
+"168 23 OFFCURVE",
+"168 4 CURVE SMOOTH",
+"168 -49 OFFCURVE",
+"120 -108 OFFCURVE",
+"49 -143 CURVE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"144 -128 OFFCURVE",
+"198 -57 OFFCURVE",
+"198 22 CURVE SMOOTH",
+"198 86 OFFCURVE",
+"163 125 OFFCURVE",
+"106 125 CURVE SMOOTH",
+"61 125 OFFCURVE",
+"34 101 OFFCURVE",
+"34 60 CURVE SMOOTH",
+"34 22 OFFCURVE",
+"57 -3 OFFCURVE",
+"94 -3 CURVE SMOOTH",
+"137 -3 OFFCURVE",
+"130 32 OFFCURVE",
+"151 32 CURVE SMOOTH",
+"162 32 OFFCURVE",
+"168 23 OFFCURVE",
+"168 4 CURVE SMOOTH",
+"168 -49 OFFCURVE",
+"120 -108 OFFCURVE",
+"49 -143 CURVE",
+"55 -165 LINE"
+);
+}
+);
+width = 232;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"258 95 OFFCURVE",
+"213 159 OFFCURVE",
+"142 159 CURVE SMOOTH",
+"86 159 OFFCURVE",
+"50 119 OFFCURVE",
+"50 67 CURVE SMOOTH",
+"50 26 OFFCURVE",
+"73 -13 OFFCURVE",
+"123 -13 CURVE SMOOTH",
+"171 -13 OFFCURVE",
+"183 23 OFFCURVE",
+"198 23 CURVE SMOOTH",
+"204 23 OFFCURVE",
+"209 17 OFFCURVE",
+"209 -7 CURVE SMOOTH",
+"209 -71 OFFCURVE",
+"174 -123 OFFCURVE",
+"96 -183 CURVE",
+"113 -204 LINE",
+"197 -152 OFFCURVE",
+"258 -80 OFFCURVE",
+"258 14 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"197 -152 OFFCURVE",
+"258 -80 OFFCURVE",
+"258 14 CURVE SMOOTH",
+"258 95 OFFCURVE",
+"213 159 OFFCURVE",
+"142 159 CURVE SMOOTH",
+"86 159 OFFCURVE",
+"50 119 OFFCURVE",
+"50 67 CURVE SMOOTH",
+"50 26 OFFCURVE",
+"73 -13 OFFCURVE",
+"123 -13 CURVE SMOOTH",
+"171 -13 OFFCURVE",
+"183 23 OFFCURVE",
+"198 23 CURVE SMOOTH",
+"204 23 OFFCURVE",
+"209 17 OFFCURVE",
+"209 -7 CURVE SMOOTH",
+"209 -71 OFFCURVE",
+"174 -123 OFFCURVE",
+"96 -183 CURVE",
+"113 -204 LINE"
+);
+}
+);
+width = 308;
+}
+);
+unicode = 002C;
+},
+{
+glyphname = ellipsis;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"655 -13 OFFCURVE",
+"688 20 OFFCURVE",
+"688 60 CURVE SMOOTH",
+"688 100 OFFCURVE",
+"655 133 OFFCURVE",
+"615 133 CURVE SMOOTH",
+"575 133 OFFCURVE",
+"542 100 OFFCURVE",
+"542 60 CURVE SMOOTH",
+"542 20 OFFCURVE",
+"575 -13 OFFCURVE",
+"615 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"163 -13 OFFCURVE",
+"196 20 OFFCURVE",
+"196 60 CURVE SMOOTH",
+"196 100 OFFCURVE",
+"163 133 OFFCURVE",
+"123 133 CURVE SMOOTH",
+"83 133 OFFCURVE",
+"50 100 OFFCURVE",
+"50 60 CURVE SMOOTH",
+"50 20 OFFCURVE",
+"83 -13 OFFCURVE",
+"123 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"409 -13 OFFCURVE",
+"442 20 OFFCURVE",
+"442 60 CURVE SMOOTH",
+"442 100 OFFCURVE",
+"409 133 OFFCURVE",
+"369 133 CURVE SMOOTH",
+"329 133 OFFCURVE",
+"296 100 OFFCURVE",
+"296 60 CURVE SMOOTH",
+"296 20 OFFCURVE",
+"329 -13 OFFCURVE",
+"369 -13 CURVE SMOOTH"
+);
+}
+);
+width = 738;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"733 -13 OFFCURVE",
+"772 26 OFFCURVE",
+"772 74 CURVE SMOOTH",
+"772 122 OFFCURVE",
+"733 161 OFFCURVE",
+"685 161 CURVE SMOOTH",
+"637 161 OFFCURVE",
+"598 122 OFFCURVE",
+"598 74 CURVE SMOOTH",
+"598 26 OFFCURVE",
+"637 -13 OFFCURVE",
+"685 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"185 -13 OFFCURVE",
+"224 26 OFFCURVE",
+"224 74 CURVE SMOOTH",
+"224 122 OFFCURVE",
+"185 161 OFFCURVE",
+"137 161 CURVE SMOOTH",
+"89 161 OFFCURVE",
+"50 122 OFFCURVE",
+"50 74 CURVE SMOOTH",
+"50 26 OFFCURVE",
+"89 -13 OFFCURVE",
+"137 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"459 -13 OFFCURVE",
+"498 26 OFFCURVE",
+"498 74 CURVE SMOOTH",
+"498 122 OFFCURVE",
+"459 161 OFFCURVE",
+"411 161 CURVE SMOOTH",
+"363 161 OFFCURVE",
+"324 122 OFFCURVE",
+"324 74 CURVE SMOOTH",
+"324 26 OFFCURVE",
+"363 -13 OFFCURVE",
+"411 -13 CURVE SMOOTH"
+);
+}
+);
+width = 822;
+}
+);
+unicode = 2026;
+},
+{
+glyphname = exclam;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"142 224 LINE",
+"142 496 OFFCURVE",
+"200 576 OFFCURVE",
+"200 669 CURVE SMOOTH",
+"200 748 OFFCURVE",
+"167 766 OFFCURVE",
+"127 766 CURVE SMOOTH",
+"80 766 OFFCURVE",
+"54 741 OFFCURVE",
+"54 671 CURVE SMOOTH",
+"54 577 OFFCURVE",
+"111 496 OFFCURVE",
+"111 224 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"167 -12 OFFCURVE",
+"200 21 OFFCURVE",
+"200 61 CURVE SMOOTH",
+"200 101 OFFCURVE",
+"167 134 OFFCURVE",
+"127 134 CURVE SMOOTH",
+"87 134 OFFCURVE",
+"54 101 OFFCURVE",
+"54 61 CURVE SMOOTH",
+"54 21 OFFCURVE",
+"87 -12 OFFCURVE",
+"127 -12 CURVE SMOOTH"
+);
+}
+);
+width = 254;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"87 727 OFFCURVE",
+"68 711 OFFCURVE",
+"58 695 CURVE",
+"48 674 OFFCURVE",
+"44 635 OFFCURVE",
+"48 611 CURVE",
+"52 597 OFFCURVE",
+"61 565 OFFCURVE",
+"66 544 CURVE",
+"69 536 OFFCURVE",
+"72 525 OFFCURVE",
+"74 519 CURVE SMOOTH",
+"76 511 OFFCURVE",
+"77 503 OFFCURVE",
+"79 501 CURVE",
+"80 498 OFFCURVE",
+"84 487 OFFCURVE",
+"87 475 CURVE",
+"88 464 OFFCURVE",
+"93 448 OFFCURVE",
+"95 440 CURVE SMOOTH",
+"101 415 OFFCURVE",
+"103 400 OFFCURVE",
+"104 386 CURVE SMOOTH",
+"104 378 OFFCURVE",
+"106 370 OFFCURVE",
+"108 365 CURVE",
+"109 355 OFFCURVE",
+"111 320 OFFCURVE",
+"112 282 CURVE SMOOTH",
+"112 247 OFFCURVE",
+"112 245 OFFCURVE",
+"116 240 CURVE SMOOTH",
+"119 237 OFFCURVE",
+"121 235 OFFCURVE",
+"130 235 CURVE SMOOTH",
+"144 235 OFFCURVE",
+"144 237 OFFCURVE",
+"144 279 CURVE SMOOTH",
+"144 298 OFFCURVE",
+"146 320 OFFCURVE",
+"148 330 CURVE",
+"148 338 OFFCURVE",
+"151 352 OFFCURVE",
+"151 362 CURVE",
+"152 371 OFFCURVE",
+"154 381 OFFCURVE",
+"156 384 CURVE",
+"156 386 OFFCURVE",
+"159 399 OFFCURVE",
+"160 413 CURVE SMOOTH",
+"162 427 OFFCURVE",
+"164 440 OFFCURVE",
+"165 440 CURVE",
+"165 442 OFFCURVE",
+"167 447 OFFCURVE",
+"167 453 CURVE SMOOTH",
+"167 464 OFFCURVE",
+"175 482 OFFCURVE",
+"192 536 CURVE",
+"215 597 OFFCURVE",
+"215 618 OFFCURVE",
+"215 648 CURVE",
+"212 685 OFFCURVE",
+"204 704 OFFCURVE",
+"183 720 CURVE SMOOTH",
+"176 725 OFFCURVE",
+"167 730 OFFCURVE",
+"162 731 CURVE SMOOTH",
+"149 735 OFFCURVE",
+"116 736 OFFCURVE",
+"106 733 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"93 159 OFFCURVE",
+"69 146 OFFCURVE",
+"60 131 CURVE SMOOTH",
+"58 128 OFFCURVE",
+"53 123 OFFCURVE",
+"52 122 CURVE SMOOTH",
+"47 117 OFFCURVE",
+"44 107 OFFCURVE",
+"40 88 CURVE SMOOTH",
+"36 66 OFFCURVE",
+"39 45 OFFCURVE",
+"53 29 CURVE SMOOTH",
+"58 23 OFFCURVE",
+"61 18 OFFCURVE",
+"61 16 CURVE SMOOTH",
+"61 16 OFFCURVE",
+"67 10 OFFCURVE",
+"76 5 CURVE",
+"90 -5 OFFCURVE",
+"95 -6 OFFCURVE",
+"104 -9 CURVE",
+"165 -24 OFFCURVE",
+"214 13 OFFCURVE",
+"216 75 CURVE",
+"218 96 OFFCURVE",
+"215 107 OFFCURVE",
+"204 123 CURVE SMOOTH",
+"192 139 OFFCURVE",
+"186 146 OFFCURVE",
+"175 152 CURVE SMOOTH",
+"159 162 OFFCURVE",
+"140 165 OFFCURVE",
+"111 162 CURVE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"171 224 LINE",
+"171 490 OFFCURVE",
+"241 562 OFFCURVE",
+"241 659 CURVE SMOOTH",
+"241 736 OFFCURVE",
+"201 763 OFFCURVE",
+"152 763 CURVE SMOOTH",
+"97 763 OFFCURVE",
+"65 729 OFFCURVE",
+"65 660 CURVE SMOOTH",
+"65 564 OFFCURVE",
+"134 490 OFFCURVE",
+"134 224 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"202 -13 OFFCURVE",
+"242 27 OFFCURVE",
+"242 75 CURVE SMOOTH",
+"242 123 OFFCURVE",
+"202 163 OFFCURVE",
+"154 163 CURVE SMOOTH",
+"106 163 OFFCURVE",
+"66 123 OFFCURVE",
+"66 75 CURVE SMOOTH",
+"66 27 OFFCURVE",
+"106 -13 OFFCURVE",
+"154 -13 CURVE SMOOTH"
+);
+}
+);
+width = 307;
+}
+);
+unicode = 0021;
+},
+{
+glyphname = exclamdown;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"54 419 OFFCURVE",
+"87 452 OFFCURVE",
+"127 452 CURVE SMOOTH",
+"167 452 OFFCURVE",
+"200 419 OFFCURVE",
+"200 379 CURVE SMOOTH",
+"200 339 OFFCURVE",
+"167 306 OFFCURVE",
+"127 306 CURVE SMOOTH",
+"87 306 OFFCURVE",
+"54 339 OFFCURVE",
+"54 379 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"142 216 LINE",
+"142 -56 OFFCURVE",
+"200 -136 OFFCURVE",
+"200 -229 CURVE SMOOTH",
+"200 -308 OFFCURVE",
+"167 -326 OFFCURVE",
+"127 -326 CURVE SMOOTH",
+"80 -326 OFFCURVE",
+"54 -301 OFFCURVE",
+"54 -231 CURVE SMOOTH",
+"54 -137 OFFCURVE",
+"111 -56 OFFCURVE",
+"111 216 CURVE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"167 -326 OFFCURVE",
+"200 -308 OFFCURVE",
+"200 -229 CURVE SMOOTH",
+"200 -136 OFFCURVE",
+"142 -56 OFFCURVE",
+"142 216 CURVE",
+"111 216 LINE",
+"111 -56 OFFCURVE",
+"54 -137 OFFCURVE",
+"54 -231 CURVE SMOOTH",
+"54 -301 OFFCURVE",
+"80 -326 OFFCURVE",
+"127 -326 CURVE SMOOTH",
+"127 -326 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"167 306 OFFCURVE",
+"200 339 OFFCURVE",
+"200 379 CURVE SMOOTH",
+"200 419 OFFCURVE",
+"167 452 OFFCURVE",
+"127 452 CURVE SMOOTH",
+"87 452 OFFCURVE",
+"54 419 OFFCURVE",
+"54 379 CURVE SMOOTH",
+"54 339 OFFCURVE",
+"87 306 OFFCURVE",
+"127 306 CURVE SMOOTH"
+);
+}
+);
+width = 254;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"241 413 OFFCURVE",
+"201 453 OFFCURVE",
+"153 453 CURVE SMOOTH",
+"105 453 OFFCURVE",
+"65 413 OFFCURVE",
+"65 365 CURVE SMOOTH",
+"65 317 OFFCURVE",
+"105 277 OFFCURVE",
+"153 277 CURVE SMOOTH",
+"201 277 OFFCURVE",
+"241 317 OFFCURVE",
+"241 365 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"136 216 LINE",
+"136 -50 OFFCURVE",
+"66 -122 OFFCURVE",
+"66 -219 CURVE SMOOTH",
+"66 -296 OFFCURVE",
+"106 -323 OFFCURVE",
+"155 -323 CURVE SMOOTH",
+"210 -323 OFFCURVE",
+"242 -289 OFFCURVE",
+"242 -220 CURVE SMOOTH",
+"242 -124 OFFCURVE",
+"173 -50 OFFCURVE",
+"173 216 CURVE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"210 -323 OFFCURVE",
+"242 -289 OFFCURVE",
+"242 -220 CURVE SMOOTH",
+"242 -124 OFFCURVE",
+"173 -50 OFFCURVE",
+"173 216 CURVE",
+"136 216 LINE",
+"136 -50 OFFCURVE",
+"66 -122 OFFCURVE",
+"66 -219 CURVE SMOOTH",
+"66 -296 OFFCURVE",
+"106 -323 OFFCURVE",
+"155 -323 CURVE SMOOTH",
+"155 -323 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"201 277 OFFCURVE",
+"241 317 OFFCURVE",
+"241 365 CURVE SMOOTH",
+"241 413 OFFCURVE",
+"201 453 OFFCURVE",
+"153 453 CURVE SMOOTH",
+"105 453 OFFCURVE",
+"65 413 OFFCURVE",
+"65 365 CURVE SMOOTH",
+"65 317 OFFCURVE",
+"105 277 OFFCURVE",
+"153 277 CURVE SMOOTH"
+);
+}
+);
+width = 307;
+}
+);
+unicode = 00A1;
+},
+{
+glyphname = numbersign;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"187 763 LINE",
+"67 0 LINE",
+"135 0 LINE",
+"255 763 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"0 224 LINE",
+"498 224 LINE",
+"498 288 LINE",
+"0 288 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"404 763 LINE",
+"284 0 LINE",
+"352 0 LINE",
+"472 763 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"49 463 LINE",
+"547 463 LINE",
+"547 527 LINE",
+"49 527 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"342 0 LINE",
+"462 763 LINE",
+"414 763 LINE",
+"294 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"498 236 LINE",
+"498 276 LINE",
+"0 276 LINE",
+"0 236 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"125 0 LINE",
+"245 763 LINE",
+"197 763 LINE",
+"77 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"547 475 LINE",
+"547 515 LINE",
+"49 515 LINE",
+"49 475 LINE"
+);
+}
+);
+width = 546;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"177 763 LINE",
+"57 0 LINE",
+"145 0 LINE",
+"265 763 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"0 219 LINE",
+"498 219 LINE",
+"498 293 LINE",
+"0 293 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"394 763 LINE",
+"274 0 LINE",
+"362 0 LINE",
+"482 763 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"49 458 LINE",
+"547 458 LINE",
+"547 532 LINE",
+"49 532 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"133 0 LINE",
+"253 763 LINE",
+"189 763 LINE",
+"69 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"498 232 LINE",
+"498 281 LINE",
+"0 281 LINE",
+"0 232 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"342 0 LINE",
+"462 763 LINE",
+"406 763 LINE",
+"286 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"547 470 LINE",
+"547 520 LINE",
+"49 520 LINE",
+"49 470 LINE"
+);
+}
+);
+width = 546;
+}
+);
+unicode = 0023;
+},
+{
+glyphname = period;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"153 -12 OFFCURVE",
+"186 21 OFFCURVE",
+"186 61 CURVE SMOOTH",
+"186 101 OFFCURVE",
+"153 134 OFFCURVE",
+"113 134 CURVE SMOOTH",
+"73 134 OFFCURVE",
+"40 101 OFFCURVE",
+"40 61 CURVE SMOOTH",
+"40 21 OFFCURVE",
+"73 -12 OFFCURVE",
+"113 -12 CURVE SMOOTH"
+);
+}
+);
+width = 226;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"86 150 OFFCURVE",
+"75 147 OFFCURVE",
+"67 142 CURVE",
+"49 134 OFFCURVE",
+"27 107 OFFCURVE",
+"22 89 CURVE",
+"22 77 OFFCURVE",
+"22 54 OFFCURVE",
+"22 41 CURVE",
+"30 8 OFFCURVE",
+"63 -19 OFFCURVE",
+"99 -24 CURVE SMOOTH",
+"126 -27 OFFCURVE",
+"151 -18 OFFCURVE",
+"171 3 CURVE SMOOTH",
+"183 17 OFFCURVE",
+"195 29 OFFCURVE",
+"195 45 CURVE",
+"199 61 OFFCURVE",
+"198 70 OFFCURVE",
+"193 89 CURVE SMOOTH",
+"188 104 OFFCURVE",
+"185 110 OFFCURVE",
+"179 120 CURVE",
+"174 126 OFFCURVE",
+"167 133 OFFCURVE",
+"166 134 CURVE SMOOTH",
+"151 145 OFFCURVE",
+"119 155 OFFCURVE",
+"99 152 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"185 -13 OFFCURVE",
+"224 26 OFFCURVE",
+"224 74 CURVE SMOOTH",
+"224 122 OFFCURVE",
+"185 161 OFFCURVE",
+"137 161 CURVE SMOOTH",
+"89 161 OFFCURVE",
+"50 122 OFFCURVE",
+"50 74 CURVE SMOOTH",
+"50 26 OFFCURVE",
+"89 -13 OFFCURVE",
+"137 -13 CURVE SMOOTH"
+);
+}
+);
+width = 274;
+}
+);
+unicode = 002E;
+},
+{
+glyphname = question;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"182 222 LINE",
+"182 376 OFFCURVE",
+"382 399 OFFCURVE",
+"382 567 CURVE SMOOTH",
+"382 690 OFFCURVE",
+"306 766 OFFCURVE",
+"191 766 CURVE SMOOTH",
+"93 766 OFFCURVE",
+"24 697 OFFCURVE",
+"24 627 CURVE SMOOTH",
+"24 578 OFFCURVE",
+"50 554 OFFCURVE",
+"83 554 CURVE SMOOTH",
+"112 554 OFFCURVE",
+"136 566 OFFCURVE",
+"136 598 CURVE SMOOTH",
+"136 653 OFFCURVE",
+"82 639 OFFCURVE",
+"82 674 CURVE SMOOTH",
+"82 703 OFFCURVE",
+"132 739 OFFCURVE",
+"197 739 CURVE SMOOTH",
+"260 739 OFFCURVE",
+"320 699 OFFCURVE",
+"320 628 CURVE SMOOTH",
+"320 522 OFFCURVE",
+"143 502 OFFCURVE",
+"143 307 CURVE SMOOTH",
+"143 292 OFFCURVE",
+"143 260 OFFCURVE",
+"152 222 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"218 -12 OFFCURVE",
+"251 21 OFFCURVE",
+"251 61 CURVE SMOOTH",
+"251 101 OFFCURVE",
+"218 134 OFFCURVE",
+"178 134 CURVE SMOOTH",
+"138 134 OFFCURVE",
+"105 101 OFFCURVE",
+"105 61 CURVE SMOOTH",
+"105 21 OFFCURVE",
+"138 -12 OFFCURVE",
+"178 -12 CURVE SMOOTH"
+);
+}
+);
+width = 414;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"171 748 OFFCURVE",
+"137 737 OFFCURVE",
+"123 726 CURVE SMOOTH",
+"121 724 OFFCURVE",
+"117 722 OFFCURVE",
+"117 722 CURVE",
+"113 722 OFFCURVE",
+"86 698 OFFCURVE",
+"78 687 CURVE",
+"73 682 OFFCURVE",
+"69 676 OFFCURVE",
+"67 673 CURVE SMOOTH",
+"62 666 OFFCURVE",
+"53 646 OFFCURVE",
+"49 633 CURVE",
+"49 628 OFFCURVE",
+"48 618 OFFCURVE",
+"48 610 CURVE SMOOTH",
+"48 591 OFFCURVE",
+"55 574 OFFCURVE",
+"65 559 CURVE",
+"81 542 OFFCURVE",
+"103 534 OFFCURVE",
+"126 538 CURVE SMOOTH",
+"148 542 OFFCURVE",
+"170 556 OFFCURVE",
+"179 574 CURVE SMOOTH",
+"185 585 OFFCURVE",
+"189 602 OFFCURVE",
+"187 612 CURVE SMOOTH",
+"184 633 OFFCURVE",
+"168 655 OFFCURVE",
+"147 665 CURVE SMOOTH",
+"136 670 OFFCURVE",
+"129 676 OFFCURVE",
+"129 682 CURVE SMOOTH",
+"129 684 OFFCURVE",
+"133 690 OFFCURVE",
+"139 695 CURVE",
+"145 702 OFFCURVE",
+"152 705 OFFCURVE",
+"165 710 CURVE SMOOTH",
+"177 714 OFFCURVE",
+"189 718 OFFCURVE",
+"189 719 CURVE",
+"198 724 OFFCURVE",
+"217 724 OFFCURVE",
+"230 719 CURVE",
+"236 718 OFFCURVE",
+"243 716 OFFCURVE",
+"249 716 CURVE SMOOTH",
+"257 716 OFFCURVE",
+"280 708 OFFCURVE",
+"285 705 CURVE",
+"285 703 OFFCURVE",
+"288 702 OFFCURVE",
+"291 698 CURVE",
+"313 686 OFFCURVE",
+"321 674 OFFCURVE",
+"326 652 CURVE",
+"326 642 OFFCURVE",
+"326 641 OFFCURVE",
+"326 625 CURVE",
+"323 607 OFFCURVE",
+"320 601 OFFCURVE",
+"310 588 CURVE SMOOTH",
+"302 577 OFFCURVE",
+"265 538 OFFCURVE",
+"246 522 CURVE SMOOTH",
+"240 516 OFFCURVE",
+"232 508 OFFCURVE",
+"229 505 CURVE",
+"227 500 OFFCURVE",
+"219 492 OFFCURVE",
+"213 486 CURVE SMOOTH",
+"206 479 OFFCURVE",
+"200 471 OFFCURVE",
+"198 468 CURVE SMOOTH",
+"197 465 OFFCURVE",
+"193 460 OFFCURVE",
+"190 457 CURVE SMOOTH",
+"187 454 OFFCURVE",
+"182 447 OFFCURVE",
+"181 444 CURVE SMOOTH",
+"171 426 OFFCURVE",
+"165 412 OFFCURVE",
+"163 406 CURVE",
+"163 402 OFFCURVE",
+"161 394 OFFCURVE",
+"160 390 CURVE",
+"160 372 OFFCURVE",
+"160 322 OFFCURVE",
+"160 295 CURVE",
+"163 279 OFFCURVE",
+"169 258 OFFCURVE",
+"174 250 CURVE",
+"174 241 OFFCURVE",
+"195 238 OFFCURVE",
+"195 244 CURVE",
+"200 247 OFFCURVE",
+"200 247 OFFCURVE",
+"200 268 CURVE",
+"198 286 OFFCURVE",
+"200 290 OFFCURVE",
+"203 298 CURVE SMOOTH",
+"208 311 OFFCURVE",
+"220 324 OFFCURVE",
+"240 337 CURVE SMOOTH",
+"247 342 OFFCURVE",
+"257 346 OFFCURVE",
+"257 348 CURVE SMOOTH",
+"257 350 OFFCURVE",
+"269 358 OFFCURVE",
+"281 364 CURVE",
+"340 402 OFFCURVE",
+"369 426 OFFCURVE",
+"395 460 CURVE SMOOTH",
+"412 482 OFFCURVE",
+"425 514 OFFCURVE",
+"432 546 CURVE",
+"433 562 OFFCURVE",
+"432 594 OFFCURVE",
+"429 606 CURVE",
+"427 610 OFFCURVE",
+"424 620 OFFCURVE",
+"422 626 CURVE SMOOTH",
+"417 650 OFFCURVE",
+"384 695 OFFCURVE",
+"361 711 CURVE SMOOTH",
+"357 713 OFFCURVE",
+"350 718 OFFCURVE",
+"345 721 CURVE SMOOTH",
+"337 727 OFFCURVE",
+"329 730 OFFCURVE",
+"305 740 CURVE SMOOTH",
+"283 748 OFFCURVE",
+"232 754 OFFCURVE",
+"203 751 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"195 161 OFFCURVE",
+"192 160 OFFCURVE",
+"187 160 CURVE",
+"168 156 OFFCURVE",
+"160 153 OFFCURVE",
+"147 142 CURVE SMOOTH",
+"141 137 OFFCURVE",
+"134 129 OFFCURVE",
+"133 126 CURVE SMOOTH",
+"133 124 OFFCURVE",
+"129 120 OFFCURVE",
+"128 118 CURVE SMOOTH",
+"117 105 OFFCURVE",
+"112 81 OFFCURVE",
+"115 64 CURVE",
+"115 44 OFFCURVE",
+"128 32 OFFCURVE",
+"134 20 CURVE",
+"157 -7 OFFCURVE",
+"184 -16 OFFCURVE",
+"219 -10 CURVE SMOOTH",
+"248 -5 OFFCURVE",
+"269 9 OFFCURVE",
+"281 36 CURVE",
+"289 51 OFFCURVE",
+"291 54 OFFCURVE",
+"291 68 CURVE",
+"296 118 OFFCURVE",
+"261 160 OFFCURVE",
+"213 161 CURVE",
+"203 163 OFFCURVE",
+"197 163 OFFCURVE",
+"195 161 CURVE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"182 224 LINE",
+"182 361 OFFCURVE",
+"430 367 OFFCURVE",
+"430 569 CURVE SMOOTH",
+"430 675 OFFCURVE",
+"345 754 OFFCURVE",
+"215 754 CURVE SMOOTH",
+"113 754 OFFCURVE",
+"45 684 OFFCURVE",
+"45 606 CURVE SMOOTH",
+"45 560 OFFCURVE",
+"78 538 OFFCURVE",
+"117 538 CURVE SMOOTH",
+"157 538 OFFCURVE",
+"187 564 OFFCURVE",
+"187 595 CURVE SMOOTH",
+"187 663 OFFCURVE",
+"126 654 OFFCURVE",
+"126 680 CURVE SMOOTH",
+"126 699 OFFCURVE",
+"165 722 OFFCURVE",
+"217 722 CURVE SMOOTH",
+"279 722 OFFCURVE",
+"331 687 OFFCURVE",
+"331 627 CURVE SMOOTH",
+"331 513 OFFCURVE",
+"148 511 OFFCURVE",
+"148 291 CURVE SMOOTH",
+"148 275 OFFCURVE",
+"149 249 OFFCURVE",
+"152 224 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"223 -13 OFFCURVE",
+"263 27 OFFCURVE",
+"263 74 CURVE SMOOTH",
+"263 122 OFFCURVE",
+"223 162 OFFCURVE",
+"175 162 CURVE SMOOTH",
+"128 162 OFFCURVE",
+"88 122 OFFCURVE",
+"88 74 CURVE SMOOTH",
+"88 27 OFFCURVE",
+"128 -13 OFFCURVE",
+"175 -13 CURVE SMOOTH"
+);
+}
+);
+width = 470;
+}
+);
+unicode = 003F;
+},
+{
+glyphname = questiondown;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"232 230 LINE",
+"232 76 OFFCURVE",
+"32 53 OFFCURVE",
+"32 -115 CURVE SMOOTH",
+"32 -238 OFFCURVE",
+"108 -314 OFFCURVE",
+"223 -314 CURVE SMOOTH",
+"321 -314 OFFCURVE",
+"390 -245 OFFCURVE",
+"390 -175 CURVE SMOOTH",
+"390 -126 OFFCURVE",
+"364 -102 OFFCURVE",
+"331 -102 CURVE SMOOTH",
+"302 -102 OFFCURVE",
+"278 -114 OFFCURVE",
+"278 -146 CURVE SMOOTH",
+"278 -201 OFFCURVE",
+"332 -187 OFFCURVE",
+"332 -222 CURVE SMOOTH",
+"332 -251 OFFCURVE",
+"282 -287 OFFCURVE",
+"217 -287 CURVE SMOOTH",
+"154 -287 OFFCURVE",
+"94 -247 OFFCURVE",
+"94 -176 CURVE SMOOTH",
+"94 -70 OFFCURVE",
+"271 -50 OFFCURVE",
+"271 145 CURVE SMOOTH",
+"271 160 OFFCURVE",
+"271 192 OFFCURVE",
+"262 230 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"309 429 OFFCURVE",
+"276 462 OFFCURVE",
+"236 462 CURVE SMOOTH",
+"196 462 OFFCURVE",
+"163 429 OFFCURVE",
+"163 389 CURVE SMOOTH",
+"163 349 OFFCURVE",
+"196 316 OFFCURVE",
+"236 316 CURVE SMOOTH",
+"276 316 OFFCURVE",
+"309 349 OFFCURVE",
+"309 389 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"321 -314 OFFCURVE",
+"390 -245 OFFCURVE",
+"390 -175 CURVE SMOOTH",
+"390 -126 OFFCURVE",
+"364 -102 OFFCURVE",
+"331 -102 CURVE SMOOTH",
+"302 -102 OFFCURVE",
+"278 -114 OFFCURVE",
+"278 -146 CURVE SMOOTH",
+"278 -201 OFFCURVE",
+"332 -187 OFFCURVE",
+"332 -222 CURVE SMOOTH",
+"332 -251 OFFCURVE",
+"282 -287 OFFCURVE",
+"217 -287 CURVE SMOOTH",
+"154 -287 OFFCURVE",
+"94 -247 OFFCURVE",
+"94 -176 CURVE SMOOTH",
+"94 -70 OFFCURVE",
+"271 -50 OFFCURVE",
+"271 145 CURVE SMOOTH",
+"271 160 OFFCURVE",
+"271 192 OFFCURVE",
+"262 230 CURVE",
+"232 230 LINE",
+"232 76 OFFCURVE",
+"32 53 OFFCURVE",
+"32 -115 CURVE SMOOTH",
+"32 -238 OFFCURVE",
+"108 -314 OFFCURVE",
+"223 -314 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"276 316 OFFCURVE",
+"309 349 OFFCURVE",
+"309 389 CURVE SMOOTH",
+"309 429 OFFCURVE",
+"276 462 OFFCURVE",
+"236 462 CURVE SMOOTH",
+"196 462 OFFCURVE",
+"163 429 OFFCURVE",
+"163 389 CURVE SMOOTH",
+"163 349 OFFCURVE",
+"196 316 OFFCURVE",
+"236 316 CURVE SMOOTH"
+);
+}
+);
+width = 414;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"382 422 OFFCURVE",
+"342 462 OFFCURVE",
+"295 462 CURVE SMOOTH",
+"247 462 OFFCURVE",
+"207 422 OFFCURVE",
+"207 375 CURVE SMOOTH",
+"207 327 OFFCURVE",
+"247 287 OFFCURVE",
+"295 287 CURVE SMOOTH",
+"342 287 OFFCURVE",
+"382 327 OFFCURVE",
+"382 375 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"288 216 LINE",
+"288 79 OFFCURVE",
+"40 73 OFFCURVE",
+"40 -129 CURVE SMOOTH",
+"40 -235 OFFCURVE",
+"125 -314 OFFCURVE",
+"255 -314 CURVE SMOOTH",
+"357 -314 OFFCURVE",
+"425 -244 OFFCURVE",
+"425 -166 CURVE SMOOTH",
+"425 -120 OFFCURVE",
+"392 -98 OFFCURVE",
+"353 -98 CURVE SMOOTH",
+"313 -98 OFFCURVE",
+"283 -124 OFFCURVE",
+"283 -155 CURVE SMOOTH",
+"283 -223 OFFCURVE",
+"344 -214 OFFCURVE",
+"344 -240 CURVE SMOOTH",
+"344 -259 OFFCURVE",
+"305 -282 OFFCURVE",
+"253 -282 CURVE SMOOTH",
+"191 -282 OFFCURVE",
+"139 -247 OFFCURVE",
+"139 -187 CURVE SMOOTH",
+"139 -73 OFFCURVE",
+"322 -71 OFFCURVE",
+"322 149 CURVE SMOOTH",
+"322 165 OFFCURVE",
+"321 191 OFFCURVE",
+"318 216 CURVE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"357 -314 OFFCURVE",
+"425 -244 OFFCURVE",
+"425 -166 CURVE SMOOTH",
+"425 -120 OFFCURVE",
+"392 -98 OFFCURVE",
+"353 -98 CURVE SMOOTH",
+"313 -98 OFFCURVE",
+"283 -124 OFFCURVE",
+"283 -155 CURVE SMOOTH",
+"283 -223 OFFCURVE",
+"344 -214 OFFCURVE",
+"344 -240 CURVE SMOOTH",
+"344 -259 OFFCURVE",
+"305 -282 OFFCURVE",
+"253 -282 CURVE SMOOTH",
+"191 -282 OFFCURVE",
+"139 -247 OFFCURVE",
+"139 -187 CURVE SMOOTH",
+"139 -73 OFFCURVE",
+"322 -71 OFFCURVE",
+"322 149 CURVE SMOOTH",
+"322 165 OFFCURVE",
+"321 191 OFFCURVE",
+"318 216 CURVE",
+"288 216 LINE",
+"288 79 OFFCURVE",
+"40 73 OFFCURVE",
+"40 -129 CURVE SMOOTH",
+"40 -235 OFFCURVE",
+"125 -314 OFFCURVE",
+"255 -314 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"342 287 OFFCURVE",
+"382 327 OFFCURVE",
+"382 375 CURVE SMOOTH",
+"382 422 OFFCURVE",
+"342 462 OFFCURVE",
+"295 462 CURVE SMOOTH",
+"247 462 OFFCURVE",
+"207 422 OFFCURVE",
+"207 375 CURVE SMOOTH",
+"207 327 OFFCURVE",
+"247 287 OFFCURVE",
+"295 287 CURVE SMOOTH"
+);
+}
+);
+width = 470;
+}
+);
+unicode = 00BF;
+},
+{
+glyphname = quotedbl;
+lastChange = "2016-08-16 11:12:00 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"296 463 LINE",
+"296 627 OFFCURVE",
+"345 647 OFFCURVE",
+"345 704 CURVE SMOOTH",
+"345 745 OFFCURVE",
+"316 763 OFFCURVE",
+"283 763 CURVE SMOOTH",
+"250 763 OFFCURVE",
+"221 745 OFFCURVE",
+"221 704 CURVE SMOOTH",
+"221 647 OFFCURVE",
+"270 627 OFFCURVE",
+"270 463 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"125 463 LINE",
+"125 627 OFFCURVE",
+"174 647 OFFCURVE",
+"174 704 CURVE SMOOTH",
+"174 745 OFFCURVE",
+"145 763 OFFCURVE",
+"112 763 CURVE SMOOTH",
+"79 763 OFFCURVE",
+"50 745 OFFCURVE",
+"50 704 CURVE SMOOTH",
+"50 647 OFFCURVE",
+"99 627 OFFCURVE",
+"99 463 CURVE"
+);
+}
+);
+width = 395;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"338 403 LINE",
+"338 595 OFFCURVE",
+"407 619 OFFCURVE",
+"407 684 CURVE SMOOTH",
+"407 739 OFFCURVE",
+"368 763 OFFCURVE",
+"325 763 CURVE SMOOTH",
+"282 763 OFFCURVE",
+"243 739 OFFCURVE",
+"243 684 CURVE SMOOTH",
+"243 619 OFFCURVE",
+"312 595 OFFCURVE",
+"312 403 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"135 403 LINE",
+"135 595 OFFCURVE",
+"204 619 OFFCURVE",
+"204 684 CURVE SMOOTH",
+"204 739 OFFCURVE",
+"165 763 OFFCURVE",
+"122 763 CURVE SMOOTH",
+"79 763 OFFCURVE",
+"40 739 OFFCURVE",
+"40 684 CURVE SMOOTH",
+"40 619 OFFCURVE",
+"109 595 OFFCURVE",
+"109 403 CURVE"
+);
+}
+);
+width = 447;
+}
+);
+unicode = 0022;
+},
+{
+glyphname = quotesingle;
+lastChange = "2016-08-16 11:12:00 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"125 463 LINE",
+"125 627 OFFCURVE",
+"174 647 OFFCURVE",
+"174 704 CURVE SMOOTH",
+"174 745 OFFCURVE",
+"145 763 OFFCURVE",
+"112 763 CURVE SMOOTH",
+"79 763 OFFCURVE",
+"50 745 OFFCURVE",
+"50 704 CURVE SMOOTH",
+"50 647 OFFCURVE",
+"99 627 OFFCURVE",
+"99 463 CURVE"
+);
+}
+);
+width = 224;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"258 699 OFFCURVE",
+"213 763 OFFCURVE",
+"142 763 CURVE SMOOTH",
+"86 763 OFFCURVE",
+"50 723 OFFCURVE",
+"50 671 CURVE SMOOTH",
+"50 630 OFFCURVE",
+"73 591 OFFCURVE",
+"123 591 CURVE SMOOTH",
+"171 591 OFFCURVE",
+"183 627 OFFCURVE",
+"198 627 CURVE SMOOTH",
+"204 627 OFFCURVE",
+"209 621 OFFCURVE",
+"209 597 CURVE SMOOTH",
+"209 533 OFFCURVE",
+"174 481 OFFCURVE",
+"96 421 CURVE",
+"113 400 LINE",
+"197 452 OFFCURVE",
+"258 524 OFFCURVE",
+"258 618 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"135 403 LINE",
+"135 595 OFFCURVE",
+"204 619 OFFCURVE",
+"204 684 CURVE SMOOTH",
+"204 739 OFFCURVE",
+"165 763 OFFCURVE",
+"122 763 CURVE SMOOTH",
+"79 763 OFFCURVE",
+"40 739 OFFCURVE",
+"40 684 CURVE SMOOTH",
+"40 619 OFFCURVE",
+"109 595 OFFCURVE",
+"109 403 CURVE"
+);
+}
+);
+width = 244;
+}
+);
+unicode = 0027;
+},
+{
+glyphname = semicolon;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"230 73 OFFCURVE",
+"191 123 OFFCURVE",
+"131 123 CURVE SMOOTH",
+"82 123 OFFCURVE",
+"50 89 OFFCURVE",
+"50 48 CURVE SMOOTH",
+"50 18 OFFCURVE",
+"68 -12 OFFCURVE",
+"108 -12 CURVE SMOOTH",
+"162 -12 OFFCURVE",
+"163 42 OFFCURVE",
+"178 42 CURVE SMOOTH",
+"186 42 OFFCURVE",
+"201 25 OFFCURVE",
+"201 -2 CURVE SMOOTH",
+"201 -45 OFFCURVE",
+"164 -107 OFFCURVE",
+"98 -154 CURVE",
+"115 -175 LINE",
+"179 -131 OFFCURVE",
+"230 -67 OFFCURVE",
+"230 8 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"53 318 OFFCURVE",
+"86 285 OFFCURVE",
+"126 285 CURVE SMOOTH",
+"166 285 OFFCURVE",
+"199 318 OFFCURVE",
+"199 358 CURVE SMOOTH",
+"199 398 OFFCURVE",
+"166 431 OFFCURVE",
+"126 431 CURVE SMOOTH",
+"86 431 OFFCURVE",
+"53 398 OFFCURVE",
+"53 358 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"55 -165 LINE",
+"144 -128 OFFCURVE",
+"198 -57 OFFCURVE",
+"198 22 CURVE SMOOTH",
+"198 86 OFFCURVE",
+"163 125 OFFCURVE",
+"106 125 CURVE SMOOTH",
+"61 125 OFFCURVE",
+"34 101 OFFCURVE",
+"34 60 CURVE SMOOTH",
+"34 22 OFFCURVE",
+"57 -3 OFFCURVE",
+"94 -3 CURVE SMOOTH",
+"137 -3 OFFCURVE",
+"130 32 OFFCURVE",
+"151 32 CURVE SMOOTH",
+"162 32 OFFCURVE",
+"168 23 OFFCURVE",
+"168 4 CURVE SMOOTH",
+"168 -49 OFFCURVE",
+"120 -108 OFFCURVE",
+"49 -143 CURVE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"144 -128 OFFCURVE",
+"198 -57 OFFCURVE",
+"198 22 CURVE SMOOTH",
+"198 86 OFFCURVE",
+"163 125 OFFCURVE",
+"106 125 CURVE SMOOTH",
+"61 125 OFFCURVE",
+"34 101 OFFCURVE",
+"34 60 CURVE SMOOTH",
+"34 22 OFFCURVE",
+"57 -3 OFFCURVE",
+"94 -3 CURVE SMOOTH",
+"137 -3 OFFCURVE",
+"130 32 OFFCURVE",
+"151 32 CURVE SMOOTH",
+"162 32 OFFCURVE",
+"168 23 OFFCURVE",
+"168 4 CURVE SMOOTH",
+"168 -49 OFFCURVE",
+"120 -108 OFFCURVE",
+"49 -143 CURVE",
+"55 -165 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"156 285 OFFCURVE",
+"189 318 OFFCURVE",
+"189 358 CURVE SMOOTH",
+"189 398 OFFCURVE",
+"156 431 OFFCURVE",
+"116 431 CURVE SMOOTH",
+"76 431 OFFCURVE",
+"43 398 OFFCURVE",
+"43 358 CURVE SMOOTH",
+"43 318 OFFCURVE",
+"76 285 OFFCURVE",
+"116 285 CURVE SMOOTH"
+);
+}
+);
+width = 280;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"114 434 OFFCURVE",
+"95 424 OFFCURVE",
+"87 416 CURVE SMOOTH",
+"77 407 OFFCURVE",
+"66 391 OFFCURVE",
+"63 378 CURVE",
+"57 359 OFFCURVE",
+"60 327 OFFCURVE",
+"71 309 CURVE",
+"78 295 OFFCURVE",
+"101 279 OFFCURVE",
+"119 276 CURVE",
+"130 272 OFFCURVE",
+"152 272 OFFCURVE",
+"167 274 CURVE",
+"187 279 OFFCURVE",
+"209 298 OFFCURVE",
+"221 319 CURVE SMOOTH",
+"228 332 OFFCURVE",
+"231 354 OFFCURVE",
+"228 367 CURVE SMOOTH",
+"223 394 OFFCURVE",
+"205 420 OFFCURVE",
+"180 431 CURVE",
+"169 437 OFFCURVE",
+"165 437 OFFCURVE",
+"149 437 CURVE",
+"140 439 OFFCURVE",
+"129 437 OFFCURVE",
+"125 437 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"108 148 OFFCURVE",
+"82 136 OFFCURVE",
+"74 127 CURVE SMOOTH",
+"66 119 OFFCURVE",
+"57 101 OFFCURVE",
+"53 92 CURVE",
+"53 88 OFFCURVE",
+"52 82 OFFCURVE",
+"50 77 CURVE SMOOTH",
+"45 66 OFFCURVE",
+"47 44 OFFCURVE",
+"55 29 CURVE SMOOTH",
+"65 10 OFFCURVE",
+"76 -3 OFFCURVE",
+"97 -9 CURVE SMOOTH",
+"113 -14 OFFCURVE",
+"130 -12 OFFCURVE",
+"146 -8 CURVE",
+"160 -3 OFFCURVE",
+"163 -1 OFFCURVE",
+"180 15 CURVE SMOOTH",
+"193 28 LINE",
+"196 24 LINE SMOOTH",
+"204 16 OFFCURVE",
+"207 7 OFFCURVE",
+"207 -12 CURVE",
+"209 -33 OFFCURVE",
+"205 -49 OFFCURVE",
+"196 -68 CURVE SMOOTH",
+"191 -80 OFFCURVE",
+"173 -107 OFFCURVE",
+"162 -118 CURVE SMOOTH",
+"151 -131 OFFCURVE",
+"124 -153 OFFCURVE",
+"113 -160 CURVE",
+"100 -166 OFFCURVE",
+"93 -174 OFFCURVE",
+"93 -182 CURVE SMOOTH",
+"93 -192 OFFCURVE",
+"97 -198 OFFCURVE",
+"106 -198 CURVE SMOOTH",
+"130 -198 OFFCURVE",
+"204 -129 OFFCURVE",
+"228 -84 CURVE",
+"233 -78 OFFCURVE",
+"239 -60 OFFCURVE",
+"244 -49 CURVE",
+"250 -30 OFFCURVE",
+"252 -20 OFFCURVE",
+"255 -1 CURVE SMOOTH",
+"258 24 OFFCURVE",
+"258 24 OFFCURVE",
+"253 48 CURVE",
+"252 61 OFFCURVE",
+"249 76 OFFCURVE",
+"249 79 CURVE",
+"244 88 OFFCURVE",
+"226 116 OFFCURVE",
+"215 125 CURVE SMOOTH",
+"205 133 OFFCURVE",
+"185 144 OFFCURVE",
+"173 148 CURVE SMOOTH",
+"164 151 OFFCURVE",
+"132 152 OFFCURVE",
+"121 151 CURVE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"197 -152 OFFCURVE",
+"258 -80 OFFCURVE",
+"258 14 CURVE SMOOTH",
+"258 95 OFFCURVE",
+"213 159 OFFCURVE",
+"142 159 CURVE SMOOTH",
+"86 159 OFFCURVE",
+"50 119 OFFCURVE",
+"50 67 CURVE SMOOTH",
+"50 26 OFFCURVE",
+"73 -13 OFFCURVE",
+"123 -13 CURVE SMOOTH",
+"171 -13 OFFCURVE",
+"183 23 OFFCURVE",
+"198 23 CURVE SMOOTH",
+"204 23 OFFCURVE",
+"209 17 OFFCURVE",
+"209 -7 CURVE SMOOTH",
+"209 -71 OFFCURVE",
+"174 -123 OFFCURVE",
+"96 -183 CURVE",
+"113 -204 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"185 280 OFFCURVE",
+"224 319 OFFCURVE",
+"224 367 CURVE SMOOTH",
+"224 415 OFFCURVE",
+"185 454 OFFCURVE",
+"137 454 CURVE SMOOTH",
+"89 454 OFFCURVE",
+"50 415 OFFCURVE",
+"50 367 CURVE SMOOTH",
+"50 319 OFFCURVE",
+"89 280 OFFCURVE",
+"137 280 CURVE SMOOTH"
+);
+}
+);
+width = 308;
+}
+);
+unicode = 003B;
+},
+{
+glyphname = slash;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"39 0 LINE",
+"249 753 LINE",
+"190 753 LINE",
+"-20 0 LINE"
+);
+}
+);
+width = 190;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"59 0 LINE",
+"249 753 LINE",
+"170 753 LINE",
+"-20 0 LINE"
+);
+}
+);
+width = 190;
+}
+);
+unicode = 002F;
+},
+{
+glyphname = underscore;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"0 -126 LINE",
+"538 -126 LINE",
+"538 -58 LINE",
+"0 -58 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"538 -114 LINE",
+"538 -70 LINE",
+"0 -70 LINE",
+"0 -114 LINE"
+);
+}
+);
+width = 538;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"0 -136 LINE",
+"584 -136 LINE",
+"584 -58 LINE",
+"0 -58 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"584 -124 LINE",
+"584 -70 LINE",
+"0 -70 LINE",
+"0 -124 LINE"
+);
+}
+);
+width = 584;
+}
+);
+unicode = 005F;
+},
+{
+glyphname = braceleft;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"319 -98 LINE",
+"248 -98 OFFCURVE",
+"229 -69 OFFCURVE",
+"229 32 CURVE SMOOTH",
+"229 204 LINE SMOOTH",
+"229 287 OFFCURVE",
+"204 321 OFFCURVE",
+"127 330 CURVE",
+"127 334 LINE",
+"204 343 OFFCURVE",
+"229 376 OFFCURVE",
+"229 459 CURVE SMOOTH",
+"229 632 LINE SMOOTH",
+"229 733 OFFCURVE",
+"248 762 OFFCURVE",
+"319 762 CURVE",
+"319 787 LINE",
+"146 787 OFFCURVE",
+"120 758 OFFCURVE",
+"120 605 CURVE SMOOTH",
+"120 462 LINE SMOOTH",
+"120 368 OFFCURVE",
+"106 340 OFFCURVE",
+"54 340 CURVE",
+"54 323 LINE",
+"106 323 OFFCURVE",
+"120 295 OFFCURVE",
+"120 201 CURVE SMOOTH",
+"120 59 LINE SMOOTH",
+"120 -94 OFFCURVE",
+"146 -123 OFFCURVE",
+"319 -123 CURVE"
+);
+}
+);
+width = 312;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"54 323 LINE",
+"106 323 OFFCURVE",
+"120 295 OFFCURVE",
+"120 201 CURVE SMOOTH",
+"120 59 LINE SMOOTH",
+"120 -94 OFFCURVE",
+"146 -123 OFFCURVE",
+"319 -123 CURVE",
+"319 -98 LINE",
+"248 -98 OFFCURVE",
+"229 -69 OFFCURVE",
+"229 32 CURVE SMOOTH",
+"229 204 LINE SMOOTH",
+"229 287 OFFCURVE",
+"204 321 OFFCURVE",
+"127 330 CURVE",
+"127 334 LINE",
+"204 343 OFFCURVE",
+"229 376 OFFCURVE",
+"229 459 CURVE SMOOTH",
+"229 632 LINE SMOOTH",
+"229 733 OFFCURVE",
+"248 762 OFFCURVE",
+"319 762 CURVE",
+"319 787 LINE",
+"146 787 OFFCURVE",
+"120 758 OFFCURVE",
+"120 605 CURVE SMOOTH",
+"120 462 LINE SMOOTH",
+"120 368 OFFCURVE",
+"106 340 OFFCURVE",
+"54 340 CURVE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"295 -91 LINE",
+"228 -91 OFFCURVE",
+"210 -62 OFFCURVE",
+"210 39 CURVE SMOOTH",
+"210 206 LINE SMOOTH",
+"210 289 OFFCURVE",
+"185 323 OFFCURVE",
+"108 332 CURVE",
+"108 336 LINE",
+"185 345 OFFCURVE",
+"210 378 OFFCURVE",
+"210 461 CURVE SMOOTH",
+"210 627 LINE SMOOTH",
+"210 728 OFFCURVE",
+"228 757 OFFCURVE",
+"295 757 CURVE",
+"295 787 LINE",
+"104 787 OFFCURVE",
+"76 758 OFFCURVE",
+"76 605 CURVE SMOOTH",
+"76 464 LINE SMOOTH",
+"76 374 OFFCURVE",
+"62 347 OFFCURVE",
+"10 347 CURVE",
+"10 320 LINE",
+"62 320 OFFCURVE",
+"76 293 OFFCURVE",
+"76 203 CURVE SMOOTH",
+"76 61 LINE SMOOTH",
+"76 -92 OFFCURVE",
+"104 -121 OFFCURVE",
+"295 -121 CURVE"
+);
+}
+);
+width = 300;
+}
+);
+unicode = 007B;
+},
+{
+glyphname = braceright;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"166 -123 OFFCURVE",
+"192 -94 OFFCURVE",
+"192 59 CURVE SMOOTH",
+"192 201 LINE SMOOTH",
+"192 295 OFFCURVE",
+"206 323 OFFCURVE",
+"258 323 CURVE",
+"258 340 LINE",
+"206 340 OFFCURVE",
+"192 368 OFFCURVE",
+"192 462 CURVE SMOOTH",
+"192 605 LINE SMOOTH",
+"192 758 OFFCURVE",
+"166 787 OFFCURVE",
+"-7 787 CURVE",
+"-7 762 LINE",
+"64 762 OFFCURVE",
+"83 733 OFFCURVE",
+"83 632 CURVE SMOOTH",
+"83 459 LINE SMOOTH",
+"83 376 OFFCURVE",
+"108 343 OFFCURVE",
+"185 334 CURVE",
+"185 330 LINE",
+"108 321 OFFCURVE",
+"83 287 OFFCURVE",
+"83 204 CURVE SMOOTH",
+"83 32 LINE SMOOTH",
+"83 -69 OFFCURVE",
+"64 -98 OFFCURVE",
+"-7 -98 CURVE",
+"-7 -123 LINE"
+);
+}
+);
+width = 312;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"290 326 LINE",
+"238 326 OFFCURVE",
+"224 353 OFFCURVE",
+"224 443 CURVE SMOOTH",
+"224 572 LINE SMOOTH",
+"224 725 OFFCURVE",
+"196 754 OFFCURVE",
+"5 754 CURVE",
+"5 724 LINE",
+"72 724 OFFCURVE",
+"90 696 OFFCURVE",
+"90 599 CURVE SMOOTH",
+"90 440 LINE SMOOTH",
+"90 357 OFFCURVE",
+"115 324 OFFCURVE",
+"192 315 CURVE",
+"192 311 LINE",
+"115 302 OFFCURVE",
+"90 268 OFFCURVE",
+"90 185 CURVE SMOOTH",
+"90 25 LINE SMOOTH",
+"90 -72 OFFCURVE",
+"72 -100 OFFCURVE",
+"5 -100 CURVE",
+"5 -130 LINE",
+"196 -130 OFFCURVE",
+"224 -101 OFFCURVE",
+"224 52 CURVE SMOOTH",
+"224 182 LINE SMOOTH",
+"224 272 OFFCURVE",
+"238 299 OFFCURVE",
+"290 299 CURVE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"197 -121 OFFCURVE",
+"225 -92 OFFCURVE",
+"225 61 CURVE SMOOTH",
+"225 203 LINE SMOOTH",
+"225 293 OFFCURVE",
+"239 320 OFFCURVE",
+"291 320 CURVE",
+"291 347 LINE",
+"239 347 OFFCURVE",
+"225 374 OFFCURVE",
+"225 464 CURVE SMOOTH",
+"225 605 LINE SMOOTH",
+"225 758 OFFCURVE",
+"197 787 OFFCURVE",
+"6 787 CURVE",
+"6 757 LINE",
+"73 757 OFFCURVE",
+"91 728 OFFCURVE",
+"91 627 CURVE SMOOTH",
+"91 461 LINE SMOOTH",
+"91 378 OFFCURVE",
+"116 345 OFFCURVE",
+"193 336 CURVE",
+"193 332 LINE",
+"116 323 OFFCURVE",
+"91 289 OFFCURVE",
+"91 206 CURVE SMOOTH",
+"91 39 LINE SMOOTH",
+"91 -62 OFFCURVE",
+"73 -91 OFFCURVE",
+"6 -91 CURVE",
+"6 -121 LINE"
+);
+}
+);
+width = 300;
+}
+);
+unicode = 007D;
+},
+{
+glyphname = bracketleft;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"301 -123 LINE",
+"301 -98 LINE",
+"191 -98 LINE",
+"191 763 LINE",
+"301 763 LINE",
+"301 788 LINE",
+"82 788 LINE",
+"82 -123 LINE"
+);
+}
+);
+width = 318;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"82 -108 LINE",
+"191 -108 LINE",
+"191 788 LINE",
+"82 788 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"82 -123 LINE",
+"301 -123 LINE",
+"301 -98 LINE",
+"82 -98 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"82 763 LINE",
+"301 763 LINE",
+"301 788 LINE",
+"82 788 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"314 -123 LINE",
+"314 -93 LINE",
+"219 -93 LINE",
+"219 758 LINE",
+"314 758 LINE",
+"314 788 LINE",
+"85 788 LINE",
+"85 -123 LINE"
+);
+}
+);
+width = 319;
+}
+);
+unicode = 005B;
+},
+{
+glyphname = bracketright;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"236 -123 LINE",
+"236 788 LINE",
+"17 788 LINE",
+"17 763 LINE",
+"127 763 LINE",
+"127 -98 LINE",
+"17 -98 LINE",
+"17 -123 LINE"
+);
+}
+);
+width = 318;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"234 754 LINE",
+"100 754 LINE",
+"100 -115 LINE",
+"234 -115 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"234 -100 LINE",
+"5 -100 LINE",
+"5 -130 LINE",
+"234 -130 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"234 754 LINE",
+"5 754 LINE",
+"5 724 LINE",
+"234 724 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"234 -123 LINE",
+"234 788 LINE",
+"5 788 LINE",
+"5 758 LINE",
+"100 758 LINE",
+"100 -93 LINE",
+"5 -93 LINE",
+"5 -123 LINE"
+);
+}
+);
+width = 319;
+}
+);
+unicode = 005D;
+},
+{
+glyphname = parenleft;
+lastChange = "2016-08-19 16:54:48 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"307 -123 LINE",
+"248 -46 OFFCURVE",
+"178 86 OFFCURVE",
+"178 334 CURVE SMOOTH",
+"178 590 OFFCURVE",
+"253 713 OFFCURVE",
+"309 788 CURVE",
+"284 804 LINE",
+"136 642 OFFCURVE",
+"70 498 OFFCURVE",
+"70 332 CURVE SMOOTH",
+"70 164 OFFCURVE",
+"137 17 OFFCURVE",
+"282 -136 CURVE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"307 -123 LINE",
+"248 -46 OFFCURVE",
+"178 86 OFFCURVE",
+"178 334 CURVE SMOOTH",
+"178 590 OFFCURVE",
+"253 713 OFFCURVE",
+"309 788 CURVE",
+"284 804 LINE",
+"136 642 OFFCURVE",
+"70 498 OFFCURVE",
+"70 332 CURVE SMOOTH",
+"70 164 OFFCURVE",
+"137 17 OFFCURVE",
+"282 -136 CURVE"
+);
+}
+);
+width = 309;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"287 -123 LINE",
+"190 31 OFFCURVE",
+"180 162 OFFCURVE",
+"180 327 CURVE SMOOTH",
+"180 530 OFFCURVE",
+"195 637 OFFCURVE",
+"289 788 CURVE",
+"264 804 LINE",
+"86 627 OFFCURVE",
+"30 482 OFFCURVE",
+"30 332 CURVE SMOOTH",
+"30 188 OFFCURVE",
+"81 38 OFFCURVE",
+"262 -136 CURVE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"287 -123 LINE",
+"190 31 OFFCURVE",
+"180 162 OFFCURVE",
+"180 327 CURVE SMOOTH",
+"180 530 OFFCURVE",
+"195 637 OFFCURVE",
+"289 788 CURVE",
+"264 804 LINE",
+"86 627 OFFCURVE",
+"30 482 OFFCURVE",
+"30 332 CURVE SMOOTH",
+"30 188 OFFCURVE",
+"81 38 OFFCURVE",
+"262 -136 CURVE"
+);
+}
+);
+width = 309;
+}
+);
+unicode = 0028;
+},
+{
+glyphname = parenright;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"172 17 OFFCURVE",
+"239 164 OFFCURVE",
+"239 332 CURVE SMOOTH",
+"239 498 OFFCURVE",
+"173 642 OFFCURVE",
+"25 804 CURVE",
+"0 788 LINE",
+"56 713 OFFCURVE",
+"131 590 OFFCURVE",
+"131 334 CURVE SMOOTH",
+"131 86 OFFCURVE",
+"61 -46 OFFCURVE",
+"2 -123 CURVE",
+"27 -136 LINE"
+);
+}
+);
+width = 309;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"228 38 OFFCURVE",
+"279 188 OFFCURVE",
+"279 332 CURVE SMOOTH",
+"279 482 OFFCURVE",
+"223 627 OFFCURVE",
+"45 804 CURVE",
+"20 788 LINE",
+"114 637 OFFCURVE",
+"129 531 OFFCURVE",
+"129 324 CURVE SMOOTH",
+"129 163 OFFCURVE",
+"119 31 OFFCURVE",
+"22 -123 CURVE",
+"47 -136 LINE"
+);
+}
+);
+width = 309;
+}
+);
+unicode = 0029;
+},
+{
+glyphname = emdash;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"0 190 LINE",
+"828 190 LINE",
+"828 258 LINE",
+"0 258 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"828 202 LINE",
+"828 246 LINE",
+"0 246 LINE",
+"0 202 LINE"
+);
+}
+);
+width = 828;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"0 180 LINE",
+"875 180 LINE",
+"875 258 LINE",
+"0 258 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"875 192 LINE",
+"875 246 LINE",
+"0 246 LINE",
+"0 192 LINE"
+);
+}
+);
+width = 875;
+}
+);
+unicode = 2014;
+},
+{
+glyphname = endash;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"0 190 LINE",
+"538 190 LINE",
+"538 258 LINE",
+"0 258 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"538 202 LINE",
+"538 246 LINE",
+"0 246 LINE",
+"0 202 LINE"
+);
+}
+);
+width = 538;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"0 180 LINE",
+"584 180 LINE",
+"584 258 LINE",
+"0 258 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"584 192 LINE",
+"584 246 LINE",
+"0 246 LINE",
+"0 192 LINE"
+);
+}
+);
+width = 584;
+}
+);
+unicode = 2013;
+},
+{
+glyphname = hyphen;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"50 190 LINE",
+"345 190 LINE",
+"345 258 LINE",
+"50 258 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"345 202 LINE",
+"345 246 LINE",
+"50 246 LINE",
+"50 202 LINE"
+);
+}
+);
+width = 395;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"50 170 LINE",
+"345 170 LINE",
+"345 258 LINE",
+"50 258 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"345 182 LINE",
+"345 246 LINE",
+"50 246 LINE",
+"50 182 LINE"
+);
+}
+);
+width = 395;
+}
+);
+unicode = 002D;
+},
+{
+glyphname = softhyphen;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"50 190 LINE",
+"345 190 LINE",
+"345 258 LINE",
+"50 258 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"345 202 LINE",
+"345 246 LINE",
+"50 246 LINE",
+"50 202 LINE"
+);
+}
+);
+width = 395;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"50 170 LINE",
+"345 170 LINE",
+"345 258 LINE",
+"50 258 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"345 182 LINE",
+"345 246 LINE",
+"50 246 LINE",
+"50 182 LINE"
+);
+}
+);
+width = 395;
+}
+);
+unicode = 00AD;
+},
+{
+glyphname = guillemetleft;
+lastChange = "2016-08-18 21:39:28 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"495 53 LINE",
+"384 220 LINE",
+"495 391 LINE",
+"480 402 LINE",
+"280 231 LINE",
+"280 209 LINE",
+"480 38 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"285 53 LINE",
+"174 220 LINE",
+"285 391 LINE",
+"270 402 LINE",
+"70 231 LINE",
+"70 209 LINE",
+"270 38 LINE"
+);
+}
+);
+width = 555;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"448 43 LINE",
+"357 220 LINE",
+"448 401 LINE",
+"433 412 LINE",
+"213 231 LINE",
+"213 209 LINE",
+"433 28 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"265 43 LINE",
+"174 220 LINE",
+"265 401 LINE",
+"250 412 LINE",
+"30 231 LINE",
+"30 209 LINE",
+"250 28 LINE"
+);
+}
+);
+width = 508;
+}
+);
+unicode = 00AB;
+},
+{
+glyphname = guillemetright;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"85 38 LINE",
+"285 209 LINE",
+"285 231 LINE",
+"85 402 LINE",
+"70 391 LINE",
+"181 220 LINE",
+"70 53 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"295 38 LINE",
+"495 209 LINE",
+"495 231 LINE",
+"295 402 LINE",
+"280 391 LINE",
+"391 220 LINE",
+"280 53 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"495 209 LINE",
+"495 231 LINE",
+"295 402 LINE",
+"280 391 LINE",
+"391 220 LINE",
+"280 53 LINE",
+"295 38 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"285 209 LINE",
+"285 231 LINE",
+"85 402 LINE",
+"70 391 LINE",
+"181 220 LINE",
+"70 53 LINE",
+"85 38 LINE"
+);
+}
+);
+width = 555;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"75 28 LINE",
+"295 209 LINE",
+"295 231 LINE",
+"75 412 LINE",
+"60 401 LINE",
+"151 220 LINE",
+"60 43 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"258 28 LINE",
+"478 209 LINE",
+"478 231 LINE",
+"258 412 LINE",
+"243 401 LINE",
+"334 220 LINE",
+"243 43 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"478 209 LINE",
+"478 231 LINE",
+"258 412 LINE",
+"243 401 LINE",
+"334 220 LINE",
+"243 43 LINE",
+"258 28 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"295 209 LINE",
+"295 231 LINE",
+"75 412 LINE",
+"60 401 LINE",
+"151 220 LINE",
+"60 43 LINE",
+"75 28 LINE"
+);
+}
+);
+width = 508;
+}
+);
+unicode = 00BB;
+},
+{
+glyphname = guilsinglleft;
+lastChange = "2016-08-16 11:12:00 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"285 53 LINE",
+"174 220 LINE",
+"285 391 LINE",
+"270 402 LINE",
+"70 231 LINE",
+"70 209 LINE",
+"270 38 LINE"
+);
+}
+);
+width = 345;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"285 43 LINE",
+"204 220 LINE",
+"285 401 LINE",
+"270 412 LINE",
+"60 231 LINE",
+"60 209 LINE",
+"270 28 LINE"
+);
+}
+);
+width = 345;
+}
+);
+unicode = 2039;
+},
+{
+glyphname = guilsinglright;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"275 209 LINE",
+"275 231 LINE",
+"75 402 LINE",
+"60 391 LINE",
+"171 220 LINE",
+"60 53 LINE",
+"75 38 LINE"
+);
+}
+);
+width = 345;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"295 209 LINE",
+"295 231 LINE",
+"75 412 LINE",
+"60 401 LINE",
+"151 220 LINE",
+"60 43 LINE",
+"75 28 LINE"
+);
+}
+);
+width = 345;
+}
+);
+unicode = 203A;
+},
+{
+glyphname = quotedblbase;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"213 95 OFFCURVE",
+"174 145 OFFCURVE",
+"111 145 CURVE SMOOTH",
+"59 145 OFFCURVE",
+"27 111 OFFCURVE",
+"27 70 CURVE SMOOTH",
+"27 40 OFFCURVE",
+"45 10 OFFCURVE",
+"87 10 CURVE SMOOTH",
+"143 10 OFFCURVE",
+"143 64 OFFCURVE",
+"158 64 CURVE SMOOTH",
+"166 64 OFFCURVE",
+"181 47 OFFCURVE",
+"181 20 CURVE SMOOTH",
+"181 -23 OFFCURVE",
+"144 -85 OFFCURVE",
+"78 -132 CURVE",
+"95 -153 LINE",
+"162 -109 OFFCURVE",
+"213 -45 OFFCURVE",
+"213 30 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"459 95 OFFCURVE",
+"420 145 OFFCURVE",
+"357 145 CURVE SMOOTH",
+"305 145 OFFCURVE",
+"273 111 OFFCURVE",
+"273 70 CURVE SMOOTH",
+"273 40 OFFCURVE",
+"291 10 OFFCURVE",
+"333 10 CURVE SMOOTH",
+"389 10 OFFCURVE",
+"389 64 OFFCURVE",
+"404 64 CURVE SMOOTH",
+"412 64 OFFCURVE",
+"427 47 OFFCURVE",
+"427 20 CURVE SMOOTH",
+"427 -23 OFFCURVE",
+"390 -85 OFFCURVE",
+"324 -132 CURVE",
+"341 -153 LINE",
+"408 -109 OFFCURVE",
+"459 -45 OFFCURVE",
+"459 30 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"408 -109 OFFCURVE",
+"459 -45 OFFCURVE",
+"459 30 CURVE SMOOTH",
+"459 95 OFFCURVE",
+"420 145 OFFCURVE",
+"357 145 CURVE SMOOTH",
+"305 145 OFFCURVE",
+"273 111 OFFCURVE",
+"273 70 CURVE SMOOTH",
+"273 40 OFFCURVE",
+"291 10 OFFCURVE",
+"333 10 CURVE SMOOTH",
+"389 10 OFFCURVE",
+"389 64 OFFCURVE",
+"404 64 CURVE SMOOTH",
+"412 64 OFFCURVE",
+"427 47 OFFCURVE",
+"427 20 CURVE SMOOTH",
+"427 -23 OFFCURVE",
+"390 -85 OFFCURVE",
+"324 -132 CURVE",
+"341 -153 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"162 -109 OFFCURVE",
+"213 -45 OFFCURVE",
+"213 30 CURVE SMOOTH",
+"213 95 OFFCURVE",
+"174 145 OFFCURVE",
+"111 145 CURVE SMOOTH",
+"59 145 OFFCURVE",
+"27 111 OFFCURVE",
+"27 70 CURVE SMOOTH",
+"27 40 OFFCURVE",
+"45 10 OFFCURVE",
+"87 10 CURVE SMOOTH",
+"143 10 OFFCURVE",
+"143 64 OFFCURVE",
+"158 64 CURVE SMOOTH",
+"166 64 OFFCURVE",
+"181 47 OFFCURVE",
+"181 20 CURVE SMOOTH",
+"181 -23 OFFCURVE",
+"144 -85 OFFCURVE",
+"78 -132 CURVE",
+"95 -153 LINE"
+);
+}
+);
+width = 500;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"258 128 OFFCURVE",
+"213 192 OFFCURVE",
+"142 192 CURVE SMOOTH",
+"86 192 OFFCURVE",
+"50 152 OFFCURVE",
+"50 100 CURVE SMOOTH",
+"50 59 OFFCURVE",
+"73 20 OFFCURVE",
+"123 20 CURVE SMOOTH",
+"171 20 OFFCURVE",
+"183 56 OFFCURVE",
+"198 56 CURVE SMOOTH",
+"204 56 OFFCURVE",
+"209 50 OFFCURVE",
+"209 26 CURVE SMOOTH",
+"209 -38 OFFCURVE",
+"174 -90 OFFCURVE",
+"96 -150 CURVE",
+"113 -171 LINE",
+"197 -119 OFFCURVE",
+"258 -47 OFFCURVE",
+"258 47 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"511 128 OFFCURVE",
+"466 192 OFFCURVE",
+"395 192 CURVE SMOOTH",
+"339 192 OFFCURVE",
+"303 152 OFFCURVE",
+"303 100 CURVE SMOOTH",
+"303 59 OFFCURVE",
+"326 20 OFFCURVE",
+"376 20 CURVE SMOOTH",
+"424 20 OFFCURVE",
+"436 56 OFFCURVE",
+"451 56 CURVE SMOOTH",
+"457 56 OFFCURVE",
+"462 50 OFFCURVE",
+"462 26 CURVE SMOOTH",
+"462 -38 OFFCURVE",
+"427 -90 OFFCURVE",
+"349 -150 CURVE",
+"366 -171 LINE",
+"450 -119 OFFCURVE",
+"511 -47 OFFCURVE",
+"511 47 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"450 -119 OFFCURVE",
+"511 -47 OFFCURVE",
+"511 47 CURVE SMOOTH",
+"511 128 OFFCURVE",
+"466 192 OFFCURVE",
+"395 192 CURVE SMOOTH",
+"339 192 OFFCURVE",
+"303 152 OFFCURVE",
+"303 100 CURVE SMOOTH",
+"303 59 OFFCURVE",
+"326 20 OFFCURVE",
+"376 20 CURVE SMOOTH",
+"424 20 OFFCURVE",
+"436 56 OFFCURVE",
+"451 56 CURVE SMOOTH",
+"457 56 OFFCURVE",
+"462 50 OFFCURVE",
+"462 26 CURVE SMOOTH",
+"462 -38 OFFCURVE",
+"427 -90 OFFCURVE",
+"349 -150 CURVE",
+"366 -171 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"197 -119 OFFCURVE",
+"258 -47 OFFCURVE",
+"258 47 CURVE SMOOTH",
+"258 128 OFFCURVE",
+"213 192 OFFCURVE",
+"142 192 CURVE SMOOTH",
+"86 192 OFFCURVE",
+"50 152 OFFCURVE",
+"50 100 CURVE SMOOTH",
+"50 59 OFFCURVE",
+"73 20 OFFCURVE",
+"123 20 CURVE SMOOTH",
+"171 20 OFFCURVE",
+"183 56 OFFCURVE",
+"198 56 CURVE SMOOTH",
+"204 56 OFFCURVE",
+"209 50 OFFCURVE",
+"209 26 CURVE SMOOTH",
+"209 -38 OFFCURVE",
+"174 -90 OFFCURVE",
+"96 -150 CURVE",
+"113 -171 LINE"
+);
+}
+);
+width = 561;
+}
+);
+unicode = 201E;
+},
+{
+glyphname = quotedblleft;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"27 515 OFFCURVE",
+"66 465 OFFCURVE",
+"129 465 CURVE SMOOTH",
+"181 465 OFFCURVE",
+"213 499 OFFCURVE",
+"213 540 CURVE SMOOTH",
+"213 570 OFFCURVE",
+"195 600 OFFCURVE",
+"153 600 CURVE SMOOTH",
+"97 600 OFFCURVE",
+"97 546 OFFCURVE",
+"82 546 CURVE SMOOTH",
+"74 546 OFFCURVE",
+"59 563 OFFCURVE",
+"59 590 CURVE SMOOTH",
+"59 633 OFFCURVE",
+"96 695 OFFCURVE",
+"162 742 CURVE",
+"145 763 LINE",
+"78 719 OFFCURVE",
+"27 655 OFFCURVE",
+"27 580 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"273 515 OFFCURVE",
+"312 465 OFFCURVE",
+"375 465 CURVE SMOOTH",
+"427 465 OFFCURVE",
+"459 499 OFFCURVE",
+"459 540 CURVE SMOOTH",
+"459 570 OFFCURVE",
+"441 600 OFFCURVE",
+"399 600 CURVE SMOOTH",
+"343 600 OFFCURVE",
+"343 546 OFFCURVE",
+"328 546 CURVE SMOOTH",
+"320 546 OFFCURVE",
+"305 563 OFFCURVE",
+"305 590 CURVE SMOOTH",
+"305 633 OFFCURVE",
+"342 695 OFFCURVE",
+"408 742 CURVE",
+"391 763 LINE",
+"324 719 OFFCURVE",
+"273 655 OFFCURVE",
+"273 580 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"427 465 OFFCURVE",
+"459 499 OFFCURVE",
+"459 540 CURVE SMOOTH",
+"459 570 OFFCURVE",
+"441 600 OFFCURVE",
+"399 600 CURVE SMOOTH",
+"343 600 OFFCURVE",
+"343 546 OFFCURVE",
+"328 546 CURVE SMOOTH",
+"320 546 OFFCURVE",
+"305 563 OFFCURVE",
+"305 590 CURVE SMOOTH",
+"305 633 OFFCURVE",
+"342 695 OFFCURVE",
+"408 742 CURVE",
+"391 763 LINE",
+"324 719 OFFCURVE",
+"273 655 OFFCURVE",
+"273 580 CURVE SMOOTH",
+"273 515 OFFCURVE",
+"312 465 OFFCURVE",
+"375 465 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"181 465 OFFCURVE",
+"213 499 OFFCURVE",
+"213 540 CURVE SMOOTH",
+"213 570 OFFCURVE",
+"195 600 OFFCURVE",
+"153 600 CURVE SMOOTH",
+"97 600 OFFCURVE",
+"97 546 OFFCURVE",
+"82 546 CURVE SMOOTH",
+"74 546 OFFCURVE",
+"59 563 OFFCURVE",
+"59 590 CURVE SMOOTH",
+"59 633 OFFCURVE",
+"96 695 OFFCURVE",
+"162 742 CURVE",
+"145 763 LINE",
+"78 719 OFFCURVE",
+"27 655 OFFCURVE",
+"27 580 CURVE SMOOTH",
+"27 515 OFFCURVE",
+"66 465 OFFCURVE",
+"129 465 CURVE SMOOTH"
+);
+}
+);
+width = 496;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"50 474 OFFCURVE",
+"95 410 OFFCURVE",
+"166 410 CURVE SMOOTH",
+"222 410 OFFCURVE",
+"258 450 OFFCURVE",
+"258 502 CURVE SMOOTH",
+"258 543 OFFCURVE",
+"235 582 OFFCURVE",
+"185 582 CURVE SMOOTH",
+"137 582 OFFCURVE",
+"125 546 OFFCURVE",
+"110 546 CURVE SMOOTH",
+"104 546 OFFCURVE",
+"99 552 OFFCURVE",
+"99 576 CURVE SMOOTH",
+"99 640 OFFCURVE",
+"134 692 OFFCURVE",
+"212 752 CURVE",
+"195 773 LINE",
+"111 721 OFFCURVE",
+"50 649 OFFCURVE",
+"50 555 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"303 474 OFFCURVE",
+"348 410 OFFCURVE",
+"419 410 CURVE SMOOTH",
+"475 410 OFFCURVE",
+"511 450 OFFCURVE",
+"511 502 CURVE SMOOTH",
+"511 543 OFFCURVE",
+"488 582 OFFCURVE",
+"438 582 CURVE SMOOTH",
+"390 582 OFFCURVE",
+"378 546 OFFCURVE",
+"363 546 CURVE SMOOTH",
+"357 546 OFFCURVE",
+"352 552 OFFCURVE",
+"352 576 CURVE SMOOTH",
+"352 640 OFFCURVE",
+"387 692 OFFCURVE",
+"465 752 CURVE",
+"448 773 LINE",
+"364 721 OFFCURVE",
+"303 649 OFFCURVE",
+"303 555 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"475 410 OFFCURVE",
+"511 450 OFFCURVE",
+"511 502 CURVE SMOOTH",
+"511 543 OFFCURVE",
+"488 582 OFFCURVE",
+"438 582 CURVE SMOOTH",
+"390 582 OFFCURVE",
+"378 546 OFFCURVE",
+"363 546 CURVE SMOOTH",
+"357 546 OFFCURVE",
+"352 552 OFFCURVE",
+"352 576 CURVE SMOOTH",
+"352 640 OFFCURVE",
+"387 692 OFFCURVE",
+"465 752 CURVE",
+"448 773 LINE",
+"364 721 OFFCURVE",
+"303 649 OFFCURVE",
+"303 555 CURVE SMOOTH",
+"303 474 OFFCURVE",
+"348 410 OFFCURVE",
+"419 410 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"222 410 OFFCURVE",
+"258 450 OFFCURVE",
+"258 502 CURVE SMOOTH",
+"258 543 OFFCURVE",
+"235 582 OFFCURVE",
+"185 582 CURVE SMOOTH",
+"137 582 OFFCURVE",
+"125 546 OFFCURVE",
+"110 546 CURVE SMOOTH",
+"104 546 OFFCURVE",
+"99 552 OFFCURVE",
+"99 576 CURVE SMOOTH",
+"99 640 OFFCURVE",
+"134 692 OFFCURVE",
+"212 752 CURVE",
+"195 773 LINE",
+"111 721 OFFCURVE",
+"50 649 OFFCURVE",
+"50 555 CURVE SMOOTH",
+"50 474 OFFCURVE",
+"95 410 OFFCURVE",
+"166 410 CURVE SMOOTH"
+);
+}
+);
+width = 561;
+}
+);
+unicode = 201C;
+},
+{
+glyphname = quotedblright;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"408 509 OFFCURVE",
+"459 573 OFFCURVE",
+"459 648 CURVE SMOOTH",
+"459 713 OFFCURVE",
+"420 763 OFFCURVE",
+"357 763 CURVE SMOOTH",
+"305 763 OFFCURVE",
+"273 729 OFFCURVE",
+"273 688 CURVE SMOOTH",
+"273 658 OFFCURVE",
+"291 628 OFFCURVE",
+"333 628 CURVE SMOOTH",
+"389 628 OFFCURVE",
+"389 682 OFFCURVE",
+"404 682 CURVE SMOOTH",
+"412 682 OFFCURVE",
+"427 665 OFFCURVE",
+"427 638 CURVE SMOOTH",
+"427 595 OFFCURVE",
+"390 533 OFFCURVE",
+"324 486 CURVE",
+"341 465 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"162 509 OFFCURVE",
+"213 573 OFFCURVE",
+"213 648 CURVE SMOOTH",
+"213 713 OFFCURVE",
+"174 763 OFFCURVE",
+"111 763 CURVE SMOOTH",
+"59 763 OFFCURVE",
+"27 729 OFFCURVE",
+"27 688 CURVE SMOOTH",
+"27 658 OFFCURVE",
+"45 628 OFFCURVE",
+"87 628 CURVE SMOOTH",
+"143 628 OFFCURVE",
+"143 682 OFFCURVE",
+"158 682 CURVE SMOOTH",
+"166 682 OFFCURVE",
+"181 665 OFFCURVE",
+"181 638 CURVE SMOOTH",
+"181 595 OFFCURVE",
+"144 533 OFFCURVE",
+"78 486 CURVE",
+"95 465 LINE"
+);
+}
+);
+width = 500;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"370 717 OFFCURVE",
+"360 715 OFFCURVE",
+"355 712 CURVE",
+"346 709 OFFCURVE",
+"320 693 OFFCURVE",
+"320 689 CURVE SMOOTH",
+"320 689 OFFCURVE",
+"318 685 OFFCURVE",
+"314 681 CURVE SMOOTH",
+"307 672 OFFCURVE",
+"301 661 OFFCURVE",
+"298 643 CURVE",
+"298 633 OFFCURVE",
+"298 629 OFFCURVE",
+"298 616 CURVE SMOOTH",
+"298 608 OFFCURVE",
+"299 597 OFFCURVE",
+"301 592 CURVE",
+"301 581 OFFCURVE",
+"301 574 OFFCURVE",
+"323 561 CURVE SMOOTH",
+"340 552 OFFCURVE",
+"360 544 OFFCURVE",
+"371 545 CURVE",
+"371 545 OFFCURVE",
+"394 547 OFFCURVE",
+"394 550 CURVE",
+"405 555 OFFCURVE",
+"409 557 OFFCURVE",
+"424 573 CURVE",
+"437 582 OFFCURVE",
+"443 590 OFFCURVE",
+"443 590 CURVE",
+"445 590 OFFCURVE",
+"450 577 OFFCURVE",
+"453 565 CURVE",
+"453 552 OFFCURVE",
+"453 541 OFFCURVE",
+"453 523 CURVE",
+"448 507 OFFCURVE",
+"435 475 OFFCURVE",
+"429 470 CURVE",
+"424 464 OFFCURVE",
+"406 443 OFFCURVE",
+"406 441 CURVE SMOOTH",
+"406 438 OFFCURVE",
+"394 427 OFFCURVE",
+"382 422 CURVE",
+"371 416 OFFCURVE",
+"368 416 OFFCURVE",
+"362 416 CURVE SMOOTH",
+"355 416 OFFCURVE",
+"354 416 OFFCURVE",
+"349 411 CURVE SMOOTH",
+"344 405 OFFCURVE",
+"339 387 OFFCURVE",
+"339 379 CURVE SMOOTH",
+"339 373 OFFCURVE",
+"346 361 OFFCURVE",
+"352 360 CURVE SMOOTH",
+"355 360 OFFCURVE",
+"358 361 OFFCURVE",
+"365 365 CURVE",
+"376 369 OFFCURVE",
+"412 400 OFFCURVE",
+"422 409 CURVE",
+"422 413 OFFCURVE",
+"443 422 OFFCURVE",
+"443 430 CURVE",
+"463 453 OFFCURVE",
+"476 475 OFFCURVE",
+"491 507 CURVE SMOOTH",
+"501 531 OFFCURVE",
+"504 547 OFFCURVE",
+"504 584 CURVE SMOOTH",
+"504 614 OFFCURVE",
+"504 617 OFFCURVE",
+"499 632 CURVE SMOOTH",
+"493 651 OFFCURVE",
+"485 665 OFFCURVE",
+"474 678 CURVE SMOOTH",
+"454 699 OFFCURVE",
+"432 713 OFFCURVE",
+"411 717 CURVE SMOOTH",
+"395 720 OFFCURVE",
+"395 720 OFFCURVE",
+"376 717 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"43 699 OFFCURVE",
+"24 670 OFFCURVE",
+"22 617 CURVE SMOOTH",
+"22 605 OFFCURVE",
+"24 601 OFFCURVE",
+"29 592 CURVE",
+"34 576 OFFCURVE",
+"51 563 OFFCURVE",
+"66 555 CURVE SMOOTH",
+"77 550 OFFCURVE",
+"82 550 OFFCURVE",
+"93 549 CURVE",
+"117 549 OFFCURVE",
+"127 553 OFFCURVE",
+"146 568 CURVE SMOOTH",
+"162 582 OFFCURVE",
+"168 585 OFFCURVE",
+"173 584 CURVE SMOOTH",
+"178 582 OFFCURVE",
+"181 574 OFFCURVE",
+"182 557 CURVE",
+"184 542 OFFCURVE",
+"184 539 OFFCURVE",
+"178 515 CURVE SMOOTH",
+"174 502 OFFCURVE",
+"158 470 OFFCURVE",
+"155 469 CURVE",
+"154 469 OFFCURVE",
+"150 464 OFFCURVE",
+"147 459 CURVE SMOOTH",
+"146 456 OFFCURVE",
+"136 445 OFFCURVE",
+"128 437 CURVE SMOOTH",
+"120 427 OFFCURVE",
+"112 419 OFFCURVE",
+"112 417 CURVE SMOOTH",
+"112 416 OFFCURVE",
+"106 413 OFFCURVE",
+"99 409 CURVE SMOOTH",
+"85 403 OFFCURVE",
+"69 392 OFFCURVE",
+"66 387 CURVE SMOOTH",
+"64 382 OFFCURVE",
+"69 369 OFFCURVE",
+"75 365 CURVE SMOOTH",
+"79 361 OFFCURVE",
+"79 361 OFFCURVE",
+"88 365 CURVE",
+"98 368 OFFCURVE",
+"115 379 OFFCURVE",
+"130 392 CURVE SMOOTH",
+"150 408 OFFCURVE",
+"179 440 OFFCURVE",
+"187 453 CURVE",
+"192 459 OFFCURVE",
+"197 467 OFFCURVE",
+"198 469 CURVE SMOOTH",
+"200 472 OFFCURVE",
+"205 480 OFFCURVE",
+"208 488 CURVE SMOOTH",
+"211 496 OFFCURVE",
+"216 505 OFFCURVE",
+"218 509 CURVE SMOOTH",
+"224 517 OFFCURVE",
+"230 531 OFFCURVE",
+"229 534 CURVE SMOOTH",
+"229 536 OFFCURVE",
+"229 547 OFFCURVE",
+"229 560 CURVE",
+"235 627 OFFCURVE",
+"214 677 OFFCURVE",
+"170 704 CURVE SMOOTH",
+"150 717 OFFCURVE",
+"110 721 OFFCURVE",
+"90 713 CURVE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"450 462 OFFCURVE",
+"511 534 OFFCURVE",
+"511 628 CURVE SMOOTH",
+"511 709 OFFCURVE",
+"466 773 OFFCURVE",
+"395 773 CURVE SMOOTH",
+"339 773 OFFCURVE",
+"303 733 OFFCURVE",
+"303 681 CURVE SMOOTH",
+"303 640 OFFCURVE",
+"326 601 OFFCURVE",
+"376 601 CURVE SMOOTH",
+"424 601 OFFCURVE",
+"436 637 OFFCURVE",
+"451 637 CURVE SMOOTH",
+"457 637 OFFCURVE",
+"462 631 OFFCURVE",
+"462 607 CURVE SMOOTH",
+"462 543 OFFCURVE",
+"427 491 OFFCURVE",
+"349 431 CURVE",
+"366 410 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"197 462 OFFCURVE",
+"258 534 OFFCURVE",
+"258 628 CURVE SMOOTH",
+"258 709 OFFCURVE",
+"213 773 OFFCURVE",
+"142 773 CURVE SMOOTH",
+"86 773 OFFCURVE",
+"50 733 OFFCURVE",
+"50 681 CURVE SMOOTH",
+"50 640 OFFCURVE",
+"73 601 OFFCURVE",
+"123 601 CURVE SMOOTH",
+"171 601 OFFCURVE",
+"183 637 OFFCURVE",
+"198 637 CURVE SMOOTH",
+"204 637 OFFCURVE",
+"209 631 OFFCURVE",
+"209 607 CURVE SMOOTH",
+"209 543 OFFCURVE",
+"174 491 OFFCURVE",
+"96 431 CURVE",
+"113 410 LINE"
+);
+}
+);
+width = 561;
+}
+);
+unicode = 201D;
+},
+{
+glyphname = quoteleft;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"181 465 OFFCURVE",
+"213 499 OFFCURVE",
+"213 540 CURVE SMOOTH",
+"213 570 OFFCURVE",
+"195 600 OFFCURVE",
+"153 600 CURVE SMOOTH",
+"97 600 OFFCURVE",
+"97 546 OFFCURVE",
+"82 546 CURVE SMOOTH",
+"74 546 OFFCURVE",
+"59 563 OFFCURVE",
+"59 590 CURVE SMOOTH",
+"59 633 OFFCURVE",
+"96 695 OFFCURVE",
+"162 742 CURVE",
+"145 763 LINE",
+"78 719 OFFCURVE",
+"27 655 OFFCURVE",
+"27 580 CURVE",
+"27 515 OFFCURVE",
+"66 465 OFFCURVE",
+"129 465 CURVE SMOOTH"
+);
+}
+);
+width = 249;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"108 707 OFFCURVE",
+"90 701 OFFCURVE",
+"85 697 CURVE SMOOTH",
+"84 696 OFFCURVE",
+"81 693 OFFCURVE",
+"77 691 CURVE SMOOTH",
+"69 688 OFFCURVE",
+"52 667 OFFCURVE",
+"44 654 CURVE",
+"41 646 OFFCURVE",
+"37 637 OFFCURVE",
+"36 632 CURVE SMOOTH",
+"34 625 OFFCURVE",
+"31 616 OFFCURVE",
+"29 609 CURVE SMOOTH",
+"23 592 OFFCURVE",
+"21 565 OFFCURVE",
+"26 545 CURVE",
+"29 537 OFFCURVE",
+"31 525 OFFCURVE",
+"33 518 CURVE",
+"34 510 OFFCURVE",
+"37 502 OFFCURVE",
+"39 499 CURVE SMOOTH",
+"51 477 OFFCURVE",
+"51 467 OFFCURVE",
+"63 454 CURVE",
+"73 438 OFFCURVE",
+"98 409 OFFCURVE",
+"108 401 CURVE",
+"111 400 OFFCURVE",
+"119 393 OFFCURVE",
+"124 387 CURVE",
+"124 382 OFFCURVE",
+"145 373 OFFCURVE",
+"145 368 CURVE",
+"154 360 OFFCURVE",
+"164 355 OFFCURVE",
+"173 357 CURVE SMOOTH",
+"180 358 OFFCURVE",
+"186 368 OFFCURVE",
+"186 376 CURVE SMOOTH",
+"186 382 OFFCURVE",
+"185 384 OFFCURVE",
+"167 395 CURVE",
+"149 408 OFFCURVE",
+"146 409 OFFCURVE",
+"143 409 CURVE SMOOTH",
+"140 409 OFFCURVE",
+"138 409 OFFCURVE",
+"138 411 CURVE SMOOTH",
+"138 413 OFFCURVE",
+"129 425 OFFCURVE",
+"121 433 CURVE SMOOTH",
+"93 461 OFFCURVE",
+"69 512 OFFCURVE",
+"68 544 CURVE SMOOTH",
+"68 565 OFFCURVE",
+"71 582 OFFCURVE",
+"79 589 CURVE",
+"84 595 OFFCURVE",
+"84 595 OFFCURVE",
+"95 582 CURVE SMOOTH",
+"103 571 OFFCURVE",
+"120 553 OFFCURVE",
+"129 550 CURVE SMOOTH",
+"162 536 OFFCURVE",
+"199 545 OFFCURVE",
+"218 574 CURVE SMOOTH",
+"228 589 OFFCURVE",
+"231 601 OFFCURVE",
+"231 621 CURVE SMOOTH",
+"231 641 OFFCURVE",
+"228 653 OFFCURVE",
+"220 667 CURVE SMOOTH",
+"201 699 OFFCURVE",
+"159 717 OFFCURVE",
+"121 710 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"222 410 OFFCURVE",
+"258 450 OFFCURVE",
+"258 502 CURVE SMOOTH",
+"258 543 OFFCURVE",
+"235 582 OFFCURVE",
+"185 582 CURVE SMOOTH",
+"137 582 OFFCURVE",
+"125 546 OFFCURVE",
+"110 546 CURVE SMOOTH",
+"104 546 OFFCURVE",
+"99 552 OFFCURVE",
+"99 576 CURVE SMOOTH",
+"99 640 OFFCURVE",
+"134 692 OFFCURVE",
+"212 752 CURVE",
+"195 773 LINE",
+"111 721 OFFCURVE",
+"50 649 OFFCURVE",
+"50 555 CURVE",
+"50 474 OFFCURVE",
+"95 410 OFFCURVE",
+"166 410 CURVE SMOOTH"
+);
+}
+);
+width = 308;
+}
+);
+unicode = 2018;
+},
+{
+glyphname = quoteright;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"162 721 OFFCURVE",
+"131 763 OFFCURVE",
+"80 763 CURVE SMOOTH",
+"37 763 OFFCURVE",
+"10 734 OFFCURVE",
+"10 699 CURVE SMOOTH",
+"10 675 OFFCURVE",
+"24 649 OFFCURVE",
+"60 649 CURVE SMOOTH",
+"91 649 OFFCURVE",
+"111 676 OFFCURVE",
+"120 676 CURVE SMOOTH",
+"123 676 OFFCURVE",
+"125 673 OFFCURVE",
+"125 662 CURVE SMOOTH",
+"125 617 OFFCURVE",
+"93 569 OFFCURVE",
+"33 529 CURVE",
+"53 506 LINE",
+"115 544 OFFCURVE",
+"162 600 OFFCURVE",
+"162 667 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"115 544 OFFCURVE",
+"162 600 OFFCURVE",
+"162 667 CURVE SMOOTH",
+"162 667 LINE SMOOTH",
+"162 721 OFFCURVE",
+"131 763 OFFCURVE",
+"80 763 CURVE SMOOTH",
+"37 763 OFFCURVE",
+"10 734 OFFCURVE",
+"10 699 CURVE SMOOTH",
+"10 675 OFFCURVE",
+"24 649 OFFCURVE",
+"60 649 CURVE SMOOTH",
+"91 649 OFFCURVE",
+"111 676 OFFCURVE",
+"120 676 CURVE SMOOTH",
+"123 676 OFFCURVE",
+"125 673 OFFCURVE",
+"125 662 CURVE SMOOTH",
+"125 617 OFFCURVE",
+"93 569 OFFCURVE",
+"33 529 CURVE",
+"53 506 LINE"
+);
+}
+);
+width = 172;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"176 709 OFFCURVE",
+"146 764 OFFCURVE",
+"89 764 CURVE SMOOTH",
+"44 764 OFFCURVE",
+"10 730 OFFCURVE",
+"10 687 CURVE SMOOTH",
+"10 653 OFFCURVE",
+"30 620 OFFCURVE",
+"68 620 CURVE SMOOTH",
+"106 620 OFFCURVE",
+"111 652 OFFCURVE",
+"123 652 CURVE SMOOTH",
+"127 652 OFFCURVE",
+"132 648 OFFCURVE",
+"132 628 CURVE SMOOTH",
+"132 581 OFFCURVE",
+"105 543 OFFCURVE",
+"46 501 CURVE",
+"66 479 LINE",
+"133 524 OFFCURVE",
+"176 573 OFFCURVE",
+"176 647 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"133 524 OFFCURVE",
+"176 573 OFFCURVE",
+"176 647 CURVE SMOOTH",
+"176 647 LINE SMOOTH",
+"176 709 OFFCURVE",
+"146 764 OFFCURVE",
+"89 764 CURVE SMOOTH",
+"44 764 OFFCURVE",
+"10 730 OFFCURVE",
+"10 687 CURVE SMOOTH",
+"10 653 OFFCURVE",
+"30 620 OFFCURVE",
+"68 620 CURVE SMOOTH",
+"106 620 OFFCURVE",
+"111 652 OFFCURVE",
+"123 652 CURVE SMOOTH",
+"127 652 OFFCURVE",
+"132 648 OFFCURVE",
+"132 628 CURVE SMOOTH",
+"132 581 OFFCURVE",
+"105 543 OFFCURVE",
+"46 501 CURVE",
+"66 479 LINE"
+);
+}
+);
+width = 186;
+}
+);
+unicode = 2019;
+},
+{
+glyphname = quoteright;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"162 509 OFFCURVE",
+"213 573 OFFCURVE",
+"213 648 CURVE SMOOTH",
+"213 713 OFFCURVE",
+"174 763 OFFCURVE",
+"111 763 CURVE SMOOTH",
+"59 763 OFFCURVE",
+"27 729 OFFCURVE",
+"27 688 CURVE SMOOTH",
+"27 658 OFFCURVE",
+"45 628 OFFCURVE",
+"87 628 CURVE SMOOTH",
+"143 628 OFFCURVE",
+"143 682 OFFCURVE",
+"158 682 CURVE SMOOTH",
+"166 682 OFFCURVE",
+"181 665 OFFCURVE",
+"181 638 CURVE SMOOTH",
+"181 595 OFFCURVE",
+"144 533 OFFCURVE",
+"78 486 CURVE",
+"95 465 LINE"
+);
+}
+);
+width = 253;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"79 704 OFFCURVE",
+"66 697 OFFCURVE",
+"50 681 CURVE SMOOTH",
+"39 669 OFFCURVE",
+"36 664 OFFCURVE",
+"31 654 CURVE",
+"26 640 OFFCURVE",
+"22 616 OFFCURVE",
+"23 613 CURVE",
+"25 613 OFFCURVE",
+"25 606 OFFCURVE",
+"26 600 CURVE",
+"26 584 OFFCURVE",
+"35 574 OFFCURVE",
+"44 563 CURVE SMOOTH",
+"51 555 OFFCURVE",
+"68 545 OFFCURVE",
+"82 542 CURVE SMOOTH",
+"94 539 OFFCURVE",
+"122 542 OFFCURVE",
+"134 549 CURVE SMOOTH",
+"140 552 OFFCURVE",
+"158 571 OFFCURVE",
+"167 584 CURVE",
+"172 589 LINE",
+"175 584 LINE",
+"182 577 OFFCURVE",
+"183 566 OFFCURVE",
+"185 541 CURVE",
+"185 515 OFFCURVE",
+"183 512 OFFCURVE",
+"170 485 CURVE SMOOTH",
+"151 445 OFFCURVE",
+"130 422 OFFCURVE",
+"87 395 CURVE SMOOTH",
+"71 384 OFFCURVE",
+"66 377 OFFCURVE",
+"70 368 CURVE SMOOTH",
+"73 360 OFFCURVE",
+"78 355 OFFCURVE",
+"86 355 CURVE SMOOTH",
+"87 355 OFFCURVE",
+"94 357 OFFCURVE",
+"98 360 CURVE SMOOTH",
+"102 363 OFFCURVE",
+"108 368 OFFCURVE",
+"111 369 CURVE SMOOTH",
+"122 374 OFFCURVE",
+"166 414 OFFCURVE",
+"174 425 CURVE SMOOTH",
+"177 430 OFFCURVE",
+"185 440 OFFCURVE",
+"190 446 CURVE SMOOTH",
+"203 462 OFFCURVE",
+"216 491 OFFCURVE",
+"222 512 CURVE",
+"223 520 OFFCURVE",
+"226 528 OFFCURVE",
+"226 528 CURVE",
+"228 529 OFFCURVE",
+"230 541 OFFCURVE",
+"231 552 CURVE",
+"231 569 OFFCURVE",
+"231 576 OFFCURVE",
+"231 592 CURVE",
+"230 601 OFFCURVE",
+"228 616 OFFCURVE",
+"226 622 CURVE SMOOTH",
+"218 653 OFFCURVE",
+"191 688 OFFCURVE",
+"166 699 CURVE SMOOTH",
+"143 710 OFFCURVE",
+"124 712 OFFCURVE",
+"98 707 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"197 452 OFFCURVE",
+"258 524 OFFCURVE",
+"258 618 CURVE SMOOTH",
+"258 699 OFFCURVE",
+"213 763 OFFCURVE",
+"142 763 CURVE SMOOTH",
+"86 763 OFFCURVE",
+"50 723 OFFCURVE",
+"50 671 CURVE SMOOTH",
+"50 630 OFFCURVE",
+"73 591 OFFCURVE",
+"123 591 CURVE SMOOTH",
+"171 591 OFFCURVE",
+"183 627 OFFCURVE",
+"198 627 CURVE SMOOTH",
+"204 627 OFFCURVE",
+"209 621 OFFCURVE",
+"209 597 CURVE SMOOTH",
+"209 533 OFFCURVE",
+"174 481 OFFCURVE",
+"96 421 CURVE",
+"113 400 LINE"
+);
+}
+);
+width = 308;
+}
+);
+unicode = 2019;
+},
+{
+glyphname = quotesinglbase;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"162 -109 OFFCURVE",
+"213 -45 OFFCURVE",
+"213 30 CURVE SMOOTH",
+"213 95 OFFCURVE",
+"174 145 OFFCURVE",
+"111 145 CURVE SMOOTH",
+"59 145 OFFCURVE",
+"27 111 OFFCURVE",
+"27 70 CURVE SMOOTH",
+"27 40 OFFCURVE",
+"45 10 OFFCURVE",
+"87 10 CURVE SMOOTH",
+"143 10 OFFCURVE",
+"143 64 OFFCURVE",
+"158 64 CURVE SMOOTH",
+"166 64 OFFCURVE",
+"181 47 OFFCURVE",
+"181 20 CURVE SMOOTH",
+"181 -23 OFFCURVE",
+"144 -85 OFFCURVE",
+"78 -132 CURVE",
+"95 -153 LINE"
+);
+}
+);
+width = 253;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"79 704 OFFCURVE",
+"66 697 OFFCURVE",
+"50 681 CURVE SMOOTH",
+"39 669 OFFCURVE",
+"36 664 OFFCURVE",
+"31 654 CURVE",
+"26 640 OFFCURVE",
+"22 616 OFFCURVE",
+"23 613 CURVE",
+"25 613 OFFCURVE",
+"25 606 OFFCURVE",
+"26 600 CURVE",
+"26 584 OFFCURVE",
+"35 574 OFFCURVE",
+"44 563 CURVE SMOOTH",
+"51 555 OFFCURVE",
+"68 545 OFFCURVE",
+"82 542 CURVE SMOOTH",
+"94 539 OFFCURVE",
+"122 542 OFFCURVE",
+"134 549 CURVE SMOOTH",
+"140 552 OFFCURVE",
+"158 571 OFFCURVE",
+"167 584 CURVE",
+"172 589 LINE",
+"175 584 LINE",
+"182 577 OFFCURVE",
+"183 566 OFFCURVE",
+"185 541 CURVE",
+"185 515 OFFCURVE",
+"183 512 OFFCURVE",
+"170 485 CURVE SMOOTH",
+"151 445 OFFCURVE",
+"130 422 OFFCURVE",
+"87 395 CURVE SMOOTH",
+"71 384 OFFCURVE",
+"66 377 OFFCURVE",
+"70 368 CURVE SMOOTH",
+"73 360 OFFCURVE",
+"78 355 OFFCURVE",
+"86 355 CURVE SMOOTH",
+"87 355 OFFCURVE",
+"94 357 OFFCURVE",
+"98 360 CURVE SMOOTH",
+"102 363 OFFCURVE",
+"108 368 OFFCURVE",
+"111 369 CURVE SMOOTH",
+"122 374 OFFCURVE",
+"166 414 OFFCURVE",
+"174 425 CURVE SMOOTH",
+"177 430 OFFCURVE",
+"185 440 OFFCURVE",
+"190 446 CURVE SMOOTH",
+"203 462 OFFCURVE",
+"216 491 OFFCURVE",
+"222 512 CURVE",
+"223 520 OFFCURVE",
+"226 528 OFFCURVE",
+"226 528 CURVE",
+"228 529 OFFCURVE",
+"230 541 OFFCURVE",
+"231 552 CURVE",
+"231 569 OFFCURVE",
+"231 576 OFFCURVE",
+"231 592 CURVE",
+"230 601 OFFCURVE",
+"228 616 OFFCURVE",
+"226 622 CURVE SMOOTH",
+"218 653 OFFCURVE",
+"191 688 OFFCURVE",
+"166 699 CURVE SMOOTH",
+"143 710 OFFCURVE",
+"124 712 OFFCURVE",
+"98 707 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"197 -119 OFFCURVE",
+"258 -47 OFFCURVE",
+"258 47 CURVE SMOOTH",
+"258 128 OFFCURVE",
+"213 192 OFFCURVE",
+"142 192 CURVE SMOOTH",
+"86 192 OFFCURVE",
+"50 152 OFFCURVE",
+"50 100 CURVE SMOOTH",
+"50 59 OFFCURVE",
+"73 20 OFFCURVE",
+"123 20 CURVE SMOOTH",
+"171 20 OFFCURVE",
+"183 56 OFFCURVE",
+"198 56 CURVE SMOOTH",
+"204 56 OFFCURVE",
+"209 50 OFFCURVE",
+"209 26 CURVE SMOOTH",
+"209 -38 OFFCURVE",
+"174 -90 OFFCURVE",
+"96 -150 CURVE",
+"113 -171 LINE"
+);
+}
+);
+width = 308;
+}
+);
+unicode = 201A;
+},
+{
+glyphname = space;
+lastChange = "2016-08-16 11:12:00 +0000";
+layers = (
+{
+layerId = UUID0;
+width = 206;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 160;
+}
+);
+unicode = 0020;
+},
+{
+glyphname = nbspace;
+lastChange = "2016-08-18 21:39:28 +0000";
+layers = (
+{
+layerId = UUID0;
+width = 206;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 160;
+}
+);
+unicode = 00A0;
+},
+{
+glyphname = CR;
+lastChange = "2016-08-16 11:12:00 +0000";
+layers = (
+{
+layerId = UUID0;
+width = 206;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 160;
+}
+);
+unicode = 000D;
+},
+{
+glyphname = .notdef;
+lastChange = "2016-08-19 17:28:22 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"201 899 LINE",
+"221 924 LINE",
+"608 -301 LINE",
+"588 -326 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"682 -326 LINE",
+"682 -301 LINE",
+"127 -301 LINE",
+"127 -326 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"221 -326 LINE",
+"221 924 LINE",
+"127 924 LINE",
+"127 -326 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"608 899 LINE",
+"588 924 LINE",
+"201 -301 LINE",
+"221 -326 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"682 -326 LINE",
+"682 924 LINE",
+"588 924 LINE",
+"588 -326 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"682 899 LINE",
+"682 924 LINE",
+"127 924 LINE",
+"127 899 LINE"
+);
+}
+);
+width = 809;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"201 899 LINE",
+"221 924 LINE",
+"608 -301 LINE",
+"588 -326 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"682 -326 LINE",
+"682 -301 LINE",
+"127 -301 LINE",
+"127 -326 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"221 -326 LINE",
+"221 924 LINE",
+"127 924 LINE",
+"127 -326 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"608 899 LINE",
+"588 924 LINE",
+"201 -301 LINE",
+"221 -326 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"682 -326 LINE",
+"682 924 LINE",
+"588 924 LINE",
+"588 -326 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"682 899 LINE",
+"682 924 LINE",
+"127 924 LINE",
+"127 899 LINE"
+);
+}
+);
+width = 809;
+}
+);
+},
+{
+glyphname = cent;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"307 576 OFFCURVE",
+"329 566 OFFCURVE",
+"329 544 CURVE SMOOTH",
+"329 520 OFFCURVE",
+"305 516 OFFCURVE",
+"305 482 CURVE SMOOTH",
+"305 445 OFFCURVE",
+"335 426 OFFCURVE",
+"367 426 CURVE SMOOTH",
+"402 426 OFFCURVE",
+"427 450 OFFCURVE",
+"427 489 CURVE SMOOTH",
+"427 556 OFFCURVE",
+"355 603 OFFCURVE",
+"267 603 CURVE SMOOTH",
+"128 603 OFFCURVE",
+"27 487 OFFCURVE",
+"27 370 CURVE SMOOTH",
+"27 251 OFFCURVE",
+"132 136 OFFCURVE",
+"259 136 CURVE SMOOTH",
+"355 136 OFFCURVE",
+"419 201 OFFCURVE",
+"445 297 CURVE",
+"417 297 LINE",
+"381 202 OFFCURVE",
+"335 166 OFFCURVE",
+"262 166 CURVE SMOOTH",
+"185 166 OFFCURVE",
+"157 206 OFFCURVE",
+"157 368 CURVE SMOOTH",
+"157 539 OFFCURVE",
+"188 576 OFFCURVE",
+"266 576 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"238 6 LINE",
+"267 6 LINE",
+"267 734 LINE",
+"238 734 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"355 136 OFFCURVE",
+"419 201 OFFCURVE",
+"445 297 CURVE",
+"417 297 LINE",
+"381 202 OFFCURVE",
+"335 166 OFFCURVE",
+"262 166 CURVE SMOOTH",
+"185 166 OFFCURVE",
+"157 206 OFFCURVE",
+"157 368 CURVE SMOOTH",
+"157 539 OFFCURVE",
+"188 576 OFFCURVE",
+"266 576 CURVE SMOOTH",
+"307 576 OFFCURVE",
+"329 566 OFFCURVE",
+"329 544 CURVE SMOOTH",
+"329 520 OFFCURVE",
+"305 516 OFFCURVE",
+"305 482 CURVE SMOOTH",
+"305 445 OFFCURVE",
+"335 426 OFFCURVE",
+"367 426 CURVE SMOOTH",
+"402 426 OFFCURVE",
+"427 450 OFFCURVE",
+"427 489 CURVE SMOOTH",
+"427 556 OFFCURVE",
+"355 603 OFFCURVE",
+"267 603 CURVE SMOOTH",
+"128 603 OFFCURVE",
+"27 487 OFFCURVE",
+"27 370 CURVE SMOOTH",
+"27 251 OFFCURVE",
+"132 136 OFFCURVE",
+"259 136 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"267 6 LINE",
+"267 734 LINE",
+"238 734 LINE",
+"238 6 LINE"
+);
+}
+);
+width = 478;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"270 6 LINE",
+"299 6 LINE",
+"299 734 LINE",
+"270 734 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"339 570 OFFCURVE",
+"357 562 OFFCURVE",
+"357 546 CURVE SMOOTH",
+"357 525 OFFCURVE",
+"328 512 OFFCURVE",
+"328 471 CURVE SMOOTH",
+"328 430 OFFCURVE",
+"355 405 OFFCURVE",
+"395 405 CURVE SMOOTH",
+"437 405 OFFCURVE",
+"469 433 OFFCURVE",
+"469 479 CURVE SMOOTH",
+"469 551 OFFCURVE",
+"388 602 OFFCURVE",
+"293 602 CURVE SMOOTH",
+"149 602 OFFCURVE",
+"45 486 OFFCURVE",
+"45 370 CURVE SMOOTH",
+"45 250 OFFCURVE",
+"155 135 OFFCURVE",
+"292 135 CURVE SMOOTH",
+"395 135 OFFCURVE",
+"463 200 OFFCURVE",
+"490 296 CURVE",
+"457 296 LINE",
+"420 205 OFFCURVE",
+"372 170 OFFCURVE",
+"300 170 CURVE SMOOTH",
+"224 170 OFFCURVE",
+"200 209 OFFCURVE",
+"200 363 CURVE SMOOTH",
+"200 536 OFFCURVE",
+"230 570 OFFCURVE",
+"299 570 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"395 135 OFFCURVE",
+"463 200 OFFCURVE",
+"490 296 CURVE",
+"457 296 LINE",
+"420 205 OFFCURVE",
+"372 170 OFFCURVE",
+"300 170 CURVE SMOOTH",
+"224 170 OFFCURVE",
+"200 209 OFFCURVE",
+"200 363 CURVE SMOOTH",
+"200 536 OFFCURVE",
+"230 570 OFFCURVE",
+"299 570 CURVE SMOOTH",
+"339 570 OFFCURVE",
+"357 562 OFFCURVE",
+"357 546 CURVE SMOOTH",
+"357 525 OFFCURVE",
+"328 512 OFFCURVE",
+"328 471 CURVE SMOOTH",
+"328 430 OFFCURVE",
+"355 405 OFFCURVE",
+"395 405 CURVE SMOOTH",
+"437 405 OFFCURVE",
+"469 433 OFFCURVE",
+"469 479 CURVE SMOOTH",
+"469 551 OFFCURVE",
+"388 602 OFFCURVE",
+"293 602 CURVE SMOOTH",
+"149 602 OFFCURVE",
+"45 486 OFFCURVE",
+"45 370 CURVE SMOOTH",
+"45 250 OFFCURVE",
+"155 135 OFFCURVE",
+"292 135 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"299 6 LINE",
+"299 734 LINE",
+"270 734 LINE",
+"270 6 LINE"
+);
+}
+);
+width = 520;
+}
+);
+unicode = 00A2;
+},
+{
+glyphname = colonsign;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"355 136 OFFCURVE",
+"419 201 OFFCURVE",
+"445 297 CURVE",
+"417 297 LINE",
+"381 202 OFFCURVE",
+"335 166 OFFCURVE",
+"262 166 CURVE SMOOTH",
+"185 166 OFFCURVE",
+"157 206 OFFCURVE",
+"157 368 CURVE SMOOTH",
+"157 529 OFFCURVE",
+"188 576 OFFCURVE",
+"266 576 CURVE SMOOTH",
+"347 576 OFFCURVE",
+"383 515 OFFCURVE",
+"394 445 CURVE",
+"419 445 LINE",
+"419 603 LINE",
+"407 603 LINE",
+"380 571 LINE",
+"342 594 OFFCURVE",
+"319 603 OFFCURVE",
+"267 603 CURVE SMOOTH",
+"128 603 OFFCURVE",
+"27 487 OFFCURVE",
+"27 370 CURVE SMOOTH",
+"27 251 OFFCURVE",
+"132 136 OFFCURVE",
+"259 136 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"162 23 LINE",
+"320 733 LINE",
+"288 733 LINE",
+"130 23 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"236 23 LINE",
+"394 733 LINE",
+"362 733 LINE",
+"204 23 LINE"
+);
+}
+);
+width = 478;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"387 137 OFFCURVE",
+"444 201 OFFCURVE",
+"470 298 CURVE",
+"437 298 LINE",
+"404 209 OFFCURVE",
+"366 172 OFFCURVE",
+"297 172 CURVE SMOOTH",
+"224 172 OFFCURVE",
+"200 214 OFFCURVE",
+"200 364 CURVE SMOOTH",
+"200 525 OFFCURVE",
+"228 572 OFFCURVE",
+"300 572 CURVE SMOOTH",
+"393 572 OFFCURVE",
+"422 492 OFFCURVE",
+"422 440 CURVE",
+"458 440 LINE",
+"458 603 LINE",
+"441 603 LINE",
+"419 568 LINE",
+"387 591 OFFCURVE",
+"342 604 OFFCURVE",
+"293 604 CURVE SMOOTH",
+"149 604 OFFCURVE",
+"45 488 OFFCURVE",
+"45 372 CURVE SMOOTH",
+"45 252 OFFCURVE",
+"157 137 OFFCURVE",
+"289 137 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"181 23 LINE",
+"339 733 LINE",
+"307 733 LINE",
+"149 23 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"255 23 LINE",
+"413 733 LINE",
+"381 733 LINE",
+"223 23 LINE"
+);
+}
+);
+width = 500;
+}
+);
+unicode = 20A1;
+},
+{
+glyphname = currency;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"464 135 OFFCURVE",
+"569 240 OFFCURVE",
+"569 368 CURVE SMOOTH",
+"569 496 OFFCURVE",
+"464 602 OFFCURVE",
+"334 602 CURVE SMOOTH",
+"204 602 OFFCURVE",
+"100 496 OFFCURVE",
+"100 368 CURVE SMOOTH",
+"100 240 OFFCURVE",
+"204 135 OFFCURVE",
+"334 135 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"211 235 LINE",
+"194 262 LINE",
+"100 152 LINE",
+"122 135 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"212 500 LINE",
+"122 601 LINE",
+"100 584 LINE",
+"194 474 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"240 200 OFFCURVE",
+"165 275 OFFCURVE",
+"165 368 CURVE SMOOTH",
+"165 461 OFFCURVE",
+"240 537 OFFCURVE",
+"334 537 CURVE SMOOTH",
+"428 537 OFFCURVE",
+"504 461 OFFCURVE",
+"504 368 CURVE SMOOTH",
+"504 275 OFFCURVE",
+"428 200 OFFCURVE",
+"334 200 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"569 152 LINE",
+"475 262 LINE",
+"458 235 LINE",
+"547 135 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"569 584 LINE",
+"547 601 LINE",
+"457 500 LINE",
+"475 474 LINE"
+);
+}
+);
+width = 669;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"464 135 OFFCURVE",
+"569 240 OFFCURVE",
+"569 368 CURVE SMOOTH",
+"569 496 OFFCURVE",
+"464 602 OFFCURVE",
+"334 602 CURVE SMOOTH",
+"204 602 OFFCURVE",
+"100 496 OFFCURVE",
+"100 368 CURVE SMOOTH",
+"100 240 OFFCURVE",
+"204 135 OFFCURVE",
+"334 135 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"231 225 LINE",
+"184 282 LINE",
+"90 172 LINE",
+"142 125 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"232 510 LINE",
+"142 611 LINE",
+"90 564 LINE",
+"184 454 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"248 215 OFFCURVE",
+"180 283 OFFCURVE",
+"180 368 CURVE SMOOTH",
+"180 453 OFFCURVE",
+"248 522 OFFCURVE",
+"334 522 CURVE SMOOTH",
+"420 522 OFFCURVE",
+"489 453 OFFCURVE",
+"489 368 CURVE SMOOTH",
+"489 283 OFFCURVE",
+"420 215 OFFCURVE",
+"334 215 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"579 172 LINE",
+"485 282 LINE",
+"438 225 LINE",
+"527 125 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"579 564 LINE",
+"527 611 LINE",
+"437 510 LINE",
+"485 454 LINE"
+);
+}
+);
+width = 669;
+}
+);
+unicode = 00A4;
+},
+{
+glyphname = dollar;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"405 -13 OFFCURVE",
+"499 82 OFFCURVE",
+"499 217 CURVE SMOOTH",
+"499 352 OFFCURVE",
+"405 390 OFFCURVE",
+"285 429 CURVE SMOOTH",
+"135 477 OFFCURVE",
+"110 502 OFFCURVE",
+"110 566 CURVE SMOOTH",
+"110 663 OFFCURVE",
+"189 703 OFFCURVE",
+"283 703 CURVE SMOOTH",
+"366 703 OFFCURVE",
+"416 672 OFFCURVE",
+"416 642 CURVE SMOOTH",
+"416 610 OFFCURVE",
+"362 620 OFFCURVE",
+"362 570 CURVE SMOOTH",
+"362 535 OFFCURVE",
+"389 522 OFFCURVE",
+"414 522 CURVE SMOOTH",
+"449 522 OFFCURVE",
+"473 549 OFFCURVE",
+"473 595 CURVE SMOOTH",
+"473 675 OFFCURVE",
+"400 733 OFFCURVE",
+"285 733 CURVE SMOOTH",
+"158 733 OFFCURVE",
+"48 663 OFFCURVE",
+"48 521 CURVE SMOOTH",
+"48 397 OFFCURVE",
+"133 347 OFFCURVE",
+"253 316 CURVE SMOOTH",
+"375 285 OFFCURVE",
+"440 267 OFFCURVE",
+"440 175 CURVE SMOOTH",
+"440 79 OFFCURVE",
+"368 17 OFFCURVE",
+"245 17 CURVE SMOOTH",
+"148 17 OFFCURVE",
+"90 56 OFFCURVE",
+"90 82 CURVE SMOOTH",
+"90 110 OFFCURVE",
+"157 103 OFFCURVE",
+"157 162 CURVE SMOOTH",
+"157 195 OFFCURVE",
+"135 216 OFFCURVE",
+"97 216 CURVE SMOOTH",
+"49 216 OFFCURVE",
+"23 181 OFFCURVE",
+"23 135 CURVE SMOOTH",
+"23 50 OFFCURVE",
+"112 -13 OFFCURVE",
+"243 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"222 -113 LINE",
+"222 801 LINE",
+"193 801 LINE",
+"193 -113 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"334 -113 LINE",
+"334 801 LINE",
+"305 801 LINE",
+"305 -113 LINE"
+);
+}
+);
+width = 556;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"363 774 OFFCURVE",
+"363 774 OFFCURVE",
+"363 757 CURVE SMOOTH",
+"363 732 OFFCURVE",
+"363 732 OFFCURVE",
+"320 732 CURVE SMOOTH",
+"301 732 OFFCURVE",
+"281 730 OFFCURVE",
+"276 730 CURVE SMOOTH",
+"259 729 OFFCURVE",
+"258 730 OFFCURVE",
+"259 754 CURVE",
+"261 772 OFFCURVE",
+"261 774 OFFCURVE",
+"256 779 CURVE SMOOTH",
+"251 786 OFFCURVE",
+"241 786 OFFCURVE",
+"234 779 CURVE SMOOTH",
+"228 774 OFFCURVE",
+"228 772 OFFCURVE",
+"230 752 CURVE SMOOTH",
+"233 724 OFFCURVE",
+"230 720 OFFCURVE",
+"217 716 CURVE SMOOTH",
+"211 715 OFFCURVE",
+"202 712 OFFCURVE",
+"193 706 CURVE SMOOTH",
+"186 703 OFFCURVE",
+"178 699 OFFCURVE",
+"178 699 CURVE",
+"177 699 OFFCURVE",
+"168 695 OFFCURVE",
+"157 687 CURVE SMOOTH",
+"137 676 OFFCURVE",
+"101 644 OFFCURVE",
+"100 637 CURVE",
+"100 635 OFFCURVE",
+"97 630 OFFCURVE",
+"92 625 CURVE SMOOTH",
+"87 620 OFFCURVE",
+"83 613 OFFCURVE",
+"81 610 CURVE",
+"80 606 OFFCURVE",
+"75 597 OFFCURVE",
+"72 589 CURVE",
+"59 571 OFFCURVE",
+"51 525 OFFCURVE",
+"56 509 CURVE",
+"56 503 OFFCURVE",
+"58 496 OFFCURVE",
+"58 489 CURVE SMOOTH",
+"58 481 OFFCURVE",
+"59 470 OFFCURVE",
+"66 442 CURVE SMOOTH",
+"72 424 OFFCURVE",
+"82 405 OFFCURVE",
+"106 382 CURVE SMOOTH",
+"129 357 OFFCURVE",
+"142 349 OFFCURVE",
+"163 337 CURVE SMOOTH",
+"177 329 OFFCURVE",
+"208 317 OFFCURVE",
+"222 314 CURVE",
+"225 312 OFFCURVE",
+"228 310 OFFCURVE",
+"230 305 CURVE",
+"230 300 OFFCURVE",
+"230 298 OFFCURVE",
+"230 290 CURVE SMOOTH",
+"230 284 OFFCURVE",
+"228 266 OFFCURVE",
+"228 249 CURVE SMOOTH",
+"227 230 OFFCURVE",
+"227 176 OFFCURVE",
+"227 129 CURVE",
+"225 80 OFFCURVE",
+"224 38 OFFCURVE",
+"224 35 CURVE",
+"222 30 OFFCURVE",
+"220 27 OFFCURVE",
+"217 27 CURVE SMOOTH",
+"210 26 OFFCURVE",
+"185 30 OFFCURVE",
+"177 36 CURVE SMOOTH",
+"174 38 OFFCURVE",
+"169 38 OFFCURVE",
+"168 38 CURVE SMOOTH",
+"163 38 OFFCURVE",
+"127 58 OFFCURVE",
+"117 68 CURVE",
+"104 78 OFFCURVE",
+"100 89 OFFCURVE",
+"106 95 CURVE",
+"106 100 OFFCURVE",
+"118 105 OFFCURVE",
+"131 109 CURVE SMOOTH",
+"156 115 OFFCURVE",
+"175 129 OFFCURVE",
+"186 153 CURVE SMOOTH",
+"191 165 OFFCURVE",
+"193 168 OFFCURVE",
+"193 182 CURVE SMOOTH",
+"193 204 OFFCURVE",
+"188 217 OFFCURVE",
+"174 230 CURVE SMOOTH",
+"161 244 OFFCURVE",
+"151 250 OFFCURVE",
+"135 255 CURVE SMOOTH",
+"120 259 OFFCURVE",
+"123 259 OFFCURVE",
+"101 258 CURVE",
+"68 255 OFFCURVE",
+"34 224 OFFCURVE",
+"24 187 CURVE SMOOTH",
+"21 171 OFFCURVE",
+"24 136 OFFCURVE",
+"29 119 CURVE SMOOTH",
+"33 112 OFFCURVE",
+"36 105 OFFCURVE",
+"38 103 CURVE SMOOTH",
+"39 102 OFFCURVE",
+"42 95 OFFCURVE",
+"46 86 CURVE SMOOTH",
+"51 78 OFFCURVE",
+"56 72 OFFCURVE",
+"58 72 CURVE",
+"58 70 OFFCURVE",
+"66 63 OFFCURVE",
+"75 56 CURVE SMOOTH",
+"96 36 OFFCURVE",
+"107 29 OFFCURVE",
+"144 16 CURVE SMOOTH",
+"170 5 OFFCURVE",
+"182 2 OFFCURVE",
+"203 1 CURVE SMOOTH",
+"225 -1 OFFCURVE",
+"225 -5 OFFCURVE",
+"225 -24 CURVE",
+"227 -30 OFFCURVE",
+"227 -42 OFFCURVE",
+"227 -49 CURVE",
+"225 -55 OFFCURVE",
+"225 -72 OFFCURVE",
+"224 -84 CURVE",
+"224 -108 LINE",
+"228 -115 LINE SMOOTH",
+"233 -120 OFFCURVE",
+"236 -120 OFFCURVE",
+"242 -120 CURVE SMOOTH",
+"247 -120 OFFCURVE",
+"253 -118 OFFCURVE",
+"254 -117 CURVE SMOOTH",
+"258 -113 OFFCURVE",
+"258 -106 OFFCURVE",
+"256 -55 CURVE",
+"256 -24 OFFCURVE",
+"256 -10 OFFCURVE",
+"256 -8 CURVE SMOOTH",
+"256 -7 OFFCURVE",
+"262 -5 OFFCURVE",
+"283 -5 CURVE SMOOTH",
+"296 -5 OFFCURVE",
+"318 -5 OFFCURVE",
+"329 -3 CURVE SMOOTH",
+"355 -1 OFFCURVE",
+"355 -3 OFFCURVE",
+"360 -20 CURVE",
+"360 -29 OFFCURVE",
+"360 -32 OFFCURVE",
+"360 -57 CURVE",
+"355 -92 OFFCURVE",
+"355 -108 OFFCURVE",
+"361 -115 CURVE SMOOTH",
+"366 -123 OFFCURVE",
+"384 -122 OFFCURVE",
+"389 -109 CURVE",
+"389 -106 OFFCURVE",
+"389 -98 OFFCURVE",
+"389 -89 CURVE SMOOTH",
+"386 -42 OFFCURVE",
+"388 -5 OFFCURVE",
+"391 2 CURVE",
+"391 4 OFFCURVE",
+"401 7 OFFCURVE",
+"410 9 CURVE SMOOTH",
+"426 13 OFFCURVE",
+"462 29 OFFCURVE",
+"471 35 CURVE SMOOTH",
+"474 36 OFFCURVE",
+"476 38 OFFCURVE",
+"478 38 CURVE SMOOTH",
+"479 38 OFFCURVE",
+"484 43 OFFCURVE",
+"491 46 CURVE",
+"496 52 OFFCURVE",
+"503 56 OFFCURVE",
+"503 56 CURVE",
+"503 56 OFFCURVE",
+"531 83 OFFCURVE",
+"541 97 CURVE",
+"555 112 OFFCURVE",
+"562 119 OFFCURVE",
+"569 140 CURVE",
+"578 163 OFFCURVE",
+"583 176 OFFCURVE",
+"588 212 CURVE",
+"588 238 OFFCURVE",
+"588 239 OFFCURVE",
+"588 255 CURVE",
+"583 276 OFFCURVE",
+"574 303 OFFCURVE",
+"566 320 CURVE SMOOTH",
+"560 331 OFFCURVE",
+"552 339 OFFCURVE",
+"532 359 CURVE SMOOTH",
+"510 382 OFFCURVE",
+"504 388 OFFCURVE",
+"493 393 CURVE SMOOTH",
+"484 396 OFFCURVE",
+"476 400 OFFCURVE",
+"473 403 CURVE SMOOTH",
+"471 405 OFFCURVE",
+"464 408 OFFCURVE",
+"459 410 CURVE SMOOTH",
+"454 411 OFFCURVE",
+"444 415 OFFCURVE",
+"436 419 CURVE SMOOTH",
+"428 422 OFFCURVE",
+"415 425 OFFCURVE",
+"408 427 CURVE SMOOTH",
+"388 432 OFFCURVE",
+"388 432 OFFCURVE",
+"389 458 CURVE SMOOTH",
+"389 469 OFFCURVE",
+"389 504 OFFCURVE",
+"391 537 CURVE",
+"393 670 OFFCURVE",
+"393 686 OFFCURVE",
+"403 689 CURVE",
+"403 693 OFFCURVE",
+"416 690 OFFCURVE",
+"428 684 CURVE",
+"441 681 OFFCURVE",
+"454 676 OFFCURVE",
+"454 674 CURVE",
+"456 672 OFFCURVE",
+"461 669 OFFCURVE",
+"464 667 CURVE SMOOTH",
+"474 662 OFFCURVE",
+"482 645 OFFCURVE",
+"479 633 CURVE",
+"479 630 OFFCURVE",
+"473 627 OFFCURVE",
+"456 619 CURVE SMOOTH",
+"425 603 OFFCURVE",
+"415 591 OFFCURVE",
+"410 564 CURVE",
+"404 542 OFFCURVE",
+"410 527 OFFCURVE",
+"430 509 CURVE SMOOTH",
+"447 492 OFFCURVE",
+"463 486 OFFCURVE",
+"490 487 CURVE",
+"512 489 OFFCURVE",
+"530 500 OFFCURVE",
+"546 523 CURVE SMOOTH",
+"557 540 OFFCURVE",
+"560 577 OFFCURVE",
+"554 608 CURVE",
+"550 620 OFFCURVE",
+"547 627 OFFCURVE",
+"538 640 CURVE SMOOTH",
+"525 659 OFFCURVE",
+"501 682 OFFCURVE",
+"491 689 CURVE",
+"488 690 OFFCURVE",
+"484 693 OFFCURVE",
+"482 695 CURVE",
+"482 696 OFFCURVE",
+"450 712 OFFCURVE",
+"448 712 CURVE SMOOTH",
+"447 712 OFFCURVE",
+"444 713 OFFCURVE",
+"440 715 CURVE SMOOTH",
+"437 716 OFFCURVE",
+"425 720 OFFCURVE",
+"415 723 CURVE SMOOTH",
+"393 730 OFFCURVE",
+"388 735 OFFCURVE",
+"389 743 CURVE",
+"391 745 OFFCURVE",
+"391 754 OFFCURVE",
+"393 762 CURVE",
+"393 779 OFFCURVE",
+"391 783 OFFCURVE",
+"380 784 CURVE",
+"374 786 OFFCURVE",
+"372 784 OFFCURVE",
+"368 779 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"361 695 OFFCURVE",
+"361 681 OFFCURVE",
+"361 564 CURVE SMOOTH",
+"361 445 OFFCURVE",
+"361 447 OFFCURVE",
+"349 445 CURVE",
+"340 445 OFFCURVE",
+"261 464 OFFCURVE",
+"259 469 CURVE SMOOTH",
+"258 470 OFFCURVE",
+"256 496 OFFCURVE",
+"256 503 CURVE SMOOTH",
+"256 504 OFFCURVE",
+"256 547 OFFCURVE",
+"258 596 CURVE",
+"258 669 OFFCURVE",
+"259 686 OFFCURVE",
+"261 689 CURVE SMOOTH",
+"266 698 OFFCURVE",
+"285 701 OFFCURVE",
+"327 701 CURVE SMOOTH",
+"347 701 OFFCURVE",
+"354 701 OFFCURVE",
+"354 698 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"227 674 OFFCURVE",
+"227 652 OFFCURVE",
+"227 608 CURVE SMOOTH",
+"227 572 OFFCURVE",
+"227 535 OFFCURVE",
+"227 527 CURVE SMOOTH",
+"228 509 OFFCURVE",
+"225 481 OFFCURVE",
+"222 478 CURVE SMOOTH",
+"219 476 OFFCURVE",
+"207 478 OFFCURVE",
+"194 483 CURVE",
+"190 486 OFFCURVE",
+"182 489 OFFCURVE",
+"177 492 CURVE SMOOTH",
+"160 498 OFFCURVE",
+"141 513 OFFCURVE",
+"132 529 CURVE SMOOTH",
+"127 538 OFFCURVE",
+"120 559 OFFCURVE",
+"118 571 CURVE",
+"118 591 OFFCURVE",
+"118 616 OFFCURVE",
+"141 633 CURVE",
+"151 645 OFFCURVE",
+"178 664 OFFCURVE",
+"186 669 CURVE",
+"190 670 OFFCURVE",
+"200 674 OFFCURVE",
+"202 678 CURVE",
+"202 682 OFFCURVE",
+"202 682 OFFCURVE",
+"225 676 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"325 288 OFFCURVE",
+"331 286 OFFCURVE",
+"344 281 CURVE",
+"364 275 OFFCURVE",
+"364 273 OFFCURVE",
+"361 238 CURVE",
+"361 224 OFFCURVE",
+"360 195 OFFCURVE",
+"360 174 CURVE SMOOTH",
+"361 33 OFFCURVE",
+"361 30 OFFCURVE",
+"352 27 CURVE SMOOTH",
+"347 26 OFFCURVE",
+"313 21 OFFCURVE",
+"300 21 CURVE SMOOTH",
+"292 21 OFFCURVE",
+"279 21 OFFCURVE",
+"273 22 CURVE SMOOTH",
+"254 24 OFFCURVE",
+"254 24 OFFCURVE",
+"254 86 CURVE SMOOTH",
+"254 115 OFFCURVE",
+"256 157 OFFCURVE",
+"256 183 CURVE SMOOTH",
+"256 239 OFFCURVE",
+"256 293 OFFCURVE",
+"256 297 CURVE SMOOTH",
+"256 300 OFFCURVE",
+"259 300 OFFCURVE",
+"290 295 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"453 246 OFFCURVE",
+"462 241 OFFCURVE",
+"478 229 CURVE SMOOTH",
+"496 216 OFFCURVE",
+"496 207 OFFCURVE",
+"504 195 CURVE",
+"510 185 OFFCURVE",
+"513 163 OFFCURVE",
+"513 149 CURVE SMOOTH",
+"513 132 OFFCURVE",
+"504 109 OFFCURVE",
+"488 89 CURVE",
+"474 70 OFFCURVE",
+"423 41 OFFCURVE",
+"402 39 CURVE",
+"393 39 OFFCURVE",
+"393 39 OFFCURVE",
+"389 44 CURVE",
+"388 49 OFFCURVE",
+"389 255 OFFCURVE",
+"391 261 CURVE",
+"394 266 OFFCURVE",
+"403 264 OFFCURVE",
+"427 256 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"483 -10 OFFCURVE",
+"586 89 OFFCURVE",
+"586 226 CURVE SMOOTH",
+"586 375 OFFCURVE",
+"463 412 OFFCURVE",
+"314 453 CURVE SMOOTH",
+"162 495 OFFCURVE",
+"118 513 OFFCURVE",
+"118 575 CURVE SMOOTH",
+"118 663 OFFCURVE",
+"207 697 OFFCURVE",
+"314 697 CURVE SMOOTH",
+"415 697 OFFCURVE",
+"479 667 OFFCURVE",
+"479 639 CURVE SMOOTH",
+"479 610 OFFCURVE",
+"413 609 OFFCURVE",
+"413 547 CURVE SMOOTH",
+"413 502 OFFCURVE",
+"448 485 OFFCURVE",
+"482 485 CURVE SMOOTH",
+"528 485 OFFCURVE",
+"559 517 OFFCURVE",
+"559 570 CURVE SMOOTH",
+"559 664 OFFCURVE",
+"462 733 OFFCURVE",
+"318 733 CURVE SMOOTH",
+"173 733 OFFCURVE",
+"49 664 OFFCURVE",
+"49 517 CURVE SMOOTH",
+"49 372 OFFCURVE",
+"170 322 OFFCURVE",
+"281 294 CURVE SMOOTH",
+"388 267 OFFCURVE",
+"514 254 OFFCURVE",
+"514 156 CURVE SMOOTH",
+"514 80 OFFCURVE",
+"437 26 OFFCURVE",
+"298 26 CURVE SMOOTH",
+"181 26 OFFCURVE",
+"107 64 OFFCURVE",
+"107 90 CURVE SMOOTH",
+"107 118 OFFCURVE",
+"191 104 OFFCURVE",
+"191 181 CURVE SMOOTH",
+"191 227 OFFCURVE",
+"160 257 OFFCURVE",
+"114 257 CURVE SMOOTH",
+"56 257 OFFCURVE",
+"23 211 OFFCURVE",
+"23 157 CURVE SMOOTH",
+"23 57 OFFCURVE",
+"138 -10 OFFCURVE",
+"294 -10 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"269 -113 LINE",
+"269 804 LINE",
+"229 804 LINE",
+"229 -113 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"391 -113 LINE",
+"391 804 LINE",
+"351 804 LINE",
+"351 -113 LINE"
+);
+}
+);
+width = 594;
+}
+);
+unicode = 0024;
+},
+{
+glyphname = euro;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"415 -13 OFFCURVE",
+"461 14 OFFCURVE",
+"481 40 CURVE",
+"521 0 LINE",
+"546 0 LINE",
+"546 179 LINE",
+"512 179 LINE",
+"497 86 OFFCURVE",
+"448 17 OFFCURVE",
+"356 17 CURVE SMOOTH",
+"271 17 OFFCURVE",
+"252 165 OFFCURVE",
+"251 279 CURVE",
+"485 279 LINE",
+"485 325 LINE",
+"251 325 LINE",
+"251 407 LINE",
+"485 407 LINE",
+"485 451 LINE",
+"251 451 LINE",
+"251 614 OFFCURVE",
+"288 703 OFFCURVE",
+"369 703 CURVE SMOOTH",
+"449 703 OFFCURVE",
+"497 633 OFFCURVE",
+"512 540 CURVE",
+"546 540 LINE",
+"546 733 LINE",
+"521 733 LINE",
+"483 679 LINE",
+"464 703 OFFCURVE",
+"421 734 OFFCURVE",
+"357 734 CURVE SMOOTH",
+"214 734 OFFCURVE",
+"135 587 OFFCURVE",
+"110 451 CURVE",
+"26 451 LINE",
+"26 407 LINE",
+"102 407 LINE",
+"101 392 OFFCURVE",
+"101 375 OFFCURVE",
+"101 360 CURVE SMOOTH",
+"101 325 LINE",
+"26 325 LINE",
+"26 279 LINE",
+"108 279 LINE",
+"130 139 OFFCURVE",
+"209 -13 OFFCURVE",
+"357 -13 CURVE SMOOTH"
+);
+}
+);
+width = 581;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"466 -13 OFFCURVE",
+"517 14 OFFCURVE",
+"541 40 CURVE",
+"581 0 LINE",
+"606 0 LINE",
+"606 179 LINE",
+"572 179 LINE",
+"556 95 OFFCURVE",
+"503 22 OFFCURVE",
+"423 22 CURVE SMOOTH",
+"310 22 OFFCURVE",
+"292 169 OFFCURVE",
+"291 279 CURVE",
+"525 279 LINE",
+"525 330 LINE",
+"291 330 LINE",
+"291 402 LINE",
+"525 402 LINE",
+"525 451 LINE",
+"291 451 LINE",
+"291 605 OFFCURVE",
+"328 698 OFFCURVE",
+"422 698 CURVE SMOOTH",
+"506 698 OFFCURVE",
+"555 625 OFFCURVE",
+"572 540 CURVE",
+"606 540 LINE",
+"606 733 LINE",
+"581 733 LINE",
+"543 679 LINE",
+"520 703 OFFCURVE",
+"472 734 OFFCURVE",
+"396 734 CURVE SMOOTH",
+"229 734 OFFCURVE",
+"138 584 OFFCURVE",
+"110 451 CURVE",
+"26 451 LINE",
+"26 402 LINE",
+"102 402 LINE",
+"101 389 OFFCURVE",
+"101 373 OFFCURVE",
+"101 360 CURVE SMOOTH",
+"101 330 LINE",
+"26 330 LINE",
+"26 279 LINE",
+"108 279 LINE",
+"134 139 OFFCURVE",
+"226 -13 OFFCURVE",
+"395 -13 CURVE SMOOTH"
+);
+}
+);
+width = 651;
+}
+);
+unicode = 20AC;
+},
+{
+glyphname = florin;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"32 -314 OFFCURVE",
+"144 -249 OFFCURVE",
+"194 45 CURVE SMOOTH",
+"271 501 LINE SMOOTH",
+"300 676 OFFCURVE",
+"335 724 OFFCURVE",
+"385 724 CURVE SMOOTH",
+"407 724 OFFCURVE",
+"420 715 OFFCURVE",
+"420 705 CURVE SMOOTH",
+"420 693 OFFCURVE",
+"402 682 OFFCURVE",
+"402 658 CURVE SMOOTH",
+"402 633 OFFCURVE",
+"420 613 OFFCURVE",
+"453 613 CURVE SMOOTH",
+"488 613 OFFCURVE",
+"505 636 OFFCURVE",
+"505 666 CURVE SMOOTH",
+"505 721 OFFCURVE",
+"447 754 OFFCURVE",
+"388 754 CURVE SMOOTH",
+"280 754 OFFCURVE",
+"160 644 OFFCURVE",
+"130 440 CURVE SMOOTH",
+"44 -140 LINE SMOOTH",
+"28 -247 OFFCURVE",
+"1 -284 OFFCURVE",
+"-40 -284 CURVE SMOOTH",
+"-59 -284 OFFCURVE",
+"-64 -276 OFFCURVE",
+"-64 -265 CURVE SMOOTH",
+"-64 -259 OFFCURVE",
+"-63 -246 OFFCURVE",
+"-63 -240 CURVE SMOOTH",
+"-63 -210 OFFCURVE",
+"-86 -193 OFFCURVE",
+"-112 -193 CURVE SMOOTH",
+"-139 -193 OFFCURVE",
+"-159 -211 OFFCURVE",
+"-159 -240 CURVE SMOOTH",
+"-159 -292 OFFCURVE",
+"-93 -314 OFFCURVE",
+"-47 -314 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"362 396 LINE",
+"362 440 LINE",
+"41 440 LINE",
+"41 396 LINE"
+);
+}
+);
+width = 435;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"10 -314 OFFCURVE",
+"144 -250 OFFCURVE",
+"194 45 CURVE SMOOTH",
+"271 501 LINE SMOOTH",
+"300 673 OFFCURVE",
+"334 724 OFFCURVE",
+"383 724 CURVE SMOOTH",
+"403 724 OFFCURVE",
+"415 715 OFFCURVE",
+"415 705 CURVE SMOOTH",
+"415 691 OFFCURVE",
+"393 676 OFFCURVE",
+"393 643 CURVE SMOOTH",
+"393 614 OFFCURVE",
+"411 588 OFFCURVE",
+"453 588 CURVE SMOOTH",
+"497 588 OFFCURVE",
+"520 615 OFFCURVE",
+"520 654 CURVE SMOOTH",
+"520 721 OFFCURVE",
+"453 754 OFFCURVE",
+"389 754 CURVE SMOOTH",
+"275 754 OFFCURVE",
+"141 649 OFFCURVE",
+"102 387 CURVE SMOOTH",
+"24 -140 LINE SMOOTH",
+"8 -247 OFFCURVE",
+"-24 -284 OFFCURVE",
+"-70 -284 CURVE SMOOTH",
+"-89 -284 OFFCURVE",
+"-94 -276 OFFCURVE",
+"-94 -265 CURVE SMOOTH",
+"-94 -257 OFFCURVE",
+"-88 -238 OFFCURVE",
+"-88 -230 CURVE SMOOTH",
+"-88 -194 OFFCURVE",
+"-115 -173 OFFCURVE",
+"-142 -173 CURVE SMOOTH",
+"-181 -173 OFFCURVE",
+"-209 -195 OFFCURVE",
+"-209 -230 CURVE SMOOTH",
+"-209 -289 OFFCURVE",
+"-132 -314 OFFCURVE",
+"-76 -314 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"382 391 LINE",
+"382 440 LINE",
+"21 440 LINE",
+"21 391 LINE"
+);
+}
+);
+width = 435;
+}
+);
+unicode = 0192;
+},
+{
+glyphname = franc;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"372 0 LINE",
+"372 25 LINE",
+"262 25 LINE",
+"262 155 LINE",
+"372 155 LINE",
+"372 199 LINE",
+"262 199 LINE",
+"262 383 LINE",
+"383 382 OFFCURVE",
+"414 347 OFFCURVE",
+"417 236 CURVE",
+"452 236 LINE",
+"452 546 LINE",
+"417 546 LINE",
+"417 439 OFFCURVE",
+"383 408 OFFCURVE",
+"262 408 CURVE",
+"262 729 LINE",
+"428 729 LINE SMOOTH",
+"527 729 OFFCURVE",
+"584 626 OFFCURVE",
+"586 509 CURVE",
+"621 509 LINE",
+"621 754 LINE",
+"10 754 LINE",
+"10 729 LINE",
+"128 729 LINE",
+"128 199 LINE",
+"10 199 LINE",
+"10 155 LINE",
+"128 155 LINE",
+"128 25 LINE",
+"10 25 LINE",
+"10 0 LINE"
+);
+}
+);
+width = 642;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"401 0 LINE",
+"401 30 LINE",
+"273 30 LINE",
+"273 150 LINE",
+"402 150 LINE",
+"402 199 LINE",
+"273 199 LINE",
+"273 365 LINE",
+"402 364 OFFCURVE",
+"450 320 OFFCURVE",
+"452 225 CURVE",
+"492 225 LINE",
+"492 525 LINE",
+"452 525 LINE",
+"450 437 OFFCURVE",
+"402 396 OFFCURVE",
+"273 395 CURVE",
+"273 724 LINE",
+"443 724 LINE SMOOTH",
+"545 724 OFFCURVE",
+"604 639 OFFCURVE",
+"606 539 CURVE",
+"646 539 LINE",
+"646 754 LINE",
+"20 754 LINE",
+"20 724 LINE",
+"115 724 LINE",
+"115 199 LINE",
+"20 199 LINE",
+"20 150 LINE",
+"115 150 LINE",
+"115 30 LINE",
+"20 30 LINE",
+"20 0 LINE"
+);
+}
+);
+width = 702;
+}
+);
+unicode = 20A3;
+},
+{
+glyphname = lira;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"157 -20 OFFCURVE",
+"206 15 OFFCURVE",
+"226 54 CURVE",
+"295 -7 OFFCURVE",
+"335 -20 OFFCURVE",
+"379 -20 CURVE SMOOTH",
+"512 -20 OFFCURVE",
+"531 101 OFFCURVE",
+"531 204 CURVE",
+"507 204 LINE",
+"503 113 OFFCURVE",
+"451 79 OFFCURVE",
+"377 79 CURVE SMOOTH",
+"335 79 OFFCURVE",
+"289 90 OFFCURVE",
+"250 111 CURVE",
+"274 167 OFFCURVE",
+"286 225 OFFCURVE",
+"286 286 CURVE SMOOTH",
+"286 398 OFFCURVE",
+"246 485 OFFCURVE",
+"246 571 CURVE SMOOTH",
+"246 649 OFFCURVE",
+"279 703 OFFCURVE",
+"363 703 CURVE SMOOTH",
+"432 703 OFFCURVE",
+"464 666 OFFCURVE",
+"464 643 CURVE SMOOTH",
+"464 612 OFFCURVE",
+"406 616 OFFCURVE",
+"406 568 CURVE SMOOTH",
+"406 540 OFFCURVE",
+"425 519 OFFCURVE",
+"458 519 CURVE SMOOTH",
+"501 519 OFFCURVE",
+"521 553 OFFCURVE",
+"521 596 CURVE SMOOTH",
+"521 679 OFFCURVE",
+"447 733 OFFCURVE",
+"350 733 CURVE SMOOTH",
+"206 733 OFFCURVE",
+"134 615 OFFCURVE",
+"134 470 CURVE SMOOTH",
+"134 330 OFFCURVE",
+"201 242 OFFCURVE",
+"201 154 CURVE",
+"201 145 OFFCURVE",
+"201 135 OFFCURVE",
+"199 126 CURVE",
+"172 135 OFFCURVE",
+"143 144 OFFCURVE",
+"114 144 CURVE SMOOTH",
+"64 144 OFFCURVE",
+"16 117 OFFCURVE",
+"16 60 CURVE SMOOTH",
+"16 12 OFFCURVE",
+"49 -20 OFFCURVE",
+"102 -20 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"75 10 OFFCURVE",
+"53 28 OFFCURVE",
+"53 58 CURVE SMOOTH",
+"53 91 OFFCURVE",
+"80 110 OFFCURVE",
+"109 110 CURVE SMOOTH",
+"134 110 OFFCURVE",
+"172 96 OFFCURVE",
+"191 78 CURVE",
+"178 47 OFFCURVE",
+"140 10 OFFCURVE",
+"102 10 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"415 276 LINE",
+"415 320 LINE",
+"41 320 LINE",
+"41 276 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"415 396 LINE",
+"415 440 LINE",
+"41 440 LINE",
+"41 396 LINE"
+);
+}
+);
+width = 559;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"53 91 OFFCURVE",
+"80 110 OFFCURVE",
+"109 110 CURVE SMOOTH",
+"134 110 OFFCURVE",
+"172 96 OFFCURVE",
+"191 78 CURVE",
+"178 47 OFFCURVE",
+"140 10 OFFCURVE",
+"102 10 CURVE SMOOTH",
+"75 10 OFFCURVE",
+"53 28 OFFCURVE",
+"53 58 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"201 145 OFFCURVE",
+"201 135 OFFCURVE",
+"199 126 CURVE",
+"172 135 OFFCURVE",
+"143 144 OFFCURVE",
+"114 144 CURVE SMOOTH",
+"64 144 OFFCURVE",
+"16 117 OFFCURVE",
+"16 60 CURVE SMOOTH",
+"16 12 OFFCURVE",
+"49 -20 OFFCURVE",
+"102 -20 CURVE SMOOTH",
+"157 -20 OFFCURVE",
+"206 15 OFFCURVE",
+"226 54 CURVE",
+"295 -7 OFFCURVE",
+"335 -20 OFFCURVE",
+"379 -20 CURVE SMOOTH",
+"512 -20 OFFCURVE",
+"531 101 OFFCURVE",
+"531 204 CURVE",
+"507 204 LINE",
+"503 113 OFFCURVE",
+"451 79 OFFCURVE",
+"377 79 CURVE SMOOTH",
+"335 79 OFFCURVE",
+"289 90 OFFCURVE",
+"250 111 CURVE",
+"274 167 OFFCURVE",
+"286 225 OFFCURVE",
+"286 286 CURVE SMOOTH",
+"286 398 OFFCURVE",
+"246 485 OFFCURVE",
+"246 571 CURVE SMOOTH",
+"246 649 OFFCURVE",
+"279 703 OFFCURVE",
+"363 703 CURVE SMOOTH",
+"432 703 OFFCURVE",
+"464 666 OFFCURVE",
+"464 643 CURVE SMOOTH",
+"464 612 OFFCURVE",
+"406 616 OFFCURVE",
+"406 568 CURVE SMOOTH",
+"406 540 OFFCURVE",
+"425 519 OFFCURVE",
+"458 519 CURVE SMOOTH",
+"501 519 OFFCURVE",
+"521 553 OFFCURVE",
+"521 596 CURVE SMOOTH",
+"521 679 OFFCURVE",
+"447 733 OFFCURVE",
+"350 733 CURVE SMOOTH",
+"206 733 OFFCURVE",
+"134 615 OFFCURVE",
+"134 470 CURVE SMOOTH",
+"134 330 OFFCURVE",
+"201 242 OFFCURVE",
+"201 154 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"41 396 LINE",
+"415 396 LINE",
+"415 440 LINE",
+"41 440 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"41 276 LINE",
+"415 276 LINE",
+"415 320 LINE",
+"41 320 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"165 -20 OFFCURVE",
+"224 17 OFFCURVE",
+"246 54 CURVE",
+"301 -3 OFFCURVE",
+"342 -20 OFFCURVE",
+"386 -20 CURVE SMOOTH",
+"508 -20 OFFCURVE",
+"546 113 OFFCURVE",
+"546 204 CURVE",
+"507 204 LINE",
+"502 122 OFFCURVE",
+"447 99 OFFCURVE",
+"374 99 CURVE SMOOTH",
+"343 99 OFFCURVE",
+"303 103 OFFCURVE",
+"270 111 CURVE",
+"294 167 OFFCURVE",
+"306 225 OFFCURVE",
+"306 286 CURVE SMOOTH",
+"306 397 OFFCURVE",
+"266 486 OFFCURVE",
+"266 569 CURVE SMOOTH",
+"266 644 OFFCURVE",
+"298 698 OFFCURVE",
+"373 698 CURVE SMOOTH",
+"429 698 OFFCURVE",
+"464 667 OFFCURVE",
+"464 643 CURVE SMOOTH",
+"464 611 OFFCURVE",
+"406 614 OFFCURVE",
+"406 563 CURVE SMOOTH",
+"406 532 OFFCURVE",
+"427 509 OFFCURVE",
+"463 509 CURVE SMOOTH",
+"510 509 OFFCURVE",
+"531 548 OFFCURVE",
+"531 593 CURVE SMOOTH",
+"531 681 OFFCURVE",
+"453 733 OFFCURVE",
+"349 733 CURVE SMOOTH",
+"192 733 OFFCURVE",
+"114 614 OFFCURVE",
+"114 471 CURVE SMOOTH",
+"114 333 OFFCURVE",
+"186 248 OFFCURVE",
+"186 164 CURVE SMOOTH",
+"186 155 OFFCURVE",
+"186 145 OFFCURVE",
+"184 136 CURVE",
+"159 139 OFFCURVE",
+"137 144 OFFCURVE",
+"115 144 CURVE SMOOTH",
+"63 144 OFFCURVE",
+"16 117 OFFCURVE",
+"16 59 CURVE SMOOTH",
+"16 12 OFFCURVE",
+"48 -20 OFFCURVE",
+"104 -20 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"79 15 OFFCURVE",
+"58 31 OFFCURVE",
+"58 58 CURVE SMOOTH",
+"58 86 OFFCURVE",
+"79 105 OFFCURVE",
+"110 105 CURVE SMOOTH",
+"129 105 OFFCURVE",
+"160 98 OFFCURVE",
+"176 88 CURVE",
+"165 55 OFFCURVE",
+"135 15 OFFCURVE",
+"101 15 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"435 271 LINE",
+"435 320 LINE",
+"41 320 LINE",
+"41 271 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"435 395 LINE",
+"435 444 LINE",
+"41 444 LINE",
+"41 395 LINE"
+);
+}
+);
+width = 559;
+}
+);
+unicode = 20A4;
+},
+{
+glyphname = liraTurkish;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"266 0 LINE SMOOTH",
+"452 0 OFFCURVE",
+"556 86 OFFCURVE",
+"556 222 CURVE SMOOTH",
+"556 298 OFFCURVE",
+"523 339 OFFCURVE",
+"470 339 CURVE SMOOTH",
+"434 339 OFFCURVE",
+"412 321 OFFCURVE",
+"412 291 CURVE SMOOTH",
+"412 267 OFFCURVE",
+"426 249 OFFCURVE",
+"454 249 CURVE SMOOTH",
+"495 249 OFFCURVE",
+"486 286 OFFCURVE",
+"505 286 CURVE SMOOTH",
+"519 286 OFFCURVE",
+"528 264 OFFCURVE",
+"528 223 CURVE SMOOTH",
+"528 96 OFFCURVE",
+"442 25 OFFCURVE",
+"269 25 CURVE SMOOTH",
+"20 25 LINE",
+"20 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"272 15 LINE",
+"272 754 LINE",
+"138 754 LINE",
+"138 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"470 427 LINE",
+"470 474 LINE",
+"35 318 LINE",
+"35 271 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"470 555 LINE",
+"470 602 LINE",
+"35 446 LINE",
+"35 399 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"393 729 LINE",
+"393 754 LINE",
+"20 754 LINE",
+"20 729 LINE"
+);
+}
+);
+width = 570;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"266 0 LINE SMOOTH",
+"452 0 OFFCURVE",
+"556 82 OFFCURVE",
+"556 212 CURVE SMOOTH",
+"556 294 OFFCURVE",
+"520 339 OFFCURVE",
+"463 339 CURVE SMOOTH",
+"421 339 OFFCURVE",
+"395 317 OFFCURVE",
+"395 281 CURVE SMOOTH",
+"395 251 OFFCURVE",
+"410 229 OFFCURVE",
+"442 229 CURVE SMOOTH",
+"487 229 OFFCURVE",
+"477 276 OFFCURVE",
+"498 276 CURVE SMOOTH",
+"512 276 OFFCURVE",
+"521 253 OFFCURVE",
+"521 213 CURVE SMOOTH",
+"521 98 OFFCURVE",
+"437 35 OFFCURVE",
+"269 35 CURVE SMOOTH",
+"20 35 LINE",
+"20 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"273 20 LINE",
+"273 754 LINE",
+"115 754 LINE",
+"115 20 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"470 422 LINE",
+"470 474 LINE",
+"35 318 LINE",
+"35 266 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"470 555 LINE",
+"470 607 LINE",
+"35 451 LINE",
+"35 399 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"393 724 LINE",
+"393 754 LINE",
+"20 754 LINE",
+"20 724 LINE"
+);
+}
+);
+width = 576;
+}
+);
+unicode = 20BA;
+},
+{
+glyphname = naira;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+components = (
+{
+name = N;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"722 512 LINE",
+"722 556 LINE",
+"20 556 LINE",
+"20 512 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"722 386 LINE",
+"722 430 LINE",
+"20 430 LINE",
+"20 386 LINE"
+);
+}
+);
+width = 744;
+},
+{
+components = (
+{
+name = N;
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"772 380 LINE",
+"772 429 LINE",
+"20 429 LINE",
+"20 380 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"772 511 LINE",
+"772 559 LINE",
+"20 559 LINE",
+"20 511 LINE"
+);
+}
+);
+width = 743;
+}
+);
+unicode = 20A6;
+},
+{
+glyphname = rupeeIndian;
+lastChange = "2016-08-19 17:07:29 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"133 367 LINE SMOOTH",
+"337 367 OFFCURVE",
+"458 446 OFFCURVE",
+"458 562 CURVE SMOOTH",
+"458 671 OFFCURVE",
+"317 734 OFFCURVE",
+"133 734 CURVE SMOOTH",
+"47 734 LINE",
+"47 690 LINE",
+"183 690 LINE SMOOTH",
+"274 690 OFFCURVE",
+"303 651 OFFCURVE",
+"303 565 CURVE SMOOTH",
+"303 427 OFFCURVE",
+"253 397 OFFCURVE",
+"133 397 CURVE SMOOTH",
+"50 397 LINE",
+"50 367 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"535 0 LINE",
+"535 25 LINE",
+"497 25 LINE SMOOTH",
+"446 25 OFFCURVE",
+"428 52 OFFCURVE",
+"428 144 CURVE SMOOTH",
+"428 176 LINE SMOOTH",
+"428 271 OFFCURVE",
+"339 354 OFFCURVE",
+"254 374 CURVE",
+"254 378 LINE",
+"217 378 LINE",
+"141 367 LINE",
+"219 367 OFFCURVE",
+"275 317 OFFCURVE",
+"279 212 CURVE SMOOTH",
+"282 153 LINE SMOOTH",
+"287 60 OFFCURVE",
+"361 0 OFFCURVE",
+"458 0 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"569 564 LINE",
+"569 608 LINE",
+"47 608 LINE",
+"47 564 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"569 690 LINE",
+"569 734 LINE",
+"47 734 LINE",
+"47 690 LINE"
+);
+}
+);
+width = 570;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"133 380 LINE SMOOTH",
+"360 380 OFFCURVE",
+"493 455 OFFCURVE",
+"493 562 CURVE SMOOTH",
+"493 671 OFFCURVE",
+"340 734 OFFCURVE",
+"133 734 CURVE SMOOTH",
+"47 734 LINE",
+"47 690 LINE",
+"183 690 LINE SMOOTH",
+"274 690 OFFCURVE",
+"303 651 OFFCURVE",
+"303 565 CURVE SMOOTH",
+"303 446 OFFCURVE",
+"253 420 OFFCURVE",
+"133 420 CURVE SMOOTH",
+"50 420 LINE",
+"50 380 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"574 0 LINE",
+"574 32 LINE",
+"532 32 LINE SMOOTH",
+"484 32 OFFCURVE",
+"466 59 OFFCURVE",
+"466 144 CURVE SMOOTH",
+"466 196 LINE SMOOTH",
+"466 275 OFFCURVE",
+"390 365 OFFCURVE",
+"289 391 CURVE",
+"289 395 LINE",
+"217 391 LINE",
+"141 380 LINE",
+"214 380 OFFCURVE",
+"269 341 OFFCURVE",
+"273 246 CURVE SMOOTH",
+"277 153 LINE SMOOTH",
+"282 60 OFFCURVE",
+"364 0 OFFCURVE",
+"453 0 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"604 559 LINE",
+"604 608 LINE",
+"47 608 LINE",
+"47 559 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"604 685 LINE",
+"604 734 LINE",
+"47 734 LINE",
+"47 685 LINE"
+);
+}
+);
+width = 604;
+}
+);
+unicode = 20B9;
+},
+{
+glyphname = sterling;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"157 -20 OFFCURVE",
+"206 15 OFFCURVE",
+"226 54 CURVE",
+"295 -7 OFFCURVE",
+"335 -20 OFFCURVE",
+"379 -20 CURVE SMOOTH",
+"512 -20 OFFCURVE",
+"531 101 OFFCURVE",
+"531 204 CURVE",
+"507 204 LINE",
+"503 113 OFFCURVE",
+"451 79 OFFCURVE",
+"377 79 CURVE SMOOTH",
+"335 79 OFFCURVE",
+"289 90 OFFCURVE",
+"250 111 CURVE",
+"274 167 OFFCURVE",
+"286 225 OFFCURVE",
+"286 286 CURVE SMOOTH",
+"286 398 OFFCURVE",
+"246 485 OFFCURVE",
+"246 571 CURVE SMOOTH",
+"246 649 OFFCURVE",
+"279 703 OFFCURVE",
+"363 703 CURVE SMOOTH",
+"432 703 OFFCURVE",
+"464 666 OFFCURVE",
+"464 643 CURVE SMOOTH",
+"464 612 OFFCURVE",
+"406 616 OFFCURVE",
+"406 568 CURVE SMOOTH",
+"406 540 OFFCURVE",
+"425 519 OFFCURVE",
+"458 519 CURVE SMOOTH",
+"501 519 OFFCURVE",
+"521 553 OFFCURVE",
+"521 596 CURVE SMOOTH",
+"521 679 OFFCURVE",
+"447 733 OFFCURVE",
+"350 733 CURVE SMOOTH",
+"206 733 OFFCURVE",
+"134 615 OFFCURVE",
+"134 470 CURVE SMOOTH",
+"134 330 OFFCURVE",
+"201 242 OFFCURVE",
+"201 154 CURVE",
+"201 145 OFFCURVE",
+"201 135 OFFCURVE",
+"199 126 CURVE",
+"172 135 OFFCURVE",
+"143 144 OFFCURVE",
+"114 144 CURVE SMOOTH",
+"64 144 OFFCURVE",
+"16 117 OFFCURVE",
+"16 60 CURVE SMOOTH",
+"16 12 OFFCURVE",
+"49 -20 OFFCURVE",
+"102 -20 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"75 10 OFFCURVE",
+"53 28 OFFCURVE",
+"53 58 CURVE SMOOTH",
+"53 91 OFFCURVE",
+"80 110 OFFCURVE",
+"109 110 CURVE SMOOTH",
+"134 110 OFFCURVE",
+"172 96 OFFCURVE",
+"191 78 CURVE",
+"178 47 OFFCURVE",
+"140 10 OFFCURVE",
+"102 10 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"415 355 LINE",
+"415 399 LINE",
+"41 399 LINE",
+"41 355 LINE"
+);
+}
+);
+width = 559;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"165 -20 OFFCURVE",
+"224 17 OFFCURVE",
+"246 54 CURVE",
+"301 -3 OFFCURVE",
+"342 -20 OFFCURVE",
+"386 -20 CURVE SMOOTH",
+"508 -20 OFFCURVE",
+"546 113 OFFCURVE",
+"546 204 CURVE",
+"507 204 LINE",
+"502 122 OFFCURVE",
+"447 99 OFFCURVE",
+"374 99 CURVE SMOOTH",
+"343 99 OFFCURVE",
+"303 103 OFFCURVE",
+"270 111 CURVE",
+"294 167 OFFCURVE",
+"306 225 OFFCURVE",
+"306 286 CURVE SMOOTH",
+"306 397 OFFCURVE",
+"266 486 OFFCURVE",
+"266 569 CURVE SMOOTH",
+"266 644 OFFCURVE",
+"298 698 OFFCURVE",
+"373 698 CURVE SMOOTH",
+"429 698 OFFCURVE",
+"464 667 OFFCURVE",
+"464 643 CURVE SMOOTH",
+"464 611 OFFCURVE",
+"406 614 OFFCURVE",
+"406 563 CURVE SMOOTH",
+"406 532 OFFCURVE",
+"427 509 OFFCURVE",
+"463 509 CURVE SMOOTH",
+"510 509 OFFCURVE",
+"531 548 OFFCURVE",
+"531 593 CURVE SMOOTH",
+"531 681 OFFCURVE",
+"453 733 OFFCURVE",
+"349 733 CURVE SMOOTH",
+"192 733 OFFCURVE",
+"114 614 OFFCURVE",
+"114 471 CURVE SMOOTH",
+"114 333 OFFCURVE",
+"186 248 OFFCURVE",
+"186 164 CURVE",
+"186 155 OFFCURVE",
+"186 145 OFFCURVE",
+"184 136 CURVE",
+"159 139 OFFCURVE",
+"137 144 OFFCURVE",
+"115 144 CURVE SMOOTH",
+"63 144 OFFCURVE",
+"16 117 OFFCURVE",
+"16 59 CURVE SMOOTH",
+"16 12 OFFCURVE",
+"48 -20 OFFCURVE",
+"104 -20 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"79 15 OFFCURVE",
+"58 31 OFFCURVE",
+"58 58 CURVE SMOOTH",
+"58 86 OFFCURVE",
+"79 105 OFFCURVE",
+"110 105 CURVE SMOOTH",
+"129 105 OFFCURVE",
+"160 98 OFFCURVE",
+"176 88 CURVE",
+"165 55 OFFCURVE",
+"135 15 OFFCURVE",
+"101 15 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"435 355 LINE",
+"435 404 LINE",
+"41 404 LINE",
+"41 355 LINE"
+);
+}
+);
+width = 559;
+}
+);
+unicode = 00A3;
+},
+{
+glyphname = won;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+components = (
+{
+name = W;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"958 502 LINE",
+"958 546 LINE",
+"40 546 LINE",
+"40 502 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"958 376 LINE",
+"958 420 LINE",
+"40 420 LINE",
+"40 376 LINE"
+);
+}
+);
+width = 907;
+},
+{
+components = (
+{
+name = W;
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"978 497 LINE",
+"978 546 LINE",
+"20 546 LINE",
+"20 497 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"978 371 LINE",
+"978 420 LINE",
+"20 420 LINE",
+"20 371 LINE"
+);
+}
+);
+width = 998;
+}
+);
+unicode = 20A9;
+},
+{
+glyphname = yen;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"577 0 LINE",
+"577 25 LINE",
+"457 25 LINE",
+"457 362 LINE",
+"654 729 LINE",
+"750 729 LINE",
+"750 754 LINE",
+"485 754 LINE",
+"485 729 LINE",
+"621 729 LINE",
+"442 402 LINE",
+"438 402 LINE",
+"249 729 LINE",
+"357 729 LINE",
+"357 754 LINE",
+"10 754 LINE",
+"10 729 LINE",
+"99 729 LINE",
+"323 343 LINE",
+"323 25 LINE",
+"203 25 LINE",
+"203 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"633 208 LINE",
+"633 252 LINE",
+"141 252 LINE",
+"141 208 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"633 334 LINE",
+"633 378 LINE",
+"141 378 LINE",
+"141 334 LINE"
+);
+}
+);
+width = 760;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"593 0 LINE",
+"593 30 LINE",
+"475 30 LINE",
+"475 342 LINE",
+"667 724 LINE",
+"756 724 LINE",
+"756 754 LINE",
+"521 754 LINE",
+"521 724 LINE",
+"629 724 LINE",
+"467 403 LINE",
+"463 403 LINE",
+"276 724 LINE",
+"362 724 LINE",
+"362 754 LINE",
+"10 754 LINE",
+"10 724 LINE",
+"78 724 LINE",
+"317 329 LINE",
+"317 30 LINE",
+"202 30 LINE",
+"202 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"633 203 LINE",
+"633 252 LINE",
+"141 252 LINE",
+"141 203 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"633 329 LINE",
+"633 378 LINE",
+"141 378 LINE",
+"141 329 LINE"
+);
+}
+);
+width = 766;
+}
+);
+unicode = 00A5;
+},
+{
+glyphname = bulletoperator;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"123 177 OFFCURVE",
+"156 210 OFFCURVE",
+"156 250 CURVE SMOOTH",
+"156 290 OFFCURVE",
+"123 323 OFFCURVE",
+"83 323 CURVE SMOOTH",
+"43 323 OFFCURVE",
+"10 290 OFFCURVE",
+"10 250 CURVE SMOOTH",
+"10 210 OFFCURVE",
+"43 177 OFFCURVE",
+"83 177 CURVE SMOOTH"
+);
+}
+);
+width = 166;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"185 167 OFFCURVE",
+"224 206 OFFCURVE",
+"224 254 CURVE SMOOTH",
+"224 302 OFFCURVE",
+"185 341 OFFCURVE",
+"137 341 CURVE SMOOTH",
+"89 341 OFFCURVE",
+"50 302 OFFCURVE",
+"50 254 CURVE SMOOTH",
+"50 206 OFFCURVE",
+"89 167 OFFCURVE",
+"137 167 CURVE SMOOTH"
+);
+}
+);
+width = 274;
+}
+);
+unicode = 2219;
+},
+{
+glyphname = divisionslash;
+lastChange = "2016-08-18 21:39:28 +0000";
+layers = (
+{
+components = (
+{
+name = fraction;
+}
+);
+layerId = UUID0;
+width = 489;
+},
+{
+components = (
+{
+name = fraction;
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 489;
+}
+);
+unicode = 2215;
+},
+{
+glyphname = plus;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"40 309 LINE",
+"538 309 LINE",
+"538 377 LINE",
+"40 377 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"323 74 LINE",
+"323 612 LINE",
+"255 612 LINE",
+"255 74 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"311 74 LINE",
+"311 612 LINE",
+"267 612 LINE",
+"267 74 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"538 321 LINE",
+"538 365 LINE",
+"40 365 LINE",
+"40 321 LINE"
+);
+}
+);
+width = 578;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"40 304 LINE",
+"538 304 LINE",
+"538 382 LINE",
+"40 382 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"328 74 LINE",
+"328 612 LINE",
+"250 612 LINE",
+"250 74 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"316 74 LINE",
+"316 612 LINE",
+"262 612 LINE",
+"262 74 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"538 316 LINE",
+"538 370 LINE",
+"40 370 LINE",
+"40 316 LINE"
+);
+}
+);
+width = 578;
+}
+);
+unicode = 002B;
+},
+{
+glyphname = minus;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"40 309 LINE",
+"538 309 LINE",
+"538 377 LINE",
+"40 377 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"538 321 LINE",
+"538 365 LINE",
+"40 365 LINE",
+"40 321 LINE"
+);
+}
+);
+width = 578;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"40 304 LINE",
+"538 304 LINE",
+"538 382 LINE",
+"40 382 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"538 316 LINE",
+"538 370 LINE",
+"40 370 LINE",
+"40 316 LINE"
+);
+}
+);
+width = 578;
+}
+);
+unicode = 2212;
+},
+{
+glyphname = multiply;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"60 524 LINE",
+"470 114 LINE",
+"518 162 LINE",
+"108 572 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"108 114 LINE",
+"518 524 LINE",
+"470 572 LINE",
+"60 162 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"510 154 LINE",
+"100 564 LINE",
+"68 532 LINE",
+"478 122 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"508 534 LINE",
+"478 564 LINE",
+"70 156 LINE",
+"98 124 LINE"
+);
+}
+);
+width = 578;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"40 309 LINE",
+"538 309 LINE",
+"538 377 LINE",
+"40 377 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"323 74 LINE",
+"323 612 LINE",
+"255 612 LINE",
+"255 74 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"56 517 LINE",
+"466 107 LINE",
+"521 169 LINE",
+"111 579 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"116 112 LINE",
+"526 522 LINE",
+"467 580 LINE",
+"57 170 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"521 532 LINE",
+"477 575 LINE",
+"67 165 LINE",
+"111 122 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"511 164 LINE",
+"101 574 LINE",
+"61 527 LINE",
+"471 117 LINE"
+);
+}
+);
+width = 578;
+}
+);
+unicode = 00D7;
+},
+{
+glyphname = divide;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"40 309 LINE",
+"538 309 LINE",
+"538 377 LINE",
+"40 377 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"221 116 OFFCURVE",
+"254 83 OFFCURVE",
+"294 83 CURVE SMOOTH",
+"334 83 OFFCURVE",
+"367 116 OFFCURVE",
+"367 156 CURVE SMOOTH",
+"367 196 OFFCURVE",
+"334 229 OFFCURVE",
+"294 229 CURVE SMOOTH",
+"254 229 OFFCURVE",
+"221 196 OFFCURVE",
+"221 156 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"221 490 OFFCURVE",
+"254 457 OFFCURVE",
+"294 457 CURVE SMOOTH",
+"334 457 OFFCURVE",
+"367 490 OFFCURVE",
+"367 530 CURVE SMOOTH",
+"367 570 OFFCURVE",
+"334 603 OFFCURVE",
+"294 603 CURVE SMOOTH",
+"254 603 OFFCURVE",
+"221 570 OFFCURVE",
+"221 530 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"538 321 LINE",
+"538 365 LINE",
+"40 365 LINE",
+"40 321 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"326 97 OFFCURVE",
+"353 124 OFFCURVE",
+"353 156 CURVE SMOOTH",
+"353 188 OFFCURVE",
+"326 215 OFFCURVE",
+"294 215 CURVE SMOOTH",
+"262 215 OFFCURVE",
+"235 188 OFFCURVE",
+"235 156 CURVE SMOOTH",
+"235 124 OFFCURVE",
+"262 97 OFFCURVE",
+"294 97 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"326 471 OFFCURVE",
+"353 498 OFFCURVE",
+"353 530 CURVE SMOOTH",
+"353 563 OFFCURVE",
+"326 589 OFFCURVE",
+"294 589 CURVE SMOOTH",
+"262 589 OFFCURVE",
+"235 563 OFFCURVE",
+"235 530 CURVE SMOOTH",
+"235 498 OFFCURVE",
+"262 471 OFFCURVE",
+"294 471 CURVE SMOOTH"
+);
+}
+);
+width = 578;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"40 304 LINE",
+"538 304 LINE",
+"538 382 LINE",
+"40 382 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"207 94 OFFCURVE",
+"246 55 OFFCURVE",
+"294 55 CURVE SMOOTH",
+"342 55 OFFCURVE",
+"381 94 OFFCURVE",
+"381 142 CURVE SMOOTH",
+"381 190 OFFCURVE",
+"342 229 OFFCURVE",
+"294 229 CURVE SMOOTH",
+"246 229 OFFCURVE",
+"207 190 OFFCURVE",
+"207 142 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"207 496 OFFCURVE",
+"246 457 OFFCURVE",
+"294 457 CURVE SMOOTH",
+"342 457 OFFCURVE",
+"381 496 OFFCURVE",
+"381 544 CURVE SMOOTH",
+"381 592 OFFCURVE",
+"342 631 OFFCURVE",
+"294 631 CURVE SMOOTH",
+"246 631 OFFCURVE",
+"207 592 OFFCURVE",
+"207 544 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"538 316 LINE",
+"538 370 LINE",
+"40 370 LINE",
+"40 316 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"336 65 OFFCURVE",
+"371 100 OFFCURVE",
+"371 142 CURVE SMOOTH",
+"371 184 OFFCURVE",
+"336 219 OFFCURVE",
+"294 219 CURVE SMOOTH",
+"252 219 OFFCURVE",
+"217 184 OFFCURVE",
+"217 142 CURVE SMOOTH",
+"217 100 OFFCURVE",
+"252 65 OFFCURVE",
+"294 65 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"336 467 OFFCURVE",
+"371 502 OFFCURVE",
+"371 544 CURVE SMOOTH",
+"371 586 OFFCURVE",
+"336 621 OFFCURVE",
+"294 621 CURVE SMOOTH",
+"252 621 OFFCURVE",
+"217 586 OFFCURVE",
+"217 544 CURVE SMOOTH",
+"217 502 OFFCURVE",
+"252 467 OFFCURVE",
+"294 467 CURVE SMOOTH"
+);
+}
+);
+width = 578;
+}
+);
+unicode = 00F7;
+},
+{
+glyphname = equal;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"50 394 LINE",
+"548 394 LINE",
+"548 462 LINE",
+"50 462 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"50 225 LINE",
+"548 225 LINE",
+"548 293 LINE",
+"50 293 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"548 402 LINE",
+"548 450 LINE",
+"50 450 LINE",
+"50 402 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"548 235 LINE",
+"548 283 LINE",
+"50 283 LINE",
+"50 235 LINE"
+);
+}
+);
+width = 598;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"50 212 LINE",
+"548 212 LINE",
+"548 290 LINE",
+"50 290 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"50 408 LINE",
+"548 408 LINE",
+"548 486 LINE",
+"50 486 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"548 420 LINE",
+"548 474 LINE",
+"50 474 LINE",
+"50 420 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"548 224 LINE",
+"548 278 LINE",
+"50 278 LINE",
+"50 224 LINE"
+);
+}
+);
+width = 598;
+}
+);
+unicode = 003D;
+},
+{
+glyphname = notequal;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"50 393 LINE",
+"548 393 LINE",
+"548 461 LINE",
+"50 461 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"50 227 LINE",
+"548 227 LINE",
+"548 295 LINE",
+"50 295 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"349 604 LINE",
+"200 72 LINE",
+"259 72 LINE",
+"408 604 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"247 72 LINE",
+"396 604 LINE",
+"361 604 LINE",
+"212 72 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"548 239 LINE",
+"548 283 LINE",
+"50 283 LINE",
+"50 239 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"548 405 LINE",
+"548 449 LINE",
+"50 449 LINE",
+"50 405 LINE"
+);
+}
+);
+width = 598;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"50 388 LINE",
+"548 388 LINE",
+"548 466 LINE",
+"50 466 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"50 222 LINE",
+"548 222 LINE",
+"548 300 LINE",
+"50 300 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"343 604 LINE",
+"194 72 LINE",
+"264 72 LINE",
+"413 604 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"252 72 LINE",
+"401 604 LINE",
+"355 604 LINE",
+"206 72 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"548 234 LINE",
+"548 288 LINE",
+"50 288 LINE",
+"50 234 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"548 400 LINE",
+"548 454 LINE",
+"50 454 LINE",
+"50 400 LINE"
+);
+}
+);
+width = 598;
+}
+);
+unicode = 2260;
+},
+{
+glyphname = greater;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"528 385 LINE",
+"60 619 LINE",
+"60 541 LINE",
+"528 307 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"528 385 LINE",
+"60 151 LINE",
+"60 70 LINE",
+"528 304 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"528 316 LINE",
+"528 373 LINE",
+"60 139 LINE",
+"60 82 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"528 373 LINE",
+"60 607 LINE",
+"60 553 LINE",
+"528 319 LINE"
+);
+}
+);
+width = 588;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"528 390 LINE",
+"60 624 LINE",
+"60 536 LINE",
+"528 302 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"528 390 LINE",
+"60 156 LINE",
+"60 65 LINE",
+"528 299 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"528 311 LINE",
+"528 378 LINE",
+"60 144 LINE",
+"60 77 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"528 378 LINE",
+"60 612 LINE",
+"60 548 LINE",
+"528 314 LINE"
+);
+}
+);
+width = 588;
+}
+);
+unicode = 003E;
+},
+{
+glyphname = less;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"60 307 LINE",
+"528 541 LINE",
+"528 619 LINE",
+"60 385 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"60 304 LINE",
+"528 70 LINE",
+"528 151 LINE",
+"60 385 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"528 139 LINE",
+"60 373 LINE",
+"60 316 LINE",
+"528 82 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"528 553 LINE",
+"528 607 LINE",
+"60 373 LINE",
+"60 319 LINE"
+);
+}
+);
+width = 588;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"60 302 LINE",
+"528 536 LINE",
+"528 624 LINE",
+"60 390 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"60 299 LINE",
+"528 65 LINE",
+"528 156 LINE",
+"60 390 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"528 144 LINE",
+"60 378 LINE",
+"60 311 LINE",
+"528 77 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"528 548 LINE",
+"528 612 LINE",
+"60 378 LINE",
+"60 314 LINE"
+);
+}
+);
+width = 588;
+}
+);
+unicode = 003C;
+},
+{
+glyphname = greaterequal;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"538 99 LINE",
+"40 99 LINE",
+"40 31 LINE",
+"538 31 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"518 476 LINE",
+"50 710 LINE",
+"50 632 LINE",
+"518 398 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"518 476 LINE",
+"50 242 LINE",
+"50 161 LINE",
+"518 395 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"518 408 LINE",
+"518 465 LINE",
+"50 699 LINE",
+"50 645 LINE",
+"464 438 LINE",
+"50 231 LINE",
+"50 174 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"538 43 LINE",
+"538 87 LINE",
+"40 87 LINE",
+"40 43 LINE"
+);
+}
+);
+width = 578;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"518 481 LINE",
+"50 247 LINE",
+"50 156 LINE",
+"518 390 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"518 481 LINE",
+"50 715 LINE",
+"50 627 LINE",
+"518 393 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"538 104 LINE",
+"40 104 LINE",
+"40 26 LINE",
+"538 26 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"518 402 LINE",
+"518 469 LINE",
+"50 703 LINE",
+"50 639 LINE",
+"454 437 LINE",
+"50 235 LINE",
+"50 168 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"538 38 LINE",
+"538 92 LINE",
+"40 92 LINE",
+"40 38 LINE"
+);
+}
+);
+width = 578;
+}
+);
+unicode = 2265;
+},
+{
+glyphname = lessequal;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"40 31 LINE",
+"538 31 LINE",
+"538 99 LINE",
+"40 99 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"60 398 LINE",
+"528 632 LINE",
+"528 710 LINE",
+"60 476 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"60 395 LINE",
+"528 161 LINE",
+"528 242 LINE",
+"60 476 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"528 231 LINE",
+"60 465 LINE",
+"60 408 LINE",
+"528 174 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"538 43 LINE",
+"538 87 LINE",
+"40 87 LINE",
+"40 43 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"528 645 LINE",
+"528 699 LINE",
+"60 465 LINE",
+"60 411 LINE"
+);
+}
+);
+width = 578;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"40 26 LINE",
+"538 26 LINE",
+"538 104 LINE",
+"40 104 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"60 393 LINE",
+"528 627 LINE",
+"528 715 LINE",
+"60 481 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"60 390 LINE",
+"528 156 LINE",
+"528 247 LINE",
+"60 481 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"528 235 LINE",
+"60 469 LINE",
+"60 402 LINE",
+"528 168 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"538 38 LINE",
+"538 92 LINE",
+"40 92 LINE",
+"40 38 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"528 639 LINE",
+"528 703 LINE",
+"60 469 LINE",
+"60 405 LINE"
+);
+}
+);
+width = 578;
+}
+);
+unicode = 2264;
+},
+{
+glyphname = plusminus;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"40 399 LINE",
+"538 399 LINE",
+"538 467 LINE",
+"40 467 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"323 164 LINE",
+"323 702 LINE",
+"255 702 LINE",
+"255 164 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"40 31 LINE",
+"538 31 LINE",
+"538 99 LINE",
+"40 99 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"311 164 LINE",
+"311 702 LINE",
+"267 702 LINE",
+"267 164 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"538 43 LINE",
+"538 87 LINE",
+"40 87 LINE",
+"40 43 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"538 411 LINE",
+"538 455 LINE",
+"40 455 LINE",
+"40 411 LINE"
+);
+}
+);
+width = 578;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"40 394 LINE",
+"538 394 LINE",
+"538 472 LINE",
+"40 472 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"328 164 LINE",
+"328 702 LINE",
+"250 702 LINE",
+"250 164 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"40 26 LINE",
+"538 26 LINE",
+"538 104 LINE",
+"40 104 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"316 164 LINE",
+"316 702 LINE",
+"262 702 LINE",
+"262 164 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"538 38 LINE",
+"538 92 LINE",
+"40 92 LINE",
+"40 38 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"538 406 LINE",
+"538 460 LINE",
+"40 460 LINE",
+"40 406 LINE"
+);
+}
+);
+width = 578;
+}
+);
+unicode = 00B1;
+},
+{
+glyphname = approxequal;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"489 493 LINE",
+"462 462 OFFCURVE",
+"439 435 OFFCURVE",
+"389 435 CURVE SMOOTH",
+"322 435 OFFCURVE",
+"256 496 OFFCURVE",
+"180 496 CURVE SMOOTH",
+"113 496 OFFCURVE",
+"76 449 OFFCURVE",
+"45 401 CURVE",
+"95 359 LINE",
+"117 393 OFFCURVE",
+"137 424 OFFCURVE",
+"182 424 CURVE SMOOTH",
+"252 424 OFFCURVE",
+"318 363 OFFCURVE",
+"393 363 CURVE SMOOTH",
+"465 363 OFFCURVE",
+"505 407 OFFCURVE",
+"540 453 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"489 326 LINE",
+"462 295 OFFCURVE",
+"439 268 OFFCURVE",
+"389 268 CURVE SMOOTH",
+"322 268 OFFCURVE",
+"256 329 OFFCURVE",
+"180 329 CURVE SMOOTH",
+"113 329 OFFCURVE",
+"76 282 OFFCURVE",
+"45 234 CURVE",
+"95 192 LINE",
+"117 226 OFFCURVE",
+"137 257 OFFCURVE",
+"182 257 CURVE SMOOTH",
+"252 257 OFFCURVE",
+"318 196 OFFCURVE",
+"393 196 CURVE SMOOTH",
+"465 196 OFFCURVE",
+"505 240 OFFCURVE",
+"540 286 CURVE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"111 400 OFFCURVE",
+"137 436 OFFCURVE",
+"182 436 CURVE SMOOTH",
+"252 436 OFFCURVE",
+"318 375 OFFCURVE",
+"393 375 CURVE SMOOTH",
+"465 375 OFFCURVE",
+"499 412 OFFCURVE",
+"534 458 CURVE",
+"496 487 LINE",
+"469 455 OFFCURVE",
+"439 423 OFFCURVE",
+"389 423 CURVE SMOOTH",
+"322 423 OFFCURVE",
+"256 484 OFFCURVE",
+"180 484 CURVE SMOOTH",
+"113 484 OFFCURVE",
+"81 445 OFFCURVE",
+"50 397 CURVE",
+"89 366 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"111 233 OFFCURVE",
+"137 269 OFFCURVE",
+"182 269 CURVE SMOOTH",
+"252 269 OFFCURVE",
+"318 208 OFFCURVE",
+"393 208 CURVE SMOOTH",
+"465 208 OFFCURVE",
+"499 245 OFFCURVE",
+"534 291 CURVE",
+"496 320 LINE",
+"469 288 OFFCURVE",
+"439 256 OFFCURVE",
+"389 256 CURVE SMOOTH",
+"322 256 OFFCURVE",
+"256 317 OFFCURVE",
+"180 317 CURVE SMOOTH",
+"113 317 OFFCURVE",
+"81 278 OFFCURVE",
+"50 230 CURVE",
+"89 199 LINE"
+);
+}
+);
+width = 585;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"489 508 LINE",
+"462 477 OFFCURVE",
+"439 450 OFFCURVE",
+"389 450 CURVE SMOOTH",
+"322 450 OFFCURVE",
+"256 511 OFFCURVE",
+"180 511 CURVE SMOOTH",
+"111 511 OFFCURVE",
+"72 464 OFFCURVE",
+"40 416 CURVE",
+"95 359 LINE",
+"117 393 OFFCURVE",
+"137 424 OFFCURVE",
+"182 424 CURVE SMOOTH",
+"252 424 OFFCURVE",
+"318 363 OFFCURVE",
+"393 363 CURVE SMOOTH",
+"467 363 OFFCURVE",
+"509 407 OFFCURVE",
+"545 453 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"489 326 LINE",
+"462 295 OFFCURVE",
+"439 268 OFFCURVE",
+"389 268 CURVE SMOOTH",
+"322 268 OFFCURVE",
+"256 329 OFFCURVE",
+"180 329 CURVE SMOOTH",
+"111 329 OFFCURVE",
+"72 282 OFFCURVE",
+"40 234 CURVE",
+"95 182 LINE",
+"117 216 OFFCURVE",
+"137 247 OFFCURVE",
+"182 247 CURVE SMOOTH",
+"252 247 OFFCURVE",
+"318 186 OFFCURVE",
+"393 186 CURVE SMOOTH",
+"467 186 OFFCURVE",
+"509 230 OFFCURVE",
+"545 276 CURVE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"112 399 OFFCURVE",
+"137 436 OFFCURVE",
+"182 436 CURVE SMOOTH",
+"252 436 OFFCURVE",
+"318 375 OFFCURVE",
+"393 375 CURVE SMOOTH",
+"467 375 OFFCURVE",
+"509 419 OFFCURVE",
+"539 458 CURVE",
+"495 503 LINE",
+"462 464 OFFCURVE",
+"439 438 OFFCURVE",
+"389 438 CURVE SMOOTH",
+"322 438 OFFCURVE",
+"256 499 OFFCURVE",
+"180 499 CURVE SMOOTH",
+"111 499 OFFCURVE",
+"72 452 OFFCURVE",
+"44 410 CURVE",
+"90 365 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"112 219 OFFCURVE",
+"137 256 OFFCURVE",
+"182 256 CURVE SMOOTH",
+"252 256 OFFCURVE",
+"318 195 OFFCURVE",
+"393 195 CURVE SMOOTH",
+"467 195 OFFCURVE",
+"509 239 OFFCURVE",
+"539 278 CURVE",
+"495 323 LINE",
+"462 284 OFFCURVE",
+"439 258 OFFCURVE",
+"389 258 CURVE SMOOTH",
+"322 258 OFFCURVE",
+"256 319 OFFCURVE",
+"180 319 CURVE SMOOTH",
+"111 319 OFFCURVE",
+"72 272 OFFCURVE",
+"44 230 CURVE",
+"90 185 LINE"
+);
+}
+);
+width = 585;
+}
+);
+unicode = 2248;
+},
+{
+glyphname = asciitilde;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"75 260 OFFCURVE",
+"97 291 OFFCURVE",
+"147 291 CURVE SMOOTH",
+"211 291 OFFCURVE",
+"271 230 OFFCURVE",
+"338 230 CURVE SMOOTH",
+"400 230 OFFCURVE",
+"433 274 OFFCURVE",
+"465 320 CURVE",
+"424 345 LINE",
+"400 309 OFFCURVE",
+"379 282 OFFCURVE",
+"334 282 CURVE SMOOTH",
+"273 282 OFFCURVE",
+"213 343 OFFCURVE",
+"145 343 CURVE SMOOTH",
+"78 343 OFFCURVE",
+"41 296 OFFCURVE",
+"10 248 CURVE",
+"50 221 LINE"
+);
+}
+);
+width = 475;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"75 250 OFFCURVE",
+"97 281 OFFCURVE",
+"147 281 CURVE SMOOTH",
+"211 281 OFFCURVE",
+"271 220 OFFCURVE",
+"338 220 CURVE SMOOTH",
+"405 220 OFFCURVE",
+"440 264 OFFCURVE",
+"475 310 CURVE",
+"424 355 LINE",
+"400 319 OFFCURVE",
+"379 292 OFFCURVE",
+"334 292 CURVE SMOOTH",
+"273 292 OFFCURVE",
+"213 353 OFFCURVE",
+"145 353 CURVE SMOOTH",
+"73 353 OFFCURVE",
+"33 306 OFFCURVE",
+"0 258 CURVE",
+"50 211 LINE"
+);
+}
+);
+width = 475;
+}
+);
+unicode = 007E;
+},
+{
+glyphname = logicalnot;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"20 270 LINE",
+"518 270 LINE",
+"518 338 LINE",
+"20 338 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"411 307 LINE",
+"411 43 LINE",
+"518 43 LINE",
+"518 307 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"518 282 LINE",
+"518 326 LINE",
+"20 326 LINE",
+"20 282 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"518 72 LINE",
+"518 307 LINE",
+"441 307 LINE",
+"441 72 LINE"
+);
+}
+);
+width = 538;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"20 265 LINE",
+"518 265 LINE",
+"518 338 LINE",
+"20 338 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"401 307 LINE",
+"401 43 LINE",
+"518 43 LINE",
+"518 307 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"518 277 LINE",
+"518 326 LINE",
+"20 326 LINE",
+"20 277 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"518 55 LINE",
+"518 307 LINE",
+"425 307 LINE",
+"425 55 LINE"
+);
+}
+);
+width = 538;
+}
+);
+unicode = 00AC;
+},
+{
+glyphname = infinity;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"290 117 OFFCURVE",
+"346 168 OFFCURVE",
+"396 231 CURVE",
+"462 141 OFFCURVE",
+"520 117 OFFCURVE",
+"573 117 CURVE SMOOTH",
+"661 117 OFFCURVE",
+"742 183 OFFCURVE",
+"742 296 CURVE SMOOTH",
+"742 401 OFFCURVE",
+"672 468 OFFCURVE",
+"581 468 CURVE SMOOTH",
+"489 468 OFFCURVE",
+"435 401 OFFCURVE",
+"400 357 CURVE",
+"348 425 OFFCURVE",
+"293 468 OFFCURVE",
+"218 468 CURVE SMOOTH",
+"121 468 OFFCURVE",
+"47 396 OFFCURVE",
+"47 291 CURVE SMOOTH",
+"47 186 OFFCURVE",
+"122 117 OFFCURVE",
+"212 117 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"154 172 OFFCURVE",
+"104 223 OFFCURVE",
+"104 293 CURVE SMOOTH",
+"104 355 OFFCURVE",
+"143 414 OFFCURVE",
+"216 414 CURVE SMOOTH",
+"290 414 OFFCURVE",
+"331 354 OFFCURVE",
+"374 287 CURVE",
+"306 198 OFFCURVE",
+"266 172 OFFCURVE",
+"219 172 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"521 172 OFFCURVE",
+"481 210 OFFCURVE",
+"418 294 CURVE",
+"474 374 OFFCURVE",
+"517 414 OFFCURVE",
+"573 414 CURVE SMOOTH",
+"641 414 OFFCURVE",
+"684 358 OFFCURVE",
+"684 294 CURVE SMOOTH",
+"684 238 OFFCURVE",
+"651 172 OFFCURVE",
+"577 172 CURVE SMOOTH"
+);
+}
+);
+width = 789;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"300 106 OFFCURVE",
+"354 153 OFFCURVE",
+"407 221 CURVE",
+"475 125 OFFCURVE",
+"536 106 OFFCURVE",
+"592 106 CURVE SMOOTH",
+"680 106 OFFCURVE",
+"766 175 OFFCURVE",
+"766 297 CURVE SMOOTH",
+"766 406 OFFCURVE",
+"689 477 OFFCURVE",
+"597 477 CURVE SMOOTH",
+"523 477 OFFCURVE",
+"478 443 OFFCURVE",
+"412 366 CURVE",
+"359 437 OFFCURVE",
+"304 477 OFFCURVE",
+"227 477 CURVE SMOOTH",
+"125 477 OFFCURVE",
+"47 401 OFFCURVE",
+"47 290 CURVE SMOOTH",
+"47 178 OFFCURVE",
+"129 106 OFFCURVE",
+"217 106 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"170 183 OFFCURVE",
+"126 232 OFFCURVE",
+"126 289 CURVE SMOOTH",
+"126 357 OFFCURVE",
+"166 401 OFFCURVE",
+"226 401 CURVE SMOOTH",
+"282 401 OFFCURVE",
+"310 374 OFFCURVE",
+"370 286 CURVE",
+"330 234 OFFCURVE",
+"287 183 OFFCURVE",
+"229 183 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"541 183 OFFCURVE",
+"509 207 OFFCURVE",
+"446 294 CURVE",
+"511 376 OFFCURVE",
+"544 401 OFFCURVE",
+"588 401 CURVE SMOOTH",
+"649 401 OFFCURVE",
+"687 352 OFFCURVE",
+"687 289 CURVE SMOOTH",
+"687 244 OFFCURVE",
+"653 183 OFFCURVE",
+"594 183 CURVE SMOOTH"
+);
+}
+);
+width = 814;
+}
+);
+unicode = 221E;
+},
+{
+glyphname = integral;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"173 -202 OFFCURVE",
+"276 -138 OFFCURVE",
+"276 159 CURVE SMOOTH",
+"276 261 OFFCURVE",
+"264 560 OFFCURVE",
+"264 658 CURVE SMOOTH",
+"264 802 OFFCURVE",
+"290 841 OFFCURVE",
+"336 841 CURVE SMOOTH",
+"357 841 OFFCURVE",
+"373 833 OFFCURVE",
+"373 815 CURVE SMOOTH",
+"373 801 OFFCURVE",
+"363 793 OFFCURVE",
+"363 772 CURVE SMOOTH",
+"363 744 OFFCURVE",
+"382 719 OFFCURVE",
+"419 719 CURVE SMOOTH",
+"453 719 OFFCURVE",
+"467 741 OFFCURVE",
+"467 771 CURVE SMOOTH",
+"467 833 OFFCURVE",
+"408 866 OFFCURVE",
+"339 866 CURVE SMOOTH",
+"229 866 OFFCURVE",
+"134 782 OFFCURVE",
+"134 545 CURVE SMOOTH",
+"134 414 OFFCURVE",
+"163 111 OFFCURVE",
+"163 -37 CURVE SMOOTH",
+"163 -139 OFFCURVE",
+"149 -177 OFFCURVE",
+"106 -177 CURVE SMOOTH",
+"78 -177 OFFCURVE",
+"77 -161 OFFCURVE",
+"75 -128 CURVE SMOOTH",
+"73 -96 OFFCURVE",
+"63 -71 OFFCURVE",
+"28 -71 CURVE SMOOTH",
+"-4 -71 OFFCURVE",
+"-20 -91 OFFCURVE",
+"-20 -120 CURVE SMOOTH",
+"-20 -176 OFFCURVE",
+"42 -202 OFFCURVE",
+"93 -202 CURVE SMOOTH"
+);
+}
+);
+width = 446;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"179 -202 OFFCURVE",
+"291 -140 OFFCURVE",
+"291 161 CURVE SMOOTH",
+"291 259 OFFCURVE",
+"279 560 OFFCURVE",
+"279 659 CURVE SMOOTH",
+"279 793 OFFCURVE",
+"301 831 OFFCURVE",
+"341 831 CURVE SMOOTH",
+"359 831 OFFCURVE",
+"373 823 OFFCURVE",
+"373 806 CURVE SMOOTH",
+"373 788 OFFCURVE",
+"358 781 OFFCURVE",
+"358 757 CURVE SMOOTH",
+"358 729 OFFCURVE",
+"377 704 OFFCURVE",
+"415 704 CURVE SMOOTH",
+"452 704 OFFCURVE",
+"467 728 OFFCURVE",
+"467 762 CURVE SMOOTH",
+"467 830 OFFCURVE",
+"409 866 OFFCURVE",
+"335 866 CURVE SMOOTH",
+"222 866 OFFCURVE",
+"119 782 OFFCURVE",
+"119 543 CURVE SMOOTH",
+"119 416 OFFCURVE",
+"148 112 OFFCURVE",
+"148 -39 CURVE SMOOTH",
+"148 -132 OFFCURVE",
+"137 -167 OFFCURVE",
+"105 -167 CURVE SMOOTH",
+"83 -167 OFFCURVE",
+"82 -151 OFFCURVE",
+"80 -118 CURVE SMOOTH",
+"78 -86 OFFCURVE",
+"67 -61 OFFCURVE",
+"28 -61 CURVE SMOOTH",
+"-11 -61 OFFCURVE",
+"-30 -86 OFFCURVE",
+"-30 -118 CURVE SMOOTH",
+"-30 -177 OFFCURVE",
+"37 -202 OFFCURVE",
+"92 -202 CURVE SMOOTH"
+);
+}
+);
+width = 446;
+}
+);
+unicode = 222B;
+},
+{
+glyphname = Ohm;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"332 0 LINE",
+"342 23 LINE",
+"254 156 OFFCURVE",
+"219 257 OFFCURVE",
+"219 412 CURVE SMOOTH",
+"219 636 OFFCURVE",
+"292 702 OFFCURVE",
+"377 702 CURVE SMOOTH",
+"468 702 OFFCURVE",
+"542 625 OFFCURVE",
+"542 408 CURVE SMOOTH",
+"542 267 OFFCURVE",
+"511 160 OFFCURVE",
+"418 23 CURVE",
+"427 0 LINE",
+"698 0 LINE",
+"727 174 LINE",
+"704 174 LINE",
+"683 109 OFFCURVE",
+"669 95 OFFCURVE",
+"627 95 CURVE SMOOTH",
+"505 95 LINE",
+"604 187 OFFCURVE",
+"691 269 OFFCURVE",
+"691 421 CURVE SMOOTH",
+"691 607 OFFCURVE",
+"562 733 OFFCURVE",
+"384 733 CURVE SMOOTH",
+"205 733 OFFCURVE",
+"69 606 OFFCURVE",
+"69 412 CURVE SMOOTH",
+"69 249 OFFCURVE",
+"165 165 OFFCURVE",
+"248 96 CURVE",
+"141 96 LINE SMOOTH",
+"97 96 OFFCURVE",
+"81 112 OFFCURVE",
+"59 174 CURVE",
+"35 174 LINE",
+"60 0 LINE"
+);
+}
+);
+width = 762;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"353 0 LINE",
+"363 26 LINE",
+"314 132 OFFCURVE",
+"251 268 OFFCURVE",
+"251 399 CURVE SMOOTH",
+"251 626 OFFCURVE",
+"311 694 OFFCURVE",
+"403 694 CURVE SMOOTH",
+"494 694 OFFCURVE",
+"560 615 OFFCURVE",
+"560 402 CURVE SMOOTH",
+"560 267 OFFCURVE",
+"488 123 OFFCURVE",
+"446 26 CURVE",
+"456 0 LINE",
+"744 0 LINE",
+"776 189 LINE",
+"735 189 LINE",
+"712 127 OFFCURVE",
+"697 116 OFFCURVE",
+"653 116 CURVE SMOOTH",
+"540 116 LINE",
+"632 188 OFFCURVE",
+"739 274 OFFCURVE",
+"739 414 CURVE SMOOTH",
+"739 612 OFFCURVE",
+"603 733 OFFCURVE",
+"407 733 CURVE SMOOTH",
+"214 733 OFFCURVE",
+"71 609 OFFCURVE",
+"71 408 CURVE SMOOTH",
+"71 253 OFFCURVE",
+"183 171 OFFCURVE",
+"262 116 CURVE",
+"164 116 LINE SMOOTH",
+"115 116 OFFCURVE",
+"99 128 OFFCURVE",
+"75 189 CURVE",
+"36 189 LINE",
+"63 0 LINE"
+);
+}
+);
+width = 812;
+}
+);
+unicode = 2126;
+},
+{
+glyphname = increment;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"645 0 LINE",
+"645 37 LINE",
+"363 729 LINE",
+"306 715 LINE",
+"35 37 LINE",
+"35 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"283 570 LINE",
+"482 37 LINE",
+"71 37 LINE"
+);
+}
+);
+width = 680;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"689 0 LINE",
+"689 43 LINE",
+"392 733 LINE",
+"322 716 LINE",
+"37 43 LINE",
+"37 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"304 527 LINE",
+"495 73 LINE",
+"119 73 LINE"
+);
+}
+);
+width = 727;
+}
+);
+unicode = 2206;
+},
+{
+glyphname = product;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"321 -79 LINE",
+"321 -54 LINE",
+"241 -54 LINE",
+"241 709 LINE",
+"470 709 LINE",
+"470 -54 LINE",
+"390 -54 LINE",
+"390 -79 LINE",
+"694 -79 LINE",
+"694 -54 LINE",
+"604 -54 LINE",
+"604 709 LINE",
+"694 709 LINE",
+"694 734 LINE",
+"17 734 LINE",
+"17 709 LINE",
+"107 709 LINE",
+"107 -54 LINE",
+"17 -54 LINE",
+"17 -79 LINE"
+);
+}
+);
+width = 711;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"773 730 LINE",
+"25 730 LINE",
+"25 691 LINE",
+"121 684 OFFCURVE",
+"129 674 OFFCURVE",
+"129 584 CURVE SMOOTH",
+"129 65 LINE SMOOTH",
+"129 -27 OFFCURVE",
+"120 -40 OFFCURVE",
+"29 -47 CURVE",
+"29 -86 LINE",
+"363 -86 LINE",
+"363 -47 LINE",
+"291 -40 OFFCURVE",
+"290 -28 OFFCURVE",
+"290 65 CURVE SMOOTH",
+"290 644 LINE SMOOTH",
+"290 677 OFFCURVE",
+"294 681 OFFCURVE",
+"328 681 CURVE SMOOTH",
+"470 681 LINE SMOOTH",
+"505 681 OFFCURVE",
+"511 677 OFFCURVE",
+"511 641 CURVE SMOOTH",
+"511 65 LINE SMOOTH",
+"511 -33 OFFCURVE",
+"507 -40 OFFCURVE",
+"431 -47 CURVE",
+"431 -86 LINE",
+"772 -86 LINE",
+"772 -47 LINE",
+"680 -39 OFFCURVE",
+"672 -29 OFFCURVE",
+"672 65 CURVE SMOOTH",
+"672 584 LINE SMOOTH",
+"672 672 OFFCURVE",
+"679 684 OFFCURVE",
+"773 691 CURVE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"361 -86 LINE",
+"361 -56 LINE",
+"288 -56 LINE",
+"288 703 LINE",
+"512 703 LINE",
+"512 -56 LINE",
+"439 -56 LINE",
+"439 -86 LINE",
+"769 -86 LINE",
+"769 -56 LINE",
+"670 -56 LINE",
+"670 703 LINE",
+"769 703 LINE",
+"769 733 LINE",
+"31 733 LINE",
+"31 703 LINE",
+"130 703 LINE",
+"130 -56 LINE",
+"31 -56 LINE",
+"31 -86 LINE"
+);
+}
+);
+width = 802;
+}
+);
+unicode = 220F;
+},
+{
+glyphname = summation;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"511 -87 LINE",
+"558 141 LINE",
+"532 148 LINE",
+"487 31 OFFCURVE",
+"473 25 OFFCURVE",
+"380 25 CURVE SMOOTH",
+"135 25 LINE",
+"367 370 LINE",
+"192 701 LINE",
+"380 701 LINE SMOOTH",
+"450 701 OFFCURVE",
+"479 660 OFFCURVE",
+"500 542 CURVE",
+"531 550 LINE",
+"519 733 LINE",
+"32 733 LINE",
+"32 709 LINE",
+"255 278 LINE",
+"28 -53 LINE",
+"28 -87 LINE"
+);
+}
+);
+width = 833;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"552 -96 LINE",
+"606 149 LINE",
+"560 149 LINE",
+"515 43 OFFCURVE",
+"502 34 OFFCURVE",
+"403 34 CURVE SMOOTH",
+"154 34 LINE",
+"394 370 LINE",
+"223 684 LINE",
+"366 684 LINE SMOOTH",
+"458 684 OFFCURVE",
+"489 659 OFFCURVE",
+"522 534 CURVE",
+"565 534 LINE",
+"551 730 LINE",
+"33 730 LINE",
+"33 690 LINE",
+"261 264 LINE",
+"28 -56 LINE",
+"28 -96 LINE"
+);
+}
+);
+width = 630;
+}
+);
+unicode = 2211;
+},
+{
+glyphname = radical;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"377 -172 LINE",
+"558 915 LINE",
+"529 915 LINE",
+"382 56 LINE",
+"378 56 LINE",
+"237 440 LINE",
+"34 440 LINE",
+"34 415 LINE",
+"128 415 LINE",
+"363 -175 LINE"
+);
+}
+);
+width = 594;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"415 -175 LINE",
+"612 914 LINE",
+"551 914 LINE",
+"405 81 LINE",
+"401 81 LINE",
+"265 440 LINE",
+"39 440 LINE",
+"39 405 LINE",
+"137 405 LINE",
+"376 -183 LINE"
+);
+}
+);
+width = 617;
+}
+);
+unicode = 221A;
+},
+{
+glyphname = micro;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"541 25 LINE",
+"352 25 LINE",
+"352 0 LINE",
+"541 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"462 426 LINE",
+"352 426 LINE",
+"352 16 LINE",
+"462 16 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"462 441 LINE",
+"270 441 LINE",
+"270 416 LINE",
+"462 416 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"179 441 LINE",
+"-9 441 LINE",
+"-9 416 LINE",
+"179 416 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"69 99 LINE SMOOTH",
+"69 38 OFFCURVE",
+"123 -10 OFFCURVE",
+"200 -10 CURVE SMOOTH",
+"274 -10 OFFCURVE",
+"319 28 OFFCURVE",
+"348 80 CURVE",
+"372 80 LINE",
+"352 230 LINE",
+"352 116 OFFCURVE",
+"296 27 OFFCURVE",
+"235 27 CURVE SMOOTH",
+"200 27 OFFCURVE",
+"179 52 OFFCURVE",
+"179 102 CURVE SMOOTH",
+"179 426 LINE",
+"69 426 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"69 101 LINE",
+"64 -72 OFFCURVE",
+"35 -124 OFFCURVE",
+"35 -190 CURVE SMOOTH",
+"35 -230 OFFCURVE",
+"51 -254 OFFCURVE",
+"86 -254 CURVE SMOOTH",
+"122 -254 OFFCURVE",
+"139 -227 OFFCURVE",
+"139 -188 CURVE SMOOTH",
+"139 -140 OFFCURVE",
+"103 -103 OFFCURVE",
+"95 28 CURVE",
+"99 28 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"290 -12 OFFCURVE",
+"335 26 OFFCURVE",
+"364 78 CURVE",
+"388 78 LINE",
+"368 228 LINE",
+"368 114 OFFCURVE",
+"312 25 OFFCURVE",
+"251 25 CURVE SMOOTH",
+"216 25 OFFCURVE",
+"195 50 OFFCURVE",
+"195 100 CURVE SMOOTH",
+"195 435 LINE",
+"85 435 LINE",
+"85 97 LINE SMOOTH",
+"85 36 OFFCURVE",
+"139 -12 OFFCURVE",
+"216 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"136 -254 OFFCURVE",
+"153 -227 OFFCURVE",
+"153 -188 CURVE SMOOTH",
+"153 -140 OFFCURVE",
+"117 -103 OFFCURVE",
+"109 28 CURVE",
+"113 28 LINE",
+"85 101 LINE",
+"80 -72 OFFCURVE",
+"49 -124 OFFCURVE",
+"49 -190 CURVE SMOOTH",
+"49 -230 OFFCURVE",
+"65 -254 OFFCURVE",
+"100 -254 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"557 0 LINE",
+"557 25 LINE",
+"368 25 LINE",
+"368 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"195 425 LINE",
+"195 450 LINE",
+"7 450 LINE",
+"7 425 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"478 16 LINE",
+"478 435 LINE",
+"368 435 LINE",
+"368 16 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"478 425 LINE",
+"478 450 LINE",
+"286 450 LINE",
+"286 425 LINE"
+);
+}
+);
+width = 570;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"603 30 LINE",
+"386 30 LINE",
+"386 0 LINE",
+"603 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"524 425 LINE",
+"386 425 LINE",
+"386 15 LINE",
+"524 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"524 440 LINE",
+"304 440 LINE",
+"304 410 LINE",
+"524 410 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"226 440 LINE",
+"10 440 LINE",
+"10 410 LINE",
+"226 410 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"88 98 LINE SMOOTH",
+"88 37 OFFCURVE",
+"140 -13 OFFCURVE",
+"222 -13 CURVE SMOOTH",
+"292 -13 OFFCURVE",
+"358 24 OFFCURVE",
+"382 79 CURVE",
+"406 79 LINE",
+"386 229 LINE",
+"386 120 OFFCURVE",
+"340 36 OFFCURVE",
+"273 36 CURVE SMOOTH",
+"241 36 OFFCURVE",
+"226 56 OFFCURVE",
+"226 111 CURVE SMOOTH",
+"226 425 LINE",
+"88 425 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"88 101 LINE",
+"83 -78 OFFCURVE",
+"54 -140 OFFCURVE",
+"54 -198 CURVE SMOOTH",
+"54 -251 OFFCURVE",
+"78 -277 OFFCURVE",
+"114 -277 CURVE SMOOTH",
+"153 -277 OFFCURVE",
+"178 -246 OFFCURVE",
+"178 -203 CURVE SMOOTH",
+"178 -152 OFFCURVE",
+"152 -119 OFFCURVE",
+"134 10 CURVE",
+"138 10 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"292 -13 OFFCURVE",
+"358 24 OFFCURVE",
+"382 79 CURVE",
+"406 79 LINE",
+"386 229 LINE",
+"386 120 OFFCURVE",
+"340 36 OFFCURVE",
+"273 36 CURVE SMOOTH",
+"241 36 OFFCURVE",
+"226 56 OFFCURVE",
+"226 111 CURVE SMOOTH",
+"226 435 LINE",
+"88 435 LINE",
+"88 98 LINE SMOOTH",
+"88 37 OFFCURVE",
+"140 -13 OFFCURVE",
+"222 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"153 -277 OFFCURVE",
+"178 -246 OFFCURVE",
+"178 -203 CURVE SMOOTH",
+"178 -152 OFFCURVE",
+"152 -119 OFFCURVE",
+"134 10 CURVE",
+"138 10 LINE",
+"88 101 LINE",
+"83 -78 OFFCURVE",
+"54 -140 OFFCURVE",
+"54 -198 CURVE SMOOTH",
+"54 -251 OFFCURVE",
+"78 -277 OFFCURVE",
+"114 -277 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"603 0 LINE",
+"603 30 LINE",
+"386 30 LINE",
+"386 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"226 420 LINE",
+"226 450 LINE",
+"10 450 LINE",
+"10 420 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"524 15 LINE",
+"524 435 LINE",
+"386 435 LINE",
+"386 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"524 420 LINE",
+"524 450 LINE",
+"304 450 LINE",
+"304 420 LINE"
+);
+}
+);
+width = 613;
+}
+);
+unicode = 00B5;
+},
+{
+glyphname = partialdiff;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"404 -11 OFFCURVE",
+"524 129 OFFCURVE",
+"524 391 CURVE SMOOTH",
+"524 657 OFFCURVE",
+"401 779 OFFCURVE",
+"236 779 CURVE SMOOTH",
+"169 779 OFFCURVE",
+"121 759 OFFCURVE",
+"85 738 CURVE",
+"125 668 LINE",
+"166 713 OFFCURVE",
+"210 741 OFFCURVE",
+"267 741 CURVE SMOOTH",
+"362 741 OFFCURVE",
+"421 664 OFFCURVE",
+"421 528 CURVE SMOOTH",
+"421 482 OFFCURVE",
+"414 434 OFFCURVE",
+"407 390 CURVE",
+"379 429 OFFCURVE",
+"337 451 OFFCURVE",
+"280 451 CURVE SMOOTH",
+"133 451 OFFCURVE",
+"43 319 OFFCURVE",
+"43 193 CURVE SMOOTH",
+"43 67 OFFCURVE",
+"123 -11 OFFCURVE",
+"243 -11 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"193 19 OFFCURVE",
+"170 58 OFFCURVE",
+"170 138 CURVE SMOOTH",
+"170 224 OFFCURVE",
+"196 411 OFFCURVE",
+"308 411 CURVE SMOOTH",
+"359 411 OFFCURVE",
+"386 372 OFFCURVE",
+"397 350 CURVE",
+"385 260 OFFCURVE",
+"371 202 OFFCURVE",
+"346 136 CURVE SMOOTH",
+"314 52 OFFCURVE",
+"289 19 OFFCURVE",
+"243 19 CURVE SMOOTH"
+);
+}
+);
+width = 569;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"450 -12 OFFCURVE",
+"565 162 OFFCURVE",
+"565 384 CURVE SMOOTH",
+"565 593 OFFCURVE",
+"463 779 OFFCURVE",
+"248 779 CURVE SMOOTH",
+"176 779 OFFCURVE",
+"128 758 OFFCURVE",
+"89 738 CURVE",
+"138 633 LINE",
+"178 678 OFFCURVE",
+"237 709 OFFCURVE",
+"299 709 CURVE SMOOTH",
+"405 709 OFFCURVE",
+"438 620 OFFCURVE",
+"438 519 CURVE SMOOTH",
+"438 476 OFFCURVE",
+"432 442 OFFCURVE",
+"424 397 CURVE",
+"393 437 OFFCURVE",
+"347 455 OFFCURVE",
+"291 455 CURVE SMOOTH",
+"149 455 OFFCURVE",
+"44 339 OFFCURVE",
+"44 197 CURVE SMOOTH",
+"44 69 OFFCURVE",
+"129 -12 OFFCURVE",
+"259 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"218 31 OFFCURVE",
+"196 63 OFFCURVE",
+"196 136 CURVE SMOOTH",
+"196 210 OFFCURVE",
+"219 399 OFFCURVE",
+"330 399 CURVE SMOOTH",
+"376 399 OFFCURVE",
+"401 366 OFFCURVE",
+"413 343 CURVE",
+"400 257 OFFCURVE",
+"386 199 OFFCURVE",
+"360 138 CURVE SMOOTH",
+"335 79 OFFCURVE",
+"304 31 OFFCURVE",
+"257 31 CURVE SMOOTH"
+);
+}
+);
+width = 616;
+}
+);
+unicode = 2202;
+},
+{
+glyphname = percent;
+lastChange = "2016-08-19 16:58:51 +0000";
+layers = (
+{
+components = (
+{
+alignment = -1;
+name = fraction;
+transform = "{1, 0, 0, 1, 206, 0}";
+},
+{
+name = zero.numerator;
+transform = "{1, 0, 0, 1, 23, 0}";
+},
+{
+name = zero.denominator;
+transform = "{1, 0, 0, 1, 483, 0}";
+}
+);
+layerId = UUID0;
+width = 913;
+},
+{
+components = (
+{
+alignment = -1;
+name = fraction;
+transform = "{1, 0, 0, 1, 215, 0}";
+},
+{
+name = zero.numerator;
+transform = "{1, 0, 0, 1, 23, 0}";
+},
+{
+name = zero.denominator;
+transform = "{1, 0, 0, 1, 483, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 913;
+}
+);
+unicode = 0025;
+},
+{
+glyphname = perthousand;
+lastChange = "2016-08-19 16:59:14 +0000";
+layers = (
+{
+components = (
+{
+alignment = -1;
+name = fraction;
+transform = "{1, 0, 0, 1, 205, 0}";
+},
+{
+name = zero.numerator;
+transform = "{1, 0, 0, 1, 23, 0}";
+},
+{
+name = zero.denominator;
+transform = "{1, 0, 0, 1, 483, 0}";
+},
+{
+name = zero.denominator;
+transform = "{1, 0, 0, 1, 923, 0}";
+}
+);
+layerId = UUID0;
+width = 1353;
+},
+{
+components = (
+{
+alignment = -1;
+name = fraction;
+transform = "{1, 0, 0, 1, 211, 0}";
+},
+{
+name = zero.numerator;
+transform = "{1, 0, 0, 1, 23, 0}";
+},
+{
+name = zero.denominator;
+transform = "{1, 0, 0, 1, 483, 0}";
+},
+{
+name = zero.denominator;
+transform = "{1, 0, 0, 1, 923, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 1353;
+}
+);
+unicode = 2030;
+},
+{
+glyphname = lozenge;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"347 -74 LINE",
+"547 347 LINE",
+"347 771 LINE",
+"251 771 LINE",
+"48 347 LINE",
+"248 -74 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"119 348 LINE",
+"297 717 LINE",
+"301 717 LINE",
+"476 347 LINE",
+"301 -24 LINE",
+"297 -24 LINE"
+);
+}
+);
+width = 595;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"373 -77 LINE",
+"584 347 LINE",
+"374 774 LINE",
+"261 774 LINE",
+"48 347 LINE",
+"258 -77 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"144 348 LINE",
+"315 700 LINE",
+"319 700 LINE",
+"488 347 LINE",
+"319 -7 LINE",
+"315 -7 LINE"
+);
+}
+);
+width = 633;
+}
+);
+unicode = 25CA;
+},
+{
+glyphname = at;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"493 -152 OFFCURVE",
+"575 -119 OFFCURVE",
+"660 -32 CURVE",
+"642 -7 LINE",
+"562 -101 OFFCURVE",
+"469 -122 OFFCURVE",
+"395 -122 CURVE SMOOTH",
+"208 -122 OFFCURVE",
+"103 11 OFFCURVE",
+"103 199 CURVE SMOOTH",
+"103 437 OFFCURVE",
+"270 600 OFFCURVE",
+"474 600 CURVE SMOOTH",
+"629 600 OFFCURVE",
+"752 506 OFFCURVE",
+"752 331 CURVE SMOOTH",
+"752 190 OFFCURVE",
+"672 94 OFFCURVE",
+"605 94 CURVE SMOOTH",
+"588 94 OFFCURVE",
+"579 100 OFFCURVE",
+"579 114 CURVE SMOOTH",
+"579 118 OFFCURVE",
+"580 124 OFFCURVE",
+"582 131 CURVE SMOOTH",
+"656 443 LINE",
+"548 443 LINE",
+"485 189 LINE SMOOTH",
+"474 144 OFFCURVE",
+"471 127 OFFCURVE",
+"471 112 CURVE SMOOTH",
+"471 65 OFFCURVE",
+"500 44 OFFCURVE",
+"552 44 CURVE SMOOTH",
+"681 44 OFFCURVE",
+"785 175 OFFCURVE",
+"785 335 CURVE SMOOTH",
+"785 501 OFFCURVE",
+"674 630 OFFCURVE",
+"477 630 CURVE SMOOTH",
+"261 630 OFFCURVE",
+"70 474 OFFCURVE",
+"70 199 CURVE SMOOTH",
+"70 -40 OFFCURVE",
+"214 -152 OFFCURVE",
+"395 -152 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"408 44 OFFCURVE",
+"445 82 OFFCURVE",
+"464 115 CURVE",
+"471 115 LINE",
+"499 237 LINE",
+"472 118 OFFCURVE",
+"408 80 OFFCURVE",
+"371 80 CURVE SMOOTH",
+"346 80 OFFCURVE",
+"335 97 OFFCURVE",
+"335 148 CURVE SMOOTH",
+"335 273 OFFCURVE",
+"401 420 OFFCURVE",
+"465 420 CURVE SMOOTH",
+"498 420 OFFCURVE",
+"518 382 OFFCURVE",
+"518 341 CURVE SMOOTH",
+"518 329 OFFCURVE",
+"516 322 OFFCURVE",
+"516 309 CURVE",
+"536 390 LINE",
+"530 390 LINE",
+"512 435 OFFCURVE",
+"491 454 OFFCURVE",
+"449 454 CURVE SMOOTH",
+"344 454 OFFCURVE",
+"225 336 OFFCURVE",
+"225 194 CURVE SMOOTH",
+"225 90 OFFCURVE",
+"288 44 OFFCURVE",
+"351 44 CURVE SMOOTH"
+);
+}
+);
+width = 835;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"681 44 OFFCURVE",
+"785 175 OFFCURVE",
+"785 335 CURVE SMOOTH",
+"785 501 OFFCURVE",
+"674 630 OFFCURVE",
+"477 630 CURVE SMOOTH",
+"261 630 OFFCURVE",
+"70 474 OFFCURVE",
+"70 199 CURVE SMOOTH",
+"70 -40 OFFCURVE",
+"214 -152 OFFCURVE",
+"395 -152 CURVE SMOOTH",
+"493 -152 OFFCURVE",
+"575 -119 OFFCURVE",
+"660 -32 CURVE",
+"642 -7 LINE",
+"562 -101 OFFCURVE",
+"469 -122 OFFCURVE",
+"395 -122 CURVE SMOOTH",
+"208 -122 OFFCURVE",
+"103 11 OFFCURVE",
+"103 199 CURVE SMOOTH",
+"103 437 OFFCURVE",
+"270 600 OFFCURVE",
+"474 600 CURVE SMOOTH",
+"629 600 OFFCURVE",
+"752 506 OFFCURVE",
+"752 331 CURVE SMOOTH",
+"752 190 OFFCURVE",
+"672 94 OFFCURVE",
+"605 94 CURVE SMOOTH",
+"588 94 OFFCURVE",
+"579 100 OFFCURVE",
+"579 114 CURVE SMOOTH",
+"579 118 OFFCURVE",
+"580 124 OFFCURVE",
+"582 131 CURVE SMOOTH",
+"656 443 LINE",
+"548 443 LINE",
+"485 189 LINE SMOOTH",
+"474 144 OFFCURVE",
+"471 127 OFFCURVE",
+"471 112 CURVE SMOOTH",
+"471 65 OFFCURVE",
+"500 44 OFFCURVE",
+"552 44 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"530 390 LINE",
+"512 435 OFFCURVE",
+"491 454 OFFCURVE",
+"449 454 CURVE SMOOTH",
+"344 454 OFFCURVE",
+"225 336 OFFCURVE",
+"225 194 CURVE SMOOTH",
+"225 90 OFFCURVE",
+"288 44 OFFCURVE",
+"351 44 CURVE SMOOTH",
+"408 44 OFFCURVE",
+"445 82 OFFCURVE",
+"464 115 CURVE",
+"471 115 LINE",
+"499 237 LINE SMOOTH",
+"472 118 OFFCURVE",
+"408 80 OFFCURVE",
+"371 80 CURVE SMOOTH",
+"346 80 OFFCURVE",
+"335 97 OFFCURVE",
+"335 148 CURVE SMOOTH",
+"335 273 OFFCURVE",
+"401 420 OFFCURVE",
+"465 420 CURVE SMOOTH",
+"498 420 OFFCURVE",
+"518 382 OFFCURVE",
+"518 341 CURVE SMOOTH",
+"518 329 OFFCURVE",
+"516 322 OFFCURVE",
+"516 309 CURVE",
+"536 390 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"479 -152 OFFCURVE",
+"561 -119 OFFCURVE",
+"646 -32 CURVE",
+"623 3 LINE",
+"545 -91 OFFCURVE",
+"454 -112 OFFCURVE",
+"381 -112 CURVE SMOOTH",
+"200 -112 OFFCURVE",
+"99 17 OFFCURVE",
+"99 199 CURVE SMOOTH",
+"99 431 OFFCURVE",
+"261 590 OFFCURVE",
+"460 590 CURVE SMOOTH",
+"609 590 OFFCURVE",
+"728 501 OFFCURVE",
+"728 327 CURVE SMOOTH",
+"728 196 OFFCURVE",
+"660 104 OFFCURVE",
+"601 104 CURVE SMOOTH",
+"586 104 OFFCURVE",
+"577 110 OFFCURVE",
+"577 124 CURVE SMOOTH",
+"577 129 OFFCURVE",
+"578 134 OFFCURVE",
+"580 141 CURVE SMOOTH",
+"652 443 LINE",
+"524 443 LINE",
+"461 189 LINE SMOOTH",
+"450 144 OFFCURVE",
+"447 127 OFFCURVE",
+"447 113 CURVE SMOOTH",
+"447 65 OFFCURVE",
+"481 44 OFFCURVE",
+"535 44 CURVE SMOOTH",
+"669 44 OFFCURVE",
+"771 176 OFFCURVE",
+"771 335 CURVE SMOOTH",
+"771 501 OFFCURVE",
+"660 630 OFFCURVE",
+"463 630 CURVE SMOOTH",
+"247 630 OFFCURVE",
+"56 474 OFFCURVE",
+"56 199 CURVE SMOOTH",
+"56 -40 OFFCURVE",
+"200 -152 OFFCURVE",
+"381 -152 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"384 44 OFFCURVE",
+"423 79 OFFCURVE",
+"440 110 CURVE",
+"447 110 LINE",
+"475 237 LINE",
+"451 130 OFFCURVE",
+"395 90 OFFCURVE",
+"357 90 CURVE SMOOTH",
+"333 90 OFFCURVE",
+"321 105 OFFCURVE",
+"321 158 CURVE SMOOTH",
+"321 275 OFFCURVE",
+"381 410 OFFCURVE",
+"443 410 CURVE SMOOTH",
+"474 410 OFFCURVE",
+"494 376 OFFCURVE",
+"494 341 CURVE SMOOTH",
+"494 329 OFFCURVE",
+"492 322 OFFCURVE",
+"492 309 CURVE",
+"513 395 LINE",
+"507 395 LINE",
+"489 436 OFFCURVE",
+"468 454 OFFCURVE",
+"425 454 CURVE SMOOTH",
+"317 454 OFFCURVE",
+"196 335 OFFCURVE",
+"196 195 CURVE SMOOTH",
+"196 90 OFFCURVE",
+"264 44 OFFCURVE",
+"328 44 CURVE SMOOTH"
+);
+}
+);
+width = 835;
+}
+);
+unicode = 0040;
+},
+{
+glyphname = ampersand;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"530 455 LINE",
+"791 455 LINE",
+"791 480 LINE",
+"530 480 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"535 0 LINE",
+"766 0 LINE",
+"766 25 LINE",
+"535 25 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"535 0 LINE",
+"689 0 LINE",
+"393 465 LINE",
+"239 465 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"272 448 LINE",
+"394 463 LINE",
+"325 562 LINE SMOOTH",
+"303 594 OFFCURVE",
+"284 624 OFFCURVE",
+"284 659 CURVE SMOOTH",
+"284 703 OFFCURVE",
+"315 739 OFFCURVE",
+"371 739 CURVE SMOOTH",
+"426 739 OFFCURVE",
+"456 703 OFFCURVE",
+"456 638 CURVE SMOOTH",
+"456 561 OFFCURVE",
+"414 498 OFFCURVE",
+"354 491 CURVE",
+"382 466 LINE",
+"526 516 OFFCURVE",
+"559 587 OFFCURVE",
+"559 638 CURVE SMOOTH",
+"559 716 OFFCURVE",
+"484 769 OFFCURVE",
+"375 769 CURVE SMOOTH",
+"245 769 OFFCURVE",
+"180 694 OFFCURVE",
+"180 608 CURVE SMOOTH",
+"180 545 OFFCURVE",
+"215 506 OFFCURVE",
+"239 465 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"263 457 LINE",
+"135 401 OFFCURVE",
+"20 316 OFFCURVE",
+"20 189 CURVE SMOOTH",
+"20 76 OFFCURVE",
+"110 -13 OFFCURVE",
+"271 -13 CURVE SMOOTH",
+"358 -13 OFFCURVE",
+"434 13 OFFCURVE",
+"515 100 CURVE",
+"493 122 LINE",
+"429 58 OFFCURVE",
+"382 36 OFFCURVE",
+"335 36 CURVE SMOOTH",
+"236 36 OFFCURVE",
+"155 134 OFFCURVE",
+"155 260 CURVE SMOOTH",
+"155 335 OFFCURVE",
+"184 395 OFFCURVE",
+"284 430 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"579 160 LINE",
+"634 232 OFFCURVE",
+"683 365 OFFCURVE",
+"683 464 CURVE",
+"649 464 LINE",
+"649 371 OFFCURVE",
+"614 255 OFFCURVE",
+"556 188 CURVE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"689 0 LINE",
+"326 556 LINE SMOOTH",
+"305 589 OFFCURVE",
+"284 622 OFFCURVE",
+"284 657 CURVE SMOOTH",
+"284 701 OFFCURVE",
+"315 737 OFFCURVE",
+"371 737 CURVE SMOOTH",
+"426 737 OFFCURVE",
+"456 701 OFFCURVE",
+"456 636 CURVE SMOOTH",
+"456 559 OFFCURVE",
+"414 498 OFFCURVE",
+"354 491 CURVE",
+"382 466 LINE",
+"526 516 OFFCURVE",
+"559 585 OFFCURVE",
+"559 636 CURVE SMOOTH",
+"559 714 OFFCURVE",
+"484 767 OFFCURVE",
+"375 767 CURVE SMOOTH",
+"245 767 OFFCURVE",
+"180 692 OFFCURVE",
+"180 606 CURVE SMOOTH",
+"180 543 OFFCURVE",
+"213 505 OFFCURVE",
+"239 465 CURVE SMOOTH",
+"535 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"358 -13 OFFCURVE",
+"434 13 OFFCURVE",
+"515 100 CURVE",
+"493 122 LINE",
+"429 58 OFFCURVE",
+"382 36 OFFCURVE",
+"335 36 CURVE SMOOTH",
+"236 36 OFFCURVE",
+"155 134 OFFCURVE",
+"155 260 CURVE SMOOTH",
+"155 335 OFFCURVE",
+"184 395 OFFCURVE",
+"284 430 CURVE",
+"263 457 LINE",
+"135 401 OFFCURVE",
+"20 316 OFFCURVE",
+"20 189 CURVE SMOOTH",
+"20 76 OFFCURVE",
+"110 -13 OFFCURVE",
+"271 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"766 0 LINE",
+"766 25 LINE",
+"575 25 LINE",
+"575 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"634 232 OFFCURVE",
+"683 365 OFFCURVE",
+"683 464 CURVE",
+"649 464 LINE",
+"649 371 OFFCURVE",
+"614 255 OFFCURVE",
+"556 188 CURVE",
+"579 160 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"791 455 LINE",
+"791 480 LINE",
+"530 480 LINE",
+"530 455 LINE"
+);
+}
+);
+width = 800;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"567 455 LINE",
+"828 455 LINE",
+"828 480 LINE",
+"567 480 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"541 0 LINE",
+"822 0 LINE",
+"822 30 LINE",
+"561 30 LINE",
+"735 0 LINE",
+"439 465 LINE",
+"245 465 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"440 463 LINE",
+"371 562 LINE SMOOTH",
+"349 593 OFFCURVE",
+"330 620 OFFCURVE",
+"330 656 CURVE SMOOTH",
+"330 694 OFFCURVE",
+"351 728 OFFCURVE",
+"409 728 CURVE SMOOTH",
+"469 728 OFFCURVE",
+"497 692 OFFCURVE",
+"497 629 CURVE SMOOTH",
+"497 551 OFFCURVE",
+"453 488 OFFCURVE",
+"390 481 CURVE",
+"418 456 LINE",
+"586 508 OFFCURVE",
+"625 579 OFFCURVE",
+"625 631 CURVE SMOOTH",
+"625 710 OFFCURVE",
+"536 763 OFFCURVE",
+"414 763 CURVE SMOOTH",
+"277 763 OFFCURVE",
+"196 696 OFFCURVE",
+"196 598 CURVE SMOOTH",
+"196 544 OFFCURVE",
+"220 499 OFFCURVE",
+"245 465 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"273 437 LINE",
+"134 382 OFFCURVE",
+"20 306 OFFCURVE",
+"20 185 CURVE SMOOTH",
+"20 78 OFFCURVE",
+"109 -13 OFFCURVE",
+"272 -13 CURVE SMOOTH",
+"358 -13 OFFCURVE",
+"434 12 OFFCURVE",
+"515 95 CURVE",
+"493 122 LINE",
+"439 72 OFFCURVE",
+"399 56 OFFCURVE",
+"363 56 CURVE SMOOTH",
+"263 56 OFFCURVE",
+"180 182 OFFCURVE",
+"180 292 CURVE SMOOTH",
+"180 350 OFFCURVE",
+"203 381 OFFCURVE",
+"294 405 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"579 160 LINE",
+"654 232 OFFCURVE",
+"723 365 OFFCURVE",
+"723 464 CURVE",
+"684 464 LINE",
+"684 371 OFFCURVE",
+"633 255 OFFCURVE",
+"551 188 CURVE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"735 0 LINE",
+"377 554 LINE SMOOTH",
+"356 587 OFFCURVE",
+"330 623 OFFCURVE",
+"330 656 CURVE SMOOTH",
+"330 694 OFFCURVE",
+"351 728 OFFCURVE",
+"409 728 CURVE SMOOTH",
+"469 728 OFFCURVE",
+"497 692 OFFCURVE",
+"497 629 CURVE SMOOTH",
+"497 551 OFFCURVE",
+"453 488 OFFCURVE",
+"390 481 CURVE",
+"418 456 LINE",
+"586 508 OFFCURVE",
+"625 579 OFFCURVE",
+"625 631 CURVE SMOOTH",
+"625 710 OFFCURVE",
+"536 763 OFFCURVE",
+"414 763 CURVE SMOOTH",
+"277 763 OFFCURVE",
+"196 696 OFFCURVE",
+"196 598 CURVE SMOOTH",
+"196 544 OFFCURVE",
+"220 499 OFFCURVE",
+"245 465 CURVE",
+"541 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"358 -13 OFFCURVE",
+"434 12 OFFCURVE",
+"515 95 CURVE",
+"493 122 LINE",
+"439 72 OFFCURVE",
+"399 56 OFFCURVE",
+"363 56 CURVE SMOOTH",
+"263 56 OFFCURVE",
+"180 182 OFFCURVE",
+"180 292 CURVE SMOOTH",
+"180 350 OFFCURVE",
+"203 381 OFFCURVE",
+"294 405 CURVE",
+"273 437 LINE",
+"134 382 OFFCURVE",
+"20 306 OFFCURVE",
+"20 185 CURVE SMOOTH",
+"20 78 OFFCURVE",
+"109 -13 OFFCURVE",
+"272 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"822 0 LINE",
+"822 30 LINE",
+"575 30 LINE",
+"575 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"654 232 OFFCURVE",
+"723 365 OFFCURVE",
+"723 464 CURVE",
+"684 464 LINE",
+"684 371 OFFCURVE",
+"633 255 OFFCURVE",
+"551 188 CURVE",
+"579 160 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"828 455 LINE",
+"828 480 LINE",
+"567 480 LINE",
+"567 455 LINE"
+);
+}
+);
+width = 836;
+}
+);
+unicode = 0026;
+},
+{
+glyphname = paragraph;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"126 15 LINE",
+"260 15 LINE",
+"260 754 LINE",
+"126 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"450 526 LINE",
+"415 526 LINE",
+"415 418 OFFCURVE",
+"381 388 OFFCURVE",
+"257 388 CURVE",
+"257 363 LINE",
+"381 363 OFFCURVE",
+"412 328 OFFCURVE",
+"415 216 CURVE",
+"450 216 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"8 729 LINE",
+"416 729 LINE SMOOTH",
+"515 729 OFFCURVE",
+"572 646 OFFCURVE",
+"574 549 CURVE",
+"609 549 LINE",
+"609 754 LINE",
+"8 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"8 0 LINE",
+"639 0 LINE",
+"639 235 LINE",
+"604 235 LINE",
+"602 123 OFFCURVE",
+"545 25 OFFCURVE",
+"446 25 CURVE SMOOTH",
+"8 25 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"311 -123 LINE",
+"311 731 LINE",
+"422 731 LINE",
+"422 -123 LINE",
+"472 -123 LINE",
+"472 731 LINE",
+"617 731 LINE",
+"617 754 LINE",
+"261 754 LINE SMOOTH",
+"140 754 OFFCURVE",
+"29 660 OFFCURVE",
+"29 535 CURVE SMOOTH",
+"29 418 OFFCURVE",
+"111 319 OFFCURVE",
+"261 309 CURVE",
+"261 -123 LINE"
+);
+}
+);
+width = 626;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"334 -157 LINE",
+"334 680 LINE",
+"431 680 LINE",
+"431 -157 LINE",
+"513 -157 LINE",
+"513 680 LINE",
+"608 680 LINE",
+"608 754 LINE",
+"252 754 LINE SMOOTH",
+"131 754 OFFCURVE",
+"20 660 OFFCURVE",
+"20 535 CURVE SMOOTH",
+"20 418 OFFCURVE",
+"102 319 OFFCURVE",
+"252 309 CURVE",
+"252 -157 LINE"
+);
+}
+);
+width = 633;
+}
+);
+unicode = 00B6;
+},
+{
+glyphname = section;
+lastChange = "2016-08-19 17:07:39 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"407 130 OFFCURVE",
+"459 182 OFFCURVE",
+"459 263 CURVE SMOOTH",
+"459 463 OFFCURVE",
+"144 530 OFFCURVE",
+"144 658 CURVE SMOOTH",
+"144 704 OFFCURVE",
+"184 736 OFFCURVE",
+"256 736 CURVE SMOOTH",
+"305 736 OFFCURVE",
+"339 716 OFFCURVE",
+"339 702 CURVE SMOOTH",
+"339 686 OFFCURVE",
+"300 672 OFFCURVE",
+"300 637 CURVE SMOOTH",
+"300 614 OFFCURVE",
+"317 587 OFFCURVE",
+"354 587 CURVE SMOOTH",
+"385 587 OFFCURVE",
+"412 607 OFFCURVE",
+"412 653 CURVE SMOOTH",
+"412 716 OFFCURVE",
+"349 766 OFFCURVE",
+"254 766 CURVE SMOOTH",
+"145 766 OFFCURVE",
+"94 700 OFFCURVE",
+"94 613 CURVE SMOOTH",
+"94 403 OFFCURVE",
+"393 331 OFFCURVE",
+"393 220 CURVE SMOOTH",
+"393 179 OFFCURVE",
+"352 155 OFFCURVE",
+"303 155 CURVE",
+"307 130 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"350 -123 OFFCURVE",
+"405 -56 OFFCURVE",
+"405 32 CURVE SMOOTH",
+"405 238 OFFCURVE",
+"106 312 OFFCURVE",
+"106 423 CURVE SMOOTH",
+"106 464 OFFCURVE",
+"147 488 OFFCURVE",
+"196 488 CURVE",
+"192 513 LINE",
+"92 513 OFFCURVE",
+"40 461 OFFCURVE",
+"40 380 CURVE SMOOTH",
+"40 182 OFFCURVE",
+"355 79 OFFCURVE",
+"355 -26 CURVE SMOOTH",
+"355 -67 OFFCURVE",
+"306 -93 OFFCURVE",
+"239 -93 CURVE SMOOTH",
+"178 -93 OFFCURVE",
+"150 -71 OFFCURVE",
+"150 -55 CURVE SMOOTH",
+"150 -36 OFFCURVE",
+"189 -24 OFFCURVE",
+"189 11 CURVE SMOOTH",
+"189 33 OFFCURVE",
+"172 61 OFFCURVE",
+"135 61 CURVE SMOOTH",
+"104 61 OFFCURVE",
+"77 42 OFFCURVE",
+"77 -2 CURVE SMOOTH",
+"77 -69 OFFCURVE",
+"139 -123 OFFCURVE",
+"239 -123 CURVE SMOOTH"
+);
+}
+);
+width = 499;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"414 118 OFFCURVE",
+"469 180 OFFCURVE",
+"469 266 CURVE SMOOTH",
+"469 468 OFFCURVE",
+"164 520 OFFCURVE",
+"164 648 CURVE SMOOTH",
+"164 689 OFFCURVE",
+"196 719 OFFCURVE",
+"258 719 CURVE SMOOTH",
+"305 719 OFFCURVE",
+"339 702 OFFCURVE",
+"339 689 CURVE SMOOTH",
+"339 675 OFFCURVE",
+"300 660 OFFCURVE",
+"300 625 CURVE SMOOTH",
+"300 602 OFFCURVE",
+"317 575 OFFCURVE",
+"353 575 CURVE SMOOTH",
+"385 575 OFFCURVE",
+"412 596 OFFCURVE",
+"412 639 CURVE SMOOTH",
+"412 704 OFFCURVE",
+"352 754 OFFCURVE",
+"250 754 CURVE SMOOTH",
+"133 754 OFFCURVE",
+"74 688 OFFCURVE",
+"74 602 CURVE SMOOTH",
+"74 409 OFFCURVE",
+"373 322 OFFCURVE",
+"373 206 CURVE SMOOTH",
+"373 168 OFFCURVE",
+"341 143 OFFCURVE",
+"303 143 CURVE",
+"307 118 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"361 -161 OFFCURVE",
+"425 -92 OFFCURVE",
+"425 -3 CURVE SMOOTH",
+"425 189 OFFCURVE",
+"126 275 OFFCURVE",
+"126 392 CURVE SMOOTH",
+"126 430 OFFCURVE",
+"157 455 OFFCURVE",
+"196 455 CURVE",
+"192 480 LINE",
+"85 480 OFFCURVE",
+"30 417 OFFCURVE",
+"30 332 CURVE SMOOTH",
+"30 132 OFFCURVE",
+"335 45 OFFCURVE",
+"335 -60 CURVE SMOOTH",
+"335 -96 OFFCURVE",
+"300 -126 OFFCURVE",
+"235 -126 CURVE SMOOTH",
+"180 -126 OFFCURVE",
+"150 -104 OFFCURVE",
+"150 -88 CURVE SMOOTH",
+"150 -69 OFFCURVE",
+"189 -57 OFFCURVE",
+"189 -22 CURVE SMOOTH",
+"189 0 OFFCURVE",
+"172 28 OFFCURVE",
+"135 28 CURVE SMOOTH",
+"104 28 OFFCURVE",
+"77 10 OFFCURVE",
+"77 -36 CURVE SMOOTH",
+"77 -105 OFFCURVE",
+"138 -161 OFFCURVE",
+"244 -161 CURVE SMOOTH"
+);
+}
+);
+width = 499;
+}
+);
+unicode = 00A7;
+},
+{
+glyphname = copyright;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"622 -10 OFFCURVE",
+"793 158 OFFCURVE",
+"793 370 CURVE SMOOTH",
+"793 586 OFFCURVE",
+"625 754 OFFCURVE",
+"414 754 CURVE SMOOTH",
+"205 754 OFFCURVE",
+"40 579 OFFCURVE",
+"40 370 CURVE SMOOTH",
+"40 165 OFFCURVE",
+"207 -10 OFFCURVE",
+"413 -10 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"464 152 OFFCURVE",
+"508 164 OFFCURVE",
+"543 187 CURVE",
+"563 160 LINE",
+"578 160 LINE",
+"578 285 LINE",
+"558 285 LINE",
+"543 224 OFFCURVE",
+"506 175 OFFCURVE",
+"419 175 CURVE SMOOTH",
+"339 175 OFFCURVE",
+"299 215 OFFCURVE",
+"299 374 CURVE SMOOTH",
+"299 551 OFFCURVE",
+"351 587 OFFCURVE",
+"420 587 CURVE SMOOTH",
+"503 587 OFFCURVE",
+"539 534 OFFCURVE",
+"553 471 CURVE",
+"572 471 LINE",
+"572 604 LINE",
+"558 604 LINE",
+"535 575 LINE",
+"500 600 OFFCURVE",
+"464 609 OFFCURVE",
+"421 609 CURVE SMOOTH",
+"288 609 OFFCURVE",
+"190 503 OFFCURVE",
+"190 384 CURVE SMOOTH",
+"190 262 OFFCURVE",
+"289 152 OFFCURVE",
+"419 152 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"233 29 OFFCURVE",
+"79 182 OFFCURVE",
+"79 371 CURVE SMOOTH",
+"79 557 OFFCURVE",
+"230 715 OFFCURVE",
+"414 715 CURVE SMOOTH",
+"602 715 OFFCURVE",
+"754 562 OFFCURVE",
+"754 371 CURVE SMOOTH",
+"754 188 OFFCURVE",
+"604 29 OFFCURVE",
+"413 29 CURVE SMOOTH"
+);
+}
+);
+width = 833;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"622 -10 OFFCURVE",
+"793 158 OFFCURVE",
+"793 372 CURVE SMOOTH",
+"793 585 OFFCURVE",
+"624 754 OFFCURVE",
+"416 754 CURVE SMOOTH",
+"205 754 OFFCURVE",
+"40 579 OFFCURVE",
+"40 372 CURVE SMOOTH",
+"40 165 OFFCURVE",
+"205 -10 OFFCURVE",
+"416 -10 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"471 152 OFFCURVE",
+"511 164 OFFCURVE",
+"543 187 CURVE",
+"558 160 LINE",
+"578 160 LINE",
+"578 285 LINE",
+"553 285 LINE",
+"540 230 OFFCURVE",
+"506 185 OFFCURVE",
+"431 185 CURVE SMOOTH",
+"362 185 OFFCURVE",
+"329 223 OFFCURVE",
+"329 372 CURVE SMOOTH",
+"329 545 OFFCURVE",
+"373 577 OFFCURVE",
+"431 577 CURVE SMOOTH",
+"503 577 OFFCURVE",
+"536 529 OFFCURVE",
+"548 471 CURVE",
+"572 471 LINE",
+"572 604 LINE",
+"553 604 LINE",
+"535 575 LINE",
+"503 600 OFFCURVE",
+"470 609 OFFCURVE",
+"430 609 CURVE SMOOTH",
+"292 609 OFFCURVE",
+"190 503 OFFCURVE",
+"190 383 CURVE SMOOTH",
+"190 262 OFFCURVE",
+"294 152 OFFCURVE",
+"427 152 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"237 39 OFFCURVE",
+"89 188 OFFCURVE",
+"89 371 CURVE SMOOTH",
+"89 552 OFFCURVE",
+"234 705 OFFCURVE",
+"416 705 CURVE SMOOTH",
+"596 705 OFFCURVE",
+"744 554 OFFCURVE",
+"744 373 CURVE SMOOTH",
+"744 193 OFFCURVE",
+"598 39 OFFCURVE",
+"416 39 CURVE SMOOTH"
+);
+}
+);
+width = 833;
+}
+);
+unicode = 00A9;
+},
+{
+glyphname = registered;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"475 -10 OFFCURVE",
+"646 158 OFFCURVE",
+"646 372 CURVE SMOOTH",
+"646 585 OFFCURVE",
+"477 754 OFFCURVE",
+"269 754 CURVE SMOOTH",
+"58 754 OFFCURVE",
+"-107 579 OFFCURVE",
+"-107 372 CURVE SMOOTH",
+"-107 165 OFFCURVE",
+"58 -10 OFFCURVE",
+"269 -10 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"455 715 OFFCURVE",
+"607 560 OFFCURVE",
+"607 373 CURVE SMOOTH",
+"607 188 OFFCURVE",
+"457 29 OFFCURVE",
+"269 29 CURVE SMOOTH",
+"85 29 OFFCURVE",
+"-68 182 OFFCURVE",
+"-68 370 CURVE SMOOTH",
+"-68 557 OFFCURVE",
+"82 715 OFFCURVE",
+"269 715 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"120 170 LINE",
+"214 170 LINE",
+"214 602 LINE",
+"120 602 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"244 387 LINE SMOOTH",
+"364 387 OFFCURVE",
+"434 434 OFFCURVE",
+"434 501 CURVE SMOOTH",
+"434 565 OFFCURVE",
+"372 602 OFFCURVE",
+"297 602 CURVE SMOOTH",
+"71 602 LINE",
+"71 580 LINE",
+"268 580 LINE SMOOTH",
+"317 580 OFFCURVE",
+"338 568 OFFCURVE",
+"338 501 CURVE SMOOTH",
+"338 422 OFFCURVE",
+"309 405 OFFCURVE",
+"244 405 CURVE SMOOTH",
+"195 405 LINE",
+"195 387 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"71 161 LINE",
+"290 161 LINE",
+"290 183 LINE",
+"71 183 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"479 161 LINE",
+"479 183 LINE",
+"457 183 LINE SMOOTH",
+"426 183 OFFCURVE",
+"416 196 OFFCURVE",
+"416 245 CURVE SMOOTH",
+"416 276 LINE SMOOTH",
+"416 331 OFFCURVE",
+"364 379 OFFCURVE",
+"315 390 CURVE",
+"315 394 LINE",
+"293 394 LINE",
+"249 387 LINE",
+"282 387 OFFCURVE",
+"307 358 OFFCURVE",
+"309 297 CURVE SMOOTH",
+"311 250 LINE SMOOTH",
+"313 196 OFFCURVE",
+"361 161 OFFCURVE",
+"424 161 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"393 323 OFFCURVE",
+"497 425 OFFCURVE",
+"497 555 CURVE SMOOTH",
+"497 684 OFFCURVE",
+"394 787 OFFCURVE",
+"269 787 CURVE SMOOTH",
+"140 787 OFFCURVE",
+"40 681 OFFCURVE",
+"40 555 CURVE SMOOTH",
+"40 430 OFFCURVE",
+"140 323 OFFCURVE",
+"269 323 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"282 427 LINE",
+"282 445 LINE",
+"148 445 LINE",
+"148 427 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"245 433 LINE",
+"245 695 LINE",
+"178 695 LINE",
+"178 433 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"162 357 OFFCURVE",
+"74 446 OFFCURVE",
+"74 554 CURVE SMOOTH",
+"74 663 OFFCURVE",
+"161 754 OFFCURVE",
+"269 754 CURVE SMOOTH",
+"376 754 OFFCURVE",
+"464 664 OFFCURVE",
+"464 555 CURVE SMOOTH",
+"464 448 OFFCURVE",
+"377 357 OFFCURVE",
+"269 357 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"396 427 LINE",
+"396 445 LINE",
+"383 445 LINE SMOOTH",
+"371 445 OFFCURVE",
+"367 453 OFFCURVE",
+"367 483 CURVE SMOOTH",
+"367 497 LINE SMOOTH",
+"367 530 OFFCURVE",
+"341 561 OFFCURVE",
+"317 568 CURVE",
+"317 574 LINE",
+"293 569 LINE",
+"266 565 LINE",
+"280 565 OFFCURVE",
+"291 546 OFFCURVE",
+"293 509 CURVE SMOOTH",
+"293 481 LINE SMOOTH",
+"295 448 OFFCURVE",
+"325 427 OFFCURVE",
+"363 427 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"264 565 LINE SMOOTH",
+"330 565 OFFCURVE",
+"369 593 OFFCURVE",
+"369 633 CURVE SMOOTH",
+"369 672 OFFCURVE",
+"331 695 OFFCURVE",
+"286 695 CURVE SMOOTH",
+"148 695 LINE",
+"148 676 LINE",
+"268 676 LINE SMOOTH",
+"290 676 OFFCURVE",
+"301 669 OFFCURVE",
+"301 633 CURVE SMOOTH",
+"301 590 OFFCURVE",
+"289 580 OFFCURVE",
+"264 580 CURVE SMOOTH",
+"234 580 LINE",
+"234 565 LINE"
+);
+}
+);
+width = 537;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"622 -10 OFFCURVE",
+"793 158 OFFCURVE",
+"793 372 CURVE SMOOTH",
+"793 585 OFFCURVE",
+"624 754 OFFCURVE",
+"416 754 CURVE SMOOTH",
+"205 754 OFFCURVE",
+"40 579 OFFCURVE",
+"40 372 CURVE SMOOTH",
+"40 165 OFFCURVE",
+"205 -10 OFFCURVE",
+"416 -10 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"596 705 OFFCURVE",
+"744 555 OFFCURVE",
+"744 373 CURVE SMOOTH",
+"744 193 OFFCURVE",
+"598 39 OFFCURVE",
+"416 39 CURVE SMOOTH",
+"237 39 OFFCURVE",
+"89 188 OFFCURVE",
+"89 370 CURVE SMOOTH",
+"89 552 OFFCURVE",
+"235 705 OFFCURVE",
+"416 705 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"257 170 LINE",
+"371 170 LINE",
+"371 602 LINE",
+"257 602 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"391 377 LINE SMOOTH",
+"517 377 OFFCURVE",
+"591 428 OFFCURVE",
+"591 501 CURVE SMOOTH",
+"591 565 OFFCURVE",
+"524 602 OFFCURVE",
+"444 602 CURVE SMOOTH",
+"218 602 LINE",
+"218 570 LINE",
+"415 570 LINE SMOOTH",
+"457 570 OFFCURVE",
+"475 550 OFFCURVE",
+"475 501 CURVE SMOOTH",
+"475 422 OFFCURVE",
+"449 405 OFFCURVE",
+"391 405 CURVE SMOOTH",
+"342 405 LINE",
+"342 377 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"218 161 LINE",
+"437 161 LINE",
+"437 193 LINE",
+"218 193 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"636 161 LINE",
+"636 183 LINE",
+"614 183 LINE SMOOTH",
+"583 183 OFFCURVE",
+"573 196 OFFCURVE",
+"573 245 CURVE SMOOTH",
+"573 276 LINE SMOOTH",
+"573 326 OFFCURVE",
+"516 370 OFFCURVE",
+"462 380 CURVE",
+"462 384 LINE",
+"440 384 LINE",
+"396 377 LINE",
+"423 377 OFFCURVE",
+"444 351 OFFCURVE",
+"446 297 CURVE SMOOTH",
+"448 250 LINE SMOOTH",
+"450 196 OFFCURVE",
+"502 161 OFFCURVE",
+"571 161 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"393 323 OFFCURVE",
+"497 425 OFFCURVE",
+"497 555 CURVE SMOOTH",
+"497 684 OFFCURVE",
+"394 787 OFFCURVE",
+"269 787 CURVE SMOOTH",
+"140 787 OFFCURVE",
+"40 681 OFFCURVE",
+"40 555 CURVE SMOOTH",
+"40 430 OFFCURVE",
+"140 323 OFFCURVE",
+"269 323 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"282 427 LINE",
+"282 445 LINE",
+"148 445 LINE",
+"148 427 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"245 433 LINE",
+"245 695 LINE",
+"168 695 LINE",
+"168 433 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"162 357 OFFCURVE",
+"74 446 OFFCURVE",
+"74 554 CURVE SMOOTH",
+"74 663 OFFCURVE",
+"161 754 OFFCURVE",
+"269 754 CURVE SMOOTH",
+"376 754 OFFCURVE",
+"464 664 OFFCURVE",
+"464 555 CURVE SMOOTH",
+"464 448 OFFCURVE",
+"377 357 OFFCURVE",
+"269 357 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"406 427 LINE",
+"406 445 LINE",
+"393 445 LINE SMOOTH",
+"381 445 OFFCURVE",
+"377 453 OFFCURVE",
+"377 483 CURVE SMOOTH",
+"377 497 LINE SMOOTH",
+"377 530 OFFCURVE",
+"346 561 OFFCURVE",
+"317 568 CURVE",
+"317 574 LINE",
+"293 569 LINE",
+"266 565 LINE",
+"280 565 OFFCURVE",
+"291 546 OFFCURVE",
+"293 509 CURVE",
+"293 481 LINE",
+"295 448 OFFCURVE",
+"330 427 OFFCURVE",
+"373 427 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"264 565 LINE SMOOTH",
+"336 565 OFFCURVE",
+"379 593 OFFCURVE",
+"379 633 CURVE SMOOTH",
+"379 672 OFFCURVE",
+"336 695 OFFCURVE",
+"286 695 CURVE SMOOTH",
+"148 695 LINE",
+"148 676 LINE",
+"268 676 LINE SMOOTH",
+"290 676 OFFCURVE",
+"301 669 OFFCURVE",
+"301 633 CURVE SMOOTH",
+"301 590 OFFCURVE",
+"289 580 OFFCURVE",
+"264 580 CURVE SMOOTH",
+"234 580 LINE",
+"234 565 LINE"
+);
+}
+);
+width = 537;
+}
+);
+unicode = 00AE;
+},
+{
+glyphname = trademark;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"591 376 LINE",
+"693 710 LINE",
+"697 710 LINE",
+"697 403 LINE",
+"642 403 LINE",
+"642 380 LINE",
+"818 380 LINE",
+"818 403 LINE",
+"783 403 LINE",
+"783 732 LINE",
+"818 732 LINE",
+"818 754 LINE",
+"688 754 LINE",
+"607 494 LINE",
+"603 494 LINE",
+"526 754 LINE",
+"372 754 LINE",
+"372 732 LINE",
+"416 732 LINE",
+"416 403 LINE",
+"372 403 LINE",
+"372 380 LINE",
+"500 380 LINE",
+"500 403 LINE",
+"445 403 LINE",
+"445 710 LINE",
+"449 710 LINE",
+"554 376 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"297 380 LINE",
+"297 403 LINE",
+"233 403 LINE",
+"233 732 LINE",
+"243 732 LINE SMOOTH",
+"292 732 OFFCURVE",
+"320 691 OFFCURVE",
+"321 633 CURVE",
+"348 633 LINE",
+"348 754 LINE",
+"27 754 LINE",
+"27 633 LINE",
+"54 633 LINE",
+"55 689 OFFCURVE",
+"82 732 OFFCURVE",
+"129 732 CURVE SMOOTH",
+"146 732 LINE",
+"146 403 LINE",
+"82 403 LINE",
+"82 380 LINE"
+);
+}
+);
+width = 845;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"601 376 LINE",
+"693 677 LINE",
+"697 677 LINE",
+"697 408 LINE",
+"642 408 LINE",
+"642 380 LINE",
+"828 380 LINE",
+"828 408 LINE",
+"793 408 LINE",
+"793 727 LINE",
+"828 727 LINE",
+"828 754 LINE",
+"688 754 LINE",
+"607 494 LINE",
+"603 494 LINE",
+"526 754 LINE",
+"372 754 LINE",
+"372 727 LINE",
+"406 727 LINE",
+"406 408 LINE",
+"372 408 LINE",
+"372 380 LINE",
+"500 380 LINE",
+"500 408 LINE",
+"445 408 LINE",
+"445 679 LINE",
+"449 679 LINE",
+"544 376 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"297 380 LINE",
+"297 408 LINE",
+"243 408 LINE",
+"243 727 LINE",
+"247 727 LINE SMOOTH",
+"291 727 OFFCURVE",
+"315 689 OFFCURVE",
+"316 633 CURVE",
+"348 633 LINE",
+"348 754 LINE",
+"27 754 LINE",
+"27 633 LINE",
+"59 633 LINE",
+"60 689 OFFCURVE",
+"85 725 OFFCURVE",
+"129 727 CURVE SMOOTH",
+"136 727 LINE",
+"136 408 LINE",
+"82 408 LINE",
+"82 380 LINE"
+);
+}
+);
+width = 845;
+}
+);
+unicode = 2122;
+},
+{
+glyphname = degree;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"280 459 OFFCURVE",
+"348 515 OFFCURVE",
+"348 608 CURVE SMOOTH",
+"348 693 OFFCURVE",
+"290 763 OFFCURVE",
+"200 763 CURVE SMOOTH",
+"118 763 OFFCURVE",
+"50 705 OFFCURVE",
+"50 610 CURVE SMOOTH",
+"50 515 OFFCURVE",
+"118 459 OFFCURVE",
+"199 459 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"141 503 OFFCURVE",
+"103 549 OFFCURVE",
+"103 612 CURVE SMOOTH",
+"103 675 OFFCURVE",
+"140 718 OFFCURVE",
+"201 718 CURVE SMOOTH",
+"264 718 OFFCURVE",
+"296 671 OFFCURVE",
+"296 611 CURVE SMOOTH",
+"296 547 OFFCURVE",
+"260 503 OFFCURVE",
+"201 503 CURVE SMOOTH"
+);
+}
+);
+width = 363;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"263 459 OFFCURVE",
+"331 515 OFFCURVE",
+"331 608 CURVE SMOOTH",
+"331 693 OFFCURVE",
+"273 763 OFFCURVE",
+"183 763 CURVE SMOOTH",
+"101 763 OFFCURVE",
+"33 705 OFFCURVE",
+"33 610 CURVE SMOOTH",
+"33 515 OFFCURVE",
+"101 459 OFFCURVE",
+"182 459 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"130 513 OFFCURVE",
+"96 555 OFFCURVE",
+"96 612 CURVE SMOOTH",
+"96 669 OFFCURVE",
+"129 708 OFFCURVE",
+"184 708 CURVE SMOOTH",
+"240 708 OFFCURVE",
+"269 665 OFFCURVE",
+"269 611 CURVE SMOOTH",
+"269 553 OFFCURVE",
+"237 513 OFFCURVE",
+"184 513 CURVE SMOOTH"
+);
+}
+);
+width = 363;
+}
+);
+unicode = 00B0;
+},
+{
+glyphname = bar;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"213 -123 LINE",
+"213 788 LINE",
+"154 788 LINE",
+"154 -123 LINE"
+);
+}
+);
+width = 367;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"223 -123 LINE",
+"223 788 LINE",
+"144 788 LINE",
+"144 -123 LINE"
+);
+}
+);
+width = 367;
+}
+);
+unicode = 007C;
+},
+{
+glyphname = brokenbar;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"154 788 LINE",
+"154 -123 LINE",
+"213 -123 LINE",
+"213 788 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"213 417 LINE",
+"213 787 LINE",
+"154 787 LINE",
+"154 417 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"213 -123 LINE",
+"213 247 LINE",
+"154 247 LINE",
+"154 -123 LINE"
+);
+}
+);
+width = 367;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"144 788 LINE",
+"144 -123 LINE",
+"223 -123 LINE",
+"223 788 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"223 377 LINE",
+"223 787 LINE",
+"144 787 LINE",
+"144 377 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"223 -122 LINE",
+"223 279 LINE",
+"144 279 LINE",
+"144 -122 LINE"
+);
+}
+);
+width = 367;
+}
+);
+unicode = 00A6;
+},
+{
+glyphname = dagger;
+lastChange = "2016-08-16 11:12:00 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"281 -123 LINE",
+"281 10 OFFCURVE",
+"296 192 OFFCURVE",
+"334 268 CURVE",
+"293 334 OFFCURVE",
+"283 395 OFFCURVE",
+"283 472 CURVE",
+"388 468 OFFCURVE",
+"418 438 OFFCURVE",
+"462 438 CURVE SMOOTH",
+"502 438 OFFCURVE",
+"521 453 OFFCURVE",
+"521 484 CURVE SMOOTH",
+"521 517 OFFCURVE",
+"499 532 OFFCURVE",
+"460 532 CURVE SMOOTH",
+"418 532 OFFCURVE",
+"387 502 OFFCURVE",
+"283 496 CURVE",
+"289 620 OFFCURVE",
+"317 657 OFFCURVE",
+"317 705 CURVE SMOOTH",
+"317 744 OFFCURVE",
+"302 766 OFFCURVE",
+"269 766 CURVE SMOOTH",
+"238 766 OFFCURVE",
+"223 747 OFFCURVE",
+"223 707 CURVE SMOOTH",
+"223 657 OFFCURVE",
+"252 621 OFFCURVE",
+"257 496 CURVE",
+"153 502 OFFCURVE",
+"122 532 OFFCURVE",
+"80 532 CURVE SMOOTH",
+"41 532 OFFCURVE",
+"19 517 OFFCURVE",
+"19 484 CURVE SMOOTH",
+"19 453 OFFCURVE",
+"38 438 OFFCURVE",
+"78 438 CURVE SMOOTH",
+"122 438 OFFCURVE",
+"152 468 OFFCURVE",
+"257 472 CURVE",
+"257 395 OFFCURVE",
+"247 334 OFFCURVE",
+"206 268 CURVE",
+"244 192 OFFCURVE",
+"259 10 OFFCURVE",
+"259 -123 CURVE"
+);
+}
+);
+width = 541;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"286 -290 LINE",
+"286 -92 OFFCURVE",
+"303 147 OFFCURVE",
+"344 255 CURVE",
+"303 319 OFFCURVE",
+"293 389 OFFCURVE",
+"293 464 CURVE",
+"370 459 OFFCURVE",
+"405 420 OFFCURVE",
+"458 420 CURVE SMOOTH",
+"496 420 OFFCURVE",
+"521 440 OFFCURVE",
+"521 481 CURVE SMOOTH",
+"521 524 OFFCURVE",
+"492 544 OFFCURVE",
+"455 544 CURVE SMOOTH",
+"405 544 OFFCURVE",
+"369 506 OFFCURVE",
+"293 498 CURVE",
+"301 593 OFFCURVE",
+"337 638 OFFCURVE",
+"337 692 CURVE SMOOTH",
+"337 733 OFFCURVE",
+"316 763 OFFCURVE",
+"269 763 CURVE SMOOTH",
+"224 763 OFFCURVE",
+"203 736 OFFCURVE",
+"203 694 CURVE SMOOTH",
+"203 637 OFFCURVE",
+"241 594 OFFCURVE",
+"247 498 CURVE",
+"171 506 OFFCURVE",
+"135 544 OFFCURVE",
+"85 544 CURVE SMOOTH",
+"48 544 OFFCURVE",
+"19 524 OFFCURVE",
+"19 481 CURVE SMOOTH",
+"19 440 OFFCURVE",
+"44 420 OFFCURVE",
+"82 420 CURVE SMOOTH",
+"135 420 OFFCURVE",
+"170 459 OFFCURVE",
+"247 464 CURVE",
+"247 389 OFFCURVE",
+"237 319 OFFCURVE",
+"196 255 CURVE",
+"237 147 OFFCURVE",
+"254 -92 OFFCURVE",
+"254 -290 CURVE"
+);
+}
+);
+width = 541;
+}
+);
+unicode = 2020;
+},
+{
+glyphname = literSign;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"340 -11 OFFCURVE",
+"402 41 OFFCURVE",
+"445 123 CURVE",
+"425 136 LINE",
+"393 84 OFFCURVE",
+"359 38 OFFCURVE",
+"302 38 CURVE SMOOTH",
+"244 38 OFFCURVE",
+"221 87 OFFCURVE",
+"221 216 CURVE SMOOTH",
+"221 331 LINE",
+"318 424 OFFCURVE",
+"375 511 OFFCURVE",
+"375 623 CURVE SMOOTH",
+"375 710 OFFCURVE",
+"341 772 OFFCURVE",
+"268 772 CURVE SMOOTH",
+"176 772 OFFCURVE",
+"94 672 OFFCURVE",
+"94 447 CURVE SMOOTH",
+"94 293 LINE",
+"21 240 LINE",
+"35 217 LINE",
+"94 256 LINE",
+"94 186 LINE SMOOTH",
+"94 65 OFFCURVE",
+"140 -11 OFFCURVE",
+"249 -11 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"221 503 LINE SMOOTH",
+"221 710 OFFCURVE",
+"238 742 OFFCURVE",
+"274 742 CURVE SMOOTH",
+"304 742 OFFCURVE",
+"333 719 OFFCURVE",
+"333 629 CURVE SMOOTH",
+"333 527 OFFCURVE",
+"296 457 OFFCURVE",
+"221 390 CURVE"
+);
+}
+);
+width = 465;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"365 -12 OFFCURVE",
+"428 34 OFFCURVE",
+"485 135 CURVE",
+"457 161 LINE",
+"419 106 OFFCURVE",
+"386 78 OFFCURVE",
+"337 78 CURVE SMOOTH",
+"270 78 OFFCURVE",
+"247 129 OFFCURVE",
+"247 257 CURVE SMOOTH",
+"247 334 LINE",
+"353 427 OFFCURVE",
+"414 509 OFFCURVE",
+"414 623 CURVE SMOOTH",
+"414 710 OFFCURVE",
+"379 779 OFFCURVE",
+"286 779 CURVE SMOOTH",
+"172 779 OFFCURVE",
+"97 675 OFFCURVE",
+"97 498 CURVE SMOOTH",
+"97 302 LINE",
+"19 251 LINE",
+"35 213 LINE",
+"97 250 LINE",
+"97 193 LINE SMOOTH",
+"97 67 OFFCURVE",
+"156 -12 OFFCURVE",
+"275 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"247 505 LINE SMOOTH",
+"247 683 OFFCURVE",
+"252 736 OFFCURVE",
+"297 736 CURVE SMOOTH",
+"340 736 OFFCURVE",
+"358 686 OFFCURVE",
+"358 624 CURVE SMOOTH",
+"358 524 OFFCURVE",
+"312 452 OFFCURVE",
+"247 400 CURVE"
+);
+}
+);
+width = 504;
+}
+);
+unicode = 2113;
+},
+{
+glyphname = daggerdbl;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"302 -123 OFFCURVE",
+"317 -102 OFFCURVE",
+"317 -62 CURVE SMOOTH",
+"317 -21 OFFCURVE",
+"289 11 OFFCURVE",
+"283 117 CURVE",
+"387 111 OFFCURVE",
+"418 81 OFFCURVE",
+"460 81 CURVE SMOOTH",
+"499 81 OFFCURVE",
+"521 96 OFFCURVE",
+"521 129 CURVE SMOOTH",
+"521 159 OFFCURVE",
+"502 175 OFFCURVE",
+"462 175 CURVE SMOOTH",
+"418 175 OFFCURVE",
+"388 145 OFFCURVE",
+"283 141 CURVE",
+"283 206 OFFCURVE",
+"293 266 OFFCURVE",
+"334 322 CURVE",
+"293 378 OFFCURVE",
+"283 437 OFFCURVE",
+"283 502 CURVE",
+"388 498 OFFCURVE",
+"418 468 OFFCURVE",
+"462 468 CURVE SMOOTH",
+"502 468 OFFCURVE",
+"521 483 OFFCURVE",
+"521 514 CURVE SMOOTH",
+"521 547 OFFCURVE",
+"499 562 OFFCURVE",
+"460 562 CURVE SMOOTH",
+"418 562 OFFCURVE",
+"387 532 OFFCURVE",
+"283 526 CURVE",
+"289 632 OFFCURVE",
+"317 663 OFFCURVE",
+"317 705 CURVE SMOOTH",
+"317 744 OFFCURVE",
+"302 766 OFFCURVE",
+"269 766 CURVE SMOOTH",
+"238 766 OFFCURVE",
+"223 747 OFFCURVE",
+"223 707 CURVE SMOOTH",
+"223 663 OFFCURVE",
+"252 633 OFFCURVE",
+"257 526 CURVE",
+"153 532 OFFCURVE",
+"122 562 OFFCURVE",
+"80 562 CURVE SMOOTH",
+"41 562 OFFCURVE",
+"19 547 OFFCURVE",
+"19 514 CURVE SMOOTH",
+"19 483 OFFCURVE",
+"38 468 OFFCURVE",
+"78 468 CURVE SMOOTH",
+"122 468 OFFCURVE",
+"152 498 OFFCURVE",
+"257 502 CURVE",
+"257 437 OFFCURVE",
+"247 378 OFFCURVE",
+"206 322 CURVE",
+"247 266 OFFCURVE",
+"257 206 OFFCURVE",
+"257 141 CURVE",
+"152 141 OFFCURVE",
+"122 175 OFFCURVE",
+"78 175 CURVE SMOOTH",
+"38 175 OFFCURVE",
+"19 160 OFFCURVE",
+"19 129 CURVE SMOOTH",
+"19 96 OFFCURVE",
+"41 81 OFFCURVE",
+"80 81 CURVE SMOOTH",
+"122 81 OFFCURVE",
+"153 108 OFFCURVE",
+"257 117 CURVE",
+"252 10 OFFCURVE",
+"223 -20 OFFCURVE",
+"223 -64 CURVE SMOOTH",
+"223 -104 OFFCURVE",
+"238 -123 OFFCURVE",
+"269 -123 CURVE SMOOTH"
+);
+}
+);
+width = 541;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"316 -290 OFFCURVE",
+"337 -260 OFFCURVE",
+"337 -219 CURVE SMOOTH",
+"337 -165 OFFCURVE",
+"301 -120 OFFCURVE",
+"293 -25 CURVE",
+"369 -33 OFFCURVE",
+"405 -71 OFFCURVE",
+"455 -71 CURVE SMOOTH",
+"492 -71 OFFCURVE",
+"521 -51 OFFCURVE",
+"521 -8 CURVE SMOOTH",
+"521 33 OFFCURVE",
+"496 53 OFFCURVE",
+"458 53 CURVE SMOOTH",
+"405 53 OFFCURVE",
+"370 14 OFFCURVE",
+"293 9 CURVE",
+"293 88 OFFCURVE",
+"303 169 OFFCURVE",
+"344 236 CURVE",
+"303 303 OFFCURVE",
+"293 385 OFFCURVE",
+"293 464 CURVE",
+"370 459 OFFCURVE",
+"405 420 OFFCURVE",
+"458 420 CURVE SMOOTH",
+"496 420 OFFCURVE",
+"521 440 OFFCURVE",
+"521 481 CURVE SMOOTH",
+"521 524 OFFCURVE",
+"492 544 OFFCURVE",
+"455 544 CURVE SMOOTH",
+"405 544 OFFCURVE",
+"369 506 OFFCURVE",
+"293 498 CURVE",
+"301 593 OFFCURVE",
+"337 638 OFFCURVE",
+"337 692 CURVE SMOOTH",
+"337 733 OFFCURVE",
+"316 763 OFFCURVE",
+"269 763 CURVE SMOOTH",
+"224 763 OFFCURVE",
+"203 736 OFFCURVE",
+"203 694 CURVE SMOOTH",
+"203 637 OFFCURVE",
+"241 594 OFFCURVE",
+"247 498 CURVE",
+"171 506 OFFCURVE",
+"135 544 OFFCURVE",
+"85 544 CURVE SMOOTH",
+"48 544 OFFCURVE",
+"19 524 OFFCURVE",
+"19 481 CURVE SMOOTH",
+"19 440 OFFCURVE",
+"44 420 OFFCURVE",
+"82 420 CURVE SMOOTH",
+"135 420 OFFCURVE",
+"170 459 OFFCURVE",
+"247 464 CURVE",
+"247 385 OFFCURVE",
+"237 303 OFFCURVE",
+"196 236 CURVE",
+"237 169 OFFCURVE",
+"247 88 OFFCURVE",
+"247 9 CURVE",
+"170 14 OFFCURVE",
+"135 53 OFFCURVE",
+"82 53 CURVE SMOOTH",
+"44 53 OFFCURVE",
+"19 33 OFFCURVE",
+"19 -8 CURVE SMOOTH",
+"19 -51 OFFCURVE",
+"48 -71 OFFCURVE",
+"85 -71 CURVE SMOOTH",
+"135 -71 OFFCURVE",
+"171 -33 OFFCURVE",
+"247 -25 CURVE",
+"241 -121 OFFCURVE",
+"203 -164 OFFCURVE",
+"203 -221 CURVE SMOOTH",
+"203 -263 OFFCURVE",
+"224 -290 OFFCURVE",
+"269 -290 CURVE SMOOTH"
+);
+}
+);
+width = 541;
+}
+);
+unicode = 2021;
+},
+{
+glyphname = numero;
+lastChange = "2016-08-18 22:15:45 +0000";
+layers = (
+{
+components = (
+{
+name = N;
+},
+{
+name = ordmasculine;
+transform = "{1, 0, 0, 1, 744, 0}";
+}
+);
+layerId = UUID0;
+width = 1082;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"793 533 OFFCURVE",
+"861 457 OFFCURVE",
+"946 457 CURVE SMOOTH",
+"1032 457 OFFCURVE",
+"1101 533 OFFCURVE",
+"1101 611 CURVE SMOOTH",
+"1101 688 OFFCURVE",
+"1032 764 OFFCURVE",
+"946 764 CURVE SMOOTH",
+"861 764 OFFCURVE",
+"793 688 OFFCURVE",
+"793 611 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"888 712 OFFCURVE",
+"903 735 OFFCURVE",
+"946 735 CURVE SMOOTH",
+"990 735 OFFCURVE",
+"1005 712 OFFCURVE",
+"1005 611 CURVE SMOOTH",
+"1005 509 OFFCURVE",
+"990 487 OFFCURVE",
+"946 487 CURVE SMOOTH",
+"903 487 OFFCURVE",
+"888 509 OFFCURVE",
+"888 611 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"130 15 LINE",
+"174 15 LINE",
+"174 754 LINE",
+"130 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 0 LINE",
+"284 0 LINE",
+"284 30 LINE",
+"20 30 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"20 724 LINE",
+"284 724 LINE",
+"284 754 LINE",
+"20 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"632 -13 LINE",
+"676 -13 LINE",
+"676 754 LINE",
+"632 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"532 724 LINE",
+"776 724 LINE",
+"776 754 LINE",
+"532 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"312 754 LINE",
+"162 754 LINE",
+"174 641 LINE",
+"178 641 LINE",
+"632 -13 LINE",
+"662 -13 LINE",
+"632 309 LINE",
+"628 309 LINE"
+);
+}
+);
+};
+components = (
+{
+name = N;
+},
+{
+name = ordmasculine;
+transform = "{1, 0, 0, 1, 791, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 1129;
+}
+);
+unicode = 2116;
+},
+{
+glyphname = estimated;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"581 -12 OFFCURVE",
+"701 45 OFFCURVE",
+"775 132 CURVE",
+"716 132 LINE",
+"651 57 OFFCURVE",
+"556 9 OFFCURVE",
+"449 9 CURVE SMOOTH",
+"350 9 OFFCURVE",
+"261 52 OFFCURVE",
+"196 119 CURVE SMOOTH",
+"190 125 OFFCURVE",
+"187 133 OFFCURVE",
+"187 142 CURVE SMOOTH",
+"187 345 LINE SMOOTH",
+"187 348 OFFCURVE",
+"189 349 OFFCURVE",
+"192 349 CURVE SMOOTH",
+"862 349 LINE",
+"862 352 OFFCURVE",
+"862 356 OFFCURVE",
+"862 359 CURVE SMOOTH",
+"862 565 OFFCURVE",
+"677 731 OFFCURVE",
+"448 731 CURVE SMOOTH",
+"220 731 OFFCURVE",
+"35 565 OFFCURVE",
+"35 359 CURVE SMOOTH",
+"35 154 OFFCURVE",
+"220 -12 OFFCURVE",
+"448 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"189 369 OFFCURVE",
+"187 373 OFFCURVE",
+"187 375 CURVE SMOOTH",
+"187 575 LINE SMOOTH",
+"187 585 OFFCURVE",
+"190 594 OFFCURVE",
+"197 600 CURVE",
+"262 666 OFFCURVE",
+"351 709 OFFCURVE",
+"449 709 CURVE SMOOTH",
+"547 709 OFFCURVE",
+"635 667 OFFCURVE",
+"700 604 CURVE SMOOTH",
+"707 597 OFFCURVE",
+"710 588 OFFCURVE",
+"710 579 CURVE SMOOTH",
+"710 375 LINE SMOOTH",
+"710 373 OFFCURVE",
+"709 369 OFFCURVE",
+"706 369 CURVE SMOOTH",
+"192 369 LINE SMOOTH"
+);
+}
+);
+width = 898;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"581 -12 OFFCURVE",
+"701 45 OFFCURVE",
+"775 132 CURVE",
+"716 132 LINE",
+"651 57 OFFCURVE",
+"556 9 OFFCURVE",
+"449 9 CURVE SMOOTH",
+"350 9 OFFCURVE",
+"261 52 OFFCURVE",
+"196 119 CURVE SMOOTH",
+"190 125 OFFCURVE",
+"187 133 OFFCURVE",
+"187 142 CURVE SMOOTH",
+"187 345 LINE SMOOTH",
+"187 348 OFFCURVE",
+"189 349 OFFCURVE",
+"192 349 CURVE SMOOTH",
+"862 349 LINE",
+"862 352 OFFCURVE",
+"862 356 OFFCURVE",
+"862 359 CURVE SMOOTH",
+"862 565 OFFCURVE",
+"677 731 OFFCURVE",
+"448 731 CURVE SMOOTH",
+"220 731 OFFCURVE",
+"35 565 OFFCURVE",
+"35 359 CURVE SMOOTH",
+"35 154 OFFCURVE",
+"220 -12 OFFCURVE",
+"448 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"189 369 OFFCURVE",
+"187 373 OFFCURVE",
+"187 375 CURVE SMOOTH",
+"187 575 LINE SMOOTH",
+"187 585 OFFCURVE",
+"190 594 OFFCURVE",
+"197 600 CURVE",
+"262 666 OFFCURVE",
+"351 709 OFFCURVE",
+"449 709 CURVE SMOOTH",
+"547 709 OFFCURVE",
+"635 667 OFFCURVE",
+"700 604 CURVE SMOOTH",
+"707 597 OFFCURVE",
+"710 588 OFFCURVE",
+"710 579 CURVE SMOOTH",
+"710 375 LINE SMOOTH",
+"710 373 OFFCURVE",
+"709 369 OFFCURVE",
+"706 369 CURVE SMOOTH",
+"192 369 LINE SMOOTH"
+);
+}
+);
+width = 898;
+}
+);
+unicode = 212E;
+},
+{
+glyphname = asciicircum;
+lastChange = "2016-08-16 11:12:00 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"64 173 LINE",
+"249 581 LINE",
+"437 173 LINE",
+"491 173 LINE",
+"274 645 LINE",
+"225 645 LINE",
+"10 173 LINE"
+);
+}
+);
+width = 501;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"84 173 LINE",
+"249 541 LINE",
+"417 173 LINE",
+"491 173 LINE",
+"274 645 LINE",
+"225 645 LINE",
+"10 173 LINE"
+);
+}
+);
+width = 501;
+}
+);
+unicode = 005E;
+},
+{
+glyphname = servicemark;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"531 376 LINE",
+"633 710 LINE",
+"637 710 LINE",
+"637 403 LINE",
+"582 403 LINE",
+"582 380 LINE",
+"758 380 LINE",
+"758 403 LINE",
+"723 403 LINE",
+"723 732 LINE",
+"758 732 LINE",
+"758 754 LINE",
+"628 754 LINE",
+"547 494 LINE",
+"543 494 LINE",
+"466 754 LINE",
+"312 754 LINE",
+"312 732 LINE",
+"356 732 LINE",
+"356 403 LINE",
+"312 403 LINE",
+"312 380 LINE",
+"440 380 LINE",
+"440 403 LINE",
+"385 403 LINE",
+"385 710 LINE",
+"389 710 LINE",
+"494 376 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"241 371 OFFCURVE",
+"284 419 OFFCURVE",
+"284 497 CURVE SMOOTH",
+"284 569 OFFCURVE",
+"247 606 OFFCURVE",
+"171 624 CURVE SMOOTH",
+"119 636 OFFCURVE",
+"80 644 OFFCURVE",
+"80 682 CURVE SMOOTH",
+"80 714 OFFCURVE",
+"113 738 OFFCURVE",
+"157 738 CURVE SMOOTH",
+"203 738 OFFCURVE",
+"233 712 OFFCURVE",
+"251 656 CURVE",
+"269 656 LINE",
+"269 759 LINE",
+"251 759 LINE",
+"239 737 LINE",
+"215 755 OFFCURVE",
+"188 763 OFFCURVE",
+"158 763 CURVE SMOOTH",
+"98 763 OFFCURVE",
+"46 725 OFFCURVE",
+"46 653 CURVE SMOOTH",
+"46 594 OFFCURVE",
+"79 549 OFFCURVE",
+"155 533 CURVE SMOOTH",
+"214 521 OFFCURVE",
+"251 513 OFFCURVE",
+"251 465 CURVE SMOOTH",
+"251 429 OFFCURVE",
+"220 397 OFFCURVE",
+"164 397 CURVE SMOOTH",
+"99 397 OFFCURVE",
+"69 444 OFFCURVE",
+"58 484 CURVE",
+"40 484 LINE",
+"40 378 LINE",
+"57 378 LINE",
+"77 403 LINE",
+"101 381 OFFCURVE",
+"128 371 OFFCURVE",
+"163 371 CURVE SMOOTH"
+);
+}
+);
+width = 785;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"541 376 LINE",
+"633 677 LINE",
+"637 677 LINE",
+"637 408 LINE",
+"582 408 LINE",
+"582 380 LINE",
+"768 380 LINE",
+"768 408 LINE",
+"733 408 LINE",
+"733 727 LINE",
+"768 727 LINE",
+"768 754 LINE",
+"628 754 LINE",
+"547 494 LINE",
+"543 494 LINE",
+"466 754 LINE",
+"312 754 LINE",
+"312 727 LINE",
+"346 727 LINE",
+"346 408 LINE",
+"312 408 LINE",
+"312 380 LINE",
+"440 380 LINE",
+"440 408 LINE",
+"385 408 LINE",
+"385 679 LINE",
+"389 679 LINE",
+"484 376 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"241 371 OFFCURVE",
+"284 419 OFFCURVE",
+"284 497 CURVE SMOOTH",
+"284 572 OFFCURVE",
+"247 610 OFFCURVE",
+"171 629 CURVE SMOOTH",
+"96 648 OFFCURVE",
+"85 660 OFFCURVE",
+"85 687 CURVE SMOOTH",
+"85 713 OFFCURVE",
+"116 733 OFFCURVE",
+"157 733 CURVE SMOOTH",
+"203 733 OFFCURVE",
+"233 709 OFFCURVE",
+"251 656 CURVE",
+"269 656 LINE",
+"269 759 LINE",
+"251 759 LINE",
+"239 737 LINE",
+"215 755 OFFCURVE",
+"188 763 OFFCURVE",
+"158 763 CURVE SMOOTH",
+"98 763 OFFCURVE",
+"46 725 OFFCURVE",
+"46 653 CURVE SMOOTH",
+"46 592 OFFCURVE",
+"79 545 OFFCURVE",
+"155 528 CURVE SMOOTH",
+"233 511 OFFCURVE",
+"246 493 OFFCURVE",
+"246 460 CURVE SMOOTH",
+"246 430 OFFCURVE",
+"217 402 OFFCURVE",
+"164 402 CURVE SMOOTH",
+"99 402 OFFCURVE",
+"69 446 OFFCURVE",
+"58 484 CURVE",
+"40 484 LINE",
+"40 378 LINE",
+"57 378 LINE",
+"77 403 LINE",
+"101 381 OFFCURVE",
+"128 371 OFFCURVE",
+"163 371 CURVE SMOOTH"
+);
+}
+);
+width = 785;
+}
+);
+unicode = 2120;
+},
+{
+glyphname = gravecomb;
+lastChange = "2016-08-22 09:45:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{287, 450}";
+},
+{
+name = top;
+position = "{287, 650}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"421 518 LINE",
+"270 614 LINE SMOOTH",
+"223 644 OFFCURVE",
+"211 650 OFFCURVE",
+"197 650 CURVE SMOOTH",
+"169 650 OFFCURVE",
+"153 633 OFFCURVE",
+"153 607 CURVE SMOOTH",
+"153 581 OFFCURVE",
+"170 561 OFFCURVE",
+"203 554 CURVE SMOOTH",
+"378 518 LINE"
+);
+}
+);
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{249, 450}";
+},
+{
+name = top;
+position = "{249, 680}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"395 543 LINE",
+"234 647 LINE SMOOTH",
+"199 670 OFFCURVE",
+"181 680 OFFCURVE",
+"152 680 CURVE SMOOTH",
+"119 680 OFFCURVE",
+"102 658 OFFCURVE",
+"102 634 CURVE SMOOTH",
+"102 611 OFFCURVE",
+"111 587 OFFCURVE",
+"155 578 CURVE SMOOTH",
+"332 543 LINE"
+);
+}
+);
+width = 600;
+}
+);
+unicode = 0300;
+},
+{
+glyphname = acutecomb;
+lastChange = "2016-08-22 10:28:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{325, 450}";
+},
+{
+name = top;
+position = "{325, 655}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"234 523 LINE",
+"409 559 LINE SMOOTH",
+"442 566 OFFCURVE",
+"459 586 OFFCURVE",
+"459 612 CURVE SMOOTH",
+"459 638 OFFCURVE",
+"443 655 OFFCURVE",
+"415 655 CURVE SMOOTH",
+"401 655 OFFCURVE",
+"389 649 OFFCURVE",
+"342 619 CURVE SMOOTH",
+"191 523 LINE"
+);
+}
+);
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{390, 450}";
+},
+{
+name = top;
+position = "{390, 656}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"306 519 LINE",
+"483 554 LINE SMOOTH",
+"527 563 OFFCURVE",
+"536 587 OFFCURVE",
+"536 610 CURVE SMOOTH",
+"536 634 OFFCURVE",
+"519 656 OFFCURVE",
+"486 656 CURVE SMOOTH",
+"457 656 OFFCURVE",
+"439 646 OFFCURVE",
+"404 623 CURVE SMOOTH",
+"243 519 LINE"
+);
+}
+);
+width = 600;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 0301;
+},
+{
+glyphname = circumflexcomb;
+lastChange = "2016-08-22 10:07:55 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{290, 450}";
+},
+{
+name = top;
+position = "{290, 577}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"181 520 LINE",
+"290 571 LINE",
+"399 520 LINE",
+"442 520 LINE",
+"321 632 LINE",
+"259 632 LINE",
+"138 520 LINE"
+);
+}
+);
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{296, 450}";
+},
+{
+name = top;
+position = "{296, 589}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"177 523 LINE",
+"296 565 LINE",
+"415 523 LINE",
+"468 523 LINE",
+"327 639 LINE",
+"265 639 LINE",
+"124 523 LINE"
+);
+}
+);
+width = 600;
+}
+);
+unicode = 0302;
+},
+{
+glyphname = brevecomb;
+lastChange = "2016-08-22 10:16:38 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{295, 450}";
+},
+{
+name = top;
+position = "{295, 648}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"401 516 OFFCURVE",
+"431 571 OFFCURVE",
+"431 648 CURVE",
+"397 648 LINE",
+"394 604 OFFCURVE",
+"364 584 OFFCURVE",
+"293 584 CURVE SMOOTH",
+"223 584 OFFCURVE",
+"195 602 OFFCURVE",
+"192 648 CURVE",
+"158 648 LINE",
+"158 567 OFFCURVE",
+"192 516 OFFCURVE",
+"295 516 CURVE SMOOTH"
+);
+}
+);
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{298, 450}";
+},
+{
+name = top;
+position = "{298, 658}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"391 521 OFFCURVE",
+"444 581 OFFCURVE",
+"444 658 CURVE",
+"400 658 LINE",
+"397 628 OFFCURVE",
+"347 614 OFFCURVE",
+"296 614 CURVE SMOOTH",
+"246 614 OFFCURVE",
+"198 626 OFFCURVE",
+"195 658 CURVE",
+"151 658 LINE",
+"151 577 OFFCURVE",
+"208 521 OFFCURVE",
+"298 521 CURVE SMOOTH"
+);
+}
+);
+width = 600;
+}
+);
+unicode = 0306;
+},
+{
+glyphname = tildecomb;
+lastChange = "2016-08-22 10:22:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{291, 450}";
+},
+{
+name = top;
+position = "{291, 700}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"148 558 LINE",
+"155 586 OFFCURVE",
+"178 607 OFFCURVE",
+"211 607 CURVE SMOOTH",
+"258 607 OFFCURVE",
+"292 559 OFFCURVE",
+"348 559 CURVE SMOOTH",
+"417 559 OFFCURVE",
+"453 623 OFFCURVE",
+"467 686 CURVE",
+"433 686 LINE",
+"426 665 OFFCURVE",
+"408 635 OFFCURVE",
+"370 635 CURVE SMOOTH",
+"324 635 OFFCURVE",
+"287 683 OFFCURVE",
+"233 683 CURVE SMOOTH",
+"167 683 OFFCURVE",
+"125 620 OFFCURVE",
+"115 558 CURVE"
+);
+}
+);
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{313, 450}";
+},
+{
+name = top;
+position = "{313, 697}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"150 560 LINE",
+"159 584 OFFCURVE",
+"190 601 OFFCURVE",
+"233 601 CURVE SMOOTH",
+"280 601 OFFCURVE",
+"314 561 OFFCURVE",
+"370 561 CURVE SMOOTH",
+"451 561 OFFCURVE",
+"493 629 OFFCURVE",
+"509 697 CURVE",
+"475 697 LINE",
+"466 680 OFFCURVE",
+"442 657 OFFCURVE",
+"392 657 CURVE SMOOTH",
+"346 657 OFFCURVE",
+"309 697 OFFCURVE",
+"255 697 CURVE SMOOTH",
+"177 697 OFFCURVE",
+"129 627 OFFCURVE",
+"117 560 CURVE"
+);
+}
+);
+width = 600;
+}
+);
+unicode = 0303;
+},
+{
+glyphname = hookabovecomb;
+lastChange = "2016-08-22 10:25:29 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{285, 450}";
+},
+{
+name = top;
+position = "{285, 659}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"312 524 LINE",
+"324 550 OFFCURVE",
+"381 560 OFFCURVE",
+"381 600 CURVE SMOOTH",
+"381 657 OFFCURVE",
+"341 683 OFFCURVE",
+"281 683 CURVE SMOOTH",
+"237 683 OFFCURVE",
+"188 662 OFFCURVE",
+"188 603 CURVE SMOOTH",
+"188 583 OFFCURVE",
+"204 568 OFFCURVE",
+"227 568 CURVE SMOOTH",
+"248 568 OFFCURVE",
+"259 576 OFFCURVE",
+"259 590 CURVE SMOOTH",
+"259 608 OFFCURVE",
+"246 606 OFFCURVE",
+"246 618 CURVE SMOOTH",
+"246 633 OFFCURVE",
+"262 643 OFFCURVE",
+"283 643 CURVE SMOOTH",
+"303 643 OFFCURVE",
+"322 636 OFFCURVE",
+"322 598 CURVE SMOOTH",
+"322 574 OFFCURVE",
+"285 560 OFFCURVE",
+"285 524 CURVE"
+);
+}
+);
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{284, 450}";
+},
+{
+name = top;
+position = "{281, 688}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"315 507 LINE",
+"315 557 OFFCURVE",
+"389 538 OFFCURVE",
+"389 600 CURVE SMOOTH",
+"389 671 OFFCURVE",
+"354 700 OFFCURVE",
+"281 700 CURVE SMOOTH",
+"221 700 OFFCURVE",
+"174 673 OFFCURVE",
+"174 608 CURVE SMOOTH",
+"174 578 OFFCURVE",
+"194 559 OFFCURVE",
+"218 559 CURVE SMOOTH",
+"235 559 OFFCURVE",
+"257 566 OFFCURVE",
+"257 585 CURVE SMOOTH",
+"257 613 OFFCURVE",
+"236 601 OFFCURVE",
+"236 625 CURVE SMOOTH",
+"236 639 OFFCURVE",
+"253 657 OFFCURVE",
+"281 657 CURVE SMOOTH",
+"310 657 OFFCURVE",
+"327 641 OFFCURVE",
+"327 609 CURVE SMOOTH",
+"327 585 OFFCURVE",
+"276 577 OFFCURVE",
+"276 507 CURVE"
+);
+}
+);
+width = 600;
+}
+);
+unicode = 0309;
+},
+{
+glyphname = dblgravecomb;
+lastChange = "2016-08-22 11:53:07 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{213, 450}";
+},
+{
+name = top;
+position = "{213, 754}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"416 554 LINE",
+"298 714 LINE SMOOTH",
+"275 745 OFFCURVE",
+"255 754 OFFCURVE",
+"234 754 CURVE SMOOTH",
+"205 754 OFFCURVE",
+"188 736 OFFCURVE",
+"188 712 CURVE SMOOTH",
+"188 695 OFFCURVE",
+"196 677 OFFCURVE",
+"238 648 CURVE SMOOTH",
+"373 554 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"238 554 LINE",
+"120 714 LINE SMOOTH",
+"97 745 OFFCURVE",
+"77 754 OFFCURVE",
+"56 754 CURVE SMOOTH",
+"27 754 OFFCURVE",
+"10 736 OFFCURVE",
+"10 712 CURVE SMOOTH",
+"10 695 OFFCURVE",
+"18 677 OFFCURVE",
+"60 648 CURVE SMOOTH",
+"195 554 LINE"
+);
+}
+);
+width = 426;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{234, 450}";
+},
+{
+name = top;
+position = "{234, 760}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"458 554 LINE",
+"337 718 LINE SMOOTH",
+"312 752 OFFCURVE",
+"289 760 OFFCURVE",
+"266 760 CURVE SMOOTH",
+"228 760 OFFCURVE",
+"210 738 OFFCURVE",
+"210 714 CURVE SMOOTH",
+"210 696 OFFCURVE",
+"220 676 OFFCURVE",
+"258 649 CURVE SMOOTH",
+"395 554 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"258 554 LINE",
+"137 718 LINE SMOOTH",
+"112 752 OFFCURVE",
+"89 760 OFFCURVE",
+"66 760 CURVE SMOOTH",
+"28 760 OFFCURVE",
+"10 738 OFFCURVE",
+"10 714 CURVE SMOOTH",
+"10 696 OFFCURVE",
+"20 676 OFFCURVE",
+"58 649 CURVE SMOOTH",
+"195 554 LINE"
+);
+}
+);
+width = 468;
+}
+);
+unicode = 030F;
+},
+{
+glyphname = breveinvertedcomb;
+lastChange = "2016-08-22 11:53:07 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{167, 450}";
+},
+{
+name = top;
+position = "{167, 733}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"44 576 LINE",
+"47 632 OFFCURVE",
+"95 655 OFFCURVE",
+"165 655 CURVE SMOOTH",
+"236 655 OFFCURVE",
+"286 631 OFFCURVE",
+"289 576 CURVE",
+"323 576 LINE",
+"323 665 OFFCURVE",
+"273 733 OFFCURVE",
+"167 733 CURVE SMOOTH",
+"64 733 OFFCURVE",
+"10 669 OFFCURVE",
+"10 576 CURVE"
+);
+}
+);
+width = 333;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{177, 450}";
+},
+{
+name = top;
+position = "{177, 733}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"54 556 LINE",
+"57 612 OFFCURVE",
+"105 635 OFFCURVE",
+"175 635 CURVE SMOOTH",
+"246 635 OFFCURVE",
+"296 611 OFFCURVE",
+"299 556 CURVE",
+"343 556 LINE",
+"343 657 OFFCURVE",
+"290 733 OFFCURVE",
+"177 733 CURVE SMOOTH",
+"67 733 OFFCURVE",
+"10 661 OFFCURVE",
+"10 556 CURVE"
+);
+}
+);
+width = 353;
+}
+);
+unicode = 0311;
+},
+{
+glyphname = horncomb;
+lastChange = "2016-08-22 09:33:02 +0000";
+layers = (
+{
+anchors = (
+{
+name = _topright;
+position = "{312, 450}";
+},
+{
+name = topright;
+position = "{312, 450}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"344 476 OFFCURVE",
+"378 499 OFFCURVE",
+"378 582 CURVE",
+"314 582 LINE",
+"311 527 OFFCURVE",
+"300 503 OFFCURVE",
+"229 503 CURVE",
+"231 476 LINE"
+);
+}
+);
+width = 600;
+},
+{
+anchors = (
+{
+name = _topright;
+position = "{199, 450}";
+},
+{
+name = topright;
+position = "{323, 450}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"344 465 OFFCURVE",
+"394 481 OFFCURVE",
+"394 582 CURVE",
+"318 582 LINE",
+"315 527 OFFCURVE",
+"300 503 OFFCURVE",
+"229 503 CURVE",
+"231 465 LINE"
+);
+}
+);
+width = 600;
+}
+);
+unicode = 031B;
+},
+{
+glyphname = dotbelowcomb;
+lastChange = "2016-08-22 09:41:38 +0000";
+layers = (
+{
+anchors = (
+{
+name = _bottom;
+position = "{284, 0}";
+},
+{
+name = bottom;
+position = "{284, -231}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"320 -231 OFFCURVE",
+"350 -201 OFFCURVE",
+"350 -165 CURVE SMOOTH",
+"350 -129 OFFCURVE",
+"320 -99 OFFCURVE",
+"284 -99 CURVE SMOOTH",
+"248 -99 OFFCURVE",
+"218 -129 OFFCURVE",
+"218 -165 CURVE SMOOTH",
+"218 -201 OFFCURVE",
+"248 -231 OFFCURVE",
+"284 -231 CURVE SMOOTH"
+);
+}
+);
+width = 600;
+},
+{
+anchors = (
+{
+name = _bottom;
+position = "{293, 0}";
+},
+{
+name = bottom;
+position = "{293, -260}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"336 -260 OFFCURVE",
+"373 -223 OFFCURVE",
+"373 -180 CURVE SMOOTH",
+"373 -136 OFFCURVE",
+"336 -99 OFFCURVE",
+"292 -99 CURVE SMOOTH",
+"249 -99 OFFCURVE",
+"212 -136 OFFCURVE",
+"212 -180 CURVE SMOOTH",
+"212 -223 OFFCURVE",
+"249 -260 OFFCURVE",
+"292 -260 CURVE SMOOTH"
+);
+}
+);
+width = 600;
+}
+);
+unicode = 0323;
+},
+{
+glyphname = commaaccentcomb;
+lastChange = "2016-08-22 11:53:07 +0000";
+layers = (
+{
+anchors = (
+{
+name = _bottom;
+position = "{86, 0}";
+},
+{
+name = bottom;
+position = "{86, -309}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"123 -272 OFFCURVE",
+"162 -232 OFFCURVE",
+"162 -172 CURVE SMOOTH",
+"162 -115 OFFCURVE",
+"126 -79 OFFCURVE",
+"78 -79 CURVE SMOOTH",
+"38 -79 OFFCURVE",
+"10 -103 OFFCURVE",
+"10 -143 CURVE SMOOTH",
+"10 -178 OFFCURVE",
+"32 -196 OFFCURVE",
+"58 -196 CURVE SMOOTH",
+"91 -196 OFFCURVE",
+"112 -168 OFFCURVE",
+"121 -168 CURVE SMOOTH",
+"123 -168 OFFCURVE",
+"125 -171 OFFCURVE",
+"125 -180 CURVE SMOOTH",
+"125 -218 OFFCURVE",
+"98 -252 OFFCURVE",
+"33 -286 CURVE",
+"53 -309 LINE"
+);
+}
+);
+width = 172;
+},
+{
+anchors = (
+{
+name = _bottom;
+position = "{93, 0}";
+},
+{
+name = bottom;
+position = "{93, -314}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"135 -276 OFFCURVE",
+"176 -236 OFFCURVE",
+"176 -174 CURVE SMOOTH",
+"176 -121 OFFCURVE",
+"147 -69 OFFCURVE",
+"86 -69 CURVE SMOOTH",
+"39 -69 OFFCURVE",
+"10 -99 OFFCURVE",
+"10 -136 CURVE SMOOTH",
+"10 -167 OFFCURVE",
+"30 -198 OFFCURVE",
+"68 -198 CURVE SMOOTH",
+"106 -198 OFFCURVE",
+"111 -166 OFFCURVE",
+"123 -166 CURVE SMOOTH",
+"130 -166 OFFCURVE",
+"138 -171 OFFCURVE",
+"138 -188 CURVE SMOOTH",
+"138 -226 OFFCURVE",
+"110 -253 OFFCURVE",
+"36 -292 CURVE",
+"56 -314 LINE"
+);
+}
+);
+width = 186;
+}
+);
+unicode = 0326;
+},
+{
+glyphname = strokeshortcomb;
+lastChange = "2016-08-22 12:09:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = _center;
+position = "{0, 0}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-23 -6 LINE",
+"-23 29 LINE",
+"-388 29 LINE",
+"-388 -6 LINE"
+);
+}
+);
+width = 600;
+},
+{
+anchors = (
+{
+name = _center;
+position = "{464, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"445 -3 LINE",
+"445 44 LINE",
+"50 44 LINE",
+"50 -3 LINE"
+);
+}
+);
+width = 495;
+}
+);
+unicode = 0335;
+},
+{
+glyphname = dblgravecomb.cap;
+lastChange = "2016-08-22 11:53:07 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{213, 754}";
+},
+{
+name = top;
+position = "{213, 924}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"416 792 LINE",
+"298 884 LINE SMOOTH",
+"254 918 OFFCURVE",
+"246 924 OFFCURVE",
+"232 924 CURVE SMOOTH",
+"204 924 OFFCURVE",
+"188 907 OFFCURVE",
+"188 881 CURVE SMOOTH",
+"188 855 OFFCURVE",
+"205 837 OFFCURVE",
+"238 828 CURVE SMOOTH",
+"373 792 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"238 792 LINE",
+"120 884 LINE SMOOTH",
+"76 918 OFFCURVE",
+"68 924 OFFCURVE",
+"54 924 CURVE SMOOTH",
+"26 924 OFFCURVE",
+"10 907 OFFCURVE",
+"10 881 CURVE SMOOTH",
+"10 855 OFFCURVE",
+"27 837 OFFCURVE",
+"60 828 CURVE SMOOTH",
+"195 792 LINE"
+);
+}
+);
+width = 426;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{268, 754}";
+},
+{
+name = top;
+position = "{268, 924}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"525 787 LINE",
+"364 891 LINE SMOOTH",
+"329 914 OFFCURVE",
+"311 924 OFFCURVE",
+"282 924 CURVE SMOOTH",
+"249 924 OFFCURVE",
+"232 902 OFFCURVE",
+"232 878 CURVE SMOOTH",
+"232 855 OFFCURVE",
+"241 831 OFFCURVE",
+"285 822 CURVE SMOOTH",
+"462 787 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"303 787 LINE",
+"142 891 LINE SMOOTH",
+"107 914 OFFCURVE",
+"89 924 OFFCURVE",
+"60 924 CURVE SMOOTH",
+"27 924 OFFCURVE",
+"10 902 OFFCURVE",
+"10 878 CURVE SMOOTH",
+"10 855 OFFCURVE",
+"19 831 OFFCURVE",
+"63 822 CURVE SMOOTH",
+"240 787 LINE"
+);
+}
+);
+width = 535;
+}
+);
+},
+{
+glyphname = breveinvertedcomb.cap;
+lastChange = "2016-08-22 11:53:07 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{167, 754}";
+},
+{
+name = top;
+position = "{167, 924}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"44 792 LINE",
+"47 838 OFFCURVE",
+"95 856 OFFCURVE",
+"165 856 CURVE SMOOTH",
+"236 856 OFFCURVE",
+"286 836 OFFCURVE",
+"289 792 CURVE",
+"323 792 LINE",
+"323 869 OFFCURVE",
+"273 924 OFFCURVE",
+"167 924 CURVE SMOOTH",
+"64 924 OFFCURVE",
+"10 873 OFFCURVE",
+"10 792 CURVE"
+);
+}
+);
+width = 333;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{177, 754}";
+},
+{
+name = top;
+position = "{177, 924}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"54 787 LINE",
+"57 819 OFFCURVE",
+"105 831 OFFCURVE",
+"175 831 CURVE SMOOTH",
+"246 831 OFFCURVE",
+"296 817 OFFCURVE",
+"299 787 CURVE",
+"343 787 LINE",
+"343 864 OFFCURVE",
+"290 924 OFFCURVE",
+"177 924 CURVE SMOOTH",
+"67 924 OFFCURVE",
+"10 868 OFFCURVE",
+"10 787 CURVE"
+);
+}
+);
+width = 353;
+}
+);
+},
+{
+glyphname = firsttonechinese;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"330 637 LINE",
+"330 703 LINE",
+"10 703 LINE",
+"10 637 LINE"
+);
+}
+);
+width = 340;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"350 627 LINE",
+"350 713 LINE",
+"10 713 LINE",
+"10 627 LINE"
+);
+}
+);
+width = 360;
+}
+);
+unicode = 02C9;
+},
+{
+glyphname = acute;
+lastChange = "2016-08-18 21:48:17 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"53 554 LINE",
+"188 648 LINE SMOOTH",
+"230 677 OFFCURVE",
+"238 695 OFFCURVE",
+"238 712 CURVE SMOOTH",
+"238 736 OFFCURVE",
+"221 754 OFFCURVE",
+"192 754 CURVE SMOOTH",
+"171 754 OFFCURVE",
+"151 745 OFFCURVE",
+"128 714 CURVE SMOOTH",
+"10 554 LINE"
+);
+}
+);
+width = 248;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"73 554 LINE",
+"210 649 LINE SMOOTH",
+"248 676 OFFCURVE",
+"258 696 OFFCURVE",
+"258 714 CURVE SMOOTH",
+"258 738 OFFCURVE",
+"240 760 OFFCURVE",
+"202 760 CURVE SMOOTH",
+"179 760 OFFCURVE",
+"156 752 OFFCURVE",
+"131 718 CURVE SMOOTH",
+"10 554 LINE"
+);
+}
+);
+width = 268;
+}
+);
+unicode = 00B4;
+},
+{
+glyphname = breve;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"273 576 OFFCURVE",
+"323 644 OFFCURVE",
+"323 733 CURVE",
+"289 733 LINE",
+"286 678 OFFCURVE",
+"236 654 OFFCURVE",
+"165 654 CURVE SMOOTH",
+"95 654 OFFCURVE",
+"47 677 OFFCURVE",
+"44 733 CURVE",
+"10 733 LINE",
+"10 640 OFFCURVE",
+"64 576 OFFCURVE",
+"167 576 CURVE SMOOTH"
+);
+}
+);
+width = 333;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"290 556 OFFCURVE",
+"343 632 OFFCURVE",
+"343 733 CURVE",
+"299 733 LINE",
+"296 678 OFFCURVE",
+"246 654 OFFCURVE",
+"175 654 CURVE SMOOTH",
+"105 654 OFFCURVE",
+"57 677 OFFCURVE",
+"54 733 CURVE",
+"10 733 LINE",
+"10 628 OFFCURVE",
+"67 556 OFFCURVE",
+"177 556 CURVE SMOOTH"
+);
+}
+);
+width = 353;
+}
+);
+unicode = 02D8;
+},
+{
+glyphname = caron;
+lastChange = "2016-08-22 12:22:57 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{165, 459}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"203 554 LINE",
+"334 754 LINE",
+"291 754 LINE",
+"172 648 LINE",
+"53 754 LINE",
+"10 754 LINE",
+"141 554 LINE"
+);
+}
+);
+width = 344;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{190, 459}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"223 554 LINE",
+"374 754 LINE",
+"331 754 LINE",
+"192 668 LINE",
+"53 754 LINE",
+"10 754 LINE",
+"161 554 LINE"
+);
+}
+);
+width = 384;
+}
+);
+unicode = 02C7;
+},
+{
+glyphname = cedilla;
+lastChange = "2016-08-22 12:01:30 +0000";
+layers = (
+{
+anchors = (
+{
+name = _bottom;
+position = "{105, -6}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"53 -107 LINE",
+"67 -113 LINE",
+"77 -110 OFFCURVE",
+"88 -108 OFFCURVE",
+"98 -108 CURVE SMOOTH",
+"121 -108 OFFCURVE",
+"142 -120 OFFCURVE",
+"142 -148 CURVE SMOOTH",
+"142 -181 OFFCURVE",
+"113 -195 OFFCURVE",
+"82 -195 CURVE SMOOTH",
+"62 -195 OFFCURVE",
+"40 -189 OFFCURVE",
+"20 -181 CURVE",
+"10 -208 LINE",
+"38 -219 OFFCURVE",
+"55 -225 OFFCURVE",
+"89 -225 CURVE SMOOTH",
+"160 -225 OFFCURVE",
+"220 -199 OFFCURVE",
+"220 -142 CURVE SMOOTH",
+"220 -97 OFFCURVE",
+"183 -69 OFFCURVE",
+"137 -69 CURVE SMOOTH",
+"125 -69 OFFCURVE",
+"113 -71 OFFCURVE",
+"101 -74 CURVE",
+"138 10 LINE",
+"106 10 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"165 -226 OFFCURVE",
+"217 -191 OFFCURVE",
+"217 -138 CURVE SMOOTH",
+"217 -92 OFFCURVE",
+"178 -66 OFFCURVE",
+"121 -66 CURVE SMOOTH",
+"102 -66 LINE",
+"126 10 LINE",
+"96 10 LINE",
+"62 -90 LINE",
+"114 -91 OFFCURVE",
+"137 -110 OFFCURVE",
+"137 -145 CURVE SMOOTH",
+"137 -179 OFFCURVE",
+"114 -195 OFFCURVE",
+"77 -195 CURVE SMOOTH",
+"57 -195 OFFCURVE",
+"31 -190 OFFCURVE",
+"21 -184 CURVE",
+"10 -209 LINE",
+"21 -216 OFFCURVE",
+"50 -226 OFFCURVE",
+"90 -226 CURVE SMOOTH"
+);
+}
+);
+width = 227;
+},
+{
+anchors = (
+{
+name = _bottom;
+position = "{117, -13}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"53 -122 LINE",
+"67 -128 LINE",
+"80 -125 OFFCURVE",
+"96 -123 OFFCURVE",
+"106 -123 CURVE SMOOTH",
+"126 -123 OFFCURVE",
+"142 -132 OFFCURVE",
+"142 -153 CURVE SMOOTH",
+"142 -179 OFFCURVE",
+"118 -190 OFFCURVE",
+"89 -190 CURVE SMOOTH",
+"71 -190 OFFCURVE",
+"46 -186 OFFCURVE",
+"25 -181 CURVE",
+"10 -218 LINE",
+"44 -230 OFFCURVE",
+"66 -235 OFFCURVE",
+"99 -235 CURVE SMOOTH",
+"178 -235 OFFCURVE",
+"240 -206 OFFCURVE",
+"240 -144 CURVE SMOOTH",
+"240 -96 OFFCURVE",
+"203 -69 OFFCURVE",
+"156 -69 CURVE SMOOTH",
+"143 -69 OFFCURVE",
+"126 -71 OFFCURVE",
+"111 -74 CURVE",
+"148 10 LINE",
+"106 10 LINE"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"180 -235 OFFCURVE",
+"240 -200 OFFCURVE",
+"240 -138 CURVE SMOOTH",
+"240 -92 OFFCURVE",
+"199 -66 OFFCURVE",
+"136 -66 CURVE SMOOTH",
+"117 -66 LINE",
+"141 10 LINE",
+"96 10 LINE",
+"57 -100 LINE",
+"112 -101 OFFCURVE",
+"137 -118 OFFCURVE",
+"137 -150 CURVE SMOOTH",
+"137 -181 OFFCURVE",
+"114 -195 OFFCURVE",
+"77 -195 CURVE SMOOTH",
+"57 -195 OFFCURVE",
+"31 -190 OFFCURVE",
+"21 -184 CURVE",
+"10 -218 LINE",
+"21 -225 OFFCURVE",
+"50 -235 OFFCURVE",
+"90 -235 CURVE SMOOTH"
+);
+}
+);
+width = 250;
+}
+);
+unicode = 00B8;
+},
+{
+glyphname = circumflex;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"53 554 LINE",
+"172 660 LINE",
+"291 554 LINE",
+"334 554 LINE",
+"203 754 LINE",
+"141 754 LINE",
+"10 554 LINE"
+);
+}
+);
+width = 344;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"53 554 LINE",
+"192 640 LINE",
+"331 554 LINE",
+"374 554 LINE",
+"223 754 LINE",
+"161 754 LINE",
+"10 554 LINE"
+);
+}
+);
+width = 384;
+}
+);
+unicode = 02C6;
+},
+{
+glyphname = dieresis;
+lastChange = "2016-08-22 12:19:29 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{154, 450}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"285 612 OFFCURVE",
+"310 637 OFFCURVE",
+"310 667 CURVE SMOOTH",
+"310 697 OFFCURVE",
+"285 722 OFFCURVE",
+"255 722 CURVE SMOOTH",
+"225 722 OFFCURVE",
+"200 697 OFFCURVE",
+"200 667 CURVE SMOOTH",
+"200 637 OFFCURVE",
+"225 612 OFFCURVE",
+"255 612 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"95 612 OFFCURVE",
+"120 637 OFFCURVE",
+"120 667 CURVE SMOOTH",
+"120 697 OFFCURVE",
+"95 722 OFFCURVE",
+"65 722 CURVE SMOOTH",
+"35 722 OFFCURVE",
+"10 697 OFFCURVE",
+"10 667 CURVE SMOOTH",
+"10 637 OFFCURVE",
+"35 612 OFFCURVE",
+"65 612 CURVE SMOOTH"
+);
+}
+);
+width = 320;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{162, 452}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"302 601 OFFCURVE",
+"332 631 OFFCURVE",
+"332 667 CURVE SMOOTH",
+"332 703 OFFCURVE",
+"302 733 OFFCURVE",
+"266 733 CURVE SMOOTH",
+"230 733 OFFCURVE",
+"200 703 OFFCURVE",
+"200 667 CURVE SMOOTH",
+"200 631 OFFCURVE",
+"230 601 OFFCURVE",
+"266 601 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"112 601 OFFCURVE",
+"142 631 OFFCURVE",
+"142 667 CURVE SMOOTH",
+"142 703 OFFCURVE",
+"112 733 OFFCURVE",
+"76 733 CURVE SMOOTH",
+"40 733 OFFCURVE",
+"10 703 OFFCURVE",
+"10 667 CURVE SMOOTH",
+"10 631 OFFCURVE",
+"40 601 OFFCURVE",
+"76 601 CURVE SMOOTH"
+);
+}
+);
+width = 342;
+}
+);
+unicode = 00A8;
+},
+{
+glyphname = dotaccent;
+lastChange = "2016-08-22 12:07:32 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{74, 453}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"112 601 OFFCURVE",
+"142 631 OFFCURVE",
+"142 667 CURVE SMOOTH",
+"142 703 OFFCURVE",
+"112 733 OFFCURVE",
+"76 733 CURVE SMOOTH",
+"40 733 OFFCURVE",
+"10 703 OFFCURVE",
+"10 667 CURVE SMOOTH",
+"10 631 OFFCURVE",
+"40 601 OFFCURVE",
+"76 601 CURVE SMOOTH"
+);
+}
+);
+width = 152;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{88, 457}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"134 573 OFFCURVE",
+"171 610 OFFCURVE",
+"171 653 CURVE SMOOTH",
+"171 697 OFFCURVE",
+"134 734 OFFCURVE",
+"90 734 CURVE SMOOTH",
+"47 734 OFFCURVE",
+"10 697 OFFCURVE",
+"10 653 CURVE SMOOTH",
+"10 610 OFFCURVE",
+"47 573 OFFCURVE",
+"90 573 CURVE SMOOTH"
+);
+}
+);
+width = 181;
+}
+);
+unicode = 02D9;
+},
+{
+glyphname = grave;
+lastChange = "2016-08-16 11:12:00 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"238 554 LINE",
+"120 714 LINE SMOOTH",
+"97 745 OFFCURVE",
+"77 754 OFFCURVE",
+"56 754 CURVE SMOOTH",
+"27 754 OFFCURVE",
+"10 736 OFFCURVE",
+"10 712 CURVE SMOOTH",
+"10 695 OFFCURVE",
+"18 677 OFFCURVE",
+"60 648 CURVE SMOOTH",
+"195 554 LINE"
+);
+}
+);
+width = 248;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"258 554 LINE",
+"137 718 LINE SMOOTH",
+"112 752 OFFCURVE",
+"89 760 OFFCURVE",
+"66 760 CURVE SMOOTH",
+"28 760 OFFCURVE",
+"10 738 OFFCURVE",
+"10 714 CURVE SMOOTH",
+"10 696 OFFCURVE",
+"20 676 OFFCURVE",
+"58 649 CURVE SMOOTH",
+"195 554 LINE"
+);
+}
+);
+width = 268;
+}
+);
+unicode = 0060;
+},
+{
+glyphname = hungarumlaut;
+lastChange = "2016-08-18 22:02:17 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"231 554 LINE",
+"366 648 LINE SMOOTH",
+"408 677 OFFCURVE",
+"416 695 OFFCURVE",
+"416 712 CURVE SMOOTH",
+"416 736 OFFCURVE",
+"399 754 OFFCURVE",
+"370 754 CURVE SMOOTH",
+"349 754 OFFCURVE",
+"329 745 OFFCURVE",
+"306 714 CURVE SMOOTH",
+"188 554 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"53 554 LINE",
+"188 648 LINE SMOOTH",
+"230 677 OFFCURVE",
+"238 695 OFFCURVE",
+"238 712 CURVE SMOOTH",
+"238 736 OFFCURVE",
+"221 754 OFFCURVE",
+"192 754 CURVE SMOOTH",
+"171 754 OFFCURVE",
+"151 745 OFFCURVE",
+"128 714 CURVE SMOOTH",
+"10 554 LINE"
+);
+}
+);
+width = 426;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"273 554 LINE",
+"410 649 LINE SMOOTH",
+"448 676 OFFCURVE",
+"458 696 OFFCURVE",
+"458 714 CURVE SMOOTH",
+"458 738 OFFCURVE",
+"440 760 OFFCURVE",
+"402 760 CURVE SMOOTH",
+"379 760 OFFCURVE",
+"356 752 OFFCURVE",
+"331 718 CURVE SMOOTH",
+"210 554 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"73 554 LINE",
+"210 649 LINE SMOOTH",
+"248 676 OFFCURVE",
+"258 696 OFFCURVE",
+"258 714 CURVE SMOOTH",
+"258 738 OFFCURVE",
+"240 760 OFFCURVE",
+"202 760 CURVE SMOOTH",
+"179 760 OFFCURVE",
+"156 752 OFFCURVE",
+"131 718 CURVE SMOOTH",
+"10 554 LINE"
+);
+}
+);
+width = 468;
+}
+);
+unicode = 02DD;
+},
+{
+glyphname = macron;
+lastChange = "2016-08-22 12:20:05 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{166, 450}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"330 637 LINE",
+"330 703 LINE",
+"10 703 LINE",
+"10 637 LINE"
+);
+}
+);
+width = 340;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{174, 450}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"350 627 LINE",
+"350 713 LINE",
+"10 713 LINE",
+"10 627 LINE"
+);
+}
+);
+width = 360;
+}
+);
+unicode = 00AF;
+},
+{
+glyphname = ogonek;
+lastChange = "2016-08-22 12:12:02 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"138 -231 OFFCURVE",
+"176 -214 OFFCURVE",
+"197 -188 CURVE",
+"197 -161 LINE",
+"193 -161 LINE",
+"164 -182 OFFCURVE",
+"144 -190 OFFCURVE",
+"126 -190 CURVE SMOOTH",
+"97 -190 OFFCURVE",
+"80 -171 OFFCURVE",
+"80 -137 CURVE SMOOTH",
+"80 -87 OFFCURVE",
+"118 -34 OFFCURVE",
+"194 22 CURVE",
+"158 22 LINE",
+"47 -51 OFFCURVE",
+"10 -94 OFFCURVE",
+"10 -147 CURVE SMOOTH",
+"10 -198 OFFCURVE",
+"46 -231 OFFCURVE",
+"100 -231 CURVE"
+);
+}
+);
+width = 210;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"138 -231 OFFCURVE",
+"176 -214 OFFCURVE",
+"197 -188 CURVE",
+"197 -161 LINE",
+"193 -161 LINE",
+"164 -182 OFFCURVE",
+"144 -190 OFFCURVE",
+"126 -190 CURVE SMOOTH",
+"97 -190 OFFCURVE",
+"80 -171 OFFCURVE",
+"80 -137 CURVE SMOOTH",
+"80 -87 OFFCURVE",
+"118 -34 OFFCURVE",
+"194 22 CURVE",
+"158 22 LINE",
+"47 -51 OFFCURVE",
+"10 -94 OFFCURVE",
+"10 -147 CURVE SMOOTH",
+"10 -198 OFFCURVE",
+"46 -231 OFFCURVE",
+"100 -231 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"138 -231 OFFCURVE",
+"174 -215 OFFCURVE",
+"197 -188 CURVE",
+"197 -153 LINE",
+"193 -153 LINE",
+"172 -171 OFFCURVE",
+"155 -178 OFFCURVE",
+"136 -178 CURVE SMOOTH",
+"112 -178 OFFCURVE",
+"100 -166 OFFCURVE",
+"100 -140 CURVE SMOOTH",
+"100 -94 OFFCURVE",
+"137 -33 OFFCURVE",
+"197 22 CURVE",
+"151 22 LINE",
+"47 -53 OFFCURVE",
+"10 -97 OFFCURVE",
+"10 -149 CURVE SMOOTH",
+"10 -199 OFFCURVE",
+"45 -231 OFFCURVE",
+"99 -231 CURVE SMOOTH"
+);
+}
+);
+width = 249;
+}
+);
+unicode = 02DB;
+},
+{
+glyphname = ring;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"168 560 OFFCURVE",
+"214 606 OFFCURVE",
+"214 662 CURVE SMOOTH",
+"214 718 OFFCURVE",
+"167 763 OFFCURVE",
+"112 763 CURVE SMOOTH",
+"57 763 OFFCURVE",
+"10 717 OFFCURVE",
+"10 662 CURVE SMOOTH",
+"10 606 OFFCURVE",
+"57 560 OFFCURVE",
+"112 560 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"82 606 OFFCURVE",
+"57 633 OFFCURVE",
+"57 662 CURVE SMOOTH",
+"57 691 OFFCURVE",
+"83 716 OFFCURVE",
+"112 716 CURVE SMOOTH",
+"141 716 OFFCURVE",
+"167 691 OFFCURVE",
+"167 662 CURVE SMOOTH",
+"167 632 OFFCURVE",
+"142 606 OFFCURVE",
+"112 606 CURVE SMOOTH"
+);
+}
+);
+width = 224;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"168 560 OFFCURVE",
+"214 606 OFFCURVE",
+"214 662 CURVE SMOOTH",
+"214 718 OFFCURVE",
+"167 763 OFFCURVE",
+"112 763 CURVE SMOOTH",
+"57 763 OFFCURVE",
+"10 717 OFFCURVE",
+"10 662 CURVE SMOOTH",
+"10 606 OFFCURVE",
+"57 560 OFFCURVE",
+"112 560 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"87 616 OFFCURVE",
+"67 638 OFFCURVE",
+"67 662 CURVE SMOOTH",
+"67 686 OFFCURVE",
+"88 706 OFFCURVE",
+"112 706 CURVE SMOOTH",
+"136 706 OFFCURVE",
+"157 686 OFFCURVE",
+"157 662 CURVE SMOOTH",
+"157 637 OFFCURVE",
+"137 616 OFFCURVE",
+"112 616 CURVE SMOOTH"
+);
+}
+);
+width = 224;
+}
+);
+unicode = 02DA;
+},
+{
+glyphname = tilde;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"43 603 LINE",
+"50 631 OFFCURVE",
+"73 652 OFFCURVE",
+"106 652 CURVE SMOOTH",
+"153 652 OFFCURVE",
+"187 604 OFFCURVE",
+"243 604 CURVE SMOOTH",
+"312 604 OFFCURVE",
+"348 668 OFFCURVE",
+"362 731 CURVE",
+"328 731 LINE",
+"321 710 OFFCURVE",
+"303 680 OFFCURVE",
+"265 680 CURVE SMOOTH",
+"219 680 OFFCURVE",
+"182 728 OFFCURVE",
+"128 728 CURVE SMOOTH",
+"62 728 OFFCURVE",
+"20 665 OFFCURVE",
+"10 603 CURVE"
+);
+}
+);
+width = 372;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"43 583 LINE",
+"52 611 OFFCURVE",
+"83 632 OFFCURVE",
+"126 632 CURVE SMOOTH",
+"173 632 OFFCURVE",
+"207 584 OFFCURVE",
+"263 584 CURVE SMOOTH",
+"344 584 OFFCURVE",
+"386 658 OFFCURVE",
+"402 731 CURVE",
+"368 731 LINE",
+"359 710 OFFCURVE",
+"335 680 OFFCURVE",
+"285 680 CURVE SMOOTH",
+"239 680 OFFCURVE",
+"202 728 OFFCURVE",
+"148 728 CURVE SMOOTH",
+"70 728 OFFCURVE",
+"22 655 OFFCURVE",
+"10 583 CURVE"
+);
+}
+);
+width = 412;
+}
+);
+unicode = 02DC;
+},
+{
+glyphname = caron.alt;
+lastChange = "2016-08-19 17:28:22 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"115 544 OFFCURVE",
+"162 600 OFFCURVE",
+"162 667 CURVE SMOOTH",
+"162 721 OFFCURVE",
+"131 763 OFFCURVE",
+"80 763 CURVE SMOOTH",
+"37 763 OFFCURVE",
+"10 734 OFFCURVE",
+"10 699 CURVE SMOOTH",
+"10 675 OFFCURVE",
+"24 649 OFFCURVE",
+"60 649 CURVE SMOOTH",
+"91 649 OFFCURVE",
+"111 676 OFFCURVE",
+"120 676 CURVE SMOOTH",
+"123 676 OFFCURVE",
+"125 673 OFFCURVE",
+"125 662 CURVE SMOOTH",
+"125 617 OFFCURVE",
+"93 569 OFFCURVE",
+"33 529 CURVE",
+"53 506 LINE"
+);
+}
+);
+width = 172;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"133 524 OFFCURVE",
+"176 573 OFFCURVE",
+"176 647 CURVE SMOOTH",
+"176 709 OFFCURVE",
+"146 764 OFFCURVE",
+"89 764 CURVE SMOOTH",
+"44 764 OFFCURVE",
+"10 730 OFFCURVE",
+"10 687 CURVE SMOOTH",
+"10 653 OFFCURVE",
+"30 620 OFFCURVE",
+"68 620 CURVE SMOOTH",
+"106 620 OFFCURVE",
+"111 652 OFFCURVE",
+"123 652 CURVE SMOOTH",
+"127 652 OFFCURVE",
+"132 648 OFFCURVE",
+"132 628 CURVE SMOOTH",
+"132 581 OFFCURVE",
+"105 543 OFFCURVE",
+"46 501 CURVE",
+"66 479 LINE"
+);
+}
+);
+width = 186;
+}
+);
+},
+{
+glyphname = acute.case;
+lastChange = "2016-08-19 17:29:47 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"53 792 LINE",
+"228 828 LINE SMOOTH",
+"261 835 OFFCURVE",
+"278 855 OFFCURVE",
+"278 881 CURVE SMOOTH",
+"278 907 OFFCURVE",
+"262 924 OFFCURVE",
+"234 924 CURVE SMOOTH",
+"220 924 OFFCURVE",
+"208 918 OFFCURVE",
+"161 888 CURVE SMOOTH",
+"10 792 LINE"
+);
+}
+);
+width = 288;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"73 787 LINE",
+"250 822 LINE SMOOTH",
+"294 831 OFFCURVE",
+"303 855 OFFCURVE",
+"303 878 CURVE SMOOTH",
+"303 902 OFFCURVE",
+"286 924 OFFCURVE",
+"253 924 CURVE SMOOTH",
+"224 924 OFFCURVE",
+"206 914 OFFCURVE",
+"171 891 CURVE SMOOTH",
+"10 787 LINE"
+);
+}
+);
+width = 313;
+}
+);
+},
+{
+glyphname = breve.case;
+lastChange = "2016-08-19 17:29:47 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"273 792 OFFCURVE",
+"323 847 OFFCURVE",
+"323 924 CURVE",
+"289 924 LINE",
+"286 880 OFFCURVE",
+"236 860 OFFCURVE",
+"165 860 CURVE SMOOTH",
+"95 860 OFFCURVE",
+"47 878 OFFCURVE",
+"44 924 CURVE",
+"10 924 LINE",
+"10 843 OFFCURVE",
+"64 792 OFFCURVE",
+"167 792 CURVE SMOOTH"
+);
+}
+);
+width = 333;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"290 787 OFFCURVE",
+"343 847 OFFCURVE",
+"343 924 CURVE",
+"299 924 LINE",
+"296 894 OFFCURVE",
+"246 880 OFFCURVE",
+"175 880 CURVE SMOOTH",
+"105 880 OFFCURVE",
+"57 892 OFFCURVE",
+"54 924 CURVE",
+"10 924 LINE",
+"10 843 OFFCURVE",
+"67 787 OFFCURVE",
+"177 787 CURVE SMOOTH"
+);
+}
+);
+width = 353;
+}
+);
+},
+{
+glyphname = caron.case;
+lastChange = "2016-08-22 12:00:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{170, 753}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"203 792 LINE",
+"334 924 LINE",
+"291 924 LINE",
+"172 863 LINE",
+"53 924 LINE",
+"10 924 LINE",
+"141 792 LINE"
+);
+}
+);
+width = 344;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{214, 752}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"243 788 LINE",
+"414 924 LINE",
+"361 924 LINE",
+"212 882 LINE",
+"63 924 LINE",
+"10 924 LINE",
+"181 788 LINE"
+);
+}
+);
+width = 424;
+}
+);
+},
+{
+glyphname = circumflex.case;
+lastChange = "2016-08-19 17:29:47 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"53 792 LINE",
+"172 853 LINE",
+"291 792 LINE",
+"334 792 LINE",
+"203 924 LINE",
+"141 924 LINE",
+"10 792 LINE"
+);
+}
+);
+width = 344;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"63 788 LINE",
+"212 830 LINE",
+"361 788 LINE",
+"414 788 LINE",
+"243 924 LINE",
+"181 924 LINE",
+"10 788 LINE"
+);
+}
+);
+width = 424;
+}
+);
+},
+{
+glyphname = dieresis.case;
+lastChange = "2016-08-22 11:55:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{164, 754}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"285 800 OFFCURVE",
+"310 825 OFFCURVE",
+"310 855 CURVE SMOOTH",
+"310 885 OFFCURVE",
+"285 910 OFFCURVE",
+"255 910 CURVE SMOOTH",
+"225 910 OFFCURVE",
+"200 885 OFFCURVE",
+"200 855 CURVE SMOOTH",
+"200 825 OFFCURVE",
+"225 800 OFFCURVE",
+"255 800 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"95 800 OFFCURVE",
+"120 825 OFFCURVE",
+"120 855 CURVE SMOOTH",
+"120 885 OFFCURVE",
+"95 910 OFFCURVE",
+"65 910 CURVE SMOOTH",
+"35 910 OFFCURVE",
+"10 885 OFFCURVE",
+"10 855 CURVE SMOOTH",
+"10 825 OFFCURVE",
+"35 800 OFFCURVE",
+"65 800 CURVE SMOOTH"
+);
+}
+);
+width = 320;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{170, 754}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"302 792 OFFCURVE",
+"332 822 OFFCURVE",
+"332 858 CURVE SMOOTH",
+"332 894 OFFCURVE",
+"302 924 OFFCURVE",
+"266 924 CURVE SMOOTH",
+"230 924 OFFCURVE",
+"200 894 OFFCURVE",
+"200 858 CURVE SMOOTH",
+"200 822 OFFCURVE",
+"230 792 OFFCURVE",
+"266 792 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"112 792 OFFCURVE",
+"142 822 OFFCURVE",
+"142 858 CURVE SMOOTH",
+"142 894 OFFCURVE",
+"112 924 OFFCURVE",
+"76 924 CURVE SMOOTH",
+"40 924 OFFCURVE",
+"10 894 OFFCURVE",
+"10 858 CURVE SMOOTH",
+"10 822 OFFCURVE",
+"40 792 OFFCURVE",
+"76 792 CURVE SMOOTH"
+);
+}
+);
+width = 342;
+}
+);
+},
+{
+glyphname = dotaccent.case;
+lastChange = "2016-08-22 12:08:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{75, 749}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"112 792 OFFCURVE",
+"142 822 OFFCURVE",
+"142 858 CURVE SMOOTH",
+"142 894 OFFCURVE",
+"112 924 OFFCURVE",
+"76 924 CURVE SMOOTH",
+"40 924 OFFCURVE",
+"10 894 OFFCURVE",
+"10 858 CURVE SMOOTH",
+"10 822 OFFCURVE",
+"40 792 OFFCURVE",
+"76 792 CURVE SMOOTH"
+);
+}
+);
+width = 152;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{79, 752}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"116 787 OFFCURVE",
+"147 818 OFFCURVE",
+"147 855 CURVE SMOOTH",
+"147 893 OFFCURVE",
+"116 924 OFFCURVE",
+"78 924 CURVE SMOOTH",
+"41 924 OFFCURVE",
+"10 893 OFFCURVE",
+"10 855 CURVE SMOOTH",
+"10 818 OFFCURVE",
+"41 787 OFFCURVE",
+"78 787 CURVE SMOOTH"
+);
+}
+);
+width = 157;
+}
+);
+},
+{
+glyphname = grave.case;
+lastChange = "2016-08-19 17:29:47 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"278 792 LINE",
+"127 888 LINE SMOOTH",
+"80 918 OFFCURVE",
+"68 924 OFFCURVE",
+"54 924 CURVE SMOOTH",
+"26 924 OFFCURVE",
+"10 907 OFFCURVE",
+"10 881 CURVE SMOOTH",
+"10 855 OFFCURVE",
+"27 835 OFFCURVE",
+"60 828 CURVE SMOOTH",
+"235 792 LINE"
+);
+}
+);
+width = 288;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"303 787 LINE",
+"142 891 LINE SMOOTH",
+"107 914 OFFCURVE",
+"89 924 OFFCURVE",
+"60 924 CURVE SMOOTH",
+"27 924 OFFCURVE",
+"10 902 OFFCURVE",
+"10 878 CURVE SMOOTH",
+"10 855 OFFCURVE",
+"19 831 OFFCURVE",
+"63 822 CURVE SMOOTH",
+"240 787 LINE"
+);
+}
+);
+width = 313;
+}
+);
+},
+{
+glyphname = hungarumlaut.case;
+lastChange = "2016-08-19 17:29:47 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"231 792 LINE",
+"366 828 LINE SMOOTH",
+"398 837 OFFCURVE",
+"416 855 OFFCURVE",
+"416 881 CURVE SMOOTH",
+"416 907 OFFCURVE",
+"400 924 OFFCURVE",
+"372 924 CURVE SMOOTH",
+"358 924 OFFCURVE",
+"350 918 OFFCURVE",
+"306 884 CURVE SMOOTH",
+"188 792 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"53 792 LINE",
+"188 828 LINE SMOOTH",
+"220 837 OFFCURVE",
+"238 855 OFFCURVE",
+"238 881 CURVE SMOOTH",
+"238 907 OFFCURVE",
+"222 924 OFFCURVE",
+"194 924 CURVE SMOOTH",
+"180 924 OFFCURVE",
+"172 918 OFFCURVE",
+"128 884 CURVE SMOOTH",
+"10 792 LINE"
+);
+}
+);
+width = 426;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"295 787 LINE",
+"472 822 LINE SMOOTH",
+"516 831 OFFCURVE",
+"525 855 OFFCURVE",
+"525 878 CURVE SMOOTH",
+"525 902 OFFCURVE",
+"508 924 OFFCURVE",
+"475 924 CURVE SMOOTH",
+"446 924 OFFCURVE",
+"428 914 OFFCURVE",
+"393 891 CURVE SMOOTH",
+"232 787 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"73 787 LINE",
+"250 822 LINE SMOOTH",
+"294 831 OFFCURVE",
+"303 855 OFFCURVE",
+"303 878 CURVE SMOOTH",
+"303 902 OFFCURVE",
+"286 924 OFFCURVE",
+"253 924 CURVE SMOOTH",
+"224 924 OFFCURVE",
+"206 914 OFFCURVE",
+"171 891 CURVE SMOOTH",
+"10 787 LINE"
+);
+}
+);
+width = 535;
+}
+);
+},
+{
+glyphname = macron.case;
+lastChange = "2016-08-22 11:58:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{168, 754}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"330 851 LINE",
+"330 917 LINE",
+"10 917 LINE",
+"10 851 LINE"
+);
+}
+);
+width = 340;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{172, 755}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"350 813 LINE",
+"350 899 LINE",
+"10 899 LINE",
+"10 813 LINE"
+);
+}
+);
+width = 360;
+}
+);
+},
+{
+glyphname = ring.case;
+lastChange = "2016-08-22 11:57:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{101, 714}";
+},
+{
+name = top;
+position = "{101, 924}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"142 777 OFFCURVE",
+"174 811 OFFCURVE",
+"174 852 CURVE SMOOTH",
+"174 893 OFFCURVE",
+"141 924 OFFCURVE",
+"101 924 CURVE SMOOTH",
+"61 924 OFFCURVE",
+"27 892 OFFCURVE",
+"27 852 CURVE SMOOTH",
+"27 811 OFFCURVE",
+"61 777 OFFCURVE",
+"101 777 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"79 810 OFFCURVE",
+"60 830 OFFCURVE",
+"60 852 CURVE SMOOTH",
+"60 873 OFFCURVE",
+"80 891 OFFCURVE",
+"101 891 CURVE SMOOTH",
+"122 891 OFFCURVE",
+"141 873 OFFCURVE",
+"141 852 CURVE SMOOTH",
+"141 830 OFFCURVE",
+"123 810 OFFCURVE",
+"101 810 CURVE SMOOTH"
+);
+}
+);
+width = 201;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{108, 674}";
+},
+{
+name = top;
+position = "{106, 924}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"159 732 OFFCURVE",
+"203 776 OFFCURVE",
+"203 828 CURVE SMOOTH",
+"203 881 OFFCURVE",
+"159 924 OFFCURVE",
+"106 924 CURVE SMOOTH",
+"54 924 OFFCURVE",
+"10 881 OFFCURVE",
+"10 828 CURVE SMOOTH",
+"10 776 OFFCURVE",
+"54 732 OFFCURVE",
+"106 732 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"83 785 OFFCURVE",
+"64 806 OFFCURVE",
+"64 828 CURVE SMOOTH",
+"64 851 OFFCURVE",
+"84 870 OFFCURVE",
+"106 870 CURVE SMOOTH",
+"129 870 OFFCURVE",
+"149 851 OFFCURVE",
+"149 828 CURVE SMOOTH",
+"149 805 OFFCURVE",
+"130 785 OFFCURVE",
+"106 785 CURVE SMOOTH"
+);
+}
+);
+width = 213;
+}
+);
+},
+{
+glyphname = tilde.case;
+lastChange = "2016-08-19 17:29:47 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"43 791 LINE",
+"50 819 OFFCURVE",
+"73 840 OFFCURVE",
+"106 840 CURVE SMOOTH",
+"153 840 OFFCURVE",
+"187 792 OFFCURVE",
+"243 792 CURVE SMOOTH",
+"312 792 OFFCURVE",
+"348 856 OFFCURVE",
+"362 919 CURVE",
+"328 919 LINE",
+"321 898 OFFCURVE",
+"303 868 OFFCURVE",
+"265 868 CURVE SMOOTH",
+"219 868 OFFCURVE",
+"182 916 OFFCURVE",
+"128 916 CURVE SMOOTH",
+"62 916 OFFCURVE",
+"20 853 OFFCURVE",
+"10 791 CURVE"
+);
+}
+);
+width = 372;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"43 787 LINE",
+"52 811 OFFCURVE",
+"83 828 OFFCURVE",
+"126 828 CURVE SMOOTH",
+"173 828 OFFCURVE",
+"207 788 OFFCURVE",
+"263 788 CURVE SMOOTH",
+"344 788 OFFCURVE",
+"386 856 OFFCURVE",
+"402 924 CURVE",
+"368 924 LINE",
+"359 907 OFFCURVE",
+"335 884 OFFCURVE",
+"285 884 CURVE SMOOTH",
+"239 884 OFFCURVE",
+"202 924 OFFCURVE",
+"148 924 CURVE SMOOTH",
+"70 924 OFFCURVE",
+"22 854 OFFCURVE",
+"10 787 CURVE"
+);
+}
+);
+width = 412;
+}
+);
+},
+{
+glyphname = brevecomb_acutecomb;
+lastChange = "2016-08-22 09:59:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{295, 450}";
+},
+{
+name = top;
+position = "{295, 853}";
+}
+);
+components = (
+{
+name = brevecomb;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -30, 198}";
+}
+);
+layerId = UUID0;
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{298, 450}";
+},
+{
+name = top;
+position = "{298, 864}";
+}
+);
+components = (
+{
+name = brevecomb;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -92, 208}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 600;
+}
+);
+},
+{
+glyphname = brevecomb_gravecomb;
+lastChange = "2016-08-22 10:27:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{295, 450}";
+},
+{
+name = top;
+position = "{295, 848}";
+}
+);
+components = (
+{
+name = brevecomb;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 8, 198}";
+}
+);
+layerId = UUID0;
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{298, 450}";
+},
+{
+name = top;
+position = "{298, 888}";
+}
+);
+components = (
+{
+name = brevecomb;
+},
+{
+alignment = -1;
+name = gravecomb;
+transform = "{1, 0, 0, 1, 49, 159}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 600;
+}
+);
+},
+{
+glyphname = brevecomb_hookabovecomb;
+lastChange = "2016-08-22 10:06:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{295, 450}";
+},
+{
+name = top;
+position = "{295, 868}";
+}
+);
+components = (
+{
+name = brevecomb;
+},
+{
+alignment = -1;
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 3, 128}";
+}
+);
+layerId = UUID0;
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{298, 450}";
+},
+{
+name = top;
+position = "{298, 898}";
+}
+);
+components = (
+{
+name = brevecomb;
+},
+{
+alignment = -1;
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, -4, 153}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 600;
+}
+);
+},
+{
+glyphname = brevecomb_tildecomb;
+lastChange = "2016-08-22 10:27:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{295, 450}";
+},
+{
+name = top;
+position = "{295, 851}";
+}
+);
+components = (
+{
+name = brevecomb;
+},
+{
+alignment = -1;
+name = tildecomb;
+transform = "{1, 0, 0, 1, 4, 128}";
+}
+);
+layerId = UUID0;
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{298, 450}";
+},
+{
+name = top;
+position = "{298, 861}";
+}
+);
+components = (
+{
+name = brevecomb;
+},
+{
+alignment = -1;
+name = tildecomb;
+transform = "{1, 0, 0, 1, -15, 144}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 600;
+}
+);
+},
+{
+glyphname = circumflexcomb_acutecomb;
+lastChange = "2016-08-22 10:07:58 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{290, 450}";
+},
+{
+name = top;
+position = "{290, 857}";
+}
+);
+components = (
+{
+name = circumflexcomb;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -35, 127}";
+}
+);
+layerId = UUID0;
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{296, 450}";
+},
+{
+name = top;
+position = "{296, 865}";
+}
+);
+components = (
+{
+name = circumflexcomb;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -94, 139}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 600;
+}
+);
+},
+{
+glyphname = circumflexcomb_gravecomb;
+lastChange = "2016-08-22 10:07:58 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{290, 450}";
+},
+{
+name = top;
+position = "{290, 852}";
+}
+);
+components = (
+{
+name = circumflexcomb;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 3, 127}";
+}
+);
+layerId = UUID0;
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{296, 450}";
+},
+{
+name = top;
+position = "{296, 889}";
+}
+);
+components = (
+{
+name = circumflexcomb;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 47, 139}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 600;
+}
+);
+},
+{
+glyphname = circumflexcomb_hookabovecomb;
+lastChange = "2016-08-22 10:06:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{290, 450}";
+},
+{
+name = top;
+position = "{290, 872}";
+}
+);
+components = (
+{
+name = circumflexcomb;
+},
+{
+alignment = -1;
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 123, 105}";
+}
+);
+layerId = UUID0;
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{296, 450}";
+},
+{
+name = top;
+position = "{296, 899}";
+}
+);
+components = (
+{
+name = circumflexcomb;
+},
+{
+alignment = -1;
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 151, 134}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 600;
+}
+);
+},
+{
+glyphname = circumflexcomb_tildecomb;
+lastChange = "2016-08-22 10:07:58 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{290, 450}";
+},
+{
+name = top;
+position = "{290, 855}";
+}
+);
+components = (
+{
+name = circumflexcomb;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, -1, 127}";
+}
+);
+layerId = UUID0;
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{296, 450}";
+},
+{
+name = top;
+position = "{296, 862}";
+}
+);
+components = (
+{
+name = circumflexcomb;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, -17, 139}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 600;
+}
+);
+},
+{
+glyphname = NULL;
+lastChange = "2016-08-19 17:28:22 +0000";
+layers = (
+{
+layerId = UUID0;
+width = 0;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 0;
+}
+);
+},
+{
+glyphname = espaciador;
+lastChange = "2016-08-19 17:28:22 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"134 -326 LINE",
+"134 924 LINE",
+"0 924 LINE",
+"0 -326 LINE"
+);
+}
+);
+width = 134;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"158 -326 LINE",
+"158 924 LINE",
+"0 924 LINE",
+"0 -326 LINE"
+);
+}
+);
+width = 158;
+}
+);
+},
+{
+glyphname = dotbelow;
+lastChange = "2016-08-22 09:40:48 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"112 -231 OFFCURVE",
+"142 -201 OFFCURVE",
+"142 -165 CURVE SMOOTH",
+"142 -129 OFFCURVE",
+"112 -99 OFFCURVE",
+"76 -99 CURVE SMOOTH",
+"40 -99 OFFCURVE",
+"10 -129 OFFCURVE",
+"10 -165 CURVE SMOOTH",
+"10 -201 OFFCURVE",
+"40 -231 OFFCURVE",
+"76 -231 CURVE SMOOTH"
+);
+}
+);
+width = 152;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"134 -260 OFFCURVE",
+"171 -223 OFFCURVE",
+"171 -180 CURVE SMOOTH",
+"171 -136 OFFCURVE",
+"134 -99 OFFCURVE",
+"90 -99 CURVE SMOOTH",
+"47 -99 OFFCURVE",
+"10 -136 OFFCURVE",
+"10 -180 CURVE SMOOTH",
+"10 -223 OFFCURVE",
+"47 -260 OFFCURVE",
+"90 -260 CURVE SMOOTH"
+);
+}
+);
+width = 181;
+}
+);
+}
+);
+instances = (
+{
+interpolationWeight = 400;
+instanceInterpolations = {
+UUID0 = 1;
+};
+name = Regular;
+},
+{
+interpolationWeight = 500;
+instanceInterpolations = {
+UUID0 = 0.666667;
+"3AE1663F-34E8-4710-91A2-69F84C961E5F" = 0.333333;
+};
+isBold = 1;
+linkStyle = Regular;
+name = Medium;
+weightClass = Medium;
+},
+{
+interpolationWeight = 700;
+instanceInterpolations = {
+"3AE1663F-34E8-4710-91A2-69F84C961E5F" = 1;
+};
+isBold = 1;
+name = Bold;
+}
+);
+kerning = {
+UUID0 = {
+"@MMK_L_A" = {
+"@MMK_R_A" = -80;
+"@MMK_R_C" = -52;
+"@MMK_R_G" = -52;
+"@MMK_R_O" = -52;
+"@MMK_R_T" = -28;
+"@MMK_R_U" = -48;
+"@MMK_R_W" = -92;
+"@MMK_R_Y" = -24;
+"@MMK_R_a" = 20;
+"@MMK_R_c" = -28;
+"@MMK_R_d" = -16;
+"@MMK_R_e" = -24;
+"@MMK_R_g" = 28;
+"@MMK_R_o" = -28;
+"@MMK_R_u" = -8;
+"@MMK_R_w" = -44;
+"@MMK_R_y" = -56;
+V = -112;
+b = -18;
+comma = 32;
+guillemetleft = -52;
+guilsinglleft = -52;
+hyphen = -12;
+period = 28;
+q = -16;
+quotedblleft = -60;
+quotedblright = -64;
+quoteleft = -60;
+quoteright = -64;
+v = -48;
+};
+"@MMK_L_C" = {
+"@MMK_R_A" = 28;
+"@MMK_R_AE" = 16;
+"@MMK_R_C" = -4;
+"@MMK_R_H" = 12;
+"@MMK_R_J" = 36;
+"@MMK_R_K" = 12;
+"@MMK_R_O" = -4;
+"@MMK_R_Y" = -16;
+"@MMK_R_Z" = 4;
+"@MMK_R_y" = -20;
+V = -36;
+comma = 40;
+hyphen = 28;
+period = 36;
+};
+"@MMK_L_D" = {
+"@MMK_R_A" = -52;
+"@MMK_R_J" = -40;
+"@MMK_R_N" = -20;
+"@MMK_R_T" = -4;
+"@MMK_R_U" = -28;
+"@MMK_R_W" = -48;
+"@MMK_R_Y" = -64;
+V = -68;
+X = -48;
+comma = -8;
+period = -8;
+quotedblleft = 20;
+quotedblright = 12;
+};
+"@MMK_L_E" = {
+"@MMK_R_C" = -12;
+"@MMK_R_O" = -8;
+"@MMK_R_S" = 8;
+"@MMK_R_T" = -12;
+"@MMK_R_U" = -28;
+"@MMK_R_W" = -28;
+V = -48;
+v = -32;
+};
+"@MMK_L_G" = {
+"@MMK_R_A" = -40;
+"@MMK_R_AE" = -58;
+"@MMK_R_T" = -24;
+"@MMK_R_W" = -40;
+"@MMK_R_Y" = -40;
+V = -60;
+X = -32;
+colon = 56;
+comma = 4;
+hyphen = 36;
+semicolon = 56;
+};
+"@MMK_L_H" = {
+"@MMK_R_y" = -12;
+};
+"@MMK_L_J" = {
+"@MMK_R_A" = -36;
+"@MMK_R_AE" = -64;
+"@MMK_R_Z" = -44;
+"@MMK_R_a" = -36;
+"@MMK_R_e" = -32;
+"@MMK_R_o" = -32;
+"@MMK_R_u" = -32;
+"@MMK_R_y" = -24;
+colon = -6;
+comma = -16;
+hyphen = -12;
+period = -16;
+};
+"@MMK_L_K" = {
+"@MMK_R_A" = -40;
+"@MMK_R_C" = -36;
+"@MMK_R_G" = -32;
+"@MMK_R_O" = -36;
+"@MMK_R_S" = 44;
+"@MMK_R_T" = -8;
+"@MMK_R_U" = -28;
+"@MMK_R_W" = -56;
+"@MMK_R_Y" = -4;
+"@MMK_R_a" = 40;
+"@MMK_R_e" = -4;
+"@MMK_R_o" = -8;
+"@MMK_R_u" = 16;
+"@MMK_R_w" = -24;
+"@MMK_R_y" = -44;
+Oslash = 12;
+V = -76;
+guillemetleft = -60;
+hyphen = -20;
+oslash = 8;
+quotedblleft = -52;
+quotedblright = -44;
+v = -40;
+};
+"@MMK_L_L" = {
+"@MMK_R_A" = 36;
+"@MMK_R_AE" = 4;
+"@MMK_R_C" = -8;
+"@MMK_R_G" = -4;
+"@MMK_R_O" = -8;
+"@MMK_R_T" = -52;
+"@MMK_R_U" = -32;
+"@MMK_R_W" = -80;
+"@MMK_R_Y" = -48;
+"@MMK_R_Z" = 16;
+"@MMK_R_w" = -16;
+"@MMK_R_y" = -24;
+V = -100;
+hyphen = 40;
+quotedblleft = -84;
+quotedblright = -96;
+quoteleft = -84;
+quoteright = -96;
+};
+"@MMK_L_N" = {
+"@MMK_R_A" = -4;
+"@MMK_R_AE" = -36;
+"@MMK_R_C" = -16;
+"@MMK_R_G" = -16;
+"@MMK_R_O" = -16;
+"@MMK_R_Z" = -24;
+"@MMK_R_a" = -16;
+"@MMK_R_e" = -12;
+"@MMK_R_o" = -12;
+"@MMK_R_u" = -12;
+"@MMK_R_y" = -4;
+comma = 12;
+oslash = -12;
+period = 8;
+};
+"@MMK_L_O" = {
+"@MMK_R_A" = -52;
+"@MMK_R_AE" = -84;
+"@MMK_R_J" = -36;
+"@MMK_R_N" = -16;
+"@MMK_R_W" = -48;
+"@MMK_R_Y" = -64;
+"@MMK_R_Z" = -20;
+V = -68;
+X = -48;
+comma = -4;
+hyphen = 24;
+period = -8;
+};
+"@MMK_L_R" = {
+"@MMK_R_A" = -16;
+"@MMK_R_C" = -12;
+"@MMK_R_G" = -8;
+"@MMK_R_J" = 68;
+"@MMK_R_O" = -8;
+"@MMK_R_U" = -20;
+"@MMK_R_W" = -28;
+"@MMK_R_Y" = -20;
+"@MMK_R_a" = 24;
+"@MMK_R_e" = -8;
+"@MMK_R_o" = -8;
+"@MMK_R_w" = -12;
+"@MMK_R_y" = -12;
+V = -48;
+hyphen = 16;
+quotedblleft = 24;
+quotedblright = 24;
+quoteleft = 24;
+quoteright = 24;
+v = -12;
+};
+"@MMK_L_S" = {
+"@MMK_R_A" = -16;
+"@MMK_R_AE" = -24;
+"@MMK_R_J" = -4;
+"@MMK_R_S" = 8;
+"@MMK_R_T" = -12;
+"@MMK_R_W" = -24;
+"@MMK_R_Y" = -28;
+"@MMK_R_w" = -12;
+"@MMK_R_y" = -16;
+V = -44;
+comma = 24;
+period = 24;
+v = -16;
+};
+"@MMK_L_T" = {
+"@MMK_R_A" = -24;
+"@MMK_R_AE" = -86;
+"@MMK_R_C" = -4;
+"@MMK_R_J" = -16;
+"@MMK_R_a" = -60;
+"@MMK_R_c" = -96;
+"@MMK_R_d" = -72;
+"@MMK_R_e" = -92;
+"@MMK_R_g" = -56;
+"@MMK_R_h" = -20;
+"@MMK_R_i" = -8;
+"@MMK_R_j" = -8;
+"@MMK_R_o" = -92;
+"@MMK_R_r" = -44;
+"@MMK_R_s" = -56;
+"@MMK_R_u" = -84;
+"@MMK_R_w" = -88;
+"@MMK_R_y" = -88;
+"@MMK_R_z" = -52;
+V = -20;
+colon = -32;
+comma = -48;
+guillemetleft = -124;
+guillemetright = -112;
+guilsinglleft = -124;
+hyphen = -76;
+m = -44;
+oslash = -92;
+period = -52;
+quotedblbase = -48;
+quotesinglbase = -48;
+semicolon = -36;
+v = -88;
+x = -24;
+};
+"@MMK_L_U" = {
+"@MMK_R_A" = -40;
+"@MMK_R_AE" = -68;
+"@MMK_R_C" = -20;
+"@MMK_R_S" = -12;
+"@MMK_R_U" = -36;
+"@MMK_R_Z" = -28;
+"@MMK_R_a" = -20;
+"@MMK_R_c" = -20;
+"@MMK_R_d" = -16;
+"@MMK_R_f" = -20;
+"@MMK_R_g" = -16;
+"@MMK_R_j" = -24;
+"@MMK_R_n" = -24;
+"@MMK_R_r" = -20;
+"@MMK_R_s" = -12;
+"@MMK_R_t" = -16;
+"@MMK_R_y" = -4;
+"@MMK_R_z" = -24;
+guillemetleft = -40;
+m = -24;
+p = -16;
+period = -4;
+v = -4;
+};
+"@MMK_L_W" = {
+"@MMK_R_A" = -92;
+"@MMK_R_AE" = -144;
+"@MMK_R_C" = -48;
+"@MMK_R_G" = -48;
+"@MMK_R_O" = -48;
+"@MMK_R_S" = -32;
+"@MMK_R_a" = -64;
+"@MMK_R_c" = -68;
+"@MMK_R_d" = -64;
+"@MMK_R_e" = -64;
+"@MMK_R_g" = -64;
+"@MMK_R_i" = -36;
+"@MMK_R_n" = -40;
+"@MMK_R_o" = -68;
+"@MMK_R_r" = -40;
+"@MMK_R_s" = -60;
+"@MMK_R_u" = -32;
+"@MMK_R_y" = -20;
+"@MMK_R_z" = -60;
+Oslash = -36;
+colon = -12;
+comma = -64;
+guillemetleft = -92;
+guillemetright = -76;
+guilsinglleft = -92;
+guilsinglright = -68;
+hyphen = -52;
+m = -40;
+oslash = -68;
+p = -32;
+period = -68;
+q = -64;
+quotedblbase = -60;
+quotesinglbase = -60;
+semicolon = -8;
+v = -20;
+x = -20;
+};
+"@MMK_L_Y" = {
+"@MMK_R_A" = -12;
+"@MMK_R_AE" = -58;
+"@MMK_R_C" = -60;
+"@MMK_R_G" = -60;
+"@MMK_R_J" = -8;
+"@MMK_R_O" = -60;
+"@MMK_R_S" = -44;
+"@MMK_R_T" = -4;
+"@MMK_R_a" = -52;
+"@MMK_R_c" = -76;
+"@MMK_R_d" = -76;
+"@MMK_R_e" = -72;
+"@MMK_R_g" = -44;
+"@MMK_R_i" = -40;
+"@MMK_R_n" = -36;
+"@MMK_R_o" = -76;
+"@MMK_R_r" = -36;
+"@MMK_R_s" = -48;
+"@MMK_R_t" = -64;
+"@MMK_R_u" = -64;
+"@MMK_R_w" = -52;
+"@MMK_R_y" = -52;
+"@MMK_R_z" = -44;
+Oslash = -52;
+colon = -20;
+comma = -40;
+guillemetleft = -108;
+guillemetright = -96;
+guilsinglleft = -108;
+guilsinglright = -92;
+hyphen = -64;
+m = -36;
+oslash = -76;
+p = -60;
+period = -44;
+q = -76;
+quotedblbase = -36;
+quotesinglbase = -36;
+semicolon = -16;
+v = -52;
+x = -16;
+};
+"@MMK_L_Z" = {
+"@MMK_R_U" = -24;
+"@MMK_R_W" = -12;
+"@MMK_R_w" = -16;
+"@MMK_R_y" = -28;
+comma = 44;
+period = 50;
+v = -24;
+};
+"@MMK_L_a" = {
+"@MMK_R_j" = -8;
+"@MMK_R_w" = -4;
+"@MMK_R_y" = -8;
+quoteright = -16;
+v = -8;
+};
+"@MMK_L_c" = {
+"@MMK_R_h" = -8;
+comma = 24;
+};
+"@MMK_L_d" = {
+"@MMK_R_j" = -4;
+"@MMK_R_w" = 12;
+"@MMK_R_y" = 12;
+v = 12;
+};
+"@MMK_L_e" = {
+"@MMK_R_y" = -4;
+v = -4;
+x = -4;
+};
+"@MMK_L_f" = {
+"@MMK_R_c" = -24;
+"@MMK_R_e" = -20;
+"@MMK_R_f" = 32;
+"@MMK_R_i" = 28;
+"@MMK_R_j" = 28;
+"@MMK_R_l" = 28;
+"@MMK_R_o" = -20;
+"@MMK_R_s" = 8;
+"@MMK_R_t" = 36;
+asterisk = 64;
+bracketright = 32;
+comma = 16;
+exclam = 56;
+guillemetleft = -56;
+oslash = -20;
+parenright = 70;
+period = 12;
+question = 78;
+quotedblleft = 70;
+quotedblright = 78;
+quoteleft = 70;
+quoteright = 68;
+};
+"@MMK_L_g" = {
+"@MMK_R_e" = -12;
+"@MMK_R_r" = 24;
+comma = -4;
+period = -12;
+};
+"@MMK_L_h" = {
+"@MMK_R_w" = -4;
+"@MMK_R_y" = -8;
+quotedblright = -12;
+quoteright = -12;
+v = -8;
+};
+"@MMK_L_i" = {
+"@MMK_R_T" = -20;
+"@MMK_R_j" = -20;
+"@MMK_R_t" = -12;
+};
+"@MMK_L_j" = {
+comma = 8;
+};
+"@MMK_L_k" = {
+"@MMK_R_a" = 32;
+"@MMK_R_c" = -16;
+"@MMK_R_e" = -8;
+"@MMK_R_g" = 44;
+"@MMK_R_o" = -12;
+"@MMK_R_s" = 40;
+"@MMK_R_u" = 30;
+"@MMK_R_y" = -12;
+comma = 48;
+hyphen = -20;
+period = 44;
+};
+"@MMK_L_l" = {
+"@MMK_R_y" = 4;
+v = 8;
+};
+"@MMK_L_n" = {
+"@MMK_R_T" = -44;
+"@MMK_R_y" = -8;
+quoteright = -12;
+v = -8;
+};
+"@MMK_L_o" = {
+"@MMK_R_T" = -100;
+"@MMK_R_f" = -16;
+"@MMK_R_t" = -8;
+"@MMK_R_w" = -16;
+"@MMK_R_y" = -20;
+comma = 8;
+period = 8;
+quotedblleft = -4;
+quoteright = -16;
+v = -20;
+x = -20;
+};
+"@MMK_L_r" = {
+"@MMK_R_a" = -4;
+"@MMK_R_c" = -12;
+"@MMK_R_d" = -8;
+"@MMK_R_e" = -8;
+"@MMK_R_f" = 24;
+"@MMK_R_g" = -8;
+"@MMK_R_h" = -16;
+"@MMK_R_i" = 20;
+"@MMK_R_j" = 20;
+"@MMK_R_k" = -12;
+"@MMK_R_l" = -12;
+"@MMK_R_n" = 16;
+"@MMK_R_o" = -12;
+"@MMK_R_r" = 20;
+"@MMK_R_t" = 28;
+"@MMK_R_u" = 28;
+"@MMK_R_w" = 40;
+"@MMK_R_y" = 36;
+b = -8;
+colon = 24;
+comma = -36;
+guillemetleft = -60;
+hyphen = -56;
+m = 20;
+oslash = -16;
+p = 28;
+period = -40;
+q = -8;
+quotedblbase = -32;
+quoteright = 12;
+quotesinglbase = -32;
+v = 40;
+x = 36;
+};
+"@MMK_L_s" = {
+"@MMK_R_t" = 8;
+"@MMK_R_w" = 20;
+"@MMK_R_y" = 20;
+v = 20;
+};
+"@MMK_L_t" = {
+"@MMK_R_S" = 8;
+"@MMK_R_a" = 16;
+"@MMK_R_c" = -12;
+"@MMK_R_e" = -8;
+"@MMK_R_h" = 12;
+"@MMK_R_o" = -12;
+colon = 40;
+quoteright = -8;
+semicolon = 40;
+};
+"@MMK_L_u" = {
+quoteright = -8;
+};
+"@MMK_L_w" = {
+"@MMK_R_a" = 8;
+"@MMK_R_c" = -12;
+"@MMK_R_e" = -4;
+"@MMK_R_l" = 16;
+"@MMK_R_o" = -8;
+"@MMK_R_s" = 16;
+colon = 40;
+comma = -20;
+hyphen = -4;
+oslash = -12;
+period = -24;
+quotedblbase = -16;
+quotesinglbase = -16;
+semicolon = 40;
+};
+"@MMK_L_y" = {
+"@MMK_R_a" = -4;
+"@MMK_R_c" = -24;
+"@MMK_R_d" = -16;
+"@MMK_R_e" = -16;
+"@MMK_R_g" = -16;
+"@MMK_R_l" = 8;
+"@MMK_R_o" = -20;
+colon = 24;
+comma = -36;
+hyphen = -16;
+oslash = -28;
+period = -36;
+quotedblbase = -28;
+quotesinglbase = -28;
+semicolon = 20;
+};
+"@MMK_L_z" = {
+colon = 60;
+comma = 36;
+};
+B = {
+"@MMK_R_A" = -28;
+"@MMK_R_AE" = -56;
+"@MMK_R_G" = -12;
+"@MMK_R_J" = -16;
+"@MMK_R_O" = -12;
+"@MMK_R_T" = -16;
+"@MMK_R_U" = -32;
+"@MMK_R_W" = -44;
+"@MMK_R_Y" = -52;
+"@MMK_R_y" = -24;
+V = -64;
+X = -20;
+comma = 20;
+hyphen = 28;
+period = -4;
+quotedblright = 8;
+slash = 38;
+};
+F = {
+"@MMK_R_A" = -84;
+"@MMK_R_G" = -8;
+"@MMK_R_J" = -60;
+"@MMK_R_O" = -4;
+"@MMK_R_T" = 12;
+"@MMK_R_a" = -64;
+"@MMK_R_e" = -68;
+"@MMK_R_i" = -12;
+"@MMK_R_j" = -12;
+"@MMK_R_o" = -72;
+"@MMK_R_r" = -12;
+"@MMK_R_u" = -8;
+colon = -16;
+comma = -80;
+guillemetleft = -92;
+hyphen = -48;
+oslash = -72;
+period = -80;
+quotedblbase = -76;
+quotesinglbase = -76;
+};
+Lslash = {
+"@MMK_R_T" = -52;
+"@MMK_R_W" = -80;
+"@MMK_R_Y" = -48;
+V = -100;
+quotedblleft = -84;
+quotedblright = -88;
+quoteleft = -84;
+quoteright = -88;
+};
+Oslash = {
+"@MMK_R_A" = -44;
+"@MMK_R_Y" = -56;
+V = -60;
+X = -36;
+comma = 8;
+hyphen = 32;
+};
+P = {
+"@MMK_R_A" = -92;
+"@MMK_R_AE" = -152;
+"@MMK_R_J" = -60;
+"@MMK_R_T" = 16;
+"@MMK_R_Y" = -32;
+"@MMK_R_a" = -52;
+"@MMK_R_c" = -72;
+"@MMK_R_e" = -64;
+"@MMK_R_g" = -60;
+"@MMK_R_o" = -68;
+"@MMK_R_s" = -44;
+"@MMK_R_u" = 8;
+"@MMK_R_y" = 16;
+colon = -24;
+comma = -108;
+guillemetleft = -116;
+hyphen = -76;
+oslash = -72;
+period = -104;
+quotedblbase = -104;
+quotedblleft = 44;
+quotesinglbase = -104;
+semicolon = -28;
+};
+Q = {
+"@MMK_R_A" = -52;
+"@MMK_R_U" = -28;
+"@MMK_R_W" = -48;
+"@MMK_R_Y" = -64;
+V = -68;
+period = -4;
+};
+V = {
+"@MMK_R_A" = -112;
+"@MMK_R_AE" = -174;
+"@MMK_R_C" = -68;
+"@MMK_R_G" = -68;
+"@MMK_R_J" = -92;
+"@MMK_R_O" = -68;
+"@MMK_R_S" = -52;
+"@MMK_R_T" = -20;
+"@MMK_R_a" = -84;
+"@MMK_R_c" = -88;
+"@MMK_R_d" = -84;
+"@MMK_R_e" = -84;
+"@MMK_R_g" = -88;
+"@MMK_R_i" = -56;
+"@MMK_R_n" = -60;
+"@MMK_R_o" = -88;
+"@MMK_R_r" = -60;
+"@MMK_R_s" = -76;
+"@MMK_R_u" = -52;
+"@MMK_R_w" = -40;
+"@MMK_R_y" = -40;
+"@MMK_R_z" = -80;
+Oslash = -56;
+colon = -32;
+comma = -84;
+guillemetleft = -112;
+guillemetright = -92;
+guilsinglleft = -112;
+guilsinglright = -88;
+hyphen = -72;
+m = -60;
+oslash = -88;
+p = -52;
+period = -88;
+q = -84;
+quotedblbase = -80;
+quotesinglbase = -80;
+semicolon = -28;
+v = -40;
+x = -40;
+};
+X = {
+"@MMK_R_A" = -66;
+"@MMK_R_C" = -48;
+"@MMK_R_G" = -44;
+"@MMK_R_O" = -48;
+"@MMK_R_T" = -24;
+"@MMK_R_a" = 28;
+"@MMK_R_e" = -12;
+"@MMK_R_o" = -16;
+"@MMK_R_y" = -60;
+Oslash = -8;
+guillemetleft = -60;
+guilsinglleft = -60;
+hyphen = -20;
+quotedblleft = -32;
+};
+b = {
+"@MMK_R_w" = -8;
+"@MMK_R_y" = -12;
+comma = 12;
+v = -12;
+};
+comma = {
+one = 24;
+quotedblright = -16;
+quoteright = -16;
+};
+eight = {
+four = 16;
+one = -20;
+seven = -12;
+};
+five = {
+four = 20;
+seven = -36;
+};
+four = {
+four = 20;
+seven = -40;
+};
+guillemetleft = {
+"@MMK_R_J" = 16;
+"@MMK_R_T" = -108;
+"@MMK_R_U" = -36;
+"@MMK_R_W" = -72;
+"@MMK_R_Y" = -100;
+V = -92;
+};
+guillemetright = {
+"@MMK_R_A" = -44;
+"@MMK_R_AE" = -80;
+"@MMK_R_J" = -52;
+"@MMK_R_T" = -120;
+"@MMK_R_U" = -44;
+"@MMK_R_W" = -88;
+"@MMK_R_Y" = -108;
+V = -108;
+X = -72;
+};
+guilsinglleft = {
+"@MMK_R_T" = -108;
+"@MMK_R_W" = -72;
+"@MMK_R_Y" = -100;
+V = -92;
+};
+guilsinglright = {
+"@MMK_R_A" = -52;
+"@MMK_R_AE" = -84;
+"@MMK_R_T" = -124;
+"@MMK_R_W" = -92;
+"@MMK_R_Y" = -112;
+V = -112;
+X = -76;
+};
+hyphen = {
+"@MMK_R_A" = -8;
+"@MMK_R_AE" = -40;
+"@MMK_R_C" = 20;
+"@MMK_R_G" = 24;
+"@MMK_R_J" = -24;
+"@MMK_R_O" = 24;
+"@MMK_R_S" = 24;
+"@MMK_R_T" = -84;
+"@MMK_R_W" = -48;
+"@MMK_R_Y" = -72;
+"@MMK_R_Z" = -8;
+V = -72;
+X = -36;
+};
+m = {
+"@MMK_R_w" = -4;
+"@MMK_R_y" = -8;
+p = -4;
+v = -8;
+};
+nine = {
+four = -4;
+one = -32;
+};
+one = {
+comma = 20;
+eight = -20;
+four = -40;
+nine = -36;
+one = 32;
+period = 16;
+seven = -52;
+six = -36;
+two = 20;
+zero = -32;
+};
+oslash = {
+x = 12;
+};
+p = {
+"@MMK_R_f" = -12;
+"@MMK_R_w" = -8;
+"@MMK_R_y" = -16;
+};
+period = {
+one = 16;
+quotedblright = -12;
+quoteright = -12;
+};
+q = {
+"@MMK_R_u" = 40;
+};
+quotedblbase = {
+"@MMK_R_A" = 32;
+"@MMK_R_AE" = 20;
+"@MMK_R_C" = -12;
+"@MMK_R_G" = -8;
+"@MMK_R_J" = 40;
+"@MMK_R_O" = -8;
+"@MMK_R_T" = -56;
+"@MMK_R_U" = -16;
+"@MMK_R_W" = -68;
+"@MMK_R_Y" = -52;
+"@MMK_R_w" = -28;
+"@MMK_R_y" = -44;
+Oslash = 8;
+V = -88;
+v = -44;
+};
+quotedblleft = {
+"@MMK_R_A" = -64;
+"@MMK_R_AE" = -136;
+"@MMK_R_J" = -24;
+"@MMK_R_T" = 24;
+"@MMK_R_W" = 8;
+"@MMK_R_Y" = -8;
+"@MMK_R_c" = -8;
+"@MMK_R_f" = 12;
+V = -8;
+};
+quotedblright = {
+"@MMK_R_A" = -72;
+"@MMK_R_AE" = -170;
+"@MMK_R_T" = 24;
+"@MMK_R_W" = 8;
+"@MMK_R_Y" = -8;
+V = -16;
+period = -16;
+};
+quoteleft = {
+"@MMK_R_A" = -64;
+"@MMK_R_AE" = -156;
+"@MMK_R_J" = -24;
+"@MMK_R_T" = 24;
+"@MMK_R_W" = 8;
+"@MMK_R_Y" = -8;
+V = -8;
+};
+quoteright = {
+"@MMK_R_A" = -72;
+"@MMK_R_AE" = -156;
+"@MMK_R_d" = -12;
+"@MMK_R_o" = -16;
+"@MMK_R_s" = -4;
+"@MMK_R_t" = 4;
+"@MMK_R_w" = 16;
+"@MMK_R_y" = 16;
+comma = -12;
+period = -16;
+v = 16;
+};
+quotesinglbase = {
+"@MMK_R_C" = -12;
+"@MMK_R_G" = -8;
+"@MMK_R_J" = 40;
+"@MMK_R_O" = -8;
+"@MMK_R_T" = -56;
+"@MMK_R_U" = -16;
+"@MMK_R_W" = -64;
+"@MMK_R_Y" = -52;
+"@MMK_R_w" = -28;
+"@MMK_R_y" = -44;
+Oslash = 8;
+V = -88;
+v = -44;
+};
+seven = {
+colon = 12;
+comma = -24;
+eight = -20;
+five = -20;
+four = -56;
+hyphen = -32;
+nine = -16;
+one = 36;
+period = -28;
+six = -32;
+three = -8;
+two = -12;
+zero = -24;
+};
+six = {
+four = 20;
+one = -28;
+seven = -52;
+};
+three = {
+four = 16;
+one = -24;
+seven = -20;
+};
+two = {
+four = 8;
+one = 12;
+seven = -4;
+};
+v = {
+"@MMK_R_a" = -4;
+"@MMK_R_c" = -24;
+"@MMK_R_d" = -16;
+"@MMK_R_e" = -16;
+"@MMK_R_g" = -16;
+"@MMK_R_o" = -24;
+colon = 24;
+comma = -36;
+hyphen = -16;
+oslash = -28;
+period = -36;
+semicolon = 24;
+};
+x = {
+"@MMK_R_a" = 20;
+"@MMK_R_c" = -24;
+"@MMK_R_d" = -16;
+"@MMK_R_e" = -20;
+"@MMK_R_o" = -24;
+oslash = -8;
+q = -16;
+};
+zero = {
+one = -32;
+seven = -12;
+two = -16;
+};
+};
+"3AE1663F-34E8-4710-91A2-69F84C961E5F" = {
+"@MMK_L_A" = {
+"@MMK_R_A" = -74;
+"@MMK_R_C" = -48;
+"@MMK_R_G" = -48;
+"@MMK_R_O" = -40;
+"@MMK_R_T" = -32;
+"@MMK_R_U" = -40;
+"@MMK_R_W" = -96;
+"@MMK_R_Y" = -52;
+"@MMK_R_a" = 20;
+"@MMK_R_c" = -16;
+"@MMK_R_d" = -16;
+"@MMK_R_e" = -16;
+"@MMK_R_g" = 28;
+"@MMK_R_o" = -12;
+"@MMK_R_w" = -28;
+"@MMK_R_y" = -44;
+V = -92;
+b = 40;
+comma = 24;
+guillemetleft = -28;
+guilsinglleft = -44;
+period = 20;
+q = -16;
+quotedblleft = -60;
+quotedblright = -72;
+quoteleft = -60;
+quoteright = -68;
+v = -40;
+};
+"@MMK_L_AE" = {
+"@MMK_R_S" = 28;
+"@MMK_R_T" = 8;
+"@MMK_R_U" = -8;
+"@MMK_R_W" = -20;
+"@MMK_R_Z" = 20;
+V = -16;
+v = -16;
+};
+"@MMK_L_C" = {
+"@MMK_R_A" = 24;
+"@MMK_R_AE" = 12;
+"@MMK_R_C" = -8;
+"@MMK_R_H" = 8;
+"@MMK_R_J" = 136;
+"@MMK_R_K" = 8;
+"@MMK_R_Y" = -36;
+"@MMK_R_Z" = 12;
+"@MMK_R_y" = -12;
+V = -20;
+comma = 32;
+hyphen = 32;
+period = 32;
+};
+"@MMK_L_D" = {
+"@MMK_R_A" = -56;
+"@MMK_R_Eng" = -20;
+"@MMK_R_T" = 8;
+"@MMK_R_U" = -16;
+"@MMK_R_W" = -56;
+"@MMK_R_Y" = -80;
+V = -48;
+X = -40;
+comma = -12;
+period = -8;
+quotedblleft = 20;
+quotedblright = 8;
+};
+"@MMK_L_G" = {
+"@MMK_R_A" = -40;
+"@MMK_R_AE" = -52;
+"@MMK_R_T" = -32;
+"@MMK_R_W" = -56;
+"@MMK_R_Y" = -68;
+V = -56;
+X = -44;
+colon = 52;
+hyphen = 36;
+quotedblright = -16;
+semicolon = 52;
+};
+"@MMK_L_H" = {
+"@MMK_R_y" = -4;
+};
+"@MMK_L_IJ" = {
+"@MMK_R_A" = -16;
+"@MMK_R_AE" = -28;
+"@MMK_R_Z" = -20;
+"@MMK_R_a" = -16;
+"@MMK_R_e" = -20;
+"@MMK_R_o" = -20;
+"@MMK_R_u" = -16;
+"@MMK_R_y" = -8;
+colon = 40;
+comma = -4;
+period = -4;
+};
+"@MMK_L_K" = {
+"@MMK_R_A" = -104;
+"@MMK_R_C" = -56;
+"@MMK_R_G" = -52;
+"@MMK_R_O" = -52;
+"@MMK_R_S" = 32;
+"@MMK_R_T" = -32;
+"@MMK_R_U" = -40;
+"@MMK_R_W" = -84;
+"@MMK_R_Y" = -52;
+"@MMK_R_a" = 20;
+"@MMK_R_e" = -16;
+"@MMK_R_o" = -12;
+"@MMK_R_w" = -40;
+"@MMK_R_y" = -64;
+Oslash = -28;
+V = -80;
+guillemetleft = -60;
+hyphen = -32;
+quotedblleft = -88;
+quotedblright = -76;
+v = -52;
+};
+"@MMK_L_L" = {
+"@MMK_R_A" = -40;
+"@MMK_R_AE" = -66;
+"@MMK_R_C" = -4;
+"@MMK_R_S" = 12;
+"@MMK_R_T" = -48;
+"@MMK_R_U" = -24;
+"@MMK_R_W" = -88;
+"@MMK_R_Y" = -72;
+"@MMK_R_Z" = 24;
+"@MMK_R_u" = 12;
+"@MMK_R_y" = -16;
+V = -84;
+hyphen = 48;
+quotedblleft = -68;
+quotedblright = -84;
+quoteleft = -68;
+quoteright = -80;
+};
+"@MMK_L_N" = {
+"@MMK_R_A" = -8;
+"@MMK_R_AE" = -24;
+"@MMK_R_C" = -24;
+"@MMK_R_G" = -24;
+"@MMK_R_O" = -16;
+"@MMK_R_Z" = -20;
+"@MMK_R_a" = -16;
+"@MMK_R_e" = -20;
+"@MMK_R_o" = -20;
+"@MMK_R_u" = -16;
+"@MMK_R_y" = -8;
+oslash = -20;
+};
+"@MMK_L_O" = {
+"@MMK_R_A" = -52;
+"@MMK_R_AE" = -64;
+"@MMK_R_Eng" = -24;
+"@MMK_R_W" = -60;
+"@MMK_R_Y" = -84;
+"@MMK_R_Z" = -16;
+V = -52;
+X = -48;
+comma = -12;
+hyphen = 24;
+period = -12;
+};
+"@MMK_L_R" = {
+"@MMK_R_A" = -24;
+"@MMK_R_C" = -16;
+"@MMK_R_G" = -16;
+"@MMK_R_J" = 104;
+"@MMK_R_O" = -12;
+"@MMK_R_U" = -20;
+"@MMK_R_W" = -40;
+"@MMK_R_Y" = -52;
+"@MMK_R_a" = 20;
+"@MMK_R_e" = -16;
+"@MMK_R_o" = -12;
+"@MMK_R_w" = -20;
+"@MMK_R_y" = -16;
+V = -40;
+hyphen = 12;
+quotedblright = -4;
+quoteright = -4;
+v = -20;
+};
+"@MMK_L_S" = {
+"@MMK_R_AE" = -22;
+"@MMK_R_J" = 76;
+"@MMK_R_S" = 24;
+"@MMK_R_W" = -24;
+"@MMK_R_Y" = -36;
+"@MMK_R_t" = 12;
+"@MMK_R_w" = 8;
+V = -24;
+comma = 8;
+period = 8;
+v = 8;
+};
+"@MMK_L_T" = {
+"@MMK_R_A" = -36;
+"@MMK_R_AE" = -48;
+"@MMK_R_C" = -4;
+"@MMK_R_G" = -4;
+"@MMK_R_J" = 46;
+"@MMK_R_S" = 12;
+"@MMK_R_Y" = -32;
+"@MMK_R_a" = -72;
+"@MMK_R_c" = -100;
+"@MMK_R_d" = -68;
+"@MMK_R_e" = -100;
+"@MMK_R_g" = -60;
+"@MMK_R_h" = -16;
+"@MMK_R_o" = -96;
+"@MMK_R_r" = -48;
+"@MMK_R_s" = -56;
+"@MMK_R_u" = -92;
+"@MMK_R_w" = -92;
+"@MMK_R_y" = -92;
+"@MMK_R_z" = -52;
+colon = -36;
+comma = -68;
+guillemetleft = -104;
+guillemetright = -104;
+guilsinglleft = -120;
+hyphen = -80;
+m = -48;
+oslash = -92;
+period = -68;
+quotedblbase = -72;
+quotesinglbase = -72;
+semicolon = -36;
+v = -92;
+x = -44;
+};
+"@MMK_L_U" = {
+"@MMK_R_A" = -36;
+"@MMK_R_AE" = -48;
+"@MMK_R_C" = -24;
+"@MMK_R_S" = -4;
+"@MMK_R_U" = -32;
+"@MMK_R_Z" = -20;
+"@MMK_R_a" = -20;
+"@MMK_R_c" = -24;
+"@MMK_R_d" = -20;
+"@MMK_R_eng" = -24;
+"@MMK_R_f" = -24;
+"@MMK_R_g" = -20;
+"@MMK_R_j" = -24;
+"@MMK_R_r" = -24;
+"@MMK_R_s" = -8;
+"@MMK_R_t" = -20;
+"@MMK_R_y" = -8;
+"@MMK_R_z" = -20;
+comma = -32;
+guillemetleft = -28;
+m = -24;
+p = -24;
+period = -12;
+v = -8;
+};
+"@MMK_L_W" = {
+"@MMK_R_A" = -112;
+"@MMK_R_AE" = -124;
+"@MMK_R_C" = -64;
+"@MMK_R_G" = -64;
+"@MMK_R_O" = -60;
+"@MMK_R_S" = -40;
+"@MMK_R_T" = -4;
+"@MMK_R_a" = -80;
+"@MMK_R_c" = -88;
+"@MMK_R_d" = -84;
+"@MMK_R_e" = -84;
+"@MMK_R_eng" = -52;
+"@MMK_R_g" = -80;
+"@MMK_R_i" = -44;
+"@MMK_R_o" = -84;
+"@MMK_R_r" = -52;
+"@MMK_R_s" = -68;
+"@MMK_R_u" = -48;
+"@MMK_R_y" = -36;
+"@MMK_R_z" = -72;
+Oslash = -60;
+colon = -32;
+comma = -84;
+guillemetleft = -92;
+guillemetright = -84;
+guilsinglleft = -108;
+guilsinglright = -84;
+hyphen = -68;
+m = -52;
+oslash = -84;
+p = -52;
+period = -84;
+q = -84;
+quotedblbase = -84;
+quotesinglbase = -84;
+semicolon = -32;
+v = -36;
+x = -52;
+};
+"@MMK_L_Y" = {
+"@MMK_R_A" = -40;
+"@MMK_R_AE" = -52;
+"@MMK_R_C" = -84;
+"@MMK_R_G" = -84;
+"@MMK_R_J" = 12;
+"@MMK_R_O" = -80;
+"@MMK_R_S" = -60;
+"@MMK_R_T" = -20;
+"@MMK_R_a" = -76;
+"@MMK_R_c" = -100;
+"@MMK_R_d" = -100;
+"@MMK_R_e" = -100;
+"@MMK_R_eng" = -52;
+"@MMK_R_g" = -64;
+"@MMK_R_i" = -52;
+"@MMK_R_o" = -100;
+"@MMK_R_r" = -52;
+"@MMK_R_s" = -60;
+"@MMK_R_t" = -84;
+"@MMK_R_u" = -84;
+"@MMK_R_w" = -72;
+"@MMK_R_y" = -68;
+"@MMK_R_z" = -56;
+Oslash = -80;
+colon = -40;
+comma = -72;
+guillemetleft = -108;
+guillemetright = -104;
+guilsinglleft = -124;
+guilsinglright = -104;
+hyphen = -84;
+m = -52;
+oslash = -96;
+p = -84;
+period = -72;
+q = -100;
+quotedblbase = -76;
+quotesinglbase = -76;
+semicolon = -40;
+v = -72;
+x = -48;
+};
+"@MMK_L_Z" = {
+"@MMK_R_T" = 28;
+"@MMK_R_U" = -4;
+"@MMK_R_y" = -12;
+comma = 48;
+period = 48;
+v = -8;
+};
+"@MMK_L_a" = {
+quoteright = -28;
+};
+"@MMK_L_ae" = {
+quoteright = -20;
+x = -4;
+};
+"@MMK_L_c" = {
+"@MMK_R_h" = -8;
+"@MMK_R_k" = -8;
+comma = 12;
+};
+"@MMK_L_d" = {
+"@MMK_R_j" = -12;
+};
+"@MMK_L_f" = {
+"@MMK_R_a" = 12;
+"@MMK_R_c" = -12;
+"@MMK_R_e" = -12;
+"@MMK_R_f" = 36;
+"@MMK_R_i" = 56;
+"@MMK_R_j" = 56;
+"@MMK_R_l" = 82;
+"@MMK_R_o" = -8;
+"@MMK_R_s" = 28;
+"@MMK_R_t" = 44;
+asterisk = 158;
+bracketright = 98;
+comma = 16;
+exclam = 114;
+guillemetleft = -24;
+oslash = -8;
+parenright = 104;
+period = 16;
+question = 112;
+quotedblleft = 104;
+quotedblright = 132;
+quoteleft = 104;
+quoteright = 112;
+};
+"@MMK_L_f_f_l" = {
+"@MMK_R_y" = 8;
+v = 8;
+};
+"@MMK_L_g" = {
+"@MMK_R_a" = 12;
+"@MMK_R_l" = 4;
+"@MMK_R_r" = 44;
+comma = -8;
+period = -12;
+};
+"@MMK_L_h" = {
+"@MMK_R_w" = 8;
+quotedblright = -24;
+quoteright = -24;
+v = 8;
+};
+"@MMK_L_k" = {
+"@MMK_R_a" = 10;
+"@MMK_R_c" = -16;
+"@MMK_R_d" = -16;
+"@MMK_R_e" = -16;
+"@MMK_R_g" = 28;
+"@MMK_R_o" = -12;
+"@MMK_R_s" = 22;
+"@MMK_R_u" = 16;
+"@MMK_R_y" = -42;
+comma = 24;
+hyphen = -44;
+period = 20;
+};
+"@MMK_L_n" = {
+"@MMK_R_T" = -40;
+"@MMK_R_w" = 8;
+"@MMK_R_y" = 4;
+p = -8;
+quotedblleft = -12;
+quoteleft = -12;
+quoteright = -24;
+v = 8;
+};
+"@MMK_L_o" = {
+"@MMK_R_T" = -96;
+"@MMK_R_f" = -12;
+"@MMK_R_t" = -8;
+"@MMK_R_w" = -16;
+"@MMK_R_y" = -20;
+quotedblleft = -24;
+quoteright = -32;
+v = -16;
+x = -20;
+};
+"@MMK_L_r" = {
+"@MMK_R_a" = -8;
+"@MMK_R_c" = -8;
+"@MMK_R_d" = -4;
+"@MMK_R_e" = -8;
+"@MMK_R_eng" = 16;
+"@MMK_R_f" = 16;
+"@MMK_R_g" = -8;
+"@MMK_R_h" = -20;
+"@MMK_R_i" = 16;
+"@MMK_R_j" = 20;
+"@MMK_R_k" = -20;
+"@MMK_R_l" = -20;
+"@MMK_R_o" = -8;
+"@MMK_R_r" = 16;
+"@MMK_R_t" = 24;
+"@MMK_R_u" = 24;
+"@MMK_R_w" = 36;
+"@MMK_R_y" = 32;
+b = -20;
+colon = 8;
+comma = -84;
+guillemetleft = -28;
+hyphen = -48;
+m = 16;
+oslash = -8;
+p = 16;
+period = -84;
+q = -4;
+quotedblbase = -84;
+quotesinglbase = -84;
+v = 36;
+x = 20;
+};
+"@MMK_L_s" = {
+"@MMK_R_t" = 12;
+"@MMK_R_w" = 24;
+"@MMK_R_y" = 24;
+quoteright = -8;
+v = 24;
+};
+"@MMK_L_t" = {
+"@MMK_R_S" = 28;
+"@MMK_R_a" = 28;
+"@MMK_R_h" = 28;
+"@MMK_R_o" = 8;
+colon = 44;
+quoteright = -8;
+semicolon = 44;
+};
+"@MMK_L_u" = {
+quoteright = -28;
+};
+"@MMK_L_uni01C5" = {
+"@MMK_R_o" = 8;
+colon = 60;
+comma = 24;
+};
+"@MMK_L_w" = {
+"@MMK_R_a" = 4;
+"@MMK_R_c" = -16;
+"@MMK_R_e" = -12;
+"@MMK_R_l" = 4;
+"@MMK_R_o" = -12;
+"@MMK_R_s" = 20;
+colon = 32;
+comma = -36;
+hyphen = -16;
+oslash = -12;
+period = -36;
+quotedblbase = -32;
+quotesinglbase = -32;
+semicolon = 32;
+};
+"@MMK_L_y" = {
+"@MMK_R_a" = -4;
+"@MMK_R_c" = -24;
+"@MMK_R_d" = -12;
+"@MMK_R_e" = -20;
+"@MMK_R_g" = -12;
+"@MMK_R_o" = -20;
+"@MMK_R_s" = 8;
+colon = 24;
+comma = -48;
+hyphen = -24;
+oslash = -20;
+period = -48;
+quotedblbase = -44;
+quotesinglbase = -44;
+semicolon = 24;
+};
+B = {
+"@MMK_R_A" = -26;
+"@MMK_R_AE" = -28;
+"@MMK_R_G" = -8;
+"@MMK_R_J" = 50;
+"@MMK_R_O" = -4;
+"@MMK_R_T" = -4;
+"@MMK_R_U" = -16;
+"@MMK_R_W" = -48;
+"@MMK_R_Y" = -64;
+"@MMK_R_y" = -8;
+V = -44;
+X = -16;
+comma = -10;
+hyphen = 36;
+slash = 44;
+};
+F = {
+"@MMK_R_A" = -104;
+"@MMK_R_G" = -32;
+"@MMK_R_J" = -40;
+"@MMK_R_O" = -28;
+"@MMK_R_T" = 4;
+"@MMK_R_a" = -84;
+"@MMK_R_e" = -84;
+"@MMK_R_i" = -28;
+"@MMK_R_j" = -28;
+"@MMK_R_o" = -80;
+"@MMK_R_r" = -36;
+"@MMK_R_u" = -40;
+"@MMK_R_y" = -24;
+colon = -28;
+comma = -88;
+guillemetleft = -80;
+hyphen = -56;
+oslash = -80;
+period = -88;
+quotedblbase = -88;
+quotesinglbase = -88;
+};
+Lslash = {
+"@MMK_R_T" = -48;
+"@MMK_R_W" = -88;
+"@MMK_R_Y" = -72;
+V = -84;
+quotedblleft = -68;
+quotedblright = -84;
+quoteleft = -68;
+quoteright = -80;
+};
+Oslash = {
+"@MMK_R_A" = -52;
+"@MMK_R_Y" = -84;
+V = -52;
+X = -48;
+comma = -12;
+hyphen = 24;
+period = -12;
+};
+P = {
+"@MMK_R_A" = -88;
+"@MMK_R_AE" = -120;
+"@MMK_R_J" = -20;
+"@MMK_R_T" = 32;
+"@MMK_R_Y" = -36;
+"@MMK_R_a" = -44;
+"@MMK_R_c" = -64;
+"@MMK_R_e" = -60;
+"@MMK_R_g" = -48;
+"@MMK_R_o" = -60;
+"@MMK_R_r" = 16;
+"@MMK_R_s" = -32;
+"@MMK_R_u" = 12;
+"@MMK_R_y" = 28;
+colon = -16;
+comma = -104;
+guillemetleft = -84;
+hyphen = -68;
+oslash = -60;
+period = -104;
+quotedblbase = -100;
+quotedblleft = 40;
+quotesinglbase = -100;
+semicolon = -16;
+};
+Q = {
+"@MMK_R_A" = -52;
+"@MMK_R_U" = -16;
+"@MMK_R_W" = -60;
+"@MMK_R_Y" = -84;
+V = -52;
+comma = -12;
+period = -12;
+};
+V = {
+"@MMK_R_A" = -104;
+"@MMK_R_AE" = -116;
+"@MMK_R_C" = -56;
+"@MMK_R_G" = -56;
+"@MMK_R_J" = -44;
+"@MMK_R_O" = -48;
+"@MMK_R_S" = -32;
+"@MMK_R_a" = -76;
+"@MMK_R_c" = -76;
+"@MMK_R_d" = -72;
+"@MMK_R_e" = -76;
+"@MMK_R_eng" = -44;
+"@MMK_R_g" = -76;
+"@MMK_R_i" = -36;
+"@MMK_R_o" = -76;
+"@MMK_R_r" = -44;
+"@MMK_R_s" = -64;
+"@MMK_R_u" = -40;
+"@MMK_R_w" = -28;
+"@MMK_R_y" = -28;
+"@MMK_R_z" = -64;
+Oslash = -48;
+colon = -20;
+comma = -80;
+guillemetleft = -80;
+guillemetright = -76;
+guilsinglleft = -96;
+guilsinglright = -76;
+hyphen = -60;
+m = -44;
+oslash = -72;
+p = -44;
+period = -80;
+q = -72;
+quotedblbase = -80;
+quotesinglbase = -80;
+semicolon = -20;
+v = -28;
+x = -40;
+};
+X = {
+"@MMK_R_A" = -94;
+"@MMK_R_C" = -56;
+"@MMK_R_G" = -52;
+"@MMK_R_O" = -52;
+"@MMK_R_T" = -32;
+"@MMK_R_a" = 20;
+"@MMK_R_e" = -16;
+"@MMK_R_o" = -12;
+"@MMK_R_y" = -64;
+Oslash = -28;
+guillemetleft = -52;
+guilsinglleft = -68;
+hyphen = -24;
+quotedblleft = -60;
+};
+b = {
+"@MMK_R_t" = -8;
+"@MMK_R_w" = -4;
+"@MMK_R_y" = -8;
+v = -4;
+};
+comma = {
+one = 12;
+quotedblright = -44;
+quoteright = -40;
+};
+eight = {
+four = 16;
+one = -16;
+seven = -20;
+};
+five = {
+four = 16;
+seven = -32;
+};
+four = {
+four = 16;
+one = -12;
+seven = -44;
+};
+germandbls = {
+quotedblleft = -24;
+};
+guillemetleft = {
+"@MMK_R_J" = 64;
+"@MMK_R_T" = -104;
+"@MMK_R_U" = -24;
+"@MMK_R_W" = -84;
+"@MMK_R_Y" = -116;
+V = -76;
+};
+guillemetright = {
+"@MMK_R_A" = -40;
+"@MMK_R_AE" = -64;
+"@MMK_R_J" = 12;
+"@MMK_R_T" = -104;
+"@MMK_R_U" = -24;
+"@MMK_R_W" = -88;
+"@MMK_R_Y" = -120;
+V = -84;
+X = -60;
+};
+guilsinglleft = {
+"@MMK_R_T" = -104;
+"@MMK_R_W" = -84;
+"@MMK_R_Y" = -116;
+V = -76;
+};
+guilsinglright = {
+"@MMK_R_A" = -52;
+"@MMK_R_AE" = -76;
+"@MMK_R_T" = -116;
+"@MMK_R_W" = -96;
+"@MMK_R_Y" = -132;
+V = -96;
+X = -72;
+};
+hyphen = {
+"@MMK_R_A" = -16;
+"@MMK_R_AE" = -36;
+"@MMK_R_C" = 20;
+"@MMK_R_G" = 20;
+"@MMK_R_O" = 24;
+"@MMK_R_S" = 32;
+"@MMK_R_T" = -80;
+"@MMK_R_U" = 4;
+"@MMK_R_W" = -64;
+"@MMK_R_Y" = -96;
+V = -60;
+X = -40;
+};
+m = {
+"@MMK_R_w" = 8;
+p = -12;
+v = 8;
+};
+nine = {
+four = -12;
+one = -36;
+};
+one = {
+comma = 12;
+eight = -16;
+four = -44;
+nine = -16;
+one = 32;
+period = 8;
+seven = -56;
+six = -36;
+two = 20;
+zero = -32;
+};
+p = {
+"@MMK_R_f" = -12;
+"@MMK_R_t" = -8;
+"@MMK_R_w" = -8;
+"@MMK_R_y" = -12;
+};
+period = {
+one = 8;
+quotedblright = -40;
+quoteright = -40;
+};
+q = {
+"@MMK_R_u" = 36;
+};
+quotedblbase = {
+"@MMK_R_A" = 24;
+"@MMK_R_AE" = 12;
+"@MMK_R_C" = -12;
+"@MMK_R_G" = -8;
+"@MMK_R_J" = 132;
+"@MMK_R_O" = -12;
+"@MMK_R_T" = -64;
+"@MMK_R_U" = -12;
+"@MMK_R_W" = -84;
+"@MMK_R_Y" = -88;
+"@MMK_R_w" = -32;
+"@MMK_R_y" = -52;
+Oslash = -8;
+V = -84;
+v = -44;
+};
+quotedblleft = {
+"@MMK_R_A" = -84;
+"@MMK_R_AE" = -132;
+"@MMK_R_T" = 8;
+"@MMK_R_W" = -8;
+"@MMK_R_Y" = -40;
+"@MMK_R_c" = -20;
+"@MMK_R_d" = -12;
+"@MMK_R_e" = -16;
+V = -8;
+q = -12;
+};
+quotedblright = {
+"@MMK_R_A" = -84;
+"@MMK_R_AE" = -132;
+"@MMK_R_T" = 16;
+"@MMK_R_W" = -8;
+"@MMK_R_Y" = -36;
+V = -8;
+period = -36;
+};
+quoteleft = {
+"@MMK_R_A" = -84;
+"@MMK_R_AE" = -132;
+"@MMK_R_T" = 18;
+"@MMK_R_W" = -8;
+"@MMK_R_Y" = -40;
+"@MMK_R_d" = -12;
+V = -8;
+q = -12;
+};
+quoteright = {
+"@MMK_R_A" = -84;
+"@MMK_R_AE" = -132;
+"@MMK_R_d" = -24;
+"@MMK_R_o" = -28;
+"@MMK_R_r" = -8;
+"@MMK_R_s" = -8;
+"@MMK_R_w" = 8;
+"@MMK_R_y" = 12;
+comma = -32;
+period = -32;
+v = 8;
+};
+quotesinglbase = {
+"@MMK_R_C" = -12;
+"@MMK_R_G" = -8;
+"@MMK_R_J" = 132;
+"@MMK_R_O" = -12;
+"@MMK_R_T" = -64;
+"@MMK_R_U" = -12;
+"@MMK_R_W" = -84;
+"@MMK_R_Y" = -88;
+"@MMK_R_w" = -32;
+"@MMK_R_y" = -52;
+Oslash = -8;
+V = -84;
+v = -44;
+};
+seven = {
+colon = -4;
+comma = -48;
+eight = -16;
+five = -24;
+four = -64;
+hyphen = -48;
+nine = -16;
+one = 28;
+period = -48;
+seven = -12;
+six = -44;
+three = -12;
+two = -16;
+zero = -32;
+};
+six = {
+four = 20;
+one = -28;
+seven = -48;
+};
+three = {
+four = 16;
+one = -24;
+seven = -24;
+};
+two = {
+four = 8;
+one = 12;
+seven = -8;
+};
+v = {
+"@MMK_R_a" = 4;
+"@MMK_R_c" = -16;
+"@MMK_R_e" = -12;
+"@MMK_R_l" = 4;
+"@MMK_R_o" = -12;
+"@MMK_R_s" = 20;
+colon = 28;
+comma = -44;
+hyphen = -20;
+oslash = -12;
+period = -44;
+semicolon = 28;
+};
+x = {
+"@MMK_R_a" = 12;
+"@MMK_R_c" = -24;
+"@MMK_R_d" = -24;
+"@MMK_R_e" = -24;
+"@MMK_R_o" = -20;
+oslash = -8;
+q = -20;
+};
+zero = {
+one = -32;
+seven = -8;
+two = -12;
+};
+};
+};
+manufacturer = "Impallari Type";
+manufacturerURL = www.impallari.com;
+unitsPerEm = 1000;
+userData = {
+GSDimensionPlugin.Dimensions = {
+"3AE1663F-34E8-4710-91A2-69F84C961E5F" = {
+nV = "138";
+oH = "35";
+};
+"426C3F01-D24D-4224-A47E-56DA036E4742" = {
+nV = "103";
+oH = "25";
+};
+"DD3DBCA6-CF88-4DA3-ACF4-A2FFC969FFEC" = {
+nV = "138";
+oH = "35";
+};
+UUID0 = {
+nV = "110";
+oH = "30";
+};
+};
+};
+versionMajor = 2;
+versionMinor = 0;
+}

--- a/source/v2000 - initial glyphs migration/LibreBodoni Romans.glyphs
+++ b/source/v2000 - initial glyphs migration/LibreBodoni Romans.glyphs
@@ -182,7 +182,7 @@ xHeight = 450;
 glyphs = (
 {
 glyphname = A;
-lastChange = "2016-08-18 22:36:21 +0000";
+lastChange = "2016-08-22 10:09:51 +0000";
 layers = (
 {
 anchors = (
@@ -278,19 +278,19 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"701 0 LINE",
-"701 25 LINE",
-"358 25 LINE",
-"358 0 LINE"
+"503 236 LINE",
+"503 261 LINE",
+"179 261 LINE",
+"179 236 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"503 236 LINE",
-"503 261 LINE",
-"179 261 LINE",
-"179 236 LINE"
+"701 0 LINE",
+"701 25 LINE",
+"358 25 LINE",
+"358 0 LINE"
 );
 },
 {
@@ -686,7 +686,7 @@ unicode = 00C1;
 },
 {
 glyphname = Abreve;
-lastChange = "2016-08-19 17:29:55 +0000";
+lastChange = "2016-08-22 10:27:51 +0000";
 layers = (
 {
 components = (
@@ -720,8 +720,223 @@ rightKerningGroup = A;
 unicode = 0102;
 },
 {
+glyphname = Abreveacute;
+lastChange = "2016-08-22 10:27:51 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, 48, 304}";
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 18, 502}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, 60, 304}";
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -32, 512}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 1EAE;
+},
+{
+glyphname = Abrevedotbelow;
+lastChange = "2016-08-22 10:27:51 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 59, 0}";
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, 48, 304}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 65, 0}";
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, 60, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 1EB6;
+},
+{
+glyphname = Abrevegrave;
+lastChange = "2016-08-22 10:27:51 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, 48, 304}";
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 56, 502}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, 60, 304}";
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 109, 512}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 1EB0;
+},
+{
+glyphname = Abrevehookabove;
+lastChange = "2016-08-22 10:27:51 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, 48, 304}";
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 58, 502}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, 60, 304}";
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 74, 512}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 1EB2;
+},
+{
+glyphname = Abrevetilde;
+lastChange = "2016-08-22 10:27:51 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, 48, 304}";
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, 52, 502}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, 60, 304}";
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, 45, 512}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 1EB4;
+},
+{
 glyphname = Acircumflex;
-lastChange = "2016-08-19 17:29:55 +0000";
+lastChange = "2016-08-22 10:27:51 +0000";
 layers = (
 {
 components = (
@@ -753,6 +968,189 @@ width = 715;
 leftKerningGroup = A;
 rightKerningGroup = A;
 unicode = 00C2;
+},
+{
+glyphname = Acircumflexacute;
+lastChange = "2016-08-22 10:27:51 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = circumflexcomb_acutecomb;
+transform = "{1, 0, 0, 1, 53, 304}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = circumflexcomb_acutecomb;
+transform = "{1, 0, 0, 1, 62, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 1EA4;
+},
+{
+glyphname = Acircumflexdotbelow;
+lastChange = "2016-08-22 10:27:51 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 59, 0}";
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 53, 304}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 65, 0}";
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 62, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 1EAC;
+},
+{
+glyphname = Acircumflexgrave;
+lastChange = "2016-08-22 10:27:51 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = circumflexcomb_gravecomb;
+transform = "{1, 0, 0, 1, 53, 304}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = circumflexcomb_gravecomb;
+transform = "{1, 0, 0, 1, 62, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 1EA6;
+},
+{
+glyphname = Acircumflexhookabove;
+lastChange = "2016-08-22 10:27:51 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = circumflexcomb_hookabovecomb;
+transform = "{1, 0, 0, 1, 53, 304}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = circumflexcomb_hookabovecomb;
+transform = "{1, 0, 0, 1, 62, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 1EA8;
+},
+{
+glyphname = Acircumflextilde;
+lastChange = "2016-08-22 10:27:51 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = circumflexcomb_tildecomb;
+transform = "{1, 0, 0, 1, 53, 304}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = circumflexcomb_tildecomb;
+transform = "{1, 0, 0, 1, 62, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 1EAA;
 },
 {
 glyphname = Adblgrave;
@@ -825,8 +1223,43 @@ rightKerningGroup = A;
 unicode = 00C4;
 },
 {
+glyphname = Adotbelow;
+lastChange = "2016-08-22 10:27:51 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 59, 0}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 65, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 1EA0;
+},
+{
 glyphname = Agrave;
-lastChange = "2016-08-19 17:29:55 +0000";
+lastChange = "2016-08-22 10:27:51 +0000";
 layers = (
 {
 components = (
@@ -858,6 +1291,41 @@ width = 715;
 leftKerningGroup = A;
 rightKerningGroup = A;
 unicode = 00C0;
+},
+{
+glyphname = Ahookabove;
+lastChange = "2016-08-22 10:27:51 +0000";
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 58, 304}";
+}
+);
+layerId = UUID0;
+width = 686;
+},
+{
+components = (
+{
+name = A;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 74, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 715;
+}
+);
+leftKerningGroup = A;
+rightKerningGroup = A;
+unicode = 1EA2;
 },
 {
 glyphname = Ainvertedbreve;
@@ -2841,9 +3309,27 @@ unicode = 01C5;
 },
 {
 glyphname = E;
-lastChange = "2016-08-19 17:05:53 +0000";
+lastChange = "2016-08-22 09:54:01 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{346, 0}";
+},
+{
+name = ogonek;
+position = "{622, 10}";
+},
+{
+name = top;
+position = "{346, 754}";
+},
+{
+name = topleft;
+position = "{20, 754}";
+}
+);
 background = {
 paths = (
 {
@@ -2954,6 +3440,24 @@ nodes = (
 width = 691;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{348, 0}";
+},
+{
+name = ogonek;
+position = "{626, 10}";
+},
+{
+name = top;
+position = "{348, 754}";
+},
+{
+name = topleft;
+position = "{20, 754}";
+}
+);
 background = {
 paths = (
 {
@@ -3070,7 +3574,7 @@ unicode = 0045;
 },
 {
 glyphname = Eacute;
-lastChange = "2016-08-19 17:29:55 +0000";
+lastChange = "2016-08-22 10:28:03 +0000";
 layers = (
 {
 components = (
@@ -3175,7 +3679,7 @@ unicode = 011A;
 },
 {
 glyphname = Ecircumflex;
-lastChange = "2016-08-19 17:29:55 +0000";
+lastChange = "2016-08-22 10:28:03 +0000";
 layers = (
 {
 components = (
@@ -3207,6 +3711,189 @@ width = 696;
 leftKerningGroup = E;
 rightKerningGroup = E;
 unicode = 00CA;
+},
+{
+glyphname = Ecircumflexacute;
+lastChange = "2016-08-22 10:28:03 +0000";
+layers = (
+{
+components = (
+{
+name = E;
+},
+{
+name = circumflexcomb_acutecomb;
+transform = "{1, 0, 0, 1, 56, 304}";
+}
+);
+layerId = UUID0;
+width = 691;
+},
+{
+components = (
+{
+name = E;
+},
+{
+name = circumflexcomb_acutecomb;
+transform = "{1, 0, 0, 1, 52, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 696;
+}
+);
+leftKerningGroup = E;
+rightKerningGroup = E;
+unicode = 1EBE;
+},
+{
+glyphname = Ecircumflexdotbelow;
+lastChange = "2016-08-22 10:28:03 +0000";
+layers = (
+{
+components = (
+{
+name = E;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 62, 0}";
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 56, 304}";
+}
+);
+layerId = UUID0;
+width = 691;
+},
+{
+components = (
+{
+name = E;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 55, 0}";
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 52, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 696;
+}
+);
+leftKerningGroup = E;
+rightKerningGroup = E;
+unicode = 1EC6;
+},
+{
+glyphname = Ecircumflexgrave;
+lastChange = "2016-08-22 10:28:03 +0000";
+layers = (
+{
+components = (
+{
+name = E;
+},
+{
+name = circumflexcomb_gravecomb;
+transform = "{1, 0, 0, 1, 56, 304}";
+}
+);
+layerId = UUID0;
+width = 691;
+},
+{
+components = (
+{
+name = E;
+},
+{
+name = circumflexcomb_gravecomb;
+transform = "{1, 0, 0, 1, 52, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 696;
+}
+);
+leftKerningGroup = E;
+rightKerningGroup = E;
+unicode = 1EC0;
+},
+{
+glyphname = Ecircumflexhookabove;
+lastChange = "2016-08-22 10:28:03 +0000";
+layers = (
+{
+components = (
+{
+name = E;
+},
+{
+name = circumflexcomb_hookabovecomb;
+transform = "{1, 0, 0, 1, 56, 304}";
+}
+);
+layerId = UUID0;
+width = 691;
+},
+{
+components = (
+{
+name = E;
+},
+{
+name = circumflexcomb_hookabovecomb;
+transform = "{1, 0, 0, 1, 52, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 696;
+}
+);
+leftKerningGroup = E;
+rightKerningGroup = E;
+unicode = 1EC2;
+},
+{
+glyphname = Ecircumflextilde;
+lastChange = "2016-08-22 10:28:03 +0000";
+layers = (
+{
+components = (
+{
+name = E;
+},
+{
+name = circumflexcomb_tildecomb;
+transform = "{1, 0, 0, 1, 56, 304}";
+}
+);
+layerId = UUID0;
+width = 691;
+},
+{
+components = (
+{
+name = E;
+},
+{
+name = circumflexcomb_tildecomb;
+transform = "{1, 0, 0, 1, 52, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 696;
+}
+);
+leftKerningGroup = E;
+rightKerningGroup = E;
+unicode = 1EC4;
 },
 {
 glyphname = Edblgrave;
@@ -3315,7 +4002,7 @@ unicode = 0116;
 },
 {
 glyphname = Edotbelow;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-22 10:28:03 +0000";
 layers = (
 {
 components = (
@@ -3350,7 +4037,7 @@ unicode = 1EB8;
 },
 {
 glyphname = Egrave;
-lastChange = "2016-08-19 17:29:55 +0000";
+lastChange = "2016-08-22 10:28:03 +0000";
 layers = (
 {
 components = (
@@ -3382,6 +4069,41 @@ width = 696;
 leftKerningGroup = E;
 rightKerningGroup = E;
 unicode = 00C8;
+},
+{
+glyphname = Ehookabove;
+lastChange = "2016-08-22 10:28:03 +0000";
+layers = (
+{
+components = (
+{
+name = E;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 61, 304}";
+}
+);
+layerId = UUID0;
+width = 691;
+},
+{
+components = (
+{
+name = E;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 64, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 696;
+}
+);
+leftKerningGroup = E;
+rightKerningGroup = E;
+unicode = 1EBA;
 },
 {
 glyphname = Einvertedbreve;
@@ -4460,9 +5182,27 @@ unicode = 1E24;
 },
 {
 glyphname = I;
-lastChange = "2016-08-19 17:05:53 +0000";
+lastChange = "2016-08-22 09:51:40 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{190, 0}";
+},
+{
+name = ogonek;
+position = "{341, 10}";
+},
+{
+name = top;
+position = "{190, 754}";
+},
+{
+name = topleft;
+position = "{20, 754}";
+}
+);
 background = {
 paths = (
 {
@@ -4527,6 +5267,24 @@ nodes = (
 width = 379;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{193, 0}";
+},
+{
+name = ogonek;
+position = "{347, 10}";
+},
+{
+name = top;
+position = "{193, 754}";
+},
+{
+name = topleft;
+position = "{20, 754}";
+}
+);
 background = {
 paths = (
 {
@@ -4975,6 +5733,39 @@ width = 388;
 leftKerningGroup = I;
 rightKerningGroup = I;
 unicode = 00CC;
+},
+{
+glyphname = Ihookabove;
+lastChange = "2016-08-22 09:59:39 +0000";
+layers = (
+{
+components = (
+{
+name = I;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, -95, 304}";
+}
+);
+layerId = UUID0;
+width = 379;
+},
+{
+components = (
+{
+name = I;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, -91, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 386;
+}
+);
+unicode = 1EC8;
 },
 {
 glyphname = Iinvertedbreve;
@@ -7559,9 +8350,35 @@ unicode = 00D1;
 },
 {
 glyphname = O;
-lastChange = "2016-08-19 16:39:23 +0000";
+lastChange = "2016-08-22 09:33:53 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{391, 0}";
+},
+{
+name = center;
+position = "{391, 377}";
+},
+{
+name = ogonek;
+position = "{704, 10}";
+},
+{
+name = top;
+position = "{391, 754}";
+},
+{
+name = topleft;
+position = "{20, 754}";
+},
+{
+name = topright;
+position = "{550, 701}";
+}
+);
 background = {
 paths = (
 {
@@ -7640,6 +8457,32 @@ nodes = (
 width = 782;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{412, 0}";
+},
+{
+name = center;
+position = "{412, 377}";
+},
+{
+name = ogonek;
+position = "{741, 10}";
+},
+{
+name = top;
+position = "{412, 754}";
+},
+{
+name = topleft;
+position = "{20, 754}";
+},
+{
+name = topright;
+position = "{451, 702}";
+}
+);
 background = {
 paths = (
 {
@@ -7992,7 +8835,7 @@ unicode = 014E;
 },
 {
 glyphname = Ocircumflex;
-lastChange = "2016-08-19 17:29:55 +0000";
+lastChange = "2016-08-22 10:28:15 +0000";
 layers = (
 {
 components = (
@@ -8024,6 +8867,189 @@ width = 823;
 leftKerningGroup = O;
 rightKerningGroup = O;
 unicode = 00D4;
+},
+{
+glyphname = Ocircumflexacute;
+lastChange = "2016-08-22 10:28:15 +0000";
+layers = (
+{
+components = (
+{
+name = O;
+},
+{
+name = circumflexcomb_acutecomb;
+transform = "{1, 0, 0, 1, 101, 304}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+name = O;
+},
+{
+name = circumflexcomb_acutecomb;
+transform = "{1, 0, 0, 1, 116, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 1ED0;
+},
+{
+glyphname = Ocircumflexdotbelow;
+lastChange = "2016-08-22 10:28:15 +0000";
+layers = (
+{
+components = (
+{
+name = O;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 107, 0}";
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 101, 304}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+name = O;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 119, 0}";
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, 116, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 1ED8;
+},
+{
+glyphname = Ocircumflexgrave;
+lastChange = "2016-08-22 10:28:15 +0000";
+layers = (
+{
+components = (
+{
+name = O;
+},
+{
+name = circumflexcomb_gravecomb;
+transform = "{1, 0, 0, 1, 101, 304}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+name = O;
+},
+{
+name = circumflexcomb_gravecomb;
+transform = "{1, 0, 0, 1, 116, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 1ED2;
+},
+{
+glyphname = Ocircumflexhookabove;
+lastChange = "2016-08-22 10:28:15 +0000";
+layers = (
+{
+components = (
+{
+name = O;
+},
+{
+name = circumflexcomb_hookabovecomb;
+transform = "{1, 0, 0, 1, 101, 304}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+name = O;
+},
+{
+name = circumflexcomb_hookabovecomb;
+transform = "{1, 0, 0, 1, 116, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 1ED4;
+},
+{
+glyphname = Ocircumflextilde;
+lastChange = "2016-08-22 10:28:15 +0000";
+layers = (
+{
+components = (
+{
+name = O;
+},
+{
+name = circumflexcomb_tildecomb;
+transform = "{1, 0, 0, 1, 101, 304}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+name = O;
+},
+{
+name = circumflexcomb_tildecomb;
+transform = "{1, 0, 0, 1, 116, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 1ED6;
 },
 {
 glyphname = Odblgrave;
@@ -8097,7 +9123,7 @@ unicode = 00D6;
 },
 {
 glyphname = Odotbelow;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-22 10:28:15 +0000";
 layers = (
 {
 components = (
@@ -8132,7 +9158,7 @@ unicode = 1ECC;
 },
 {
 glyphname = Ograve;
-lastChange = "2016-08-19 17:29:55 +0000";
+lastChange = "2016-08-22 10:28:15 +0000";
 layers = (
 {
 components = (
@@ -8164,6 +9190,251 @@ width = 823;
 leftKerningGroup = O;
 rightKerningGroup = O;
 unicode = 00D2;
+},
+{
+glyphname = Ohookabove;
+lastChange = "2016-08-22 10:28:15 +0000";
+layers = (
+{
+components = (
+{
+name = O;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 106, 304}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+name = O;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 128, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 1ECE;
+},
+{
+glyphname = Ohorn;
+lastChange = "2016-08-22 10:28:15 +0000";
+layers = (
+{
+components = (
+{
+name = O;
+},
+{
+name = horncomb;
+transform = "{1, 0, 0, 1, 238, 251}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+name = O;
+},
+{
+name = horncomb;
+transform = "{1, 0, 0, 1, 252, 252}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 01A0;
+},
+{
+glyphname = Ohornacute;
+lastChange = "2016-08-22 10:28:15 +0000";
+layers = (
+{
+components = (
+{
+name = Ohorn;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 66, 304}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+name = Ohorn;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 22, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 1EDA;
+},
+{
+glyphname = Ohorndotbelow;
+lastChange = "2016-08-22 10:28:15 +0000";
+layers = (
+{
+components = (
+{
+name = Ohorn;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 107, 0}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+name = Ohorn;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 119, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 1EE2;
+},
+{
+glyphname = Ohorngrave;
+lastChange = "2016-08-22 10:28:15 +0000";
+layers = (
+{
+components = (
+{
+name = Ohorn;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 104, 304}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+name = Ohorn;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 163, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 1EDC;
+},
+{
+glyphname = Ohornhookabove;
+lastChange = "2016-08-22 10:28:15 +0000";
+layers = (
+{
+components = (
+{
+name = Ohorn;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 106, 304}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+name = Ohorn;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 128, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 1EDE;
+},
+{
+glyphname = Ohorntilde;
+lastChange = "2016-08-22 10:28:15 +0000";
+layers = (
+{
+components = (
+{
+name = Ohorn;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, 100, 304}";
+}
+);
+layerId = UUID0;
+width = 782;
+},
+{
+components = (
+{
+name = Ohorn;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, 99, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 823;
+}
+);
+leftKerningGroup = O;
+rightKerningGroup = O;
+unicode = 1EE0;
 },
 {
 glyphname = Ohungarumlaut;
@@ -10793,9 +12064,27 @@ unicode = 1E6C;
 },
 {
 glyphname = U;
-lastChange = "2016-08-19 17:05:53 +0000";
+lastChange = "2016-08-22 09:34:02 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{369, 0}";
+},
+{
+name = ogonek;
+position = "{663, 10}";
+},
+{
+name = top;
+position = "{369, 754}";
+},
+{
+name = topright;
+position = "{680, 701}";
+}
+);
 background = {
 paths = (
 {
@@ -10868,6 +12157,24 @@ nodes = (
 width = 737;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{387, 0}";
+},
+{
+name = ogonek;
+position = "{697, 10}";
+},
+{
+name = top;
+position = "{387, 754}";
+},
+{
+name = topright;
+position = "{605, 700}";
+}
+);
 background = {
 paths = (
 {
@@ -11342,6 +12649,343 @@ rightKerningGroup = U;
 unicode = 00D9;
 },
 {
+glyphname = Uhookabove;
+lastChange = "2016-08-22 10:28:25 +0000";
+layers = (
+{
+components = (
+{
+name = U;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 84, 304}";
+}
+);
+layerId = UUID0;
+width = 737;
+},
+{
+components = (
+{
+name = U;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 103, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 774;
+}
+);
+leftKerningGroup = U;
+rightKerningGroup = U;
+unicode = 1EE6;
+},
+{
+glyphname = Uhorn;
+lastChange = "2016-08-22 10:28:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{369, 0}";
+},
+{
+name = ogonek;
+position = "{663, 10}";
+},
+{
+name = top;
+position = "{369, 754}";
+},
+{
+name = topright;
+position = "{680, 701}";
+}
+);
+components = (
+{
+name = horncomb;
+transform = "{1, 0, 0, 1, 368, 251}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"545 -12 OFFCURVE",
+"625 53 OFFCURVE",
+"625 196 CURVE SMOOTH",
+"625 754 LINE",
+"487 754 LINE",
+"487 729 LINE",
+"592 729 LINE",
+"592 196 LINE SMOOTH",
+"592 80 OFFCURVE",
+"525 23 OFFCURVE",
+"418 23 CURVE SMOOTH",
+"318 23 OFFCURVE",
+"257 72 OFFCURVE",
+"257 196 CURVE SMOOTH",
+"257 729 LINE",
+"352 729 LINE",
+"352 754 LINE",
+"6 754 LINE",
+"6 729 LINE",
+"123 729 LINE",
+"123 195 LINE SMOOTH",
+"123 54 OFFCURVE",
+"227 -12 OFFCURVE",
+"387 -12 CURVE SMOOTH"
+);
+}
+);
+width = 737;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{387, 0}";
+},
+{
+name = ogonek;
+position = "{697, 10}";
+},
+{
+name = top;
+position = "{387, 754}";
+},
+{
+name = topright;
+position = "{605, 700}";
+}
+);
+components = (
+{
+name = horncomb;
+transform = "{1, 0, 0, 1, 406, 250}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"574 -13 OFFCURVE",
+"659 51 OFFCURVE",
+"659 195 CURVE SMOOTH",
+"659 754 LINE",
+"526 754 LINE",
+"526 724 LINE",
+"621 724 LINE",
+"621 200 LINE SMOOTH",
+"621 84 OFFCURVE",
+"553 27 OFFCURVE",
+"441 27 CURVE SMOOTH",
+"337 27 OFFCURVE",
+"270 76 OFFCURVE",
+"270 200 CURVE SMOOTH",
+"270 724 LINE",
+"376 724 LINE",
+"376 754 LINE",
+"15 754 LINE",
+"15 724 LINE",
+"112 724 LINE",
+"112 194 LINE SMOOTH",
+"112 53 OFFCURVE",
+"229 -13 OFFCURVE",
+"403 -13 CURVE SMOOTH"
+);
+}
+);
+width = 774;
+}
+);
+leftKerningGroup = U;
+rightKerningGroup = U;
+unicode = 01AF;
+},
+{
+glyphname = Uhornacute;
+lastChange = "2016-08-22 10:28:25 +0000";
+layers = (
+{
+components = (
+{
+name = Uhorn;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 44, 304}";
+}
+);
+layerId = UUID0;
+width = 737;
+},
+{
+components = (
+{
+name = Uhorn;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -3, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 774;
+}
+);
+leftKerningGroup = U;
+rightKerningGroup = U;
+unicode = 1EE8;
+},
+{
+glyphname = Uhorndotbelow;
+lastChange = "2016-08-22 10:28:25 +0000";
+layers = (
+{
+components = (
+{
+name = Uhorn;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 85, 0}";
+}
+);
+layerId = UUID0;
+width = 737;
+},
+{
+components = (
+{
+name = Uhorn;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 94, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 774;
+}
+);
+leftKerningGroup = U;
+rightKerningGroup = U;
+unicode = 1EF0;
+},
+{
+glyphname = Uhorngrave;
+lastChange = "2016-08-22 10:28:25 +0000";
+layers = (
+{
+components = (
+{
+name = Uhorn;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 82, 304}";
+}
+);
+layerId = UUID0;
+width = 737;
+},
+{
+components = (
+{
+name = Uhorn;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 138, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 774;
+}
+);
+leftKerningGroup = U;
+rightKerningGroup = U;
+unicode = 1EEA;
+},
+{
+glyphname = Uhornhookabove;
+lastChange = "2016-08-22 10:28:25 +0000";
+layers = (
+{
+components = (
+{
+name = Uhorn;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 84, 304}";
+}
+);
+layerId = UUID0;
+width = 737;
+},
+{
+components = (
+{
+name = Uhorn;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 103, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 774;
+}
+);
+leftKerningGroup = U;
+rightKerningGroup = U;
+unicode = 1EEC;
+},
+{
+glyphname = Uhorntilde;
+lastChange = "2016-08-22 10:28:25 +0000";
+layers = (
+{
+components = (
+{
+name = Uhorn;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, 78, 304}";
+}
+);
+layerId = UUID0;
+width = 737;
+},
+{
+components = (
+{
+name = Uhorn;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, 74, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 774;
+}
+);
+leftKerningGroup = U;
+rightKerningGroup = U;
+unicode = 1EEE;
+},
+{
 glyphname = Uhungarumlaut;
 lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
@@ -11518,7 +13162,7 @@ unicode = 016E;
 },
 {
 glyphname = Utilde;
-lastChange = "2016-08-19 17:29:55 +0000";
+lastChange = "2016-08-22 10:28:25 +0000";
 layers = (
 {
 components = (
@@ -11526,8 +13170,8 @@ components = (
 name = U;
 },
 {
-name = tilde.case;
-transform = "{1, 0, 0, 1, 234, 0}";
+name = tildecomb;
+transform = "{1, 0, 0, 1, 78, 304}";
 }
 );
 layerId = UUID0;
@@ -11539,8 +13183,8 @@ components = (
 name = U;
 },
 {
-name = tilde.case;
-transform = "{1, 0, 0, 1, 245, 0}";
+name = tildecomb;
+transform = "{1, 0, 0, 1, 74, 304}";
 }
 );
 layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
@@ -12586,9 +14230,23 @@ unicode = 0058;
 },
 {
 glyphname = Y;
-lastChange = "2016-08-19 17:05:53 +0000";
+lastChange = "2016-08-22 09:54:01 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{329, 0}";
+},
+{
+name = top;
+position = "{329, 754}";
+},
+{
+name = topleft;
+position = "{20, 754}";
+}
+);
 background = {
 paths = (
 {
@@ -12682,6 +14340,20 @@ nodes = (
 width = 657;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{383, 0}";
+},
+{
+name = top;
+position = "{383, 754}";
+},
+{
+name = topleft;
+position = "{20, 754}";
+}
+);
 background = {
 paths = (
 {
@@ -12886,8 +14558,43 @@ rightKerningGroup = Y;
 unicode = 0178;
 },
 {
+glyphname = Ydotbelow;
+lastChange = "2016-08-22 10:28:32 +0000";
+layers = (
+{
+components = (
+{
+name = Y;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 45, 0}";
+}
+);
+layerId = UUID0;
+width = 657;
+},
+{
+components = (
+{
+name = Y;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 90, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 766;
+}
+);
+leftKerningGroup = Y;
+rightKerningGroup = Y;
+unicode = 1EF4;
+},
+{
 glyphname = Ygrave;
-lastChange = "2016-08-19 17:29:55 +0000";
+lastChange = "2016-08-22 10:28:32 +0000";
 layers = (
 {
 components = (
@@ -12919,6 +14626,41 @@ width = 766;
 leftKerningGroup = Y;
 rightKerningGroup = Y;
 unicode = 1EF2;
+},
+{
+glyphname = Yhookabove;
+lastChange = "2016-08-22 10:28:32 +0000";
+layers = (
+{
+components = (
+{
+name = Y;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 44, 304}";
+}
+);
+layerId = UUID0;
+width = 657;
+},
+{
+components = (
+{
+name = Y;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 99, 304}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 766;
+}
+);
+leftKerningGroup = Y;
+rightKerningGroup = Y;
+unicode = 1EF6;
 },
 {
 glyphname = Ytilde;
@@ -13497,9 +15239,23 @@ unicode = 1E92;
 },
 {
 glyphname = a;
-lastChange = "2016-08-19 16:41:25 +0000";
+lastChange = "2016-08-22 09:54:01 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{253, 0}";
+},
+{
+name = ogonek;
+position = "{455, 10}";
+},
+{
+name = top;
+position = "{253, 450}";
+}
+);
 background = {
 paths = (
 {
@@ -13642,6 +15398,20 @@ nodes = (
 width = 506;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{271, 0}";
+},
+{
+name = ogonek;
+position = "{487, 10}";
+},
+{
+name = top;
+position = "{271, 450}";
+}
+);
 background = {
 paths = (
 {
@@ -13790,7 +15560,7 @@ unicode = 0061;
 },
 {
 glyphname = aacute;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-22 09:20:04 +0000";
 layers = (
 {
 components = (
@@ -13799,7 +15569,7 @@ name = a;
 },
 {
 name = acute;
-transform = "{1, 0, 0, 1, 131, 0}";
+transform = "{1, 0, 0, 1, 187, -14}";
 }
 );
 layerId = UUID0;
@@ -13859,8 +15629,192 @@ rightKerningGroup = a;
 unicode = 0103;
 },
 {
+glyphname = abreveacute;
+lastChange = "2016-08-22 10:28:40 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = brevecomb_acutecomb;
+transform = "{1, 0, 0, 1, -42, 0}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = brevecomb_acutecomb;
+transform = "{1, 0, 0, 1, -27, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 1EAF;
+},
+{
+glyphname = abrevedotbelow;
+lastChange = "2016-08-22 10:28:40 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -31, 0}";
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, -42, 0}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -22, 0}";
+},
+{
+name = brevecomb;
+transform = "{1, 0, 0, 1, -27, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 1EB7;
+},
+{
+glyphname = abrevegrave;
+lastChange = "2016-08-22 10:28:40 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = brevecomb_gravecomb;
+transform = "{1, 0, 0, 1, -42, 0}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = brevecomb_gravecomb;
+transform = "{1, 0, 0, 1, -27, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 1EB1;
+},
+{
+glyphname = abrevehookabove;
+lastChange = "2016-08-22 10:28:40 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = brevecomb_hookabovecomb;
+transform = "{1, 0, 0, 1, -42, 0}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = brevecomb_hookabovecomb;
+transform = "{1, 0, 0, 1, -27, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 1EB3;
+},
+{
+glyphname = abrevetilde;
+lastChange = "2016-08-22 10:28:40 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = brevecomb_tildecomb;
+transform = "{1, 0, 0, 1, -42, 0}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+alignment = 1;
+name = brevecomb_tildecomb;
+transform = "{1, 0, 0, 1, -27, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 1EB5;
+},
+{
 glyphname = acircumflex;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-22 10:28:40 +0000";
 layers = (
 {
 components = (
@@ -13892,6 +15846,189 @@ width = 541;
 leftKerningGroup = a;
 rightKerningGroup = a;
 unicode = 00E2;
+},
+{
+glyphname = acircumflexacute;
+lastChange = "2016-08-22 10:28:40 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = circumflexcomb_acutecomb;
+transform = "{1, 0, 0, 1, -37, 0}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = circumflexcomb_acutecomb;
+transform = "{1, 0, 0, 1, -25, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 1EA5;
+},
+{
+glyphname = acircumflexdotbelow;
+lastChange = "2016-08-22 10:28:40 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -31, 0}";
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -37, 0}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -22, 0}";
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -25, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 1EAD;
+},
+{
+glyphname = acircumflexgrave;
+lastChange = "2016-08-22 10:28:40 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = circumflexcomb_gravecomb;
+transform = "{1, 0, 0, 1, -37, 0}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = circumflexcomb_gravecomb;
+transform = "{1, 0, 0, 1, -25, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 1EA7;
+},
+{
+glyphname = acircumflexhookabove;
+lastChange = "2016-08-22 10:28:40 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = circumflexcomb_hookabovecomb;
+transform = "{1, 0, 0, 1, -37, 0}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = circumflexcomb_hookabovecomb;
+transform = "{1, 0, 0, 1, -25, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 1EA9;
+},
+{
+glyphname = acircumflextilde;
+lastChange = "2016-08-22 10:28:40 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = circumflexcomb_tildecomb;
+transform = "{1, 0, 0, 1, -37, 0}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = circumflexcomb_tildecomb;
+transform = "{1, 0, 0, 1, -25, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 1EAB;
 },
 {
 glyphname = adblgrave;
@@ -13963,8 +16100,43 @@ rightKerningGroup = a;
 unicode = 00E4;
 },
 {
+glyphname = adotbelow;
+lastChange = "2016-08-22 10:28:40 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -31, 0}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -22, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 1EA1;
+},
+{
 glyphname = agrave;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-22 10:28:40 +0000";
 layers = (
 {
 components = (
@@ -13996,6 +16168,41 @@ width = 541;
 leftKerningGroup = a;
 rightKerningGroup = a;
 unicode = 00E0;
+},
+{
+glyphname = ahookabove;
+lastChange = "2016-08-22 10:28:40 +0000";
+layers = (
+{
+components = (
+{
+name = a;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, -32, 0}";
+}
+);
+layerId = UUID0;
+width = 506;
+},
+{
+components = (
+{
+name = a;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, -13, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 541;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 1EA3;
 },
 {
 glyphname = ainvertedbreve;
@@ -14182,7 +16389,7 @@ unicode = 01FB;
 },
 {
 glyphname = atilde;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-22 10:28:40 +0000";
 layers = (
 {
 components = (
@@ -15864,9 +18071,23 @@ unicode = 01C6;
 },
 {
 glyphname = e;
-lastChange = "2016-08-19 17:05:53 +0000";
+lastChange = "2016-08-22 09:54:01 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{253, 0}";
+},
+{
+name = ogonek;
+position = "{454, 10}";
+},
+{
+name = top;
+position = "{253, 450}";
+}
+);
 layerId = UUID0;
 paths = (
 {
@@ -15908,6 +18129,20 @@ nodes = (
 width = 505;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{269, 0}";
+},
+{
+name = ogonek;
+position = "{483, 10}";
+},
+{
+name = top;
+position = "{269, 450}";
+}
+);
 background = {
 paths = (
 {
@@ -15994,7 +18229,7 @@ unicode = 0065;
 },
 {
 glyphname = eacute;
-lastChange = "2016-08-18 21:45:32 +0000";
+lastChange = "2016-08-22 10:28:54 +0000";
 layers = (
 {
 components = (
@@ -16099,7 +18334,7 @@ unicode = 011B;
 },
 {
 glyphname = ecircumflex;
-lastChange = "2016-08-18 21:45:32 +0000";
+lastChange = "2016-08-22 10:28:54 +0000";
 layers = (
 {
 components = (
@@ -16131,6 +18366,189 @@ width = 537;
 leftKerningGroup = e;
 rightKerningGroup = e;
 unicode = 00EA;
+},
+{
+glyphname = ecircumflexacute;
+lastChange = "2016-08-22 10:28:54 +0000";
+layers = (
+{
+components = (
+{
+name = e;
+},
+{
+name = circumflexcomb_acutecomb;
+transform = "{1, 0, 0, 1, -37, 0}";
+}
+);
+layerId = UUID0;
+width = 505;
+},
+{
+components = (
+{
+name = e;
+},
+{
+name = circumflexcomb_acutecomb;
+transform = "{1, 0, 0, 1, -27, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 537;
+}
+);
+leftKerningGroup = e;
+rightKerningGroup = e;
+unicode = 1EBF;
+},
+{
+glyphname = ecircumflexdotbelow;
+lastChange = "2016-08-22 10:28:54 +0000";
+layers = (
+{
+components = (
+{
+name = e;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -31, 0}";
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -37, 0}";
+}
+);
+layerId = UUID0;
+width = 505;
+},
+{
+components = (
+{
+name = e;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -24, 0}";
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -27, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 537;
+}
+);
+leftKerningGroup = e;
+rightKerningGroup = e;
+unicode = 1EC7;
+},
+{
+glyphname = ecircumflexgrave;
+lastChange = "2016-08-22 10:28:54 +0000";
+layers = (
+{
+components = (
+{
+name = e;
+},
+{
+name = circumflexcomb_gravecomb;
+transform = "{1, 0, 0, 1, -37, 0}";
+}
+);
+layerId = UUID0;
+width = 505;
+},
+{
+components = (
+{
+name = e;
+},
+{
+name = circumflexcomb_gravecomb;
+transform = "{1, 0, 0, 1, -27, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 537;
+}
+);
+leftKerningGroup = e;
+rightKerningGroup = e;
+unicode = 1EC1;
+},
+{
+glyphname = ecircumflexhookabove;
+lastChange = "2016-08-22 10:28:54 +0000";
+layers = (
+{
+components = (
+{
+name = e;
+},
+{
+name = circumflexcomb_hookabovecomb;
+transform = "{1, 0, 0, 1, -37, 0}";
+}
+);
+layerId = UUID0;
+width = 505;
+},
+{
+components = (
+{
+name = e;
+},
+{
+name = circumflexcomb_hookabovecomb;
+transform = "{1, 0, 0, 1, -27, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 537;
+}
+);
+leftKerningGroup = e;
+rightKerningGroup = e;
+unicode = 1EC3;
+},
+{
+glyphname = ecircumflextilde;
+lastChange = "2016-08-22 10:28:54 +0000";
+layers = (
+{
+components = (
+{
+name = e;
+},
+{
+name = circumflexcomb_tildecomb;
+transform = "{1, 0, 0, 1, -37, 0}";
+}
+);
+layerId = UUID0;
+width = 505;
+},
+{
+components = (
+{
+name = e;
+},
+{
+name = circumflexcomb_tildecomb;
+transform = "{1, 0, 0, 1, -27, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 537;
+}
+);
+leftKerningGroup = e;
+rightKerningGroup = e;
+unicode = 1EC5;
 },
 {
 glyphname = edblgrave;
@@ -16239,7 +18657,7 @@ unicode = 0117;
 },
 {
 glyphname = edotbelow;
-lastChange = "2016-08-18 21:45:32 +0000";
+lastChange = "2016-08-22 10:28:54 +0000";
 layers = (
 {
 components = (
@@ -16274,7 +18692,7 @@ unicode = 1EB9;
 },
 {
 glyphname = egrave;
-lastChange = "2016-08-18 21:45:32 +0000";
+lastChange = "2016-08-22 10:28:54 +0000";
 layers = (
 {
 components = (
@@ -16306,6 +18724,41 @@ width = 537;
 leftKerningGroup = e;
 rightKerningGroup = e;
 unicode = 00E8;
+},
+{
+glyphname = ehookabove;
+lastChange = "2016-08-22 10:28:54 +0000";
+layers = (
+{
+components = (
+{
+name = e;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, -32, 0}";
+}
+);
+layerId = UUID0;
+width = 505;
+},
+{
+components = (
+{
+name = e;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, -15, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 537;
+}
+);
+leftKerningGroup = e;
+rightKerningGroup = e;
+unicode = 1EBB;
 },
 {
 glyphname = einvertedbreve;
@@ -16414,7 +18867,7 @@ unicode = 0119;
 },
 {
 glyphname = etilde;
-lastChange = "2016-08-18 21:45:32 +0000";
+lastChange = "2016-08-22 10:28:54 +0000";
 layers = (
 {
 components = (
@@ -17769,9 +20222,19 @@ unicode = 1E25;
 },
 {
 glyphname = i;
-lastChange = "2016-08-19 17:05:53 +0000";
+lastChange = "2016-08-22 10:12:01 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{165, 0}";
+},
+{
+name = top;
+position = "{175, 450}";
+}
+);
 layerId = UUID0;
 paths = (
 {
@@ -17822,6 +20285,16 @@ nodes = (
 width = 330;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{160, 0}";
+},
+{
+name = top;
+position = "{177, 450}";
+}
+);
 background = {
 paths = (
 {
@@ -17926,9 +20399,23 @@ unicode = 0069;
 },
 {
 glyphname = idotless;
-lastChange = "2016-08-19 17:05:53 +0000";
+lastChange = "2016-08-22 10:12:19 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{165, 0}";
+},
+{
+name = ogonek;
+position = "{297, 10}";
+},
+{
+name = top;
+position = "{165, 450}";
+}
+);
 layerId = UUID0;
 paths = (
 {
@@ -17962,6 +20449,20 @@ nodes = (
 width = 330;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{160, 0}";
+},
+{
+name = ogonek;
+position = "{287, 10}";
+},
+{
+name = top;
+position = "{160, 450}";
+}
+);
 layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
 paths = (
 {
@@ -18240,6 +20741,41 @@ width = 319;
 leftKerningGroup = i;
 rightKerningGroup = i;
 unicode = 00EC;
+},
+{
+glyphname = ihookabove;
+lastChange = "2016-08-22 10:29:03 +0000";
+layers = (
+{
+components = (
+{
+name = idotless;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, -120, 0}";
+}
+);
+layerId = UUID0;
+width = 330;
+},
+{
+components = (
+{
+name = idotless;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, -124, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 319;
+}
+);
+leftKerningGroup = i;
+rightKerningGroup = i;
+unicode = 1EC9;
 },
 {
 glyphname = iinvertedbreve;
@@ -20854,9 +23390,31 @@ unicode = 00F1;
 },
 {
 glyphname = o;
-lastChange = "2016-08-19 17:05:53 +0000";
+lastChange = "2016-08-22 09:33:38 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{281, 0}";
+},
+{
+name = center;
+position = "{281, 225}";
+},
+{
+name = ogonek;
+position = "{506, 10}";
+},
+{
+name = top;
+position = "{281, 450}";
+},
+{
+name = topright;
+position = "{429, 397}";
+}
+);
 layerId = UUID0;
 paths = (
 {
@@ -20897,6 +23455,28 @@ nodes = (
 width = 562;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{295, 0}";
+},
+{
+name = center;
+position = "{295, 225}";
+},
+{
+name = ogonek;
+position = "{530, 10}";
+},
+{
+name = top;
+position = "{295, 450}";
+},
+{
+name = topright;
+position = "{341, 395}";
+}
+);
 background = {
 paths = (
 {
@@ -21085,6 +23665,189 @@ rightKerningGroup = o;
 unicode = 00F4;
 },
 {
+glyphname = ocircumflexacute;
+lastChange = "2016-08-22 10:29:11 +0000";
+layers = (
+{
+components = (
+{
+name = o;
+},
+{
+name = circumflexcomb_acutecomb;
+transform = "{1, 0, 0, 1, -9, 0}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = o;
+},
+{
+name = circumflexcomb_acutecomb;
+transform = "{1, 0, 0, 1, -1, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 1ED1;
+},
+{
+glyphname = ocircumflexdotbelow;
+lastChange = "2016-08-22 10:29:11 +0000";
+layers = (
+{
+components = (
+{
+name = o;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -3, 0}";
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -9, 0}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = o;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 2, 0}";
+},
+{
+name = circumflexcomb;
+transform = "{1, 0, 0, 1, -1, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 1ED9;
+},
+{
+glyphname = ocircumflexgrave;
+lastChange = "2016-08-22 10:29:11 +0000";
+layers = (
+{
+components = (
+{
+name = o;
+},
+{
+name = circumflexcomb_gravecomb;
+transform = "{1, 0, 0, 1, -9, 0}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = o;
+},
+{
+name = circumflexcomb_gravecomb;
+transform = "{1, 0, 0, 1, -1, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 1ED3;
+},
+{
+glyphname = ocircumflexhookabove;
+lastChange = "2016-08-22 10:29:11 +0000";
+layers = (
+{
+components = (
+{
+name = o;
+},
+{
+name = circumflexcomb_hookabovecomb;
+transform = "{1, 0, 0, 1, -9, 0}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = o;
+},
+{
+name = circumflexcomb_hookabovecomb;
+transform = "{1, 0, 0, 1, -1, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 1ED5;
+},
+{
+glyphname = ocircumflextilde;
+lastChange = "2016-08-22 10:29:11 +0000";
+layers = (
+{
+components = (
+{
+name = o;
+},
+{
+name = circumflexcomb_tildecomb;
+transform = "{1, 0, 0, 1, -9, 0}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = o;
+},
+{
+name = circumflexcomb_tildecomb;
+transform = "{1, 0, 0, 1, -1, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 1ED7;
+},
+{
 glyphname = odblgrave;
 lastChange = "2016-08-18 21:39:36 +0000";
 layers = (
@@ -21156,7 +23919,7 @@ unicode = 00F6;
 },
 {
 glyphname = odotbelow;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-22 10:29:11 +0000";
 layers = (
 {
 components = (
@@ -21191,7 +23954,7 @@ unicode = 1ECD;
 },
 {
 glyphname = ograve;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-22 10:29:11 +0000";
 layers = (
 {
 components = (
@@ -21223,6 +23986,251 @@ width = 589;
 leftKerningGroup = o;
 rightKerningGroup = o;
 unicode = 00F2;
+},
+{
+glyphname = ohookabove;
+lastChange = "2016-08-22 10:29:11 +0000";
+layers = (
+{
+components = (
+{
+name = o;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, -4, 0}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = o;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 11, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 1ECF;
+},
+{
+glyphname = ohorn;
+lastChange = "2016-08-22 10:29:11 +0000";
+layers = (
+{
+components = (
+{
+name = o;
+},
+{
+name = horncomb;
+transform = "{1, 0, 0, 1, 117, -53}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = o;
+},
+{
+name = horncomb;
+transform = "{1, 0, 0, 1, 142, -55}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 01A1;
+},
+{
+glyphname = ohornacute;
+lastChange = "2016-08-22 10:29:11 +0000";
+layers = (
+{
+components = (
+{
+name = ohorn;
+},
+{
+name = acute;
+transform = "{1, 0, 0, 1, 234, -9}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = ohorn;
+},
+{
+name = acute;
+transform = "{1, 0, 0, 1, 243, -11}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 1EDB;
+},
+{
+glyphname = ohorndotbelow;
+lastChange = "2016-08-22 10:29:11 +0000";
+layers = (
+{
+components = (
+{
+name = ohorn;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -3, 0}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = ohorn;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 2, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 1EE3;
+},
+{
+glyphname = ohorngrave;
+lastChange = "2016-08-22 10:29:11 +0000";
+layers = (
+{
+components = (
+{
+name = ohorn;
+},
+{
+name = grave;
+transform = "{1, 0, 0, 1, 99, -30}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = ohorn;
+},
+{
+name = grave;
+transform = "{1, 0, 0, 1, 112, -8}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 1EDD;
+},
+{
+glyphname = ohornhookabove;
+lastChange = "2016-08-22 10:29:11 +0000";
+layers = (
+{
+components = (
+{
+name = ohorn;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, -4, 0}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = ohorn;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 11, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 1EDF;
+},
+{
+glyphname = ohorntilde;
+lastChange = "2016-08-22 10:29:11 +0000";
+layers = (
+{
+components = (
+{
+name = ohorn;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, -10, 0}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = ohorn;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, -18, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
+unicode = 1EE1;
 },
 {
 glyphname = ohungarumlaut;
@@ -21598,7 +24606,7 @@ unicode = 01FF;
 },
 {
 glyphname = otilde;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-22 10:29:11 +0000";
 layers = (
 {
 components = (
@@ -24028,9 +27036,27 @@ unicode = 1E6D;
 },
 {
 glyphname = u;
-lastChange = "2016-08-19 17:05:53 +0000";
+lastChange = "2016-08-22 09:33:30 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{285, 0}";
+},
+{
+name = ogonek;
+position = "{513, 10}";
+},
+{
+name = top;
+position = "{285, 450}";
+},
+{
+name = topright;
+position = "{517, 396}";
+}
+);
 layerId = UUID0;
 paths = (
 {
@@ -24095,6 +27121,24 @@ nodes = (
 width = 570;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{307, 0}";
+},
+{
+name = ogonek;
+position = "{552, 10}";
+},
+{
+name = top;
+position = "{307, 450}";
+},
+{
+name = topright;
+position = "{453, 391}";
+}
+);
 background = {
 paths = (
 {
@@ -24227,7 +27271,7 @@ unicode = 0075;
 },
 {
 glyphname = uacute;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-22 10:29:22 +0000";
 layers = (
 {
 components = (
@@ -24402,7 +27446,7 @@ unicode = 00FC;
 },
 {
 glyphname = udotbelow;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-22 10:29:22 +0000";
 layers = (
 {
 components = (
@@ -24437,7 +27481,7 @@ unicode = 1EE5;
 },
 {
 glyphname = ugrave;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-22 10:29:22 +0000";
 layers = (
 {
 components = (
@@ -24469,6 +27513,249 @@ width = 613;
 leftKerningGroup = u;
 rightKerningGroup = u;
 unicode = 00F9;
+},
+{
+glyphname = uhookabove;
+lastChange = "2016-08-22 10:29:22 +0000";
+layers = (
+{
+components = (
+{
+name = u;
+},
+{
+name = hookabovecomb;
+}
+);
+layerId = UUID0;
+width = 570;
+},
+{
+components = (
+{
+name = u;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 23, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 613;
+}
+);
+leftKerningGroup = u;
+rightKerningGroup = u;
+unicode = 1EE7;
+},
+{
+glyphname = uhorn;
+lastChange = "2016-08-22 10:29:22 +0000";
+layers = (
+{
+components = (
+{
+name = u;
+},
+{
+name = horncomb;
+transform = "{1, 0, 0, 1, 205, -54}";
+}
+);
+layerId = UUID0;
+width = 570;
+},
+{
+components = (
+{
+name = u;
+},
+{
+name = horncomb;
+transform = "{1, 0, 0, 1, 254, -59}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 613;
+}
+);
+leftKerningGroup = u;
+rightKerningGroup = u;
+unicode = 01B0;
+},
+{
+glyphname = uhornacute;
+lastChange = "2016-08-22 10:29:22 +0000";
+layers = (
+{
+components = (
+{
+name = uhorn;
+},
+{
+name = acute;
+transform = "{1, 0, 0, 1, 214, 0}";
+}
+);
+layerId = UUID0;
+width = 570;
+},
+{
+components = (
+{
+name = uhorn;
+},
+{
+name = acute;
+transform = "{1, 0, 0, 1, 235, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 613;
+}
+);
+leftKerningGroup = u;
+rightKerningGroup = u;
+unicode = 1EE9;
+},
+{
+glyphname = uhorndotbelow;
+lastChange = "2016-08-22 10:29:22 +0000";
+layers = (
+{
+components = (
+{
+name = uhorn;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 1, 0}";
+}
+);
+layerId = UUID0;
+width = 570;
+},
+{
+components = (
+{
+name = uhorn;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, 14, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 613;
+}
+);
+leftKerningGroup = u;
+rightKerningGroup = u;
+unicode = 1EF1;
+},
+{
+glyphname = uhorngrave;
+lastChange = "2016-08-22 10:29:22 +0000";
+layers = (
+{
+components = (
+{
+name = uhorn;
+},
+{
+name = grave;
+transform = "{1, 0, 0, 1, 127, -3}";
+}
+);
+layerId = UUID0;
+width = 570;
+},
+{
+components = (
+{
+name = uhorn;
+},
+{
+name = grave;
+transform = "{1, 0, 0, 1, 133, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 613;
+}
+);
+leftKerningGroup = u;
+rightKerningGroup = u;
+unicode = 1EEB;
+},
+{
+glyphname = uhornhookabove;
+lastChange = "2016-08-22 10:29:22 +0000";
+layers = (
+{
+components = (
+{
+name = uhorn;
+},
+{
+name = hookabovecomb;
+}
+);
+layerId = UUID0;
+width = 570;
+},
+{
+components = (
+{
+name = uhorn;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 23, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 613;
+}
+);
+leftKerningGroup = u;
+rightKerningGroup = u;
+unicode = 1EED;
+},
+{
+glyphname = uhorntilde;
+lastChange = "2016-08-22 10:29:22 +0000";
+layers = (
+{
+components = (
+{
+name = uhorn;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, -6, 0}";
+}
+);
+layerId = UUID0;
+width = 570;
+},
+{
+components = (
+{
+name = uhorn;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, -6, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 613;
+}
+);
+leftKerningGroup = u;
+rightKerningGroup = u;
+unicode = 1EEF;
 },
 {
 glyphname = uhungarumlaut;
@@ -24647,7 +27934,7 @@ unicode = 016F;
 },
 {
 glyphname = utilde;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-22 10:29:22 +0000";
 layers = (
 {
 components = (
@@ -25358,9 +28645,19 @@ unicode = 0078;
 },
 {
 glyphname = y;
-lastChange = "2016-08-19 17:05:53 +0000";
+lastChange = "2016-08-22 09:54:01 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{243, 0}";
+},
+{
+name = top;
+position = "{243, 450}";
+}
+);
 background = {
 paths = (
 {
@@ -25472,6 +28769,16 @@ nodes = (
 width = 486;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{251, 0}";
+},
+{
+name = top;
+position = "{251, 450}";
+}
+);
 background = {
 paths = (
 {
@@ -25590,7 +28897,7 @@ unicode = 0079;
 },
 {
 glyphname = yacute;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-22 10:29:29 +0000";
 layers = (
 {
 components = (
@@ -25694,8 +29001,43 @@ rightKerningGroup = y;
 unicode = 00FF;
 },
 {
+glyphname = ydotbelow;
+lastChange = "2016-08-22 10:29:29 +0000";
+layers = (
+{
+components = (
+{
+name = y;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -41, 0}";
+}
+);
+layerId = UUID0;
+width = 486;
+},
+{
+components = (
+{
+name = y;
+},
+{
+name = dotbelowcomb;
+transform = "{1, 0, 0, 1, -42, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 501;
+}
+);
+leftKerningGroup = y;
+rightKerningGroup = y;
+unicode = 1EF5;
+},
+{
 glyphname = ygrave;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-22 10:29:29 +0000";
 layers = (
 {
 components = (
@@ -25729,8 +29071,43 @@ rightKerningGroup = y;
 unicode = 1EF3;
 },
 {
+glyphname = yhookabove;
+lastChange = "2016-08-22 10:29:29 +0000";
+layers = (
+{
+components = (
+{
+name = y;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, -42, 0}";
+}
+);
+layerId = UUID0;
+width = 486;
+},
+{
+components = (
+{
+name = y;
+},
+{
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, -33, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 501;
+}
+);
+leftKerningGroup = y;
+rightKerningGroup = y;
+unicode = 1EF7;
+},
+{
 glyphname = ytilde;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-22 10:29:29 +0000";
 layers = (
 {
 components = (
@@ -26047,6 +29424,40 @@ width = 476;
 leftKerningGroup = z;
 rightKerningGroup = z;
 unicode = 1E93;
+},
+{
+glyphname = odotbelow.001;
+lastChange = "2016-08-22 09:39:42 +0000";
+layers = (
+{
+components = (
+{
+name = o;
+},
+{
+name = dotbelow;
+transform = "{1, 0, 0, 1, 208, 0}";
+}
+);
+layerId = UUID0;
+width = 562;
+},
+{
+components = (
+{
+name = o;
+},
+{
+name = dotbelow;
+transform = "{1, 0, 0, 1, 202, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 589;
+}
+);
+leftKerningGroup = o;
+rightKerningGroup = o;
 },
 {
 glyphname = f_f;
@@ -49441,6 +52852,488 @@ width = 785;
 unicode = 2120;
 },
 {
+glyphname = gravecomb;
+lastChange = "2016-08-22 09:45:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{287, 450}";
+},
+{
+name = top;
+position = "{287, 650}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"421 518 LINE",
+"270 614 LINE SMOOTH",
+"223 644 OFFCURVE",
+"211 650 OFFCURVE",
+"197 650 CURVE SMOOTH",
+"169 650 OFFCURVE",
+"153 633 OFFCURVE",
+"153 607 CURVE SMOOTH",
+"153 581 OFFCURVE",
+"170 561 OFFCURVE",
+"203 554 CURVE SMOOTH",
+"378 518 LINE"
+);
+}
+);
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{249, 450}";
+},
+{
+name = top;
+position = "{249, 680}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"395 543 LINE",
+"234 647 LINE SMOOTH",
+"199 670 OFFCURVE",
+"181 680 OFFCURVE",
+"152 680 CURVE SMOOTH",
+"119 680 OFFCURVE",
+"102 658 OFFCURVE",
+"102 634 CURVE SMOOTH",
+"102 611 OFFCURVE",
+"111 587 OFFCURVE",
+"155 578 CURVE SMOOTH",
+"332 543 LINE"
+);
+}
+);
+width = 600;
+}
+);
+unicode = 0300;
+},
+{
+glyphname = acutecomb;
+lastChange = "2016-08-22 10:28:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{325, 450}";
+},
+{
+name = top;
+position = "{325, 655}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"234 523 LINE",
+"409 559 LINE SMOOTH",
+"442 566 OFFCURVE",
+"459 586 OFFCURVE",
+"459 612 CURVE SMOOTH",
+"459 638 OFFCURVE",
+"443 655 OFFCURVE",
+"415 655 CURVE SMOOTH",
+"401 655 OFFCURVE",
+"389 649 OFFCURVE",
+"342 619 CURVE SMOOTH",
+"191 523 LINE"
+);
+}
+);
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{390, 450}";
+},
+{
+name = top;
+position = "{390, 656}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"306 519 LINE",
+"483 554 LINE SMOOTH",
+"527 563 OFFCURVE",
+"536 587 OFFCURVE",
+"536 610 CURVE SMOOTH",
+"536 634 OFFCURVE",
+"519 656 OFFCURVE",
+"486 656 CURVE SMOOTH",
+"457 656 OFFCURVE",
+"439 646 OFFCURVE",
+"404 623 CURVE SMOOTH",
+"243 519 LINE"
+);
+}
+);
+width = 600;
+}
+);
+leftKerningGroup = a;
+rightKerningGroup = a;
+unicode = 0301;
+},
+{
+glyphname = circumflexcomb;
+lastChange = "2016-08-22 10:07:55 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{290, 450}";
+},
+{
+name = top;
+position = "{290, 577}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"181 520 LINE",
+"290 571 LINE",
+"399 520 LINE",
+"442 520 LINE",
+"321 632 LINE",
+"259 632 LINE",
+"138 520 LINE"
+);
+}
+);
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{296, 450}";
+},
+{
+name = top;
+position = "{296, 589}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"177 523 LINE",
+"296 565 LINE",
+"415 523 LINE",
+"468 523 LINE",
+"327 639 LINE",
+"265 639 LINE",
+"124 523 LINE"
+);
+}
+);
+width = 600;
+}
+);
+unicode = 0302;
+},
+{
+glyphname = brevecomb;
+lastChange = "2016-08-22 10:16:38 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{295, 450}";
+},
+{
+name = top;
+position = "{295, 648}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"401 516 OFFCURVE",
+"431 571 OFFCURVE",
+"431 648 CURVE",
+"397 648 LINE",
+"394 604 OFFCURVE",
+"364 584 OFFCURVE",
+"293 584 CURVE SMOOTH",
+"223 584 OFFCURVE",
+"195 602 OFFCURVE",
+"192 648 CURVE",
+"158 648 LINE",
+"158 567 OFFCURVE",
+"192 516 OFFCURVE",
+"295 516 CURVE SMOOTH"
+);
+}
+);
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{298, 450}";
+},
+{
+name = top;
+position = "{298, 658}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"391 521 OFFCURVE",
+"444 581 OFFCURVE",
+"444 658 CURVE",
+"400 658 LINE",
+"397 628 OFFCURVE",
+"347 614 OFFCURVE",
+"296 614 CURVE SMOOTH",
+"246 614 OFFCURVE",
+"198 626 OFFCURVE",
+"195 658 CURVE",
+"151 658 LINE",
+"151 577 OFFCURVE",
+"208 521 OFFCURVE",
+"298 521 CURVE SMOOTH"
+);
+}
+);
+width = 600;
+}
+);
+unicode = 0306;
+},
+{
+glyphname = tildecomb;
+lastChange = "2016-08-22 10:22:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{291, 450}";
+},
+{
+name = top;
+position = "{291, 700}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"148 558 LINE",
+"155 586 OFFCURVE",
+"178 607 OFFCURVE",
+"211 607 CURVE SMOOTH",
+"258 607 OFFCURVE",
+"292 559 OFFCURVE",
+"348 559 CURVE SMOOTH",
+"417 559 OFFCURVE",
+"453 623 OFFCURVE",
+"467 686 CURVE",
+"433 686 LINE",
+"426 665 OFFCURVE",
+"408 635 OFFCURVE",
+"370 635 CURVE SMOOTH",
+"324 635 OFFCURVE",
+"287 683 OFFCURVE",
+"233 683 CURVE SMOOTH",
+"167 683 OFFCURVE",
+"125 620 OFFCURVE",
+"115 558 CURVE"
+);
+}
+);
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{313, 450}";
+},
+{
+name = top;
+position = "{313, 697}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"150 560 LINE",
+"159 584 OFFCURVE",
+"190 601 OFFCURVE",
+"233 601 CURVE SMOOTH",
+"280 601 OFFCURVE",
+"314 561 OFFCURVE",
+"370 561 CURVE SMOOTH",
+"451 561 OFFCURVE",
+"493 629 OFFCURVE",
+"509 697 CURVE",
+"475 697 LINE",
+"466 680 OFFCURVE",
+"442 657 OFFCURVE",
+"392 657 CURVE SMOOTH",
+"346 657 OFFCURVE",
+"309 697 OFFCURVE",
+"255 697 CURVE SMOOTH",
+"177 697 OFFCURVE",
+"129 627 OFFCURVE",
+"117 560 CURVE"
+);
+}
+);
+width = 600;
+}
+);
+unicode = 0303;
+},
+{
+glyphname = hookabovecomb;
+lastChange = "2016-08-22 10:25:29 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{285, 450}";
+},
+{
+name = top;
+position = "{285, 659}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"312 524 LINE",
+"324 550 OFFCURVE",
+"381 560 OFFCURVE",
+"381 600 CURVE SMOOTH",
+"381 657 OFFCURVE",
+"341 683 OFFCURVE",
+"281 683 CURVE SMOOTH",
+"237 683 OFFCURVE",
+"188 662 OFFCURVE",
+"188 603 CURVE SMOOTH",
+"188 583 OFFCURVE",
+"204 568 OFFCURVE",
+"227 568 CURVE SMOOTH",
+"248 568 OFFCURVE",
+"259 576 OFFCURVE",
+"259 590 CURVE SMOOTH",
+"259 608 OFFCURVE",
+"246 606 OFFCURVE",
+"246 618 CURVE SMOOTH",
+"246 633 OFFCURVE",
+"262 643 OFFCURVE",
+"283 643 CURVE SMOOTH",
+"303 643 OFFCURVE",
+"322 636 OFFCURVE",
+"322 598 CURVE SMOOTH",
+"322 574 OFFCURVE",
+"285 560 OFFCURVE",
+"285 524 CURVE"
+);
+}
+);
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{284, 450}";
+},
+{
+name = top;
+position = "{281, 688}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"315 507 LINE",
+"315 557 OFFCURVE",
+"389 538 OFFCURVE",
+"389 600 CURVE SMOOTH",
+"389 671 OFFCURVE",
+"354 700 OFFCURVE",
+"281 700 CURVE SMOOTH",
+"221 700 OFFCURVE",
+"174 673 OFFCURVE",
+"174 608 CURVE SMOOTH",
+"174 578 OFFCURVE",
+"194 559 OFFCURVE",
+"218 559 CURVE SMOOTH",
+"235 559 OFFCURVE",
+"257 566 OFFCURVE",
+"257 585 CURVE SMOOTH",
+"257 613 OFFCURVE",
+"236 601 OFFCURVE",
+"236 625 CURVE SMOOTH",
+"236 639 OFFCURVE",
+"253 657 OFFCURVE",
+"281 657 CURVE SMOOTH",
+"310 657 OFFCURVE",
+"327 641 OFFCURVE",
+"327 609 CURVE SMOOTH",
+"327 585 OFFCURVE",
+"276 577 OFFCURVE",
+"276 507 CURVE"
+);
+}
+);
+width = 600;
+}
+);
+unicode = 0309;
+},
+{
 glyphname = dblgravecomb;
 lastChange = "2016-08-18 21:39:28 +0000";
 layers = (
@@ -49585,6 +53478,144 @@ width = 353;
 unicode = 0311;
 },
 {
+glyphname = horncomb;
+lastChange = "2016-08-22 09:33:02 +0000";
+layers = (
+{
+anchors = (
+{
+name = _topright;
+position = "{312, 450}";
+},
+{
+name = topright;
+position = "{312, 450}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"344 476 OFFCURVE",
+"378 499 OFFCURVE",
+"378 582 CURVE",
+"314 582 LINE",
+"311 527 OFFCURVE",
+"300 503 OFFCURVE",
+"229 503 CURVE",
+"231 476 LINE"
+);
+}
+);
+width = 600;
+},
+{
+anchors = (
+{
+name = _topright;
+position = "{199, 450}";
+},
+{
+name = topright;
+position = "{323, 450}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"344 465 OFFCURVE",
+"394 481 OFFCURVE",
+"394 582 CURVE",
+"318 582 LINE",
+"315 527 OFFCURVE",
+"300 503 OFFCURVE",
+"229 503 CURVE",
+"231 465 LINE"
+);
+}
+);
+width = 600;
+}
+);
+unicode = 031B;
+},
+{
+glyphname = dotbelowcomb;
+lastChange = "2016-08-22 09:41:38 +0000";
+layers = (
+{
+anchors = (
+{
+name = _bottom;
+position = "{284, 0}";
+},
+{
+name = bottom;
+position = "{284, -231}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"320 -231 OFFCURVE",
+"350 -201 OFFCURVE",
+"350 -165 CURVE SMOOTH",
+"350 -129 OFFCURVE",
+"320 -99 OFFCURVE",
+"284 -99 CURVE SMOOTH",
+"248 -99 OFFCURVE",
+"218 -129 OFFCURVE",
+"218 -165 CURVE SMOOTH",
+"218 -201 OFFCURVE",
+"248 -231 OFFCURVE",
+"284 -231 CURVE SMOOTH"
+);
+}
+);
+width = 600;
+},
+{
+anchors = (
+{
+name = _bottom;
+position = "{293, 0}";
+},
+{
+name = bottom;
+position = "{293, -260}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"336 -260 OFFCURVE",
+"373 -223 OFFCURVE",
+"373 -180 CURVE SMOOTH",
+"373 -136 OFFCURVE",
+"336 -99 OFFCURVE",
+"292 -99 CURVE SMOOTH",
+"249 -99 OFFCURVE",
+"212 -136 OFFCURVE",
+"212 -180 CURVE SMOOTH",
+"212 -223 OFFCURVE",
+"249 -260 OFFCURVE",
+"292 -260 CURVE SMOOTH"
+);
+}
+);
+width = 600;
+}
+);
+unicode = 0323;
+},
+{
 glyphname = commaaccentcomb;
 lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
@@ -49656,6 +53687,21 @@ width = 186;
 }
 );
 unicode = 0326;
+},
+{
+glyphname = strokeshortcomb;
+lastChange = "2016-08-22 09:41:48 +0000";
+layers = (
+{
+layerId = UUID0;
+width = 600;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 600;
+}
+);
+unicode = 0335;
 },
 {
 glyphname = dblgravecomb.cap;
@@ -51490,6 +55536,429 @@ width = 412;
 );
 },
 {
+glyphname = brevecomb_acutecomb;
+lastChange = "2016-08-22 09:59:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{295, 450}";
+},
+{
+name = top;
+position = "{295, 853}";
+}
+);
+components = (
+{
+name = brevecomb;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -30, 198}";
+}
+);
+layerId = UUID0;
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{298, 450}";
+},
+{
+name = top;
+position = "{298, 864}";
+}
+);
+components = (
+{
+name = brevecomb;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -92, 208}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 600;
+}
+);
+},
+{
+glyphname = brevecomb_gravecomb;
+lastChange = "2016-08-22 10:27:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{295, 450}";
+},
+{
+name = top;
+position = "{295, 848}";
+}
+);
+components = (
+{
+name = brevecomb;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 8, 198}";
+}
+);
+layerId = UUID0;
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{298, 450}";
+},
+{
+name = top;
+position = "{298, 888}";
+}
+);
+components = (
+{
+name = brevecomb;
+},
+{
+alignment = -1;
+name = gravecomb;
+transform = "{1, 0, 0, 1, 49, 159}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 600;
+}
+);
+},
+{
+glyphname = brevecomb_hookabovecomb;
+lastChange = "2016-08-22 10:06:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{295, 450}";
+},
+{
+name = top;
+position = "{295, 868}";
+}
+);
+components = (
+{
+name = brevecomb;
+},
+{
+alignment = -1;
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 3, 128}";
+}
+);
+layerId = UUID0;
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{298, 450}";
+},
+{
+name = top;
+position = "{298, 898}";
+}
+);
+components = (
+{
+name = brevecomb;
+},
+{
+alignment = -1;
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, -4, 153}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 600;
+}
+);
+},
+{
+glyphname = brevecomb_tildecomb;
+lastChange = "2016-08-22 10:27:03 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{295, 450}";
+},
+{
+name = top;
+position = "{295, 851}";
+}
+);
+components = (
+{
+name = brevecomb;
+},
+{
+alignment = -1;
+name = tildecomb;
+transform = "{1, 0, 0, 1, 4, 128}";
+}
+);
+layerId = UUID0;
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{298, 450}";
+},
+{
+name = top;
+position = "{298, 861}";
+}
+);
+components = (
+{
+name = brevecomb;
+},
+{
+alignment = -1;
+name = tildecomb;
+transform = "{1, 0, 0, 1, -15, 144}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 600;
+}
+);
+},
+{
+glyphname = circumflexcomb_acutecomb;
+lastChange = "2016-08-22 10:07:58 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{290, 450}";
+},
+{
+name = top;
+position = "{290, 857}";
+}
+);
+components = (
+{
+name = circumflexcomb;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -35, 127}";
+}
+);
+layerId = UUID0;
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{296, 450}";
+},
+{
+name = top;
+position = "{296, 865}";
+}
+);
+components = (
+{
+name = circumflexcomb;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, -94, 139}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 600;
+}
+);
+},
+{
+glyphname = circumflexcomb_gravecomb;
+lastChange = "2016-08-22 10:07:58 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{290, 450}";
+},
+{
+name = top;
+position = "{290, 852}";
+}
+);
+components = (
+{
+name = circumflexcomb;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 3, 127}";
+}
+);
+layerId = UUID0;
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{296, 450}";
+},
+{
+name = top;
+position = "{296, 889}";
+}
+);
+components = (
+{
+name = circumflexcomb;
+},
+{
+name = gravecomb;
+transform = "{1, 0, 0, 1, 47, 139}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 600;
+}
+);
+},
+{
+glyphname = circumflexcomb_hookabovecomb;
+lastChange = "2016-08-22 10:06:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{290, 450}";
+},
+{
+name = top;
+position = "{290, 872}";
+}
+);
+components = (
+{
+name = circumflexcomb;
+},
+{
+alignment = -1;
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 123, 105}";
+}
+);
+layerId = UUID0;
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{296, 450}";
+},
+{
+name = top;
+position = "{296, 899}";
+}
+);
+components = (
+{
+name = circumflexcomb;
+},
+{
+alignment = -1;
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 151, 134}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 600;
+}
+);
+},
+{
+glyphname = circumflexcomb_tildecomb;
+lastChange = "2016-08-22 10:07:58 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{290, 450}";
+},
+{
+name = top;
+position = "{290, 855}";
+}
+);
+components = (
+{
+name = circumflexcomb;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, -1, 127}";
+}
+);
+layerId = UUID0;
+width = 600;
+},
+{
+anchors = (
+{
+name = _top;
+position = "{296, 450}";
+},
+{
+name = top;
+position = "{296, 862}";
+}
+);
+components = (
+{
+name = circumflexcomb;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, -17, 139}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 600;
+}
+);
+},
+{
 glyphname = NULL;
 lastChange = "2016-08-19 17:28:22 +0000";
 layers = (
@@ -51541,7 +56010,7 @@ width = 158;
 },
 {
 glyphname = dotbelow;
-lastChange = "2016-08-19 17:28:22 +0000";
+lastChange = "2016-08-22 09:40:48 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -51558,7 +56027,6 @@ nodes = (
 "40 -99 OFFCURVE",
 "10 -129 OFFCURVE",
 "10 -165 CURVE SMOOTH",
-"10 -165 LINE SMOOTH",
 "10 -201 OFFCURVE",
 "40 -231 OFFCURVE",
 "76 -231 CURVE SMOOTH"
@@ -51582,7 +56050,6 @@ nodes = (
 "47 -99 OFFCURVE",
 "10 -136 OFFCURVE",
 "10 -180 CURVE SMOOTH",
-"10 -180 LINE SMOOTH",
 "10 -223 OFFCURVE",
 "47 -260 OFFCURVE",
 "90 -260 CURVE SMOOTH"

--- a/source/v2000 - initial glyphs migration/LibreBodoni Romans.glyphs
+++ b/source/v2000 - initial glyphs migration/LibreBodoni Romans.glyphs
@@ -1,8 +1,5 @@
 {
 .appVersion = "913";
-DisplayStrings = (
-oin
-);
 copyright = "Copyright (c) 2014, Impallari Type (www.impallari.com)";
 customParameters = (
 {
@@ -185,17 +182,21 @@ xHeight = 450;
 glyphs = (
 {
 glyphname = A;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 22:36:21 +0000";
 layers = (
 {
 anchors = (
+{
+name = bottom;
+position = "{343, 0}";
+},
 {
 name = ogonek;
 position = "{590, 44}";
 },
 {
-name = topUC;
-position = "{342, 915}";
+name = top;
+position = "{343, 754}";
 }
 );
 background = {
@@ -256,56 +257,70 @@ paths = (
 {
 closed = 1;
 nodes = (
-"478 15 LINE",
 "612 15 LINE",
 "361 766 LINE",
 "331 766 LINE",
 "283 594 LINE",
 "290 565 LINE",
-"294 565 LINE"
+"294 565 LINE",
+"478 15 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"358 0 LINE",
-"701 0 LINE",
-"701 25 LINE",
-"358 25 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"179 236 LINE",
-"503 236 LINE",
-"503 261 LINE",
-"179 261 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"-16 0 LINE",
 "224 0 LINE",
 "224 25 LINE",
-"-16 25 LINE"
+"-16 25 LINE",
+"-16 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
+"701 0 LINE",
+"701 25 LINE",
+"358 25 LINE",
+"358 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"503 236 LINE",
+"503 261 LINE",
+"179 261 LINE",
+"179 236 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"103 15 LINE",
 "300 594 LINE",
 "361 766 LINE",
 "331 766 LINE",
-"70 15 LINE",
-"103 15 LINE"
+"70 15 LINE"
 );
 }
 );
 width = 686;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{358, 0}";
+},
+{
+name = ogonek;
+position = "{643, 10}";
+},
+{
+name = top;
+position = "{358, 754}";
+}
+);
 background = {
 paths = (
 {
@@ -580,50 +595,50 @@ paths = (
 {
 closed = 1;
 nodes = (
-"493 15 LINE",
 "666 15 LINE",
 "394 763 LINE",
 "368 763 LINE",
 "300 553 LINE",
 "306 516 LINE",
-"310 516 LINE"
+"310 516 LINE",
+"493 15 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"383 0 LINE",
-"730 0 LINE",
-"730 30 LINE",
-"383 30 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"164 204 LINE",
-"508 204 LINE",
-"508 233 LINE",
-"164 233 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"-15 0 LINE",
 "229 0 LINE",
 "229 30 LINE",
-"-15 30 LINE"
+"-15 30 LINE",
+"-15 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
+"508 204 LINE",
+"508 233 LINE",
+"164 233 LINE",
+"164 204 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"730 0 LINE",
+"730 30 LINE",
+"383 30 LINE",
+"383 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"106 15 LINE",
 "342 604 LINE",
 "394 763 LINE",
 "368 763 LINE",
-"73 15 LINE",
-"106 15 LINE"
+"73 15 LINE"
 );
 }
 );
@@ -636,7 +651,7 @@ unicode = 0041;
 },
 {
 glyphname = Aacute;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -644,7 +659,7 @@ components = (
 name = A;
 },
 {
-name = acute.cap;
+name = acute.case;
 transform = "{1, 0, 0, 1, 202, 0}";
 }
 );
@@ -657,7 +672,7 @@ components = (
 name = A;
 },
 {
-name = acute.cap;
+name = acute.case;
 transform = "{1, 0, 0, 1, 232, 0}";
 }
 );
@@ -671,7 +686,7 @@ unicode = 00C1;
 },
 {
 glyphname = Abreve;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -679,7 +694,7 @@ components = (
 name = A;
 },
 {
-name = breve.cap;
+name = breve.case;
 transform = "{1, 0, 0, 1, 180, 0}";
 }
 );
@@ -692,7 +707,7 @@ components = (
 name = A;
 },
 {
-name = breve.cap;
+name = breve.case;
 transform = "{1, 0, 0, 1, 200, 0}";
 }
 );
@@ -706,7 +721,7 @@ unicode = 0102;
 },
 {
 glyphname = Acircumflex;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -714,7 +729,7 @@ components = (
 name = A;
 },
 {
-name = circumflex.cap;
+name = circumflex.case;
 transform = "{1, 0, 0, 1, 173, 0}";
 }
 );
@@ -727,7 +742,7 @@ components = (
 name = A;
 },
 {
-name = circumflex.cap;
+name = circumflex.case;
 transform = "{1, 0, 0, 1, 167, 0}";
 }
 );
@@ -741,7 +756,7 @@ unicode = 00C2;
 },
 {
 glyphname = Adblgrave;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 21:39:36 +0000";
 layers = (
 {
 components = (
@@ -749,7 +764,7 @@ components = (
 name = A;
 },
 {
-name = uni030F.cap;
+name = dblgravecomb.cap;
 transform = "{1, 0, 0, 1, 113, 0}";
 }
 );
@@ -762,7 +777,7 @@ components = (
 name = A;
 },
 {
-name = uni030F.cap;
+name = dblgravecomb.cap;
 transform = "{1, 0, 0, 1, 83, 0}";
 }
 );
@@ -776,7 +791,7 @@ unicode = 0200;
 },
 {
 glyphname = Adieresis;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -784,7 +799,7 @@ components = (
 name = A;
 },
 {
-name = dieresis.cap;
+name = dieresis.case;
 transform = "{1, 0, 0, 1, 186, 0}";
 }
 );
@@ -797,7 +812,7 @@ components = (
 name = A;
 },
 {
-name = dieresis.cap;
+name = dieresis.case;
 transform = "{1, 0, 0, 1, 209, 0}";
 }
 );
@@ -811,7 +826,7 @@ unicode = 00C4;
 },
 {
 glyphname = Agrave;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -819,7 +834,7 @@ components = (
 name = A;
 },
 {
-name = grave.cap;
+name = grave.case;
 transform = "{1, 0, 0, 1, 201, 0}";
 }
 );
@@ -832,7 +847,7 @@ components = (
 name = A;
 },
 {
-name = grave.cap;
+name = grave.case;
 transform = "{1, 0, 0, 1, 204, 0}";
 }
 );
@@ -846,7 +861,7 @@ unicode = 00C0;
 },
 {
 glyphname = Ainvertedbreve;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 21:39:36 +0000";
 layers = (
 {
 components = (
@@ -854,7 +869,7 @@ components = (
 name = A;
 },
 {
-name = uni0311.cap;
+name = breveinvertedcomb.cap;
 transform = "{1, 0, 0, 1, 180, 0}";
 }
 );
@@ -867,7 +882,7 @@ components = (
 name = A;
 },
 {
-name = uni0311.cap;
+name = breveinvertedcomb.cap;
 transform = "{1, 0, 0, 1, 204, 0}";
 }
 );
@@ -881,7 +896,7 @@ unicode = 0202;
 },
 {
 glyphname = Amacron;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -889,7 +904,7 @@ components = (
 name = A;
 },
 {
-name = macron.cap;
+name = macron.case;
 transform = "{1, 0, 0, 1, 175, 0}";
 }
 );
@@ -902,7 +917,7 @@ components = (
 name = A;
 },
 {
-name = macron.cap;
+name = macron.case;
 transform = "{1, 0, 0, 1, 201, 0}";
 }
 );
@@ -951,7 +966,7 @@ unicode = 0104;
 },
 {
 glyphname = Aring;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -959,7 +974,7 @@ components = (
 name = A;
 },
 {
-name = ring.cap;
+name = ring.case;
 transform = "{1, 0, 0, 1, 245, 0}";
 }
 );
@@ -972,7 +987,7 @@ components = (
 name = A;
 },
 {
-name = ring.cap;
+name = ring.case;
 transform = "{1, 0, 0, 1, 275, 0}";
 }
 );
@@ -986,16 +1001,16 @@ unicode = 00C5;
 },
 {
 glyphname = Aringacute;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
 {
-name = ring.cap;
+name = ring.case;
 transform = "{1, 0, 0, 1, 273, -86}";
 },
 {
-name = acute.cap;
+name = acute.case;
 transform = "{1, 0, 0, 1, 256, 0}";
 }
 );
@@ -1004,10 +1019,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"346 724 LINE",
-"103 25 LINE",
-"10 25 LINE",
-"10 0 LINE",
 "254 0 LINE",
 "254 25 LINE",
 "136 25 LINE",
@@ -1019,16 +1030,20 @@ nodes = (
 "735 0 LINE",
 "735 25 LINE",
 "638 25 LINE",
-"405 724 LINE"
+"405 724 LINE",
+"346 724 LINE",
+"103 25 LINE",
+"10 25 LINE",
+"10 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
+"320 565 LINE",
 "324 565 LINE",
 "425 261 LINE",
-"217 261 LINE",
-"320 565 LINE"
+"217 261 LINE"
 );
 }
 );
@@ -1037,12 +1052,12 @@ width = 745;
 {
 components = (
 {
-name = acute.cap;
-transform = "{1, 0, 0, 1, 222, 0}";
+name = ring.case;
+transform = "{1, 0, 0, 1, 268, -90}";
 },
 {
-name = ring.cap;
-transform = "{1, 0, 0, 1, 268, -90}";
+name = acute.case;
+transform = "{1, 0, 0, 1, 222, 0}";
 }
 );
 layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
@@ -1050,10 +1065,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"336 683 LINE",
-"79 30 LINE",
-"-15 30 LINE",
-"-15 0 LINE",
 "229 0 LINE",
 "229 30 LINE",
 "112 30 LINE",
@@ -1065,16 +1076,20 @@ nodes = (
 "730 0 LINE",
 "730 30 LINE",
 "660 30 LINE",
-"423 683 LINE"
+"423 683 LINE",
+"336 683 LINE",
+"79 30 LINE",
+"-15 30 LINE",
+"-15 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
+"306 516 LINE",
 "310 516 LINE",
 "413 233 LINE",
-"193 233 LINE",
-"306 516 LINE"
+"193 233 LINE"
 );
 }
 );
@@ -1087,7 +1102,7 @@ unicode = 01FA;
 },
 {
 glyphname = Atilde;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -1095,7 +1110,7 @@ components = (
 name = A;
 },
 {
-name = tilde.cap;
+name = tilde.case;
 transform = "{1, 0, 0, 1, 161, 0}";
 }
 );
@@ -1108,7 +1123,7 @@ components = (
 name = A;
 },
 {
-name = tilde.cap;
+name = tilde.case;
 transform = "{1, 0, 0, 1, 175, 0}";
 }
 );
@@ -1122,7 +1137,7 @@ unicode = 00C3;
 },
 {
 glyphname = AE;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -1186,6 +1201,13 @@ paths = (
 {
 closed = 1;
 nodes = (
+"254 0 LINE",
+"254 25 LINE",
+"138 25 LINE",
+"238 236 LINE",
+"497 236 LINE",
+"497 25 LINE",
+"379 25 LINE",
 "379 0 LINE",
 "1010 0 LINE",
 "1010 235 LINE",
@@ -1216,14 +1238,7 @@ nodes = (
 "442 729 LINE",
 "108 25 LINE",
 "10 25 LINE",
-"10 0 LINE",
-"254 0 LINE",
-"254 25 LINE",
-"138 25 LINE",
-"238 236 LINE",
-"497 236 LINE",
-"497 25 LINE",
-"379 25 LINE"
+"10 0 LINE"
 );
 },
 {
@@ -1300,6 +1315,13 @@ paths = (
 {
 closed = 1;
 nodes = (
+"254 0 LINE",
+"254 30 LINE",
+"150 30 LINE",
+"257 231 LINE",
+"550 231 LINE",
+"550 30 LINE",
+"455 30 LINE",
 "455 0 LINE",
 "1096 0 LINE",
 "1096 245 LINE",
@@ -1330,14 +1352,7 @@ nodes = (
 "470 724 LINE",
 "102 30 LINE",
 "10 30 LINE",
-"10 0 LINE",
-"254 0 LINE",
-"254 30 LINE",
-"150 30 LINE",
-"257 231 LINE",
-"550 231 LINE",
-"550 30 LINE",
-"455 30 LINE"
+"10 0 LINE"
 );
 },
 {
@@ -1359,7 +1374,7 @@ unicode = 00C6;
 },
 {
 glyphname = AEacute;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -1367,7 +1382,7 @@ components = (
 name = AE;
 },
 {
-name = acute.cap;
+name = acute.case;
 transform = "{1, 0, 0, 1, 420, 0}";
 }
 );
@@ -1380,7 +1395,7 @@ components = (
 name = AE;
 },
 {
-name = acute.cap;
+name = acute.case;
 transform = "{1, 0, 0, 1, 581, 0}";
 }
 );
@@ -1394,7 +1409,7 @@ unicode = 01FC;
 },
 {
 glyphname = B;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -1459,10 +1474,31 @@ paths = (
 {
 closed = 1;
 nodes = (
-"104 15 LINE",
+"380 0 LINE SMOOTH",
+"529 0 OFFCURVE",
+"643 83 OFFCURVE",
+"643 204 CURVE SMOOTH",
+"643 345 OFFCURVE",
+"487 412 OFFCURVE",
+"280 412 CURVE",
+"310 382 LINE",
+"445 382 OFFCURVE",
+"490 344 OFFCURVE",
+"490 209 CURVE SMOOTH",
+"490 59 OFFCURVE",
+"434 25 OFFCURVE",
+"340 25 CURVE SMOOTH",
+"-6 25 LINE",
+"-6 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "238 15 LINE",
 "238 754 LINE",
-"104 754 LINE"
+"104 754 LINE",
+"104 15 LINE"
 );
 },
 {
@@ -1486,27 +1522,6 @@ nodes = (
 "340 412 CURVE SMOOTH",
 "207 412 LINE",
 "207 382 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"310 382 LINE",
-"445 382 OFFCURVE",
-"490 344 OFFCURVE",
-"490 209 CURVE SMOOTH",
-"490 59 OFFCURVE",
-"434 25 OFFCURVE",
-"340 25 CURVE SMOOTH",
-"-6 25 LINE",
-"-6 0 LINE",
-"380 0 LINE SMOOTH",
-"529 0 OFFCURVE",
-"643 83 OFFCURVE",
-"643 204 CURVE SMOOTH",
-"643 345 OFFCURVE",
-"487 412 OFFCURVE",
-"280 412 CURVE"
 );
 }
 );
@@ -1731,10 +1746,31 @@ paths = (
 {
 closed = 1;
 nodes = (
-"125 15 LINE",
+"428 0 LINE SMOOTH",
+"586 0 OFFCURVE",
+"706 60 OFFCURVE",
+"706 194 CURVE SMOOTH",
+"706 345 OFFCURVE",
+"558 402 OFFCURVE",
+"341 402 CURVE",
+"371 367 LINE",
+"489 367 OFFCURVE",
+"528 332 OFFCURVE",
+"528 206 CURVE SMOOTH",
+"528 63 OFFCURVE",
+"475 30 OFFCURVE",
+"388 30 CURVE SMOOTH",
+"25 30 LINE",
+"25 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "283 15 LINE",
 "283 754 LINE",
-"125 754 LINE"
+"125 754 LINE",
+"125 15 LINE"
 );
 },
 {
@@ -1759,27 +1795,6 @@ nodes = (
 "228 402 LINE",
 "228 367 LINE"
 );
-},
-{
-closed = 1;
-nodes = (
-"371 367 LINE",
-"489 367 OFFCURVE",
-"528 332 OFFCURVE",
-"528 206 CURVE SMOOTH",
-"528 63 OFFCURVE",
-"475 30 OFFCURVE",
-"388 30 CURVE SMOOTH",
-"25 30 LINE",
-"25 0 LINE",
-"428 0 LINE SMOOTH",
-"586 0 OFFCURVE",
-"706 60 OFFCURVE",
-"706 194 CURVE SMOOTH",
-"706 345 OFFCURVE",
-"558 402 OFFCURVE",
-"341 402 CURVE"
-);
 }
 );
 width = 751;
@@ -1789,7 +1804,7 @@ unicode = 0042;
 },
 {
 glyphname = C;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 16:37:52 +0000";
 layers = (
 {
 background = {
@@ -1838,7 +1853,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"393 -12 LINE",
 "458 -12 OFFCURVE",
 "525 6 OFFCURVE",
 "578 46 CURVE",
@@ -1923,7 +1937,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"412 -13 LINE",
 "476 -13 OFFCURVE",
 "534 4 OFFCURVE",
 "592 46 CURVE",
@@ -1968,7 +1981,7 @@ unicode = 0043;
 },
 {
 glyphname = Cacute;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -1976,7 +1989,7 @@ components = (
 name = C;
 },
 {
-name = acute.cap;
+name = acute.case;
 transform = "{1, 0, 0, 1, 259, 0}";
 }
 );
@@ -1989,7 +2002,7 @@ components = (
 name = C;
 },
 {
-name = acute.cap;
+name = acute.case;
 transform = "{1, 0, 0, 1, 241, 0}";
 }
 );
@@ -2003,7 +2016,7 @@ unicode = 0106;
 },
 {
 glyphname = Ccaron;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -2011,7 +2024,7 @@ components = (
 name = C;
 },
 {
-name = caron.cap;
+name = caron.case;
 transform = "{1, 0, 0, 1, 231, 0}";
 }
 );
@@ -2024,7 +2037,7 @@ components = (
 name = C;
 },
 {
-name = caron.cap;
+name = caron.case;
 transform = "{1, 0, 0, 1, 209, 0}";
 }
 );
@@ -2073,7 +2086,7 @@ unicode = 00C7;
 },
 {
 glyphname = Ccircumflex;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -2081,7 +2094,7 @@ components = (
 name = C;
 },
 {
-name = circumflex.cap;
+name = circumflex.case;
 transform = "{1, 0, 0, 1, 228, 0}";
 }
 );
@@ -2094,7 +2107,7 @@ components = (
 name = C;
 },
 {
-name = circumflex.cap;
+name = circumflex.case;
 transform = "{1, 0, 0, 1, 203, 0}";
 }
 );
@@ -2108,7 +2121,7 @@ unicode = 0108;
 },
 {
 glyphname = Cdotaccent;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -2116,7 +2129,7 @@ components = (
 name = C;
 },
 {
-name = dotaccent.cap;
+name = dotaccent.case;
 transform = "{1, 0, 0, 1, 327, 0}";
 }
 );
@@ -2129,7 +2142,7 @@ components = (
 name = C;
 },
 {
-name = dotaccent.cap;
+name = dotaccent.case;
 transform = "{1, 0, 0, 1, 341, 0}";
 }
 );
@@ -2143,7 +2156,7 @@ unicode = 010A;
 },
 {
 glyphname = D;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -2187,24 +2200,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"121 15 LINE",
-"255 15 LINE",
-"255 754 LINE",
-"121 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"345 729 LINE SMOOTH",
-"509 729 OFFCURVE",
-"573 663 OFFCURVE",
-"573 377 CURVE SMOOTH",
-"573 91 OFFCURVE",
-"510 25 OFFCURVE",
-"346 25 CURVE SMOOTH",
-"11 25 LINE",
-"11 0 LINE",
 "376 0 LINE SMOOTH",
 "576 0 OFFCURVE",
 "733 179 OFFCURVE",
@@ -2213,7 +2208,25 @@ nodes = (
 "577 754 OFFCURVE",
 "377 754 CURVE SMOOTH",
 "11 754 LINE",
-"11 729 LINE"
+"11 729 LINE",
+"345 729 LINE SMOOTH",
+"509 729 OFFCURVE",
+"573 663 OFFCURVE",
+"573 377 CURVE SMOOTH",
+"573 91 OFFCURVE",
+"510 25 OFFCURVE",
+"346 25 CURVE SMOOTH",
+"11 25 LINE",
+"11 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"255 15 LINE",
+"255 754 LINE",
+"121 754 LINE",
+"121 15 LINE"
 );
 }
 );
@@ -2422,24 +2435,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"115 15 LINE",
-"273 15 LINE",
-"273 754 LINE",
-"115 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"390 724 LINE SMOOTH",
-"527 724 OFFCURVE",
-"578 657 OFFCURVE",
-"578 379 CURVE SMOOTH",
-"578 95 OFFCURVE",
-"525 30 OFFCURVE",
-"381 30 CURVE SMOOTH",
-"20 30 LINE",
-"20 0 LINE",
 "411 0 LINE SMOOTH",
 "611 0 OFFCURVE",
 "768 180 OFFCURVE",
@@ -2448,7 +2443,25 @@ nodes = (
 "615 754 OFFCURVE",
 "421 754 CURVE SMOOTH",
 "20 754 LINE",
-"20 724 LINE"
+"20 724 LINE",
+"390 724 LINE SMOOTH",
+"527 724 OFFCURVE",
+"578 657 OFFCURVE",
+"578 379 CURVE SMOOTH",
+"578 95 OFFCURVE",
+"525 30 OFFCURVE",
+"381 30 CURVE SMOOTH",
+"20 30 LINE",
+"20 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"273 15 LINE",
+"273 754 LINE",
+"115 754 LINE",
+"115 15 LINE"
 );
 }
 );
@@ -2460,8 +2473,86 @@ rightKerningGroup = D;
 unicode = 0044;
 },
 {
+glyphname = DZ;
+lastChange = "2016-08-18 21:42:31 +0000";
+layers = (
+{
+components = (
+{
+name = D;
+},
+{
+name = Z;
+transform = "{1, 0, 0, 1, 777, 0}";
+}
+);
+layerId = UUID0;
+width = 1428;
+},
+{
+components = (
+{
+name = D;
+},
+{
+name = Z;
+transform = "{1, 0, 0, 1, 798, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 1419;
+}
+);
+leftKerningGroup = D;
+rightKerningGroup = Z;
+unicode = 01F1;
+},
+{
+glyphname = DZcaron;
+lastChange = "2016-08-19 17:29:55 +0000";
+layers = (
+{
+components = (
+{
+name = D;
+},
+{
+name = Z;
+transform = "{1, 0, 0, 1, 777, 0}";
+},
+{
+name = caron.case;
+transform = "{1, 0, 0, 1, 922, 0}";
+}
+);
+layerId = UUID0;
+width = 1422;
+},
+{
+components = (
+{
+name = D;
+},
+{
+name = Z;
+transform = "{1, 0, 0, 1, 798, 0}";
+},
+{
+name = caron.case;
+transform = "{1, 0, 0, 1, 924, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 1419;
+}
+);
+leftKerningGroup = D;
+rightKerningGroup = Z;
+unicode = 01C4;
+},
+{
 glyphname = Eth;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -2519,10 +2610,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"16 367 LINE",
 "381 367 LINE",
 "381 402 LINE",
-"16 402 LINE"
+"16 402 LINE",
+"16 367 LINE"
 );
 }
 );
@@ -2539,10 +2630,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"16 361 LINE",
 "411 361 LINE",
 "411 408 LINE",
-"16 408 LINE"
+"16 408 LINE",
+"16 361 LINE"
 );
 }
 );
@@ -2554,7 +2645,7 @@ unicode = 00D0;
 },
 {
 glyphname = Dcaron;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -2562,7 +2653,7 @@ components = (
 name = D;
 },
 {
-name = caron.cap;
+name = caron.case;
 transform = "{1, 0, 0, 1, 188, 0}";
 }
 );
@@ -2575,7 +2666,7 @@ components = (
 name = D;
 },
 {
-name = caron.cap;
+name = caron.case;
 transform = "{1, 0, 0, 1, 184, 0}";
 }
 );
@@ -2589,7 +2680,7 @@ unicode = 010E;
 },
 {
 glyphname = Dcroat;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 components = (
@@ -2602,10 +2693,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"16 367 LINE",
 "381 367 LINE",
 "381 402 LINE",
-"16 402 LINE"
+"16 402 LINE",
+"16 367 LINE"
 );
 }
 );
@@ -2622,10 +2713,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"16 361 LINE",
 "411 361 LINE",
 "411 408 LINE",
-"16 408 LINE"
+"16 408 LINE",
+"16 361 LINE"
 );
 }
 );
@@ -2671,8 +2762,86 @@ rightKerningGroup = D;
 unicode = 1E0C;
 },
 {
+glyphname = Dz;
+lastChange = "2016-08-18 21:42:31 +0000";
+layers = (
+{
+components = (
+{
+name = D;
+},
+{
+name = z;
+transform = "{1, 0, 0, 1, 777, 0}";
+}
+);
+layerId = UUID0;
+width = 1257;
+},
+{
+components = (
+{
+name = D;
+},
+{
+name = z;
+transform = "{1, 0, 0, 1, 798, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 1274;
+}
+);
+leftKerningGroup = D;
+rightKerningGroup = z;
+unicode = 01F2;
+},
+{
+glyphname = Dzcaron;
+lastChange = "2016-08-18 21:42:31 +0000";
+layers = (
+{
+components = (
+{
+name = D;
+},
+{
+name = z;
+transform = "{1, 0, 0, 1, 777, 0}";
+},
+{
+name = caron;
+transform = "{1, 0, 0, 1, 833, 0}";
+}
+);
+layerId = UUID0;
+width = 1239;
+},
+{
+components = (
+{
+name = D;
+},
+{
+name = z;
+transform = "{1, 0, 0, 1, 798, 0}";
+},
+{
+name = caron;
+transform = "{1, 0, 0, 1, 878, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 1274;
+}
+);
+leftKerningGroup = D;
+rightKerningGroup = z;
+unicode = 01C5;
+},
+{
 glyphname = E;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -2734,42 +2903,28 @@ paths = (
 {
 closed = 1;
 nodes = (
-"126 15 LINE",
-"260 15 LINE",
-"260 744 LINE",
-"126 744 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"8 0 LINE",
 "639 0 LINE",
 "639 235 LINE",
 "604 235 LINE",
 "602 123 OFFCURVE",
 "545 25 OFFCURVE",
 "446 25 CURVE SMOOTH",
-"8 25 LINE"
+"8 25 LINE",
+"8 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"8 729 LINE",
-"416 729 LINE SMOOTH",
-"515 729 OFFCURVE",
-"572 646 OFFCURVE",
-"574 549 CURVE",
-"609 549 LINE",
-"609 754 LINE",
-"8 754 LINE"
+"260 15 LINE",
+"260 744 LINE",
+"126 744 LINE",
+"126 15 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"415 216 LINE",
 "450 216 LINE",
 "450 526 LINE",
 "415 526 LINE",
@@ -2780,6 +2935,19 @@ nodes = (
 "381 363 OFFCURVE",
 "412 328 OFFCURVE",
 "415 216 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"609 549 LINE",
+"609 754 LINE",
+"8 754 LINE",
+"8 729 LINE",
+"416 729 LINE SMOOTH",
+"515 729 OFFCURVE",
+"572 646 OFFCURVE",
+"574 549 CURVE"
 );
 }
 );
@@ -2845,42 +3013,28 @@ paths = (
 {
 closed = 1;
 nodes = (
-"115 15 LINE",
-"273 15 LINE",
-"273 754 LINE",
-"115 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"20 0 LINE",
 "661 0 LINE",
 "661 245 LINE",
 "621 245 LINE",
 "619 131 OFFCURVE",
 "554 30 OFFCURVE",
 "443 30 CURVE SMOOTH",
-"20 30 LINE"
+"20 30 LINE",
+"20 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"20 724 LINE",
-"443 724 LINE SMOOTH",
-"545 724 OFFCURVE",
-"604 646 OFFCURVE",
-"606 554 CURVE",
-"646 554 LINE",
-"646 754 LINE",
-"20 754 LINE"
+"273 15 LINE",
+"273 754 LINE",
+"115 754 LINE",
+"115 15 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"452 216 LINE",
 "492 216 LINE",
 "492 516 LINE",
 "452 516 LINE",
@@ -2891,6 +3045,19 @@ nodes = (
 "401 356 OFFCURVE",
 "450 312 OFFCURVE",
 "452 216 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"646 554 LINE",
+"646 754 LINE",
+"20 754 LINE",
+"20 724 LINE",
+"443 724 LINE SMOOTH",
+"545 724 OFFCURVE",
+"604 646 OFFCURVE",
+"606 554 CURVE"
 );
 }
 );
@@ -2903,7 +3070,7 @@ unicode = 0045;
 },
 {
 glyphname = Eacute;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -2911,7 +3078,7 @@ components = (
 name = E;
 },
 {
-name = acute.cap;
+name = acute.case;
 transform = "{1, 0, 0, 1, 182, 0}";
 }
 );
@@ -2924,7 +3091,7 @@ components = (
 name = E;
 },
 {
-name = acute.cap;
+name = acute.case;
 transform = "{1, 0, 0, 1, 196, 0}";
 }
 );
@@ -2938,7 +3105,7 @@ unicode = 00C9;
 },
 {
 glyphname = Ebreve;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -2946,7 +3113,7 @@ components = (
 name = E;
 },
 {
-name = breve.cap;
+name = breve.case;
 transform = "{1, 0, 0, 1, 156, 0}";
 }
 );
@@ -2959,7 +3126,7 @@ components = (
 name = E;
 },
 {
-name = breve.cap;
+name = breve.case;
 transform = "{1, 0, 0, 1, 176, 0}";
 }
 );
@@ -2973,7 +3140,7 @@ unicode = 0114;
 },
 {
 glyphname = Ecaron;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -2981,7 +3148,7 @@ components = (
 name = E;
 },
 {
-name = caron.cap;
+name = caron.case;
 transform = "{1, 0, 0, 1, 147, 0}";
 }
 );
@@ -2994,7 +3161,7 @@ components = (
 name = E;
 },
 {
-name = caron.cap;
+name = caron.case;
 transform = "{1, 0, 0, 1, 147, 0}";
 }
 );
@@ -3008,7 +3175,7 @@ unicode = 011A;
 },
 {
 glyphname = Ecircumflex;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -3016,7 +3183,7 @@ components = (
 name = E;
 },
 {
-name = circumflex.cap;
+name = circumflex.case;
 transform = "{1, 0, 0, 1, 144, 0}";
 }
 );
@@ -3029,7 +3196,7 @@ components = (
 name = E;
 },
 {
-name = circumflex.cap;
+name = circumflex.case;
 transform = "{1, 0, 0, 1, 143, 0}";
 }
 );
@@ -3043,7 +3210,7 @@ unicode = 00CA;
 },
 {
 glyphname = Edblgrave;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 21:39:36 +0000";
 layers = (
 {
 components = (
@@ -3051,7 +3218,7 @@ components = (
 name = E;
 },
 {
-name = uni030F.cap;
+name = dblgravecomb.cap;
 transform = "{1, 0, 0, 1, 85, 0}";
 }
 );
@@ -3064,7 +3231,7 @@ components = (
 name = E;
 },
 {
-name = uni030F.cap;
+name = dblgravecomb.cap;
 transform = "{1, 0, 0, 1, 71, 0}";
 }
 );
@@ -3078,7 +3245,7 @@ unicode = 0204;
 },
 {
 glyphname = Edieresis;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -3086,7 +3253,7 @@ components = (
 name = E;
 },
 {
-name = dieresis.cap;
+name = dieresis.case;
 transform = "{1, 0, 0, 1, 165, 0}";
 }
 );
@@ -3099,7 +3266,7 @@ components = (
 name = E;
 },
 {
-name = dieresis.cap;
+name = dieresis.case;
 transform = "{1, 0, 0, 1, 179, 0}";
 }
 );
@@ -3113,7 +3280,7 @@ unicode = 00CB;
 },
 {
 glyphname = Edotaccent;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -3121,7 +3288,7 @@ components = (
 name = E;
 },
 {
-name = dotaccent.cap;
+name = dotaccent.case;
 transform = "{1, 0, 0, 1, 253, 0}";
 }
 );
@@ -3134,7 +3301,7 @@ components = (
 name = E;
 },
 {
-name = dotaccent.cap;
+name = dotaccent.case;
 transform = "{1, 0, 0, 1, 276, 0}";
 }
 );
@@ -3183,7 +3350,7 @@ unicode = 1EB8;
 },
 {
 glyphname = Egrave;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -3191,7 +3358,7 @@ components = (
 name = E;
 },
 {
-name = grave.cap;
+name = grave.case;
 transform = "{1, 0, 0, 1, 198, 0}";
 }
 );
@@ -3204,7 +3371,7 @@ components = (
 name = E;
 },
 {
-name = grave.cap;
+name = grave.case;
 transform = "{1, 0, 0, 1, 186, 0}";
 }
 );
@@ -3218,7 +3385,7 @@ unicode = 00C8;
 },
 {
 glyphname = Einvertedbreve;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 21:39:36 +0000";
 layers = (
 {
 components = (
@@ -3226,7 +3393,7 @@ components = (
 name = E;
 },
 {
-name = uni0311.cap;
+name = breveinvertedcomb.cap;
 transform = "{1, 0, 0, 1, 165, 0}";
 }
 );
@@ -3239,7 +3406,7 @@ components = (
 name = E;
 },
 {
-name = uni0311.cap;
+name = breveinvertedcomb.cap;
 transform = "{1, 0, 0, 1, 162, 0}";
 }
 );
@@ -3253,7 +3420,7 @@ unicode = 0206;
 },
 {
 glyphname = Emacron;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -3261,7 +3428,7 @@ components = (
 name = E;
 },
 {
-name = macron.cap;
+name = macron.case;
 transform = "{1, 0, 0, 1, 146, 0}";
 }
 );
@@ -3274,7 +3441,7 @@ components = (
 name = E;
 },
 {
-name = macron.cap;
+name = macron.case;
 transform = "{1, 0, 0, 1, 173, 0}";
 }
 );
@@ -3323,7 +3490,7 @@ unicode = 0118;
 },
 {
 glyphname = Etilde;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -3331,7 +3498,7 @@ components = (
 name = E;
 },
 {
-name = tilde.cap;
+name = tilde.case;
 transform = "{1, 0, 0, 1, 139, 0}";
 }
 );
@@ -3344,7 +3511,7 @@ components = (
 name = E;
 },
 {
-name = tilde.cap;
+name = tilde.case;
 transform = "{1, 0, 0, 1, 161, 0}";
 }
 );
@@ -3358,7 +3525,7 @@ unicode = 1EBC;
 },
 {
 glyphname = F;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -3416,25 +3583,37 @@ paths = (
 {
 closed = 1;
 nodes = (
-"129 15 LINE",
-"263 15 LINE",
-"263 754 LINE",
-"129 754 LINE"
+"622 509 LINE",
+"622 754 LINE",
+"11 754 LINE",
+"11 729 LINE",
+"429 729 LINE SMOOTH",
+"528 729 OFFCURVE",
+"585 626 OFFCURVE",
+"587 509 CURVE"
 );
 },
 {
 closed = 1;
 nodes = (
-"11 0 LINE",
 "373 0 LINE",
 "373 25 LINE",
-"11 25 LINE"
+"11 25 LINE",
+"11 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"418 216 LINE",
+"263 15 LINE",
+"263 754 LINE",
+"129 754 LINE",
+"129 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "453 216 LINE",
 "453 526 LINE",
 "418 526 LINE",
@@ -3445,19 +3624,6 @@ nodes = (
 "384 363 OFFCURVE",
 "415 328 OFFCURVE",
 "418 216 CURVE"
-);
-},
-{
-closed = 1;
-nodes = (
-"11 729 LINE",
-"429 729 LINE SMOOTH",
-"528 729 OFFCURVE",
-"585 626 OFFCURVE",
-"587 509 CURVE",
-"622 509 LINE",
-"622 754 LINE",
-"11 754 LINE"
 );
 }
 );
@@ -3521,25 +3687,37 @@ paths = (
 {
 closed = 1;
 nodes = (
-"115 14 LINE",
-"273 14 LINE",
-"273 754 LINE",
-"115 754 LINE"
+"646 539 LINE",
+"646 754 LINE",
+"20 754 LINE",
+"20 724 LINE",
+"443 724 LINE SMOOTH",
+"545 724 OFFCURVE",
+"604 639 OFFCURVE",
+"606 539 CURVE"
 );
 },
 {
 closed = 1;
 nodes = (
-"20 0 LINE",
 "401 0 LINE",
 "401 30 LINE",
-"20 30 LINE"
+"20 30 LINE",
+"20 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"452 215 LINE",
+"273 14 LINE",
+"273 754 LINE",
+"115 754 LINE",
+"115 14 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "492 215 LINE",
 "492 515 LINE",
 "452 515 LINE",
@@ -3551,19 +3729,6 @@ nodes = (
 "450 311 OFFCURVE",
 "452 215 CURVE"
 );
-},
-{
-closed = 1;
-nodes = (
-"20 724 LINE",
-"443 724 LINE SMOOTH",
-"545 724 OFFCURVE",
-"604 639 OFFCURVE",
-"606 539 CURVE",
-"646 539 LINE",
-"646 754 LINE",
-"20 754 LINE"
-);
 }
 );
 width = 702;
@@ -3573,7 +3738,7 @@ unicode = 0046;
 },
 {
 glyphname = G;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -3630,7 +3795,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"381 -12 LINE",
 "532 -12 OFFCURVE",
 "665 89 OFFCURVE",
 "665 259 CURVE SMOOTH",
@@ -3667,10 +3831,10 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"393 268 LINE",
 "723 268 LINE",
 "723 293 LINE",
-"393 293 LINE"
+"393 293 LINE",
+"393 268 LINE"
 );
 }
 );
@@ -3731,7 +3895,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"397 -13 LINE",
 "532 -13 OFFCURVE",
 "669 68 OFFCURVE",
 "701 170 CURVE",
@@ -3768,10 +3931,10 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"423 270 LINE",
 "778 270 LINE",
 "778 300 LINE",
-"423 300 LINE"
+"423 300 LINE",
+"423 270 LINE"
 );
 }
 );
@@ -3784,7 +3947,7 @@ unicode = 0047;
 },
 {
 glyphname = Gacute;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -3792,7 +3955,7 @@ components = (
 name = G;
 },
 {
-name = acute.cap;
+name = acute.case;
 transform = "{1, 0, 0, 1, 252, 0}";
 }
 );
@@ -3805,7 +3968,7 @@ components = (
 name = G;
 },
 {
-name = acute.cap;
+name = acute.case;
 transform = "{1, 0, 0, 1, 274, 0}";
 }
 );
@@ -3819,7 +3982,7 @@ unicode = 01F4;
 },
 {
 glyphname = Gbreve;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -3827,7 +3990,7 @@ components = (
 name = G;
 },
 {
-name = breve.cap;
+name = breve.case;
 transform = "{1, 0, 0, 1, 230, 0}";
 }
 );
@@ -3840,7 +4003,7 @@ components = (
 name = G;
 },
 {
-name = breve.cap;
+name = breve.case;
 transform = "{1, 0, 0, 1, 254, 0}";
 }
 );
@@ -3854,7 +4017,7 @@ unicode = 011E;
 },
 {
 glyphname = Gcircumflex;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -3862,7 +4025,7 @@ components = (
 name = G;
 },
 {
-name = circumflex.cap;
+name = circumflex.case;
 transform = "{1, 0, 0, 1, 222, 0}";
 }
 );
@@ -3875,7 +4038,7 @@ components = (
 name = G;
 },
 {
-name = circumflex.cap;
+name = circumflex.case;
 transform = "{1, 0, 0, 1, 218, 0}";
 }
 );
@@ -3889,7 +4052,7 @@ unicode = 011C;
 },
 {
 glyphname = Gcommaaccent;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 21:39:36 +0000";
 layers = (
 {
 components = (
@@ -3897,7 +4060,7 @@ components = (
 name = G;
 },
 {
-name = commaaccent;
+name = commaaccentcomb;
 transform = "{1, 0, 0, 1, 309, 0}";
 }
 );
@@ -3910,7 +4073,7 @@ components = (
 name = G;
 },
 {
-name = commaaccent;
+name = commaaccentcomb;
 transform = "{1, 0, 0, 1, 322, 0}";
 }
 );
@@ -3924,7 +4087,7 @@ unicode = 0122;
 },
 {
 glyphname = Gdotaccent;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -3932,7 +4095,7 @@ components = (
 name = G;
 },
 {
-name = dotaccent.cap;
+name = dotaccent.case;
 transform = "{1, 0, 0, 1, 318, 0}";
 }
 );
@@ -3945,7 +4108,7 @@ components = (
 name = G;
 },
 {
-name = dotaccent.cap;
+name = dotaccent.case;
 transform = "{1, 0, 0, 1, 350, 0}";
 }
 );
@@ -3959,7 +4122,7 @@ unicode = 0120;
 },
 {
 glyphname = H;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -4034,11 +4197,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"13 729 LINE",
-"123 729 LINE",
-"123 25 LINE",
-"13 25 LINE",
-"13 0 LINE",
 "367 0 LINE",
 "367 25 LINE",
 "257 25 LINE",
@@ -4061,7 +4219,12 @@ nodes = (
 "257 729 LINE",
 "367 729 LINE",
 "367 754 LINE",
-"13 754 LINE"
+"13 754 LINE",
+"13 729 LINE",
+"123 729 LINE",
+"123 25 LINE",
+"13 25 LINE",
+"13 0 LINE"
 );
 }
 );
@@ -4140,11 +4303,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"20 724 LINE",
-"115 724 LINE",
-"115 30 LINE",
-"20 30 LINE",
-"20 0 LINE",
 "371 0 LINE",
 "371 30 LINE",
 "273 30 LINE",
@@ -4167,7 +4325,12 @@ nodes = (
 "273 724 LINE",
 "371 724 LINE",
 "371 754 LINE",
-"20 754 LINE"
+"20 754 LINE",
+"20 724 LINE",
+"115 724 LINE",
+"115 30 LINE",
+"20 30 LINE",
+"20 0 LINE"
 );
 }
 );
@@ -4180,7 +4343,7 @@ unicode = 0048;
 },
 {
 glyphname = Hbar;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 components = (
@@ -4193,10 +4356,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"20 548 LINE",
 "789 548 LINE",
 "789 578 LINE",
-"20 578 LINE"
+"20 578 LINE",
+"20 548 LINE"
 );
 }
 );
@@ -4213,10 +4376,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"20 541 LINE",
 "789 541 LINE",
 "789 578 LINE",
-"20 578 LINE"
+"20 578 LINE",
+"20 541 LINE"
 );
 }
 );
@@ -4227,7 +4390,7 @@ unicode = 0126;
 },
 {
 glyphname = Hcircumflex;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -4235,7 +4398,7 @@ components = (
 name = H;
 },
 {
-name = circumflex.cap;
+name = circumflex.case;
 transform = "{1, 0, 0, 1, 229, 0}";
 }
 );
@@ -4248,7 +4411,7 @@ components = (
 name = H;
 },
 {
-name = circumflex.cap;
+name = circumflex.case;
 transform = "{1, 0, 0, 1, 203, 0}";
 }
 );
@@ -4297,7 +4460,7 @@ unicode = 1E24;
 },
 {
 glyphname = I;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -4336,28 +4499,28 @@ paths = (
 {
 closed = 1;
 nodes = (
-"123 15 LINE",
 "257 15 LINE",
 "257 754 LINE",
-"123 754 LINE"
+"123 754 LINE",
+"123 15 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"13 0 LINE",
 "367 0 LINE",
 "367 25 LINE",
-"13 25 LINE"
+"13 25 LINE",
+"13 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"13 729 LINE",
 "367 729 LINE",
 "367 754 LINE",
-"13 754 LINE"
+"13 754 LINE",
+"13 729 LINE"
 );
 }
 );
@@ -4466,28 +4629,28 @@ paths = (
 {
 closed = 1;
 nodes = (
-"115 15 LINE",
 "273 15 LINE",
 "273 754 LINE",
-"115 754 LINE"
+"115 754 LINE",
+"115 15 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"20 0 LINE",
 "371 0 LINE",
 "371 30 LINE",
-"20 30 LINE"
+"20 30 LINE",
+"20 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"20 724 LINE",
 "371 724 LINE",
 "371 754 LINE",
-"20 754 LINE"
+"20 754 LINE",
+"20 724 LINE"
 );
 }
 );
@@ -4500,7 +4663,7 @@ unicode = 0049;
 },
 {
 glyphname = IJ;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 21:42:31 +0000";
 layers = (
 {
 components = (
@@ -4509,11 +4672,11 @@ name = I;
 },
 {
 name = J;
-transform = "{1, 0, 0, 1, 388, 0}";
+transform = "{1, 0, 0, 1, 379, 0}";
 }
 );
 layerId = UUID0;
-width = 848;
+width = 839;
 },
 {
 components = (
@@ -4522,11 +4685,11 @@ name = I;
 },
 {
 name = J;
-transform = "{1, 0, 0, 1, 416, 0}";
+transform = "{1, 0, 0, 1, 386, 0}";
 }
 );
 layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
-width = 802;
+width = 772;
 }
 );
 leftKerningGroup = I;
@@ -4535,7 +4698,7 @@ unicode = 0132;
 },
 {
 glyphname = Iacute;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -4543,7 +4706,7 @@ components = (
 name = I;
 },
 {
-name = acute.cap;
+name = acute.case;
 transform = "{1, 0, 0, 1, 45, 0}";
 }
 );
@@ -4556,7 +4719,7 @@ components = (
 name = I;
 },
 {
-name = acute.cap;
+name = acute.case;
 transform = "{1, 0, 0, 1, 40, 0}";
 }
 );
@@ -4570,7 +4733,7 @@ unicode = 00CD;
 },
 {
 glyphname = Ibreve;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -4578,7 +4741,7 @@ components = (
 name = I;
 },
 {
-name = breve.cap;
+name = breve.case;
 transform = "{1, 0, 0, 1, 23, 0}";
 }
 );
@@ -4591,7 +4754,7 @@ components = (
 name = I;
 },
 {
-name = breve.cap;
+name = breve.case;
 transform = "{1, 0, 0, 1, 18, 0}";
 }
 );
@@ -4605,7 +4768,7 @@ unicode = 012C;
 },
 {
 glyphname = Icircumflex;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -4613,7 +4776,7 @@ components = (
 name = I;
 },
 {
-name = circumflex.cap;
+name = circumflex.case;
 transform = "{1, 0, 0, 1, 15, 0}";
 }
 );
@@ -4626,7 +4789,7 @@ components = (
 name = I;
 },
 {
-name = circumflex.cap;
+name = circumflex.case;
 transform = "{1, 0, 0, 1, -16, 0}";
 }
 );
@@ -4640,7 +4803,7 @@ unicode = 00CE;
 },
 {
 glyphname = Idblgrave;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 21:39:36 +0000";
 layers = (
 {
 components = (
@@ -4648,7 +4811,7 @@ components = (
 name = I;
 },
 {
-name = uni030F.cap;
+name = dblgravecomb.cap;
 transform = "{1, 0, 0, 1, -23, 0}";
 }
 );
@@ -4661,7 +4824,7 @@ components = (
 name = I;
 },
 {
-name = uni030F.cap;
+name = dblgravecomb.cap;
 transform = "{1, 0, 0, 1, -60, 0}";
 }
 );
@@ -4675,7 +4838,7 @@ unicode = 0208;
 },
 {
 glyphname = Idieresis;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -4683,7 +4846,7 @@ components = (
 name = I;
 },
 {
-name = dieresis.cap;
+name = dieresis.case;
 transform = "{1, 0, 0, 1, 28, 0}";
 }
 );
@@ -4696,7 +4859,7 @@ components = (
 name = I;
 },
 {
-name = dieresis.cap;
+name = dieresis.case;
 transform = "{1, 0, 0, 1, 24, 0}";
 }
 );
@@ -4710,7 +4873,7 @@ unicode = 00CF;
 },
 {
 glyphname = Idotaccent;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -4718,7 +4881,7 @@ components = (
 name = I;
 },
 {
-name = dotaccent.cap;
+name = dotaccent.case;
 transform = "{1, 0, 0, 1, 114, 0}";
 }
 );
@@ -4731,7 +4894,7 @@ components = (
 name = I;
 },
 {
-name = dotaccent.cap;
+name = dotaccent.case;
 transform = "{1, 0, 0, 1, 104, 0}";
 }
 );
@@ -4780,7 +4943,7 @@ unicode = 1ECA;
 },
 {
 glyphname = Igrave;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -4788,7 +4951,7 @@ components = (
 name = I;
 },
 {
-name = grave.cap;
+name = grave.case;
 transform = "{1, 0, 0, 1, 46, 0}";
 }
 );
@@ -4801,7 +4964,7 @@ components = (
 name = I;
 },
 {
-name = grave.cap;
+name = grave.case;
 transform = "{1, 0, 0, 1, 39, 0}";
 }
 );
@@ -4815,7 +4978,7 @@ unicode = 00CC;
 },
 {
 glyphname = Iinvertedbreve;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 21:39:36 +0000";
 layers = (
 {
 components = (
@@ -4823,7 +4986,7 @@ components = (
 name = I;
 },
 {
-name = uni0311.cap;
+name = breveinvertedcomb.cap;
 transform = "{1, 0, 0, 1, 23, 0}";
 }
 );
@@ -4836,7 +4999,7 @@ components = (
 name = I;
 },
 {
-name = uni0311.cap;
+name = breveinvertedcomb.cap;
 transform = "{1, 0, 0, 1, 19, 0}";
 }
 );
@@ -4850,7 +5013,7 @@ unicode = 020A;
 },
 {
 glyphname = Imacron;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -4858,7 +5021,7 @@ components = (
 name = I;
 },
 {
-name = macron.cap;
+name = macron.case;
 transform = "{1, 0, 0, 1, 21, 0}";
 }
 );
@@ -4871,7 +5034,7 @@ components = (
 name = I;
 },
 {
-name = macron.cap;
+name = macron.case;
 transform = "{1, 0, 0, 1, 16, 0}";
 }
 );
@@ -4920,7 +5083,7 @@ unicode = 012E;
 },
 {
 glyphname = Itilde;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -4928,7 +5091,7 @@ components = (
 name = I;
 },
 {
-name = tilde.cap;
+name = tilde.case;
 transform = "{1, 0, 0, 1, 2, 0}";
 }
 );
@@ -4941,7 +5104,7 @@ components = (
 name = I;
 },
 {
-name = tilde.cap;
+name = tilde.case;
 transform = "{1, 0, 0, 1, -11, 0}";
 }
 );
@@ -4955,7 +5118,7 @@ unicode = 0128;
 },
 {
 glyphname = J;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -5005,16 +5168,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"46 729 LINE",
-"400 729 LINE",
-"400 754 LINE",
-"46 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"91 -108 LINE SMOOTH",
 "204 -108 OFFCURVE",
 "310 -1 OFFCURVE",
 "310 125 CURVE SMOOTH",
@@ -5039,6 +5192,15 @@ nodes = (
 "-29 -63 OFFCURVE",
 "17 -108 OFFCURVE",
 "91 -108 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"400 729 LINE",
+"400 754 LINE",
+"46 754 LINE",
+"46 729 LINE"
 );
 }
 );
@@ -5092,16 +5254,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"20 724 LINE",
-"371 724 LINE",
-"371 754 LINE",
-"20 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"35 -102 LINE SMOOTH",
 "168 -102 OFFCURVE",
 "273 -24 OFFCURVE",
 "273 137 CURVE SMOOTH",
@@ -5127,6 +5279,15 @@ nodes = (
 "-63 -102 OFFCURVE",
 "35 -102 CURVE SMOOTH"
 );
+},
+{
+closed = 1;
+nodes = (
+"371 724 LINE",
+"371 754 LINE",
+"20 754 LINE",
+"20 724 LINE"
+);
 }
 );
 width = 386;
@@ -5138,7 +5299,7 @@ unicode = 004A;
 },
 {
 glyphname = Jcircumflex;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -5146,7 +5307,7 @@ components = (
 name = J;
 },
 {
-name = circumflex.cap;
+name = circumflex.case;
 transform = "{1, 0, 0, 1, 64, 0}";
 }
 );
@@ -5159,7 +5320,7 @@ components = (
 name = J;
 },
 {
-name = circumflex.cap;
+name = circumflex.case;
 transform = "{1, 0, 0, 1, -18, 0}";
 }
 );
@@ -5173,7 +5334,7 @@ unicode = 0134;
 },
 {
 glyphname = K;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -5238,54 +5399,54 @@ paths = (
 {
 closed = 1;
 nodes = (
-"13 729 LINE",
-"123 729 LINE",
-"123 25 LINE",
-"13 25 LINE",
-"13 0 LINE",
 "357 0 LINE",
 "357 25 LINE",
 "257 25 LINE",
 "257 729 LINE",
 "357 729 LINE",
 "357 754 LINE",
-"13 754 LINE"
+"13 754 LINE",
+"13 729 LINE",
+"123 729 LINE",
+"123 25 LINE",
+"13 25 LINE",
+"13 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"436 0 LINE",
 "784 0 LINE",
 "784 25 LINE",
-"436 25 LINE"
+"436 25 LINE",
+"436 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"555 15 LINE",
 "723 15 LINE",
 "362 469 LINE",
-"267 384 LINE"
+"267 384 LINE",
+"555 15 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"438 729 LINE",
+"612 736 LINE",
+"569 736 LINE",
+"235 361 LINE",
+"235 310 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "721 729 LINE",
 "721 754 LINE",
-"438 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"235 361 LINE",
-"235 310 LINE",
-"612 736 LINE",
-"569 736 LINE"
+"438 754 LINE",
+"438 729 LINE"
 );
 }
 );
@@ -5354,54 +5515,54 @@ paths = (
 {
 closed = 1;
 nodes = (
-"20 724 LINE",
-"115 724 LINE",
-"115 30 LINE",
-"20 30 LINE",
-"20 0 LINE",
 "371 0 LINE",
 "371 30 LINE",
 "273 30 LINE",
 "273 724 LINE",
 "371 724 LINE",
 "371 754 LINE",
-"20 754 LINE"
+"20 754 LINE",
+"20 724 LINE",
+"115 724 LINE",
+"115 30 LINE",
+"20 30 LINE",
+"20 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"440 0 LINE",
 "826 0 LINE",
 "826 31 LINE",
-"440 31 LINE"
+"440 31 LINE",
+"440 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"559 15 LINE",
 "757 15 LINE",
 "423 500 LINE",
-"298 385 LINE"
+"298 385 LINE",
+"559 15 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"482 724 LINE",
+"659 736 LINE",
+"613 736 LINE",
+"249 364 LINE",
+"249 314 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "765 724 LINE",
 "765 754 LINE",
-"482 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"249 364 LINE",
-"249 314 LINE",
-"659 736 LINE",
-"613 736 LINE"
+"482 754 LINE",
+"482 724 LINE"
 );
 }
 );
@@ -5414,7 +5575,7 @@ unicode = 004B;
 },
 {
 glyphname = Kcommaaccent;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 21:39:36 +0000";
 layers = (
 {
 components = (
@@ -5422,7 +5583,7 @@ components = (
 name = K;
 },
 {
-name = commaaccent;
+name = commaaccentcomb;
 transform = "{1, 0, 0, 1, 303, 0}";
 }
 );
@@ -5435,7 +5596,7 @@ components = (
 name = K;
 },
 {
-name = commaaccent;
+name = commaaccentcomb;
 transform = "{1, 0, 0, 1, 313, 0}";
 }
 );
@@ -5449,7 +5610,7 @@ unicode = 0136;
 },
 {
 glyphname = L;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -5492,32 +5653,32 @@ paths = (
 {
 closed = 1;
 nodes = (
-"131 15 LINE",
-"265 15 LINE",
-"265 754 LINE",
-"131 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"13 729 LINE",
-"386 729 LINE",
-"386 754 LINE",
-"13 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"13 0 LINE",
 "629 0 LINE",
 "629 235 LINE",
 "594 235 LINE",
 "592 123 OFFCURVE",
 "535 25 OFFCURVE",
 "436 25 CURVE SMOOTH",
-"13 25 LINE"
+"13 25 LINE",
+"13 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"265 15 LINE",
+"265 754 LINE",
+"131 754 LINE",
+"131 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"386 729 LINE",
+"386 754 LINE",
+"13 754 LINE",
+"13 729 LINE"
 );
 }
 );
@@ -5665,32 +5826,32 @@ paths = (
 {
 closed = 1;
 nodes = (
-"115 15 LINE",
-"273 15 LINE",
-"273 754 LINE",
-"115 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"20 724 LINE",
-"391 724 LINE",
-"391 754 LINE",
-"20 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"20 0 LINE",
 "661 0 LINE",
 "661 245 LINE",
 "621 245 LINE",
 "619 131 OFFCURVE",
 "554 30 OFFCURVE",
 "443 30 CURVE SMOOTH",
-"20 30 LINE"
+"20 30 LINE",
+"20 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"273 15 LINE",
+"273 754 LINE",
+"115 754 LINE",
+"115 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"391 724 LINE",
+"391 754 LINE",
+"20 754 LINE",
+"20 724 LINE"
 );
 }
 );
@@ -5702,8 +5863,8 @@ rightKerningGroup = L;
 unicode = 004C;
 },
 {
-glyphname = Lacute;
-lastChange = "2016-08-16 11:12:00 +0000";
+glyphname = LJ;
+lastChange = "2016-08-18 21:42:31 +0000";
 layers = (
 {
 components = (
@@ -5711,7 +5872,42 @@ components = (
 name = L;
 },
 {
-name = acute.cap;
+name = J;
+transform = "{1, 0, 0, 1, 662, 0}";
+}
+);
+layerId = UUID0;
+width = 1122;
+},
+{
+components = (
+{
+name = L;
+},
+{
+name = J;
+transform = "{1, 0, 0, 1, 681, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 1067;
+}
+);
+leftKerningGroup = L;
+rightKerningGroup = J;
+unicode = 01C7;
+},
+{
+glyphname = Lacute;
+lastChange = "2016-08-19 17:29:55 +0000";
+layers = (
+{
+components = (
+{
+name = L;
+},
+{
+name = acute.case;
 transform = "{1, 0, 0, 1, 53, 0}";
 }
 );
@@ -5724,7 +5920,7 @@ components = (
 name = L;
 },
 {
-name = acute.cap;
+name = acute.case;
 transform = "{1, 0, 0, 1, 125, 0}";
 }
 );
@@ -5772,7 +5968,7 @@ unicode = 013D;
 },
 {
 glyphname = Lcommaaccent;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 21:39:36 +0000";
 layers = (
 {
 components = (
@@ -5780,7 +5976,7 @@ components = (
 name = L;
 },
 {
-name = commaaccent;
+name = commaaccentcomb;
 transform = "{1, 0, 0, 1, 236, 0}";
 }
 );
@@ -5793,7 +5989,7 @@ components = (
 name = L;
 },
 {
-name = commaaccent;
+name = commaaccentcomb;
 transform = "{1, 0, 0, 1, 242, 0}";
 }
 );
@@ -5840,8 +6036,43 @@ leftKerningGroup = L;
 unicode = 013F;
 },
 {
+glyphname = Lj;
+lastChange = "2016-08-18 21:42:31 +0000";
+layers = (
+{
+components = (
+{
+name = L;
+},
+{
+name = j;
+transform = "{1, 0, 0, 1, 662, 0}";
+}
+);
+layerId = UUID0;
+width = 992;
+},
+{
+components = (
+{
+name = L;
+},
+{
+name = j;
+transform = "{1, 0, 0, 1, 681, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 999;
+}
+);
+leftKerningGroup = L;
+rightKerningGroup = j;
+unicode = 01C8;
+},
+{
 glyphname = Lslash;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 components = (
@@ -5854,10 +6085,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"28 237 LINE",
 "415 463 LINE",
 "415 503 LINE",
-"28 277 LINE"
+"28 277 LINE",
+"28 237 LINE"
 );
 }
 );
@@ -5874,10 +6105,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"28 237 LINE",
 "415 463 LINE",
 "415 503 LINE",
-"28 277 LINE"
+"28 277 LINE",
+"28 237 LINE"
 );
 }
 );
@@ -5888,7 +6119,7 @@ unicode = 0141;
 },
 {
 glyphname = M;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -5981,19 +6212,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"283 754 LINE",
-"12 754 LINE",
-"12 729 LINE",
-"122 729 LINE",
-"122 25 LINE",
-"12 25 LINE",
-"12 0 LINE",
-"271 0 LINE",
-"271 25 LINE",
-"161 25 LINE",
-"161 665 LINE",
-"165 665 LINE",
-"379 -9 LINE",
 "415 -9 LINE",
 "624 665 LINE",
 "628 665 LINE",
@@ -6008,7 +6226,20 @@ nodes = (
 "872 754 LINE",
 "609 754 LINE",
 "446 226 LINE",
-"442 226 LINE"
+"442 226 LINE",
+"283 754 LINE",
+"12 754 LINE",
+"12 729 LINE",
+"122 729 LINE",
+"122 25 LINE",
+"12 25 LINE",
+"12 0 LINE",
+"271 0 LINE",
+"271 25 LINE",
+"161 25 LINE",
+"161 665 LINE",
+"165 665 LINE",
+"379 -9 LINE"
 );
 }
 );
@@ -6383,19 +6614,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"336 754 LINE",
-"20 754 LINE",
-"20 724 LINE",
-"130 724 LINE",
-"130 30 LINE",
-"20 30 LINE",
-"20 0 LINE",
-"284 0 LINE",
-"284 30 LINE",
-"174 30 LINE",
-"174 684 LINE",
-"178 684 LINE",
-"392 -9 LINE",
 "433 -9 LINE",
 "646 684 LINE",
 "650 684 LINE",
@@ -6410,7 +6628,20 @@ nodes = (
 "912 754 LINE",
 "622 754 LINE",
 "481 299 LINE",
-"477 299 LINE"
+"477 299 LINE",
+"336 754 LINE",
+"20 754 LINE",
+"20 724 LINE",
+"130 724 LINE",
+"130 30 LINE",
+"20 30 LINE",
+"20 0 LINE",
+"284 0 LINE",
+"284 30 LINE",
+"174 30 LINE",
+"174 684 LINE",
+"178 684 LINE",
+"392 -9 LINE"
 );
 }
 );
@@ -6421,7 +6652,7 @@ unicode = 004D;
 },
 {
 glyphname = N;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -6492,6 +6723,11 @@ paths = (
 {
 closed = 1;
 nodes = (
+"633 -12 LINE",
+"633 729 LINE",
+"733 729 LINE",
+"733 754 LINE",
+"494 754 LINE",
 "494 729 LINE",
 "594 729 LINE",
 "594 268 LINE",
@@ -6508,12 +6744,7 @@ nodes = (
 "162 25 LINE",
 "162 683 LINE",
 "166 683 LINE",
-"602 -12 LINE",
-"633 -12 LINE",
-"633 729 LINE",
-"733 729 LINE",
-"733 754 LINE",
-"494 754 LINE"
+"602 -12 LINE"
 );
 }
 );
@@ -6758,6 +6989,11 @@ paths = (
 {
 closed = 1;
 nodes = (
+"676 -13 LINE",
+"676 724 LINE",
+"776 724 LINE",
+"776 754 LINE",
+"532 754 LINE",
 "532 724 LINE",
 "632 724 LINE",
 "632 309 LINE",
@@ -6774,12 +7010,7 @@ nodes = (
 "174 30 LINE",
 "174 641 LINE",
 "178 641 LINE",
-"632 -13 LINE",
-"676 -13 LINE",
-"676 724 LINE",
-"776 724 LINE",
-"776 754 LINE",
-"532 754 LINE"
+"632 -13 LINE"
 );
 }
 );
@@ -6791,8 +7022,8 @@ rightKerningGroup = N;
 unicode = 004E;
 },
 {
-glyphname = Nacute;
-lastChange = "2016-08-16 11:12:00 +0000";
+glyphname = NJ;
+lastChange = "2016-08-18 21:42:31 +0000";
 layers = (
 {
 components = (
@@ -6800,7 +7031,42 @@ components = (
 name = N;
 },
 {
-name = acute.cap;
+name = J;
+transform = "{1, 0, 0, 1, 744, 0}";
+}
+);
+layerId = UUID0;
+width = 1204;
+},
+{
+components = (
+{
+name = N;
+},
+{
+name = J;
+transform = "{1, 0, 0, 1, 791, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 1177;
+}
+);
+leftKerningGroup = N;
+rightKerningGroup = J;
+unicode = 01CA;
+},
+{
+glyphname = Nacute;
+lastChange = "2016-08-19 17:29:55 +0000";
+layers = (
+{
+components = (
+{
+name = N;
+},
+{
+name = acute.case;
 transform = "{1, 0, 0, 1, 251, 0}";
 }
 );
@@ -6813,7 +7079,7 @@ components = (
 name = N;
 },
 {
-name = acute.cap;
+name = acute.case;
 transform = "{1, 0, 0, 1, 254, 0}";
 }
 );
@@ -6827,7 +7093,7 @@ unicode = 0143;
 },
 {
 glyphname = Ncaron;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -6835,7 +7101,7 @@ components = (
 name = N;
 },
 {
-name = caron.cap;
+name = caron.case;
 transform = "{1, 0, 0, 1, 206, 0}";
 }
 );
@@ -6848,7 +7114,7 @@ components = (
 name = N;
 },
 {
-name = caron.cap;
+name = caron.case;
 transform = "{1, 0, 0, 1, 209, 0}";
 }
 );
@@ -6862,7 +7128,7 @@ unicode = 0147;
 },
 {
 glyphname = Ncommaaccent;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 21:39:36 +0000";
 layers = (
 {
 components = (
@@ -6870,7 +7136,7 @@ components = (
 name = N;
 },
 {
-name = commaaccent;
+name = commaaccentcomb;
 transform = "{1, 0, 0, 1, 292, 0}";
 }
 );
@@ -6883,7 +7149,7 @@ components = (
 name = N;
 },
 {
-name = commaaccent;
+name = commaaccentcomb;
 transform = "{1, 0, 0, 1, 323, 0}";
 }
 );
@@ -6897,7 +7163,7 @@ unicode = 0145;
 },
 {
 glyphname = Ndotaccent;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -6905,7 +7171,7 @@ components = (
 name = N;
 },
 {
-name = dotaccent.cap;
+name = dotaccent.case;
 transform = "{1, 0, 0, 1, 303, 0}";
 }
 );
@@ -6918,7 +7184,7 @@ components = (
 name = N;
 },
 {
-name = dotaccent.cap;
+name = dotaccent.case;
 transform = "{1, 0, 0, 1, 346, 0}";
 }
 );
@@ -6932,7 +7198,7 @@ unicode = 1E44;
 },
 {
 glyphname = Eng;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -7022,7 +7288,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"513 -157 LINE SMOOTH",
 "574 -157 OFFCURVE",
 "635 -127 OFFCURVE",
 "635 76 CURVE SMOOTH",
@@ -7065,7 +7330,8 @@ nodes = (
 "392 -54 CURVE SMOOTH",
 "392 -112 OFFCURVE",
 "438 -157 OFFCURVE",
-"513 -157 CURVE SMOOTH"
+"513 -157 CURVE SMOOTH",
+"513 -157 LINE SMOOTH"
 );
 }
 );
@@ -7168,7 +7434,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"536 -170 LINE",
 "642 -170 OFFCURVE",
 "676 -102 OFFCURVE",
 "676 20 CURVE SMOOTH",
@@ -7211,7 +7476,8 @@ nodes = (
 "402 -67 CURVE SMOOTH",
 "402 -128 OFFCURVE",
 "452 -170 OFFCURVE",
-"536 -170 CURVE SMOOTH"
+"536 -170 CURVE SMOOTH",
+"536 -170 LINE"
 );
 }
 );
@@ -7222,8 +7488,8 @@ leftKerningGroup = N;
 unicode = 014A;
 },
 {
-glyphname = Ntilde;
-lastChange = "2016-08-16 11:12:00 +0000";
+glyphname = Nj;
+lastChange = "2016-08-18 21:42:31 +0000";
 layers = (
 {
 components = (
@@ -7231,7 +7497,42 @@ components = (
 name = N;
 },
 {
-name = tilde.cap;
+name = j;
+transform = "{1, 0, 0, 1, 744, 0}";
+}
+);
+layerId = UUID0;
+width = 1074;
+},
+{
+components = (
+{
+name = N;
+},
+{
+name = j;
+transform = "{1, 0, 0, 1, 791, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 1109;
+}
+);
+leftKerningGroup = N;
+rightKerningGroup = j;
+unicode = 01CB;
+},
+{
+glyphname = Ntilde;
+lastChange = "2016-08-19 17:29:55 +0000";
+layers = (
+{
+components = (
+{
+name = N;
+},
+{
+name = tilde.case;
 transform = "{1, 0, 0, 1, 199, 0}";
 }
 );
@@ -7244,7 +7545,7 @@ components = (
 name = N;
 },
 {
-name = tilde.cap;
+name = tilde.case;
 transform = "{1, 0, 0, 1, 219, 0}";
 }
 );
@@ -7258,7 +7559,7 @@ unicode = 00D1;
 },
 {
 glyphname = O;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 16:39:23 +0000";
 layers = (
 {
 background = {
@@ -7304,7 +7605,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"391 -12 LINE",
 "585 -12 OFFCURVE",
 "738 169 OFFCURVE",
 "738 377 CURVE SMOOTH",
@@ -7322,7 +7622,6 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"391 18 LINE",
 "255 18 OFFCURVE",
 "204 91 OFFCURVE",
 "204 377 CURVE SMOOTH",
@@ -7582,7 +7881,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"411 -13 LINE",
 "620 -13 OFFCURVE",
 "783 173 OFFCURVE",
 "783 378 CURVE SMOOTH",
@@ -7600,7 +7898,6 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"410 22 LINE",
 "278 22 OFFCURVE",
 "230 88 OFFCURVE",
 "230 378 CURVE SMOOTH",
@@ -7625,7 +7922,7 @@ unicode = 004F;
 },
 {
 glyphname = Oacute;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -7633,7 +7930,7 @@ components = (
 name = O;
 },
 {
-name = acute.cap;
+name = acute.case;
 transform = "{1, 0, 0, 1, 255, 0}";
 }
 );
@@ -7646,7 +7943,7 @@ components = (
 name = O;
 },
 {
-name = acute.cap;
+name = acute.case;
 transform = "{1, 0, 0, 1, 263, 0}";
 }
 );
@@ -7660,7 +7957,7 @@ unicode = 00D3;
 },
 {
 glyphname = Obreve;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -7668,7 +7965,7 @@ components = (
 name = O;
 },
 {
-name = breve.cap;
+name = breve.case;
 transform = "{1, 0, 0, 1, 229, 0}";
 }
 );
@@ -7681,7 +7978,7 @@ components = (
 name = O;
 },
 {
-name = breve.cap;
+name = breve.case;
 transform = "{1, 0, 0, 1, 239, 0}";
 }
 );
@@ -7695,7 +7992,7 @@ unicode = 014E;
 },
 {
 glyphname = Ocircumflex;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -7703,7 +8000,7 @@ components = (
 name = O;
 },
 {
-name = circumflex.cap;
+name = circumflex.case;
 transform = "{1, 0, 0, 1, 224, 0}";
 }
 );
@@ -7716,7 +8013,7 @@ components = (
 name = O;
 },
 {
-name = circumflex.cap;
+name = circumflex.case;
 transform = "{1, 0, 0, 1, 198, 0}";
 }
 );
@@ -7730,7 +8027,7 @@ unicode = 00D4;
 },
 {
 glyphname = Odblgrave;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 21:39:36 +0000";
 layers = (
 {
 components = (
@@ -7738,7 +8035,7 @@ components = (
 name = O;
 },
 {
-name = uni030F.cap;
+name = dblgravecomb.cap;
 transform = "{1, 0, 0, 1, 178, 0}";
 }
 );
@@ -7751,7 +8048,7 @@ components = (
 name = O;
 },
 {
-name = uni030F.cap;
+name = dblgravecomb.cap;
 transform = "{1, 0, 0, 1, 132, 0}";
 }
 );
@@ -7765,7 +8062,7 @@ unicode = 020C;
 },
 {
 glyphname = Odieresis;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -7773,7 +8070,7 @@ components = (
 name = O;
 },
 {
-name = dieresis.cap;
+name = dieresis.case;
 transform = "{1, 0, 0, 1, 232, 0}";
 }
 );
@@ -7786,7 +8083,7 @@ components = (
 name = O;
 },
 {
-name = dieresis.cap;
+name = dieresis.case;
 transform = "{1, 0, 0, 1, 243, 0}";
 }
 );
@@ -7835,7 +8132,7 @@ unicode = 1ECC;
 },
 {
 glyphname = Ograve;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -7843,7 +8140,7 @@ components = (
 name = O;
 },
 {
-name = grave.cap;
+name = grave.case;
 transform = "{1, 0, 0, 1, 258, 0}";
 }
 );
@@ -7856,7 +8153,7 @@ components = (
 name = O;
 },
 {
-name = grave.cap;
+name = grave.case;
 transform = "{1, 0, 0, 1, 274, 0}";
 }
 );
@@ -7870,7 +8167,7 @@ unicode = 00D2;
 },
 {
 glyphname = Ohungarumlaut;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -7878,7 +8175,7 @@ components = (
 name = O;
 },
 {
-name = hungarumlaut.cap;
+name = hungarumlaut.case;
 transform = "{1, 0, 0, 1, 182, 0}";
 }
 );
@@ -7891,7 +8188,7 @@ components = (
 name = O;
 },
 {
-name = hungarumlaut.cap;
+name = hungarumlaut.case;
 transform = "{1, 0, 0, 1, 185, 0}";
 }
 );
@@ -7905,7 +8202,7 @@ unicode = 0150;
 },
 {
 glyphname = Oinvertedbreve;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 21:39:36 +0000";
 layers = (
 {
 components = (
@@ -7913,7 +8210,7 @@ components = (
 name = O;
 },
 {
-name = uni0311.cap;
+name = breveinvertedcomb.cap;
 transform = "{1, 0, 0, 1, 229, 0}";
 }
 );
@@ -7926,7 +8223,7 @@ components = (
 name = O;
 },
 {
-name = uni0311.cap;
+name = breveinvertedcomb.cap;
 transform = "{1, 0, 0, 1, 243, 0}";
 }
 );
@@ -7940,7 +8237,7 @@ unicode = 020E;
 },
 {
 glyphname = Omacron;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -7948,7 +8245,7 @@ components = (
 name = O;
 },
 {
-name = macron.cap;
+name = macron.case;
 transform = "{1, 0, 0, 1, 226, 0}";
 }
 );
@@ -7961,7 +8258,7 @@ components = (
 name = O;
 },
 {
-name = macron.cap;
+name = macron.case;
 transform = "{1, 0, 0, 1, 240, 0}";
 }
 );
@@ -8010,11 +8307,28 @@ unicode = 01EA;
 },
 {
 glyphname = Oslash;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
 paths = (
+{
+closed = 1;
+nodes = (
+"570 -13 OFFCURVE",
+"723 172 OFFCURVE",
+"723 380 CURVE SMOOTH",
+"723 582 OFFCURVE",
+"570 763 OFFCURVE",
+"376 763 CURVE SMOOTH",
+"182 763 OFFCURVE",
+"30 582 OFFCURVE",
+"30 380 CURVE SMOOTH",
+"30 172 OFFCURVE",
+"182 -13 OFFCURVE",
+"376 -13 CURVE SMOOTH"
+);
+},
 {
 closed = 1;
 nodes = (
@@ -8027,25 +8341,9 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"30 380 LINE SMOOTH",
-"30 172 OFFCURVE",
-"182 -13 OFFCURVE",
-"376 -13 CURVE SMOOTH",
-"570 -13 OFFCURVE",
-"723 172 OFFCURVE",
-"723 380 CURVE SMOOTH",
-"723 582 OFFCURVE",
-"570 763 OFFCURVE",
-"376 763 CURVE SMOOTH",
-"182 763 OFFCURVE",
-"30 582 OFFCURVE",
-"30 380 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"190 380 LINE SMOOTH",
+"239 17 OFFCURVE",
+"190 85 OFFCURVE",
+"190 380 CURVE SMOOTH",
 "190 666 OFFCURVE",
 "239 733 OFFCURVE",
 "375 733 CURVE SMOOTH",
@@ -8054,10 +8352,7 @@ nodes = (
 "563 378 CURVE SMOOTH",
 "563 86 OFFCURVE",
 "513 17 OFFCURVE",
-"376 17 CURVE SMOOTH",
-"239 17 OFFCURVE",
-"190 85 OFFCURVE",
-"190 380 CURVE SMOOTH"
+"376 17 CURVE SMOOTH"
 );
 }
 );
@@ -8066,6 +8361,23 @@ width = 753;
 {
 layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
 paths = (
+{
+closed = 1;
+nodes = (
+"620 -13 OFFCURVE",
+"783 173 OFFCURVE",
+"783 378 CURVE SMOOTH",
+"783 583 OFFCURVE",
+"620 763 OFFCURVE",
+"411 763 CURVE SMOOTH",
+"202 763 OFFCURVE",
+"40 583 OFFCURVE",
+"40 378 CURVE SMOOTH",
+"40 173 OFFCURVE",
+"202 -13 OFFCURVE",
+"411 -13 CURVE SMOOTH"
+);
+},
 {
 closed = 1;
 nodes = (
@@ -8078,25 +8390,9 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"40 378 LINE SMOOTH",
-"40 173 OFFCURVE",
-"202 -13 OFFCURVE",
-"411 -13 CURVE SMOOTH",
-"620 -13 OFFCURVE",
-"783 173 OFFCURVE",
-"783 378 CURVE SMOOTH",
-"783 583 OFFCURVE",
-"620 763 OFFCURVE",
-"411 763 CURVE SMOOTH",
-"202 763 OFFCURVE",
-"40 583 OFFCURVE",
-"40 378 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"230 378 LINE SMOOTH",
+"278 22 OFFCURVE",
+"230 88 OFFCURVE",
+"230 378 CURVE SMOOTH",
 "230 661 OFFCURVE",
 "276 728 OFFCURVE",
 "410 728 CURVE SMOOTH",
@@ -8105,10 +8401,7 @@ nodes = (
 "593 376 CURVE SMOOTH",
 "593 91 OFFCURVE",
 "545 22 OFFCURVE",
-"410 22 CURVE SMOOTH",
-"278 22 OFFCURVE",
-"230 88 OFFCURVE",
-"230 378 CURVE SMOOTH"
+"410 22 CURVE SMOOTH"
 );
 }
 );
@@ -8119,16 +8412,15 @@ unicode = 00D8;
 },
 {
 glyphname = Oslashacute;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
 {
 name = Oslash;
-transform = "{1, 0, 0, 1, 13, 0}";
 },
 {
-name = acute.cap;
+name = acute.case;
 transform = "{1, 0, 0, 1, 246, 0}";
 }
 );
@@ -8141,7 +8433,7 @@ components = (
 name = Oslash;
 },
 {
-name = acute.cap;
+name = acute.case;
 transform = "{1, 0, 0, 1, 275, 0}";
 }
 );
@@ -8153,7 +8445,7 @@ unicode = 01FE;
 },
 {
 glyphname = Otilde;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -8161,7 +8453,7 @@ components = (
 name = O;
 },
 {
-name = tilde.cap;
+name = tilde.case;
 transform = "{1, 0, 0, 1, 209, 0}";
 }
 );
@@ -8174,7 +8466,7 @@ components = (
 name = O;
 },
 {
-name = tilde.cap;
+name = tilde.case;
 transform = "{1, 0, 0, 1, 207, 0}";
 }
 );
@@ -8188,7 +8480,7 @@ unicode = 00D5;
 },
 {
 glyphname = OE;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -8289,7 +8581,9 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"190 380 LINE SMOOTH",
+"239 30 OFFCURVE",
+"190 96 OFFCURVE",
+"190 380 CURVE SMOOTH",
 "190 659 OFFCURVE",
 "239 724 OFFCURVE",
 "375 724 CURVE SMOOTH",
@@ -8298,10 +8592,7 @@ nodes = (
 "543 367 CURVE SMOOTH",
 "543 94 OFFCURVE",
 "490 30 OFFCURVE",
-"376 30 CURVE SMOOTH",
-"239 30 OFFCURVE",
-"190 96 OFFCURVE",
-"190 380 CURVE SMOOTH"
+"376 30 CURVE SMOOTH"
 );
 }
 );
@@ -8406,7 +8697,9 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"230 378 LINE SMOOTH",
+"278 35 OFFCURVE",
+"230 99 OFFCURVE",
+"230 378 CURVE SMOOTH",
 "230 654 OFFCURVE",
 "276 719 OFFCURVE",
 "410 719 CURVE SMOOTH",
@@ -8415,10 +8708,7 @@ nodes = (
 "593 376 CURVE SMOOTH",
 "593 102 OFFCURVE",
 "545 35 OFFCURVE",
-"410 35 CURVE SMOOTH",
-"278 35 OFFCURVE",
-"230 99 OFFCURVE",
-"230 378 CURVE SMOOTH"
+"410 35 CURVE SMOOTH"
 );
 }
 );
@@ -8431,7 +8721,7 @@ unicode = 0152;
 },
 {
 glyphname = P;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -8484,24 +8774,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"121 15 LINE",
-"255 15 LINE",
-"255 754 LINE",
-"121 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"11 0 LINE",
-"385 0 LINE",
-"385 25 LINE",
-"11 25 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
 "307 342 LINE SMOOTH",
 "522 342 OFFCURVE",
 "652 427 OFFCURVE",
@@ -8520,6 +8792,24 @@ nodes = (
 "307 372 CURVE SMOOTH",
 "224 372 LINE",
 "224 342 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"385 0 LINE",
+"385 25 LINE",
+"11 25 LINE",
+"11 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"255 15 LINE",
+"255 754 LINE",
+"121 754 LINE",
+"121 15 LINE"
 );
 }
 );
@@ -8576,24 +8866,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"115 15 LINE",
-"273 15 LINE",
-"273 754 LINE",
-"115 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"20 0 LINE",
-"391 0 LINE",
-"391 30 LINE",
-"20 30 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
 "350 342 LINE SMOOTH",
 "565 342 OFFCURVE",
 "695 427 OFFCURVE",
@@ -8613,6 +8885,24 @@ nodes = (
 "267 372 LINE",
 "267 342 LINE"
 );
+},
+{
+closed = 1;
+nodes = (
+"391 0 LINE",
+"391 30 LINE",
+"20 30 LINE",
+"20 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"273 15 LINE",
+"273 754 LINE",
+"115 754 LINE",
+"115 15 LINE"
+);
 }
 );
 width = 700;
@@ -8623,7 +8913,7 @@ unicode = 0050;
 },
 {
 glyphname = Thorn;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -8631,7 +8921,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"17 0 LINE",
 "391 0 LINE",
 "391 25 LINE",
 "261 25 LINE",
@@ -8651,13 +8940,13 @@ nodes = (
 "17 728 LINE",
 "127 728 LINE",
 "127 25 LINE",
-"17 25 LINE"
+"17 25 LINE",
+"17 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"261 209 LINE",
 "261 566 LINE",
 "363 566 LINE SMOOTH",
 "456 566 OFFCURVE",
@@ -8665,7 +8954,8 @@ nodes = (
 "503 395 CURVE SMOOTH",
 "503 242 OFFCURVE",
 "449 209 OFFCURVE",
-"313 209 CURVE SMOOTH"
+"313 209 CURVE SMOOTH",
+"261 209 LINE"
 );
 }
 );
@@ -8677,7 +8967,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"20 0 LINE",
 "391 0 LINE",
 "391 30 LINE",
 "273 30 LINE",
@@ -8697,13 +8986,13 @@ nodes = (
 "20 724 LINE",
 "115 724 LINE",
 "115 30 LINE",
-"20 30 LINE"
+"20 30 LINE",
+"20 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"273 211 LINE",
 "273 563 LINE",
 "390 563 LINE SMOOTH",
 "465 563 OFFCURVE",
@@ -8711,7 +9000,8 @@ nodes = (
 "505 394 CURVE SMOOTH",
 "505 244 OFFCURVE",
 "460 211 OFFCURVE",
-"350 211 CURVE SMOOTH"
+"350 211 CURVE SMOOTH",
+"273 211 LINE"
 );
 }
 );
@@ -8722,7 +9012,7 @@ unicode = 00DE;
 },
 {
 glyphname = Q;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 16:40:06 +0000";
 layers = (
 {
 background = {
@@ -8784,7 +9074,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"391 -12 LINE SMOOTH",
 "585 -12 OFFCURVE",
 "738 169 OFFCURVE",
 "738 377 CURVE SMOOTH",
@@ -8818,7 +9107,6 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"391 18 LINE",
 "255 18 OFFCURVE",
 "205 91 OFFCURVE",
 "205 377 CURVE SMOOTH",
@@ -8896,7 +9184,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"411 -13 LINE SMOOTH",
 "620 -13 OFFCURVE",
 "783 173 OFFCURVE",
 "783 378 CURVE SMOOTH",
@@ -8930,7 +9217,6 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"410 22 LINE SMOOTH",
 "278 22 OFFCURVE",
 "230 88 OFFCURVE",
 "230 378 CURVE SMOOTH",
@@ -8954,7 +9240,7 @@ unicode = 0051;
 },
 {
 glyphname = R;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -9032,15 +9318,14 @@ paths = (
 {
 closed = 1;
 nodes = (
-"123 15 LINE",
-"257 15 LINE",
-"257 754 LINE",
-"123 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"309 387 LINE SMOOTH",
+"513 387 OFFCURVE",
+"634 466 OFFCURVE",
+"634 582 CURVE SMOOTH",
+"634 691 OFFCURVE",
+"529 754 OFFCURVE",
+"399 754 CURVE SMOOTH",
+"13 754 LINE",
 "13 729 LINE",
 "359 729 LINE SMOOTH",
 "440 729 OFFCURVE",
@@ -9050,24 +9335,25 @@ nodes = (
 "429 417 OFFCURVE",
 "309 417 CURVE SMOOTH",
 "226 417 LINE",
-"226 387 LINE",
-"309 387 LINE SMOOTH",
-"513 387 OFFCURVE",
-"634 466 OFFCURVE",
-"634 582 CURVE SMOOTH",
-"634 691 OFFCURVE",
-"529 754 OFFCURVE",
-"399 754 CURVE SMOOTH",
-"13 754 LINE"
+"226 387 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"13 0 LINE",
 "387 0 LINE",
 "387 25 LINE",
-"13 25 LINE"
+"13 25 LINE",
+"13 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"257 15 LINE",
+"257 754 LINE",
+"123 754 LINE",
+"123 15 LINE"
 );
 },
 {
@@ -9174,15 +9460,14 @@ paths = (
 {
 closed = 1;
 nodes = (
-"115 15 LINE",
-"273 15 LINE",
-"273 754 LINE",
-"115 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"350 392 LINE SMOOTH",
+"553 392 OFFCURVE",
+"675 459 OFFCURVE",
+"675 582 CURVE SMOOTH",
+"675 691 OFFCURVE",
+"563 754 OFFCURVE",
+"420 754 CURVE SMOOTH",
+"20 754 LINE",
 "20 724 LINE",
 "370 724 LINE SMOOTH",
 "445 724 OFFCURVE",
@@ -9192,24 +9477,25 @@ nodes = (
 "446 422 OFFCURVE",
 "350 422 CURVE SMOOTH",
 "267 422 LINE",
-"267 392 LINE",
-"350 392 LINE SMOOTH",
-"553 392 OFFCURVE",
-"675 459 OFFCURVE",
-"675 582 CURVE SMOOTH",
-"675 691 OFFCURVE",
-"563 754 OFFCURVE",
-"420 754 CURVE SMOOTH",
-"20 754 LINE"
+"267 392 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"20 0 LINE",
 "391 0 LINE",
 "391 30 LINE",
-"20 30 LINE"
+"20 30 LINE",
+"20 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"273 15 LINE",
+"273 754 LINE",
+"115 754 LINE",
+"115 15 LINE"
 );
 },
 {
@@ -9247,7 +9533,7 @@ unicode = 0052;
 },
 {
 glyphname = Racute;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -9255,7 +9541,7 @@ components = (
 name = R;
 },
 {
-name = acute.cap;
+name = acute.case;
 transform = "{1, 0, 0, 1, 193, 0}";
 }
 );
@@ -9268,7 +9554,7 @@ components = (
 name = R;
 },
 {
-name = acute.cap;
+name = acute.case;
 transform = "{1, 0, 0, 1, 193, 0}";
 }
 );
@@ -9282,7 +9568,7 @@ unicode = 0154;
 },
 {
 glyphname = Rcaron;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -9290,7 +9576,7 @@ components = (
 name = R;
 },
 {
-name = caron.cap;
+name = caron.case;
 transform = "{1, 0, 0, 1, 166, 0}";
 }
 );
@@ -9303,7 +9589,7 @@ components = (
 name = R;
 },
 {
-name = caron.cap;
+name = caron.case;
 transform = "{1, 0, 0, 1, 146, 0}";
 }
 );
@@ -9317,7 +9603,7 @@ unicode = 0158;
 },
 {
 glyphname = Rcommaaccent;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 21:39:36 +0000";
 layers = (
 {
 components = (
@@ -9325,7 +9611,7 @@ components = (
 name = R;
 },
 {
-name = commaaccent;
+name = commaaccentcomb;
 transform = "{1, 0, 0, 1, 278, 0}";
 }
 );
@@ -9338,7 +9624,7 @@ components = (
 name = R;
 },
 {
-name = commaaccent;
+name = commaaccentcomb;
 transform = "{1, 0, 0, 1, 277, 0}";
 }
 );
@@ -9352,7 +9638,7 @@ unicode = 0156;
 },
 {
 glyphname = Rdblgrave;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 21:39:36 +0000";
 layers = (
 {
 components = (
@@ -9360,7 +9646,7 @@ components = (
 name = R;
 },
 {
-name = uni030F.cap;
+name = dblgravecomb.cap;
 transform = "{1, 0, 0, 1, 90, 0}";
 }
 );
@@ -9373,7 +9659,7 @@ components = (
 name = R;
 },
 {
-name = uni030F.cap;
+name = dblgravecomb.cap;
 transform = "{1, 0, 0, 1, 65, 0}";
 }
 );
@@ -9422,7 +9708,7 @@ unicode = 1E5A;
 },
 {
 glyphname = Rinvertedbreve;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 21:39:36 +0000";
 layers = (
 {
 components = (
@@ -9430,7 +9716,7 @@ components = (
 name = R;
 },
 {
-name = uni0311.cap;
+name = breveinvertedcomb.cap;
 transform = "{1, 0, 0, 1, 168, 0}";
 }
 );
@@ -9443,7 +9729,7 @@ components = (
 name = R;
 },
 {
-name = uni0311.cap;
+name = breveinvertedcomb.cap;
 transform = "{1, 0, 0, 1, 182, 0}";
 }
 );
@@ -9457,7 +9743,7 @@ unicode = 0212;
 },
 {
 glyphname = S;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -9518,10 +9804,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"115 47 LINE",
-"164 8 OFFCURVE",
-"211 -12 OFFCURVE",
-"283 -12 CURVE SMOOTH",
 "438 -12 OFFCURVE",
 "524 81 OFFCURVE",
 "524 232 CURVE SMOOTH",
@@ -9561,7 +9843,11 @@ nodes = (
 "80 210 CURVE",
 "54 210 LINE",
 "54 0 LINE",
-"79 0 LINE"
+"79 0 LINE",
+"115 47 LINE",
+"164 8 OFFCURVE",
+"211 -12 OFFCURVE",
+"283 -12 CURVE SMOOTH"
 );
 }
 );
@@ -9836,10 +10122,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"112 48 LINE",
-"161 12 OFFCURVE",
-"216 -13 OFFCURVE",
-"298 -13 CURVE SMOOTH",
 "457 -13 OFFCURVE",
 "544 80 OFFCURVE",
 "544 237 CURVE SMOOTH",
@@ -9879,7 +10161,11 @@ nodes = (
 "66 210 CURVE",
 "35 210 LINE",
 "35 0 LINE",
-"65 0 LINE"
+"65 0 LINE",
+"112 48 LINE",
+"161 12 OFFCURVE",
+"216 -13 OFFCURVE",
+"298 -13 CURVE SMOOTH"
 );
 }
 );
@@ -9892,7 +10178,7 @@ unicode = 0053;
 },
 {
 glyphname = Sacute;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -9900,7 +10186,7 @@ components = (
 name = S;
 },
 {
-name = acute.cap;
+name = acute.case;
 transform = "{1, 0, 0, 1, 138, 0}";
 }
 );
@@ -9913,7 +10199,7 @@ components = (
 name = S;
 },
 {
-name = acute.cap;
+name = acute.case;
 transform = "{1, 0, 0, 1, 120, 0}";
 }
 );
@@ -9927,7 +10213,7 @@ unicode = 015A;
 },
 {
 glyphname = Scaron;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -9935,7 +10221,7 @@ components = (
 name = S;
 },
 {
-name = caron.cap;
+name = caron.case;
 transform = "{1, 0, 0, 1, 119, 0}";
 }
 );
@@ -9948,7 +10234,7 @@ components = (
 name = S;
 },
 {
-name = caron.cap;
+name = caron.case;
 transform = "{1, 0, 0, 1, 65, 0}";
 }
 );
@@ -9961,8 +10247,8 @@ rightKerningGroup = S;
 unicode = 0160;
 },
 {
-glyphname = Scircumflex;
-lastChange = "2016-08-16 11:12:00 +0000";
+glyphname = Scedilla;
+lastChange = "2016-08-18 21:39:28 +0000";
 layers = (
 {
 components = (
@@ -9970,7 +10256,42 @@ components = (
 name = S;
 },
 {
-name = circumflex.cap;
+name = cedilla;
+transform = "{1, 0, 0, 1, 153, 0}";
+}
+);
+layerId = UUID0;
+width = 574;
+},
+{
+components = (
+{
+name = S;
+},
+{
+name = cedilla;
+transform = "{1, 0, 0, 1, 163, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 569;
+}
+);
+leftKerningGroup = S;
+rightKerningGroup = S;
+unicode = 015E;
+},
+{
+glyphname = Scircumflex;
+lastChange = "2016-08-19 17:29:55 +0000";
+layers = (
+{
+components = (
+{
+name = S;
+},
+{
+name = circumflex.case;
 transform = "{1, 0, 0, 1, 120, 0}";
 }
 );
@@ -9983,7 +10304,7 @@ components = (
 name = S;
 },
 {
-name = circumflex.cap;
+name = circumflex.case;
 transform = "{1, 0, 0, 1, 69, 0}";
 }
 );
@@ -9994,6 +10315,41 @@ width = 569;
 leftKerningGroup = S;
 rightKerningGroup = S;
 unicode = 015C;
+},
+{
+glyphname = Scommaaccent;
+lastChange = "2016-08-18 21:39:36 +0000";
+layers = (
+{
+components = (
+{
+name = S;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 200, 0}";
+}
+);
+layerId = UUID0;
+width = 574;
+},
+{
+components = (
+{
+name = S;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 208, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 569;
+}
+);
+leftKerningGroup = S;
+rightKerningGroup = S;
+unicode = 0218;
 },
 {
 glyphname = Sdotbelow;
@@ -10032,7 +10388,7 @@ unicode = 1E62;
 },
 {
 glyphname = Schwa;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -10040,14 +10396,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"215 309 LINE",
-"596 309 LINE",
-"596 343 LINE",
-"52 343 LINE",
-"52 333 LINE SMOOTH",
-"52 120 OFFCURVE",
-"206 -13 OFFCURVE",
-"377 -13 CURVE SMOOTH",
 "587 -13 OFFCURVE",
 "723 187 OFFCURVE",
 "723 378 CURVE SMOOTH",
@@ -10069,7 +10417,15 @@ nodes = (
 "380 17 CURVE SMOOTH",
 "269 17 OFFCURVE",
 "215 69 OFFCURVE",
-"215 183 CURVE SMOOTH"
+"215 183 CURVE SMOOTH",
+"215 309 LINE",
+"596 309 LINE",
+"596 343 LINE",
+"52 343 LINE",
+"52 333 LINE SMOOTH",
+"52 120 OFFCURVE",
+"206 -13 OFFCURVE",
+"377 -13 CURVE SMOOTH"
 );
 }
 );
@@ -10081,14 +10437,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"223 309 LINE",
-"604 309 LINE",
-"604 348 LINE",
-"40 348 LINE",
-"40 333 LINE SMOOTH",
-"40 120 OFFCURVE",
-"204 -13 OFFCURVE",
-"385 -13 CURVE SMOOTH",
 "611 -13 OFFCURVE",
 "755 187 OFFCURVE",
 "755 378 CURVE SMOOTH",
@@ -10110,7 +10458,15 @@ nodes = (
 "388 21 CURVE SMOOTH",
 "277 21 OFFCURVE",
 "223 73 OFFCURVE",
-"223 183 CURVE SMOOTH"
+"223 183 CURVE SMOOTH",
+"223 309 LINE",
+"604 309 LINE",
+"604 348 LINE",
+"40 348 LINE",
+"40 333 LINE SMOOTH",
+"40 120 OFFCURVE",
+"204 -13 OFFCURVE",
+"385 -13 CURVE SMOOTH"
 );
 }
 );
@@ -10121,7 +10477,7 @@ unicode = 018F;
 },
 {
 glyphname = T;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -10158,7 +10514,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"160 0 LINE",
 "554 0 LINE",
 "554 25 LINE",
 "424 25 LINE",
@@ -10177,7 +10532,8 @@ nodes = (
 "214 729 CURVE",
 "290 729 LINE",
 "290 25 LINE",
-"160 25 LINE"
+"160 25 LINE",
+"160 0 LINE"
 );
 }
 );
@@ -10218,7 +10574,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"158 0 LINE",
 "559 0 LINE",
 "559 30 LINE",
 "441 30 LINE",
@@ -10237,7 +10592,8 @@ nodes = (
 "233 724 CURVE SMOOTH",
 "283 724 LINE",
 "283 30 LINE",
-"158 30 LINE"
+"158 30 LINE",
+"158 0 LINE"
 );
 }
 );
@@ -10250,7 +10606,7 @@ unicode = 0054;
 },
 {
 glyphname = Tbar;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 components = (
@@ -10263,10 +10619,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"148 416 LINE",
 "563 416 LINE",
 "563 451 LINE",
-"148 451 LINE"
+"148 451 LINE",
+"148 416 LINE"
 );
 }
 );
@@ -10283,10 +10639,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"148 416 LINE",
 "563 416 LINE",
 "563 451 LINE",
-"148 451 LINE"
+"148 451 LINE",
+"148 416 LINE"
 );
 }
 );
@@ -10297,7 +10653,7 @@ unicode = 0166;
 },
 {
 glyphname = Tcaron;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -10305,7 +10661,7 @@ components = (
 name = T;
 },
 {
-name = caron.cap;
+name = caron.case;
 transform = "{1, 0, 0, 1, 185, 0}";
 }
 );
@@ -10318,7 +10674,7 @@ components = (
 name = T;
 },
 {
-name = caron.cap;
+name = caron.case;
 transform = "{1, 0, 0, 1, 152, 0}";
 }
 );
@@ -10329,6 +10685,76 @@ width = 724;
 leftKerningGroup = T;
 rightKerningGroup = T;
 unicode = 0164;
+},
+{
+glyphname = Tcedilla;
+lastChange = "2016-08-18 21:39:28 +0000";
+layers = (
+{
+components = (
+{
+name = T;
+},
+{
+name = cedilla;
+transform = "{1, 0, 0, 1, 239, 0}";
+}
+);
+layerId = UUID0;
+width = 705;
+},
+{
+components = (
+{
+name = T;
+},
+{
+name = cedilla;
+transform = "{1, 0, 0, 1, 246, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 724;
+}
+);
+leftKerningGroup = T;
+rightKerningGroup = T;
+unicode = 0162;
+},
+{
+glyphname = Tcommaaccent;
+lastChange = "2016-08-18 21:39:36 +0000";
+layers = (
+{
+components = (
+{
+name = T;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 269, 0}";
+}
+);
+layerId = UUID0;
+width = 705;
+},
+{
+components = (
+{
+name = T;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 267, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 724;
+}
+);
+leftKerningGroup = T;
+rightKerningGroup = T;
+unicode = 021A;
 },
 {
 glyphname = Tdotbelow;
@@ -10367,7 +10793,7 @@ unicode = 1E6C;
 },
 {
 glyphname = U;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -10410,12 +10836,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"6 729 LINE",
-"123 729 LINE",
-"123 195 LINE SMOOTH",
-"123 54 OFFCURVE",
-"227 -12 OFFCURVE",
-"387 -12 CURVE SMOOTH",
 "545 -12 OFFCURVE",
 "625 53 OFFCURVE",
 "625 196 CURVE SMOOTH",
@@ -10435,7 +10855,13 @@ nodes = (
 "257 729 LINE",
 "352 729 LINE",
 "352 754 LINE",
-"6 754 LINE"
+"6 754 LINE",
+"6 729 LINE",
+"123 729 LINE",
+"123 195 LINE SMOOTH",
+"123 54 OFFCURVE",
+"227 -12 OFFCURVE",
+"387 -12 CURVE SMOOTH"
 );
 }
 );
@@ -10634,12 +11060,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"15 724 LINE",
-"112 724 LINE",
-"112 194 LINE SMOOTH",
-"112 53 OFFCURVE",
-"229 -13 OFFCURVE",
-"403 -13 CURVE SMOOTH",
 "574 -13 OFFCURVE",
 "659 51 OFFCURVE",
 "659 195 CURVE SMOOTH",
@@ -10659,7 +11079,13 @@ nodes = (
 "270 724 LINE",
 "376 724 LINE",
 "376 754 LINE",
-"15 754 LINE"
+"15 754 LINE",
+"15 724 LINE",
+"112 724 LINE",
+"112 194 LINE SMOOTH",
+"112 53 OFFCURVE",
+"229 -13 OFFCURVE",
+"403 -13 CURVE SMOOTH"
 );
 }
 );
@@ -10672,7 +11098,7 @@ unicode = 0055;
 },
 {
 glyphname = Uacute;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -10680,7 +11106,7 @@ components = (
 name = U;
 },
 {
-name = acute.cap;
+name = acute.case;
 transform = "{1, 0, 0, 1, 280, 0}";
 }
 );
@@ -10693,7 +11119,7 @@ components = (
 name = U;
 },
 {
-name = acute.cap;
+name = acute.case;
 transform = "{1, 0, 0, 1, 292, 0}";
 }
 );
@@ -10707,7 +11133,7 @@ unicode = 00DA;
 },
 {
 glyphname = Ubreve;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -10715,7 +11141,7 @@ components = (
 name = U;
 },
 {
-name = breve.cap;
+name = breve.case;
 transform = "{1, 0, 0, 1, 248, 0}";
 }
 );
@@ -10728,7 +11154,7 @@ components = (
 name = U;
 },
 {
-name = breve.cap;
+name = breve.case;
 transform = "{1, 0, 0, 1, 270, 0}";
 }
 );
@@ -10742,7 +11168,7 @@ unicode = 016C;
 },
 {
 glyphname = Ucircumflex;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -10750,7 +11176,7 @@ components = (
 name = U;
 },
 {
-name = circumflex.cap;
+name = circumflex.case;
 transform = "{1, 0, 0, 1, 247, 0}";
 }
 );
@@ -10763,7 +11189,7 @@ components = (
 name = U;
 },
 {
-name = circumflex.cap;
+name = circumflex.case;
 transform = "{1, 0, 0, 1, 236, 0}";
 }
 );
@@ -10777,7 +11203,7 @@ unicode = 00DB;
 },
 {
 glyphname = Udblgrave;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 21:39:36 +0000";
 layers = (
 {
 components = (
@@ -10785,7 +11211,7 @@ components = (
 name = U;
 },
 {
-name = uni030F.cap;
+name = dblgravecomb.cap;
 transform = "{1, 0, 0, 1, 197, 0}";
 }
 );
@@ -10798,7 +11224,7 @@ components = (
 name = U;
 },
 {
-name = uni030F.cap;
+name = dblgravecomb.cap;
 transform = "{1, 0, 0, 1, 111, 0}";
 }
 );
@@ -10812,7 +11238,7 @@ unicode = 0214;
 },
 {
 glyphname = Udieresis;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -10820,7 +11246,7 @@ components = (
 name = U;
 },
 {
-name = dieresis.cap;
+name = dieresis.case;
 transform = "{1, 0, 0, 1, 261, 0}";
 }
 );
@@ -10833,7 +11259,7 @@ components = (
 name = U;
 },
 {
-name = dieresis.cap;
+name = dieresis.case;
 transform = "{1, 0, 0, 1, 277, 0}";
 }
 );
@@ -10882,7 +11308,7 @@ unicode = 1EE4;
 },
 {
 glyphname = Ugrave;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -10890,7 +11316,7 @@ components = (
 name = U;
 },
 {
-name = grave.cap;
+name = grave.case;
 transform = "{1, 0, 0, 1, 282, 0}";
 }
 );
@@ -10903,7 +11329,7 @@ components = (
 name = U;
 },
 {
-name = grave.cap;
+name = grave.case;
 transform = "{1, 0, 0, 1, 298, 0}";
 }
 );
@@ -10917,7 +11343,7 @@ unicode = 00D9;
 },
 {
 glyphname = Uhungarumlaut;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -10925,7 +11351,7 @@ components = (
 name = U;
 },
 {
-name = hungarumlaut.cap;
+name = hungarumlaut.case;
 transform = "{1, 0, 0, 1, 217, 0}";
 }
 );
@@ -10938,7 +11364,7 @@ components = (
 name = U;
 },
 {
-name = hungarumlaut.cap;
+name = hungarumlaut.case;
 transform = "{1, 0, 0, 1, 204, 0}";
 }
 );
@@ -10952,7 +11378,7 @@ unicode = 0170;
 },
 {
 glyphname = Uinvertedbreve;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 21:39:36 +0000";
 layers = (
 {
 components = (
@@ -10960,7 +11386,7 @@ components = (
 name = U;
 },
 {
-name = uni0311.cap;
+name = breveinvertedcomb.cap;
 transform = "{1, 0, 0, 1, 247, 0}";
 }
 );
@@ -10973,7 +11399,7 @@ components = (
 name = U;
 },
 {
-name = uni0311.cap;
+name = breveinvertedcomb.cap;
 transform = "{1, 0, 0, 1, 270, 0}";
 }
 );
@@ -10987,7 +11413,7 @@ unicode = 0216;
 },
 {
 glyphname = Umacron;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -10995,7 +11421,7 @@ components = (
 name = U;
 },
 {
-name = macron.cap;
+name = macron.case;
 transform = "{1, 0, 0, 1, 250, 0}";
 }
 );
@@ -11008,7 +11434,7 @@ components = (
 name = U;
 },
 {
-name = macron.cap;
+name = macron.case;
 transform = "{1, 0, 0, 1, 265, 0}";
 }
 );
@@ -11057,7 +11483,7 @@ unicode = 0172;
 },
 {
 glyphname = Uring;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -11065,7 +11491,7 @@ components = (
 name = U;
 },
 {
-name = ring.cap;
+name = ring.case;
 transform = "{1, 0, 0, 1, 317, 0}";
 }
 );
@@ -11078,7 +11504,7 @@ components = (
 name = U;
 },
 {
-name = ring.cap;
+name = ring.case;
 transform = "{1, 0, 0, 1, 350, 0}";
 }
 );
@@ -11092,7 +11518,7 @@ unicode = 016E;
 },
 {
 glyphname = Utilde;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -11100,7 +11526,7 @@ components = (
 name = U;
 },
 {
-name = tilde.cap;
+name = tilde.case;
 transform = "{1, 0, 0, 1, 234, 0}";
 }
 );
@@ -11113,7 +11539,7 @@ components = (
 name = U;
 },
 {
-name = tilde.cap;
+name = tilde.case;
 transform = "{1, 0, 0, 1, 245, 0}";
 }
 );
@@ -11127,7 +11553,7 @@ unicode = 0168;
 },
 {
 glyphname = V;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -11179,41 +11605,41 @@ paths = (
 {
 closed = 1;
 nodes = (
-"221 739 LINE",
-"87 739 LINE",
-"343 -12 LINE",
 "373 -12 LINE",
 "421 160 LINE",
 "411 194 LINE",
-"407 194 LINE"
+"407 194 LINE",
+"221 739 LINE",
+"87 739 LINE",
+"343 -12 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"341 754 LINE",
-"-6 754 LINE",
-"-6 729 LINE",
-"341 729 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"719 754 LINE",
-"475 754 LINE",
-"475 729 LINE",
-"719 729 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"401 165 LINE",
-"343 -12 LINE",
 "373 -12 LINE",
 "629 739 LINE",
-"596 739 LINE"
+"596 739 LINE",
+"401 165 LINE",
+"343 -12 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"341 729 LINE",
+"341 754 LINE",
+"-6 754 LINE",
+"-6 729 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"719 729 LINE",
+"719 754 LINE",
+"475 754 LINE",
+"475 729 LINE"
 );
 }
 );
@@ -11499,41 +11925,41 @@ paths = (
 {
 closed = 1;
 nodes = (
-"222 739 LINE",
-"49 739 LINE",
-"321 -9 LINE",
 "347 -9 LINE",
 "413 205 LINE",
 "407 242 LINE",
-"403 242 LINE"
+"403 242 LINE",
+"222 739 LINE",
+"49 739 LINE",
+"321 -9 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"307 754 LINE",
-"-25 754 LINE",
-"-25 724 LINE",
-"307 724 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"687 754 LINE",
-"466 754 LINE",
-"466 724 LINE",
-"687 724 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"373 150 LINE",
-"321 -9 LINE",
 "347 -9 LINE",
 "622 739 LINE",
-"589 739 LINE"
+"589 739 LINE",
+"373 150 LINE",
+"321 -9 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"307 724 LINE",
+"307 754 LINE",
+"-25 754 LINE",
+"-25 724 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"687 724 LINE",
+"687 754 LINE",
+"466 754 LINE",
+"466 724 LINE"
 );
 }
 );
@@ -11544,7 +11970,7 @@ unicode = 0056;
 },
 {
 glyphname = W;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -11627,6 +12053,12 @@ paths = (
 {
 closed = 1;
 nodes = (
+"333 -12 LINE",
+"455 333 LINE",
+"573 -12 LINE",
+"603 -12 LINE",
+"860 729 LINE",
+"932 729 LINE",
 "932 754 LINE",
 "724 754 LINE",
 "724 729 LINE",
@@ -11640,23 +12072,17 @@ nodes = (
 "-26 754 LINE",
 "-26 729 LINE",
 "50 729 LINE",
-"303 -12 LINE",
-"333 -12 LINE",
-"455 333 LINE",
-"573 -12 LINE",
-"603 -12 LINE",
-"860 729 LINE",
-"932 729 LINE"
+"303 -12 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"368 192 LINE",
 "184 729 LINE",
 "320 729 LINE",
 "439 381 LINE",
-"372 192 LINE"
+"372 192 LINE",
+"368 192 LINE"
 );
 },
 {
@@ -11751,6 +12177,12 @@ paths = (
 {
 closed = 1;
 nodes = (
+"384 -9 LINE",
+"524 337 LINE",
+"656 -9 LINE",
+"682 -9 LINE",
+"951 724 LINE",
+"1039 724 LINE",
 "1039 754 LINE",
 "818 754 LINE",
 "818 724 LINE",
@@ -11764,23 +12196,17 @@ nodes = (
 "-20 754 LINE",
 "-20 724 LINE",
 "59 724 LINE",
-"338 -9 LINE",
-"384 -9 LINE",
-"524 337 LINE",
-"656 -9 LINE",
-"682 -9 LINE",
-"951 724 LINE",
-"1039 724 LINE"
+"338 -9 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"431 208 LINE",
 "233 724 LINE",
 "377 724 LINE",
 "508 379 LINE",
-"435 208 LINE"
+"435 208 LINE",
+"431 208 LINE"
 );
 },
 {
@@ -11801,7 +12227,7 @@ unicode = 0057;
 },
 {
 glyphname = Wacute;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -11809,7 +12235,7 @@ components = (
 name = W;
 },
 {
-name = acute.cap;
+name = acute.case;
 transform = "{1, 0, 0, 1, 337, 0}";
 }
 );
@@ -11822,7 +12248,7 @@ components = (
 name = W;
 },
 {
-name = acute.cap;
+name = acute.case;
 transform = "{1, 0, 0, 1, 423, 0}";
 }
 );
@@ -11836,7 +12262,7 @@ unicode = 1E82;
 },
 {
 glyphname = Wcircumflex;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -11844,7 +12270,7 @@ components = (
 name = W;
 },
 {
-name = circumflex.cap;
+name = circumflex.case;
 transform = "{1, 0, 0, 1, 320, 0}";
 }
 );
@@ -11857,7 +12283,7 @@ components = (
 name = W;
 },
 {
-name = circumflex.cap;
+name = circumflex.case;
 transform = "{1, 0, 0, 1, 302, 0}";
 }
 );
@@ -11871,7 +12297,7 @@ unicode = 0174;
 },
 {
 glyphname = Wdieresis;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -11879,7 +12305,7 @@ components = (
 name = W;
 },
 {
-name = dieresis.cap;
+name = dieresis.case;
 transform = "{1, 0, 0, 1, 330, 0}";
 }
 );
@@ -11892,7 +12318,7 @@ components = (
 name = W;
 },
 {
-name = dieresis.cap;
+name = dieresis.case;
 transform = "{1, 0, 0, 1, 344, 0}";
 }
 );
@@ -11906,7 +12332,7 @@ unicode = 1E84;
 },
 {
 glyphname = Wgrave;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -11914,7 +12340,7 @@ components = (
 name = W;
 },
 {
-name = grave.cap;
+name = grave.case;
 transform = "{1, 0, 0, 1, 330, 0}";
 }
 );
@@ -11927,7 +12353,7 @@ components = (
 name = W;
 },
 {
-name = grave.cap;
+name = grave.case;
 transform = "{1, 0, 0, 1, 354, 0}";
 }
 );
@@ -11941,7 +12367,7 @@ unicode = 1E80;
 },
 {
 glyphname = X;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -12016,7 +12442,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"-22 0 LINE",
 "240 0 LINE",
 "240 25 LINE",
 "110 25 LINE",
@@ -12043,7 +12468,8 @@ nodes = (
 "78 729 LINE",
 "283 363 LINE",
 "73 25 LINE",
-"-22 25 LINE"
+"-22 25 LINE",
+"-22 0 LINE"
 );
 }
 );
@@ -12122,7 +12548,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"-11 0 LINE",
 "240 0 LINE",
 "240 30 LINE",
 "124 30 LINE",
@@ -12149,7 +12574,8 @@ nodes = (
 "58 724 LINE",
 "287 338 LINE",
 "87 30 LINE",
-"-11 30 LINE"
+"-11 30 LINE",
+"-11 0 LINE"
 );
 }
 );
@@ -12160,7 +12586,7 @@ unicode = 0058;
 },
 {
 glyphname = Y;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -12228,7 +12654,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"151 0 LINE",
 "525 0 LINE",
 "525 25 LINE",
 "405 25 LINE",
@@ -12249,7 +12674,8 @@ nodes = (
 "47 729 LINE",
 "271 343 LINE",
 "271 25 LINE",
-"151 25 LINE"
+"151 25 LINE",
+"151 0 LINE"
 );
 }
 );
@@ -12322,7 +12748,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"202 0 LINE",
 "593 0 LINE",
 "593 30 LINE",
 "475 30 LINE",
@@ -12343,7 +12768,8 @@ nodes = (
 "78 724 LINE",
 "317 329 LINE",
 "317 30 LINE",
-"202 30 LINE"
+"202 30 LINE",
+"202 0 LINE"
 );
 }
 );
@@ -12356,7 +12782,7 @@ unicode = 0059;
 },
 {
 glyphname = Yacute;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -12364,7 +12790,7 @@ components = (
 name = Y;
 },
 {
-name = acute.cap;
+name = acute.case;
 transform = "{1, 0, 0, 1, 235, 0}";
 }
 );
@@ -12377,7 +12803,7 @@ components = (
 name = Y;
 },
 {
-name = acute.cap;
+name = acute.case;
 transform = "{1, 0, 0, 1, 330, 0}";
 }
 );
@@ -12391,7 +12817,7 @@ unicode = 00DD;
 },
 {
 glyphname = Ycircumflex;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -12399,7 +12825,7 @@ components = (
 name = Y;
 },
 {
-name = circumflex.cap;
+name = circumflex.case;
 transform = "{1, 0, 0, 1, 214, 0}";
 }
 );
@@ -12412,7 +12838,7 @@ components = (
 name = Y;
 },
 {
-name = circumflex.cap;
+name = circumflex.case;
 transform = "{1, 0, 0, 1, 248, 0}";
 }
 );
@@ -12426,7 +12852,7 @@ unicode = 0176;
 },
 {
 glyphname = Ydieresis;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -12434,7 +12860,7 @@ components = (
 name = Y;
 },
 {
-name = dieresis.cap;
+name = dieresis.case;
 transform = "{1, 0, 0, 1, 228, 0}";
 }
 );
@@ -12447,7 +12873,7 @@ components = (
 name = Y;
 },
 {
-name = dieresis.cap;
+name = dieresis.case;
 transform = "{1, 0, 0, 1, 276, 0}";
 }
 );
@@ -12461,7 +12887,7 @@ unicode = 0178;
 },
 {
 glyphname = Ygrave;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -12469,7 +12895,7 @@ components = (
 name = Y;
 },
 {
-name = grave.cap;
+name = grave.case;
 transform = "{1, 0, 0, 1, 242, 0}";
 }
 );
@@ -12482,7 +12908,7 @@ components = (
 name = Y;
 },
 {
-name = grave.cap;
+name = grave.case;
 transform = "{1, 0, 0, 1, 220, 0}";
 }
 );
@@ -12496,7 +12922,7 @@ unicode = 1EF2;
 },
 {
 glyphname = Ytilde;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -12504,7 +12930,7 @@ components = (
 name = Y;
 },
 {
-name = tilde.cap;
+name = tilde.case;
 transform = "{1, 0, 0, 1, 196, 0}";
 }
 );
@@ -12517,7 +12943,7 @@ components = (
 name = Y;
 },
 {
-name = tilde.cap;
+name = tilde.case;
 transform = "{1, 0, 0, 1, 254, 0}";
 }
 );
@@ -12531,7 +12957,7 @@ unicode = 1EF8;
 },
 {
 glyphname = Z;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -12582,40 +13008,40 @@ paths = (
 {
 closed = 1;
 nodes = (
-"28 0 LINE",
+"193 18 LINE",
+"193 29 LINE",
+"608 719 LINE",
+"608 737 LINE",
+"446 731 LINE",
+"446 725 LINE",
+"28 32 LINE",
+"28 7 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "608 0 LINE",
 "608 245 LINE",
 "573 245 LINE",
 "571 128 OFFCURVE",
 "514 25 OFFCURVE",
 "415 25 CURVE SMOOTH",
-"28 25 LINE"
+"28 25 LINE",
+"28 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"608 754 LINE",
-"68 754 LINE",
-"68 549 LINE",
 "103 549 LINE",
 "105 646 OFFCURVE",
 "162 729 OFFCURVE",
 "261 729 CURVE SMOOTH",
-"608 729 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"28 32 LINE",
-"28 7 LINE",
-"193 18 LINE",
-"193 29 LINE",
-"608 719 LINE",
-"608 737 LINE",
-"446 731 LINE",
-"446 725 LINE"
+"608 729 LINE",
+"608 754 LINE",
+"68 754 LINE",
+"68 549 LINE"
 );
 }
 );
@@ -12885,40 +13311,40 @@ paths = (
 {
 closed = 1;
 nodes = (
-"10 0 LINE",
+"195 23 LINE",
+"195 36 LINE",
+"616 714 LINE",
+"616 732 LINE",
+"424 726 LINE",
+"424 720 LINE",
+"10 39 LINE",
+"10 7 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "606 0 LINE",
 "606 245 LINE",
 "566 245 LINE",
 "564 133 OFFCURVE",
 "491 32 OFFCURVE",
 "368 32 CURVE SMOOTH",
-"10 32 LINE"
+"10 32 LINE",
+"10 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"616 754 LINE",
-"60 754 LINE",
-"60 549 LINE",
 "100 549 LINE",
 "102 643 OFFCURVE",
 "171 724 OFFCURVE",
 "288 724 CURVE SMOOTH",
-"616 724 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"10 39 LINE",
-"10 7 LINE",
-"195 23 LINE",
-"195 36 LINE",
-"616 714 LINE",
-"616 732 LINE",
-"424 726 LINE",
-"424 720 LINE"
+"616 724 LINE",
+"616 754 LINE",
+"60 754 LINE",
+"60 549 LINE"
 );
 }
 );
@@ -12931,7 +13357,7 @@ unicode = 005A;
 },
 {
 glyphname = Zacute;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -12939,7 +13365,7 @@ components = (
 name = Z;
 },
 {
-name = acute.cap;
+name = acute.case;
 transform = "{1, 0, 0, 1, 204, 0}";
 }
 );
@@ -12952,7 +13378,7 @@ components = (
 name = Z;
 },
 {
-name = acute.cap;
+name = acute.case;
 transform = "{1, 0, 0, 1, 191, 0}";
 }
 );
@@ -12966,7 +13392,7 @@ unicode = 0179;
 },
 {
 glyphname = Zcaron;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -12974,7 +13400,7 @@ components = (
 name = Z;
 },
 {
-name = caron.cap;
+name = caron.case;
 transform = "{1, 0, 0, 1, 146, 0}";
 }
 );
@@ -12987,7 +13413,7 @@ components = (
 name = Z;
 },
 {
-name = caron.cap;
+name = caron.case;
 transform = "{1, 0, 0, 1, 131, 0}";
 }
 );
@@ -13001,7 +13427,7 @@ unicode = 017D;
 },
 {
 glyphname = Zdotaccent;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -13009,7 +13435,7 @@ components = (
 name = Z;
 },
 {
-name = dotaccent.cap;
+name = dotaccent.case;
 transform = "{1, 0, 0, 1, 251, 0}";
 }
 );
@@ -13022,7 +13448,7 @@ components = (
 name = Z;
 },
 {
-name = dotaccent.cap;
+name = dotaccent.case;
 transform = "{1, 0, 0, 1, 259, 0}";
 }
 );
@@ -13070,444 +13496,8 @@ rightKerningGroup = Z;
 unicode = 1E92;
 },
 {
-glyphname = uni015E;
-lastChange = "2016-08-16 11:12:00 +0000";
-layers = (
-{
-components = (
-{
-name = S;
-},
-{
-name = cedilla;
-transform = "{1, 0, 0, 1, 153, 0}";
-}
-);
-layerId = UUID0;
-width = 574;
-},
-{
-components = (
-{
-name = S;
-},
-{
-name = cedilla;
-transform = "{1, 0, 0, 1, 163, 0}";
-}
-);
-layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
-width = 569;
-}
-);
-leftKerningGroup = S;
-rightKerningGroup = S;
-unicode = 015E;
-},
-{
-glyphname = uni0162;
-lastChange = "2016-08-16 11:12:00 +0000";
-layers = (
-{
-components = (
-{
-name = T;
-},
-{
-name = cedilla;
-transform = "{1, 0, 0, 1, 239, 0}";
-}
-);
-layerId = UUID0;
-width = 705;
-},
-{
-components = (
-{
-name = T;
-},
-{
-name = cedilla;
-transform = "{1, 0, 0, 1, 246, 0}";
-}
-);
-layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
-width = 724;
-}
-);
-leftKerningGroup = T;
-rightKerningGroup = T;
-unicode = 0162;
-},
-{
-glyphname = uni01C4;
-lastChange = "2016-08-16 11:12:00 +0000";
-layers = (
-{
-components = (
-{
-name = D;
-},
-{
-name = Z;
-transform = "{1, 0, 0, 1, 771, 0}";
-},
-{
-name = caron.cap;
-transform = "{1, 0, 0, 1, 922, 0}";
-}
-);
-layerId = UUID0;
-width = 1422;
-},
-{
-components = (
-{
-name = D;
-},
-{
-name = Z;
-transform = "{1, 0, 0, 1, 798, 0}";
-},
-{
-name = caron.cap;
-transform = "{1, 0, 0, 1, 924, 0}";
-}
-);
-layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
-width = 1419;
-}
-);
-leftKerningGroup = D;
-rightKerningGroup = Z;
-unicode = 01C4;
-},
-{
-glyphname = uni01C5;
-lastChange = "2016-08-16 11:12:00 +0000";
-layers = (
-{
-components = (
-{
-name = D;
-},
-{
-name = z;
-transform = "{1, 0, 0, 1, 759, 0}";
-},
-{
-name = caron;
-transform = "{1, 0, 0, 1, 833, 0}";
-}
-);
-layerId = UUID0;
-width = 1239;
-},
-{
-components = (
-{
-name = D;
-},
-{
-name = z;
-transform = "{1, 0, 0, 1, 798, 0}";
-},
-{
-name = caron;
-transform = "{1, 0, 0, 1, 878, 0}";
-}
-);
-layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
-width = 1274;
-}
-);
-leftKerningGroup = D;
-rightKerningGroup = z;
-unicode = 01C5;
-},
-{
-glyphname = uni01C7;
-lastChange = "2016-08-16 11:12:00 +0000";
-layers = (
-{
-components = (
-{
-name = L;
-},
-{
-name = J;
-transform = "{1, 0, 0, 1, 653, 0}";
-}
-);
-layerId = UUID0;
-width = 1113;
-},
-{
-components = (
-{
-name = L;
-},
-{
-name = J;
-transform = "{1, 0, 0, 1, 681, 0}";
-}
-);
-layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
-width = 1067;
-}
-);
-leftKerningGroup = L;
-rightKerningGroup = J;
-unicode = 01C7;
-},
-{
-glyphname = uni01C8;
-lastChange = "2016-08-16 11:12:00 +0000";
-layers = (
-{
-components = (
-{
-name = L;
-},
-{
-name = j;
-transform = "{1, 0, 0, 1, 641, 0}";
-}
-);
-layerId = UUID0;
-width = 971;
-},
-{
-components = (
-{
-name = L;
-},
-{
-name = j;
-transform = "{1, 0, 0, 1, 681, 0}";
-}
-);
-layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
-width = 999;
-}
-);
-leftKerningGroup = L;
-rightKerningGroup = j;
-unicode = 01C8;
-},
-{
-glyphname = uni01CA;
-lastChange = "2016-08-16 11:12:00 +0000";
-layers = (
-{
-components = (
-{
-name = N;
-},
-{
-name = J;
-transform = "{1, 0, 0, 1, 743, 0}";
-}
-);
-layerId = UUID0;
-width = 1203;
-},
-{
-components = (
-{
-name = N;
-},
-{
-name = J;
-transform = "{1, 0, 0, 1, 791, 0}";
-}
-);
-layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
-width = 1177;
-}
-);
-leftKerningGroup = N;
-rightKerningGroup = J;
-unicode = 01CA;
-},
-{
-glyphname = uni01CB;
-lastChange = "2016-08-16 11:12:00 +0000";
-layers = (
-{
-components = (
-{
-name = N;
-},
-{
-name = j;
-transform = "{1, 0, 0, 1, 731, 0}";
-}
-);
-layerId = UUID0;
-width = 1061;
-},
-{
-components = (
-{
-name = N;
-},
-{
-name = j;
-transform = "{1, 0, 0, 1, 791, 0}";
-}
-);
-layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
-width = 1109;
-}
-);
-leftKerningGroup = N;
-rightKerningGroup = j;
-unicode = 01CB;
-},
-{
-glyphname = uni01F1;
-lastChange = "2016-08-16 11:12:00 +0000";
-layers = (
-{
-components = (
-{
-name = D;
-},
-{
-name = Z;
-transform = "{1, 0, 0, 1, 771, 0}";
-}
-);
-layerId = UUID0;
-width = 1422;
-},
-{
-components = (
-{
-name = D;
-},
-{
-name = Z;
-transform = "{1, 0, 0, 1, 798, 0}";
-}
-);
-layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
-width = 1419;
-}
-);
-leftKerningGroup = D;
-rightKerningGroup = Z;
-unicode = 01F1;
-},
-{
-glyphname = uni01F2;
-lastChange = "2016-08-16 11:12:00 +0000";
-layers = (
-{
-components = (
-{
-name = D;
-},
-{
-name = z;
-transform = "{1, 0, 0, 1, 759, 0}";
-}
-);
-layerId = UUID0;
-width = 1239;
-},
-{
-components = (
-{
-name = D;
-},
-{
-name = z;
-transform = "{1, 0, 0, 1, 798, 0}";
-}
-);
-layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
-width = 1274;
-}
-);
-leftKerningGroup = D;
-rightKerningGroup = z;
-unicode = 01F2;
-},
-{
-glyphname = uni0218;
-lastChange = "2016-08-16 11:12:00 +0000";
-layers = (
-{
-components = (
-{
-name = S;
-},
-{
-name = commaaccent;
-transform = "{1, 0, 0, 1, 200, 0}";
-}
-);
-layerId = UUID0;
-width = 574;
-},
-{
-components = (
-{
-name = S;
-},
-{
-name = commaaccent;
-transform = "{1, 0, 0, 1, 208, 0}";
-}
-);
-layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
-width = 569;
-}
-);
-leftKerningGroup = S;
-rightKerningGroup = S;
-unicode = 0218;
-},
-{
-glyphname = uni021A;
-lastChange = "2016-08-16 11:12:00 +0000";
-layers = (
-{
-components = (
-{
-name = T;
-},
-{
-name = commaaccent;
-transform = "{1, 0, 0, 1, 269, 0}";
-}
-);
-layerId = UUID0;
-width = 705;
-},
-{
-components = (
-{
-name = T;
-},
-{
-name = commaaccent;
-transform = "{1, 0, 0, 1, 267, 0}";
-}
-);
-layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
-width = 724;
-}
-);
-leftKerningGroup = T;
-rightKerningGroup = T;
-unicode = 021A;
-},
-{
 glyphname = a;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 16:41:25 +0000";
 layers = (
 {
 background = {
@@ -13585,7 +13575,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"163 -12 LINE",
 "222 -12 OFFCURVE",
 "283 19 OFFCURVE",
 "308 62 CURVE",
@@ -13637,7 +13626,6 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"223 43 LINE",
 "181 43 OFFCURVE",
 "157 71 OFFCURVE",
 "157 119 CURVE SMOOTH",
@@ -13729,7 +13717,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"177 -12 LINE SMOOTH",
 "245 -12 OFFCURVE",
 "297 22 OFFCURVE",
 "321 57 CURVE",
@@ -13781,7 +13768,6 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"244 43 LINE SMOOTH",
 "207 43 OFFCURVE",
 "187 72 OFFCURVE",
 "187 118 CURVE SMOOTH",
@@ -13909,7 +13895,7 @@ unicode = 00E2;
 },
 {
 glyphname = adblgrave;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 21:39:36 +0000";
 layers = (
 {
 components = (
@@ -13917,7 +13903,7 @@ components = (
 name = a;
 },
 {
-name = uni030F;
+name = dblgravecomb;
 transform = "{1, 0, 0, 1, 13, 0}";
 }
 );
@@ -13930,7 +13916,7 @@ components = (
 name = a;
 },
 {
-name = uni030F;
+name = dblgravecomb;
 }
 );
 layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
@@ -14013,7 +13999,7 @@ unicode = 00E0;
 },
 {
 glyphname = ainvertedbreve;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 21:39:36 +0000";
 layers = (
 {
 components = (
@@ -14021,7 +14007,7 @@ components = (
 name = a;
 },
 {
-name = uni0311;
+name = breveinvertedcomb;
 transform = "{1, 0, 0, 1, 84, 0}";
 }
 );
@@ -14034,7 +14020,7 @@ components = (
 name = a;
 },
 {
-name = uni0311;
+name = breveinvertedcomb;
 transform = "{1, 0, 0, 1, 101, 0}";
 }
 );
@@ -14231,7 +14217,7 @@ unicode = 00E3;
 },
 {
 glyphname = ae;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -14332,7 +14318,56 @@ paths = (
 {
 closed = 1;
 nodes = (
-"168 -12 LINE",
+"613 -12 OFFCURVE",
+"687 46 OFFCURVE",
+"713 139 CURVE",
+"685 139 LINE",
+"650 52 OFFCURVE",
+"598 18 OFFCURVE",
+"528 18 CURVE SMOOTH",
+"448 18 OFFCURVE",
+"421 62 OFFCURVE",
+"421 225 CURVE SMOOTH",
+"421 384 OFFCURVE",
+"447 435 OFFCURVE",
+"514 435 CURVE SMOOTH",
+"567 435 OFFCURVE",
+"594 404 OFFCURVE",
+"594 344 CURVE SMOOTH",
+"594 287 LINE",
+"383 287 LINE",
+"383 262 LINE",
+"710 262 LINE",
+"710 268 LINE SMOOTH",
+"710 382 OFFCURVE",
+"626 462 OFFCURVE",
+"521 462 CURVE SMOOTH",
+"396 462 OFFCURVE",
+"314 347 OFFCURVE",
+"314 228 CURVE SMOOTH",
+"314 102 OFFCURVE",
+"407 -12 OFFCURVE",
+"527 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"184 43 OFFCURVE",
+"160 71 OFFCURVE",
+"160 119 CURVE SMOOTH",
+"160 190 OFFCURVE",
+"211 227 OFFCURVE",
+"311 227 CURVE",
+"311 146 LINE SMOOTH",
+"311 84 OFFCURVE",
+"277 43 OFFCURVE",
+"226 43 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
 "245 -12 OFFCURVE",
 "308 35 OFFCURVE",
 "339 109 CURVE",
@@ -14367,57 +14402,6 @@ nodes = (
 "44 33 OFFCURVE",
 "93 -12 OFFCURVE",
 "168 -12 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"226 43 LINE",
-"184 43 OFFCURVE",
-"160 71 OFFCURVE",
-"160 119 CURVE SMOOTH",
-"160 190 OFFCURVE",
-"211 227 OFFCURVE",
-"311 227 CURVE",
-"311 146 LINE SMOOTH",
-"311 84 OFFCURVE",
-"277 43 OFFCURVE",
-"226 43 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"594 287 LINE",
-"383 287 LINE",
-"383 262 LINE",
-"710 262 LINE",
-"710 268 LINE SMOOTH",
-"710 382 OFFCURVE",
-"626 462 OFFCURVE",
-"521 462 CURVE SMOOTH",
-"396 462 OFFCURVE",
-"314 347 OFFCURVE",
-"314 228 CURVE SMOOTH",
-"314 102 OFFCURVE",
-"407 -12 OFFCURVE",
-"527 -12 CURVE SMOOTH",
-"613 -12 OFFCURVE",
-"687 46 OFFCURVE",
-"713 139 CURVE",
-"685 139 LINE",
-"650 52 OFFCURVE",
-"598 18 OFFCURVE",
-"528 18 CURVE SMOOTH",
-"448 18 OFFCURVE",
-"421 62 OFFCURVE",
-"421 225 CURVE SMOOTH",
-"421 384 OFFCURVE",
-"447 435 OFFCURVE",
-"514 435 CURVE SMOOTH",
-"567 435 OFFCURVE",
-"594 404 OFFCURVE",
-"594 344 CURVE SMOOTH"
 );
 }
 );
@@ -14522,7 +14506,56 @@ paths = (
 {
 closed = 1;
 nodes = (
-"180 -12 LINE SMOOTH",
+"653 -13 OFFCURVE",
+"735 49 OFFCURVE",
+"761 138 CURVE",
+"728 138 LINE",
+"689 53 OFFCURVE",
+"629 22 OFFCURVE",
+"559 22 CURVE SMOOTH",
+"483 22 OFFCURVE",
+"459 60 OFFCURVE",
+"459 222 CURVE SMOOTH",
+"459 380 OFFCURVE",
+"482 430 OFFCURVE",
+"545 430 CURVE SMOOTH",
+"593 430 OFFCURVE",
+"617 401 OFFCURVE",
+"617 344 CURVE SMOOTH",
+"617 283 LINE",
+"411 283 LINE",
+"411 253 LINE",
+"758 253 LINE",
+"758 264 LINE SMOOTH",
+"758 386 OFFCURVE",
+"664 462 OFFCURVE",
+"553 462 CURVE SMOOTH",
+"414 462 OFFCURVE",
+"334 343 OFFCURVE",
+"334 228 CURVE SMOOTH",
+"334 103 OFFCURVE",
+"429 -13 OFFCURVE",
+"558 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"207 43 OFFCURVE",
+"187 72 OFFCURVE",
+"187 118 CURVE SMOOTH",
+"187 189 OFFCURVE",
+"235 225 OFFCURVE",
+"321 225 CURVE",
+"321 146 LINE SMOOTH",
+"321 84 OFFCURVE",
+"287 43 OFFCURVE",
+"244 43 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
 "261 -12 OFFCURVE",
 "332 30 OFFCURVE",
 "357 115 CURVE",
@@ -14557,57 +14590,6 @@ nodes = (
 "42 33 OFFCURVE",
 "97 -12 OFFCURVE",
 "180 -12 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"244 43 LINE SMOOTH",
-"207 43 OFFCURVE",
-"187 72 OFFCURVE",
-"187 118 CURVE SMOOTH",
-"187 189 OFFCURVE",
-"235 225 OFFCURVE",
-"321 225 CURVE",
-"321 146 LINE SMOOTH",
-"321 84 OFFCURVE",
-"287 43 OFFCURVE",
-"244 43 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"617 283 LINE",
-"411 283 LINE",
-"411 253 LINE",
-"758 253 LINE",
-"758 264 LINE SMOOTH",
-"758 386 OFFCURVE",
-"664 462 OFFCURVE",
-"553 462 CURVE SMOOTH",
-"414 462 OFFCURVE",
-"334 343 OFFCURVE",
-"334 228 CURVE SMOOTH",
-"334 103 OFFCURVE",
-"429 -13 OFFCURVE",
-"558 -13 CURVE SMOOTH",
-"653 -13 OFFCURVE",
-"735 49 OFFCURVE",
-"761 138 CURVE",
-"728 138 LINE",
-"689 53 OFFCURVE",
-"629 22 OFFCURVE",
-"559 22 CURVE SMOOTH",
-"483 22 OFFCURVE",
-"459 60 OFFCURVE",
-"459 222 CURVE SMOOTH",
-"459 380 OFFCURVE",
-"482 430 OFFCURVE",
-"545 430 CURVE SMOOTH",
-"593 430 OFFCURVE",
-"617 401 OFFCURVE",
-"617 344 CURVE SMOOTH"
 );
 }
 );
@@ -14655,7 +14637,7 @@ unicode = 01FD;
 },
 {
 glyphname = b;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -14727,42 +14709,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"4 729 LINE",
-"193 729 LINE",
-"193 754 LINE",
-"4 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"83 15 LINE",
-"193 15 LINE",
-"193 738 LINE",
-"83 738 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"4 0 LINE",
-"193 0 LINE",
-"193 25 LINE",
-"4 25 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"319 22 LINE SMOOTH",
-"247 22 OFFCURVE",
-"193 80 OFFCURVE",
-"193 210 CURVE",
-"173 58 LINE",
-"197 58 LINE",
-"219 18 OFFCURVE",
-"268 -12 OFFCURVE",
-"330 -12 CURVE SMOOTH",
 "430 -12 OFFCURVE",
 "524 83 OFFCURVE",
 "524 225 CURVE SMOOTH",
@@ -14782,7 +14728,42 @@ nodes = (
 "396 224 CURVE SMOOTH",
 "396 59 OFFCURVE",
 "375 22 OFFCURVE",
-"319 22 CURVE SMOOTH"
+"319 22 CURVE SMOOTH",
+"247 22 OFFCURVE",
+"193 80 OFFCURVE",
+"193 210 CURVE",
+"173 58 LINE",
+"197 58 LINE",
+"219 18 OFFCURVE",
+"268 -12 OFFCURVE",
+"330 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"193 0 LINE",
+"193 25 LINE",
+"4 25 LINE",
+"4 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"193 15 LINE",
+"193 738 LINE",
+"83 738 LINE",
+"83 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"193 729 LINE",
+"193 754 LINE",
+"4 754 LINE",
+"4 729 LINE"
 );
 }
 );
@@ -14858,42 +14839,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"20 724 LINE",
-"239 724 LINE",
-"239 754 LINE",
-"20 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"101 15 LINE",
-"239 15 LINE",
-"239 738 LINE",
-"101 738 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"20 0 LINE",
-"239 0 LINE",
-"239 30 LINE",
-"20 30 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"354 27 LINE SMOOTH",
-"288 27 OFFCURVE",
-"239 85 OFFCURVE",
-"239 210 CURVE",
-"219 58 LINE",
-"243 58 LINE",
-"265 18 OFFCURVE",
-"314 -12 OFFCURVE",
-"376 -12 CURVE SMOOTH",
 "486 -12 OFFCURVE",
 "585 83 OFFCURVE",
 "585 225 CURVE SMOOTH",
@@ -14913,7 +14858,42 @@ nodes = (
 "430 223 CURVE SMOOTH",
 "430 63 OFFCURVE",
 "406 27 OFFCURVE",
-"354 27 CURVE SMOOTH"
+"354 27 CURVE SMOOTH",
+"288 27 OFFCURVE",
+"239 85 OFFCURVE",
+"239 210 CURVE",
+"219 58 LINE",
+"243 58 LINE",
+"265 18 OFFCURVE",
+"314 -12 OFFCURVE",
+"376 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"239 0 LINE",
+"239 30 LINE",
+"20 30 LINE",
+"20 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"239 15 LINE",
+"239 738 LINE",
+"101 738 LINE",
+"101 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"239 724 LINE",
+"239 754 LINE",
+"20 754 LINE",
+"20 724 LINE"
 );
 }
 );
@@ -14924,7 +14904,7 @@ unicode = 0062;
 },
 {
 glyphname = c;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -14932,7 +14912,19 @@ paths = (
 {
 closed = 1;
 nodes = (
-"288 435 LINE SMOOTH",
+"377 -12 OFFCURVE",
+"441 53 OFFCURVE",
+"467 149 CURVE",
+"439 149 LINE",
+"403 54 OFFCURVE",
+"357 18 OFFCURVE",
+"284 18 CURVE SMOOTH",
+"207 18 OFFCURVE",
+"179 62 OFFCURVE",
+"179 224 CURVE SMOOTH",
+"179 395 OFFCURVE",
+"210 435 OFFCURVE",
+"288 435 CURVE SMOOTH",
 "329 435 OFFCURVE",
 "351 425 OFFCURVE",
 "351 403 CURVE SMOOTH",
@@ -14953,20 +14945,7 @@ nodes = (
 "49 226 CURVE SMOOTH",
 "49 107 OFFCURVE",
 "154 -12 OFFCURVE",
-"281 -12 CURVE SMOOTH",
-"377 -12 OFFCURVE",
-"441 53 OFFCURVE",
-"467 149 CURVE",
-"439 149 LINE",
-"403 54 OFFCURVE",
-"357 18 OFFCURVE",
-"284 18 CURVE SMOOTH",
-"207 18 OFFCURVE",
-"179 62 OFFCURVE",
-"179 224 CURVE SMOOTH",
-"179 395 OFFCURVE",
-"210 435 OFFCURVE",
-"288 435 CURVE SMOOTH"
+"281 -12 CURVE SMOOTH"
 );
 }
 );
@@ -15021,7 +15000,19 @@ paths = (
 {
 closed = 1;
 nodes = (
-"297 430 LINE SMOOTH",
+"395 -13 OFFCURVE",
+"463 52 OFFCURVE",
+"490 148 CURVE",
+"457 148 LINE",
+"421 58 OFFCURVE",
+"373 21 OFFCURVE",
+"301 21 CURVE SMOOTH",
+"226 21 OFFCURVE",
+"200 61 OFFCURVE",
+"200 210 CURVE SMOOTH",
+"200 393 OFFCURVE",
+"239 430 OFFCURVE",
+"297 430 CURVE SMOOTH",
 "328 430 OFFCURVE",
 "347 419 OFFCURVE",
 "347 399 CURVE SMOOTH",
@@ -15042,20 +15033,7 @@ nodes = (
 "45 226 CURVE SMOOTH",
 "45 104 OFFCURVE",
 "155 -13 OFFCURVE",
-"292 -13 CURVE SMOOTH",
-"395 -13 OFFCURVE",
-"463 52 OFFCURVE",
-"490 148 CURVE",
-"457 148 LINE",
-"421 58 OFFCURVE",
-"373 21 OFFCURVE",
-"301 21 CURVE SMOOTH",
-"226 21 OFFCURVE",
-"200 61 OFFCURVE",
-"200 210 CURVE SMOOTH",
-"200 393 OFFCURVE",
-"239 430 OFFCURVE",
-"297 430 CURVE SMOOTH"
+"292 -13 CURVE SMOOTH"
 );
 }
 );
@@ -15243,7 +15221,7 @@ unicode = 010B;
 },
 {
 glyphname = d;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -15251,34 +15229,14 @@ paths = (
 {
 closed = 1;
 nodes = (
-"489 754 LINE",
-"280 754 LINE",
-"280 729 LINE",
-"489 729 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"489 738 LINE",
-"379 738 LINE",
-"379 15 LINE",
-"489 15 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"557 25 LINE",
-"379 25 LINE",
-"379 0 LINE",
-"557 0 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"253 22 LINE",
+"304 -12 OFFCURVE",
+"353 18 OFFCURVE",
+"375 58 CURVE",
+"399 58 LINE",
+"379 210 LINE",
+"379 80 OFFCURVE",
+"325 22 OFFCURVE",
+"253 22 CURVE SMOOTH",
 "197 22 OFFCURVE",
 "176 59 OFFCURVE",
 "176 224 CURVE SMOOTH",
@@ -15298,15 +15256,34 @@ nodes = (
 "48 225 CURVE SMOOTH",
 "48 83 OFFCURVE",
 "142 -12 OFFCURVE",
-"242 -12 CURVE SMOOTH",
-"304 -12 OFFCURVE",
-"353 18 OFFCURVE",
-"375 58 CURVE",
-"399 58 LINE",
-"379 210 LINE",
-"379 80 OFFCURVE",
-"325 22 OFFCURVE",
-"253 22 CURVE SMOOTH"
+"242 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"557 0 LINE",
+"557 25 LINE",
+"379 25 LINE",
+"379 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"489 15 LINE",
+"489 738 LINE",
+"379 738 LINE",
+"379 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"489 729 LINE",
+"489 754 LINE",
+"280 754 LINE",
+"280 729 LINE"
 );
 }
 );
@@ -15382,34 +15359,14 @@ paths = (
 {
 closed = 1;
 nodes = (
-"530 754 LINE",
-"293 754 LINE",
-"293 724 LINE",
-"530 724 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"530 738 LINE",
-"392 738 LINE",
-"392 15 LINE",
-"530 15 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"611 30 LINE",
-"392 30 LINE",
-"392 0 LINE",
-"611 0 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"276 27 LINE SMOOTH",
+"317 -12 OFFCURVE",
+"366 18 OFFCURVE",
+"388 58 CURVE",
+"412 58 LINE",
+"392 210 LINE",
+"392 83 OFFCURVE",
+"342 27 OFFCURVE",
+"276 27 CURVE SMOOTH",
 "221 27 OFFCURVE",
 "200 63 OFFCURVE",
 "200 224 CURVE SMOOTH",
@@ -15429,15 +15386,34 @@ nodes = (
 "45 225 CURVE SMOOTH",
 "45 83 OFFCURVE",
 "149 -12 OFFCURVE",
-"255 -12 CURVE SMOOTH",
-"317 -12 OFFCURVE",
-"366 18 OFFCURVE",
-"388 58 CURVE",
-"412 58 LINE",
-"392 210 LINE",
-"392 83 OFFCURVE",
-"342 27 OFFCURVE",
-"276 27 CURVE SMOOTH"
+"255 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"611 0 LINE",
+"611 30 LINE",
+"392 30 LINE",
+"392 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"530 15 LINE",
+"530 738 LINE",
+"392 738 LINE",
+"392 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"530 724 LINE",
+"530 754 LINE",
+"293 754 LINE",
+"293 724 LINE"
 );
 }
 );
@@ -15450,7 +15426,7 @@ unicode = 0064;
 },
 {
 glyphname = eth;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -15516,7 +15492,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"287 -13 LINE",
 "431 -13 OFFCURVE",
 "544 103 OFFCURVE",
 "544 297 CURVE SMOOTH",
@@ -15542,7 +15517,6 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"290 17 LINE",
 "201 17 OFFCURVE",
 "172 54 OFFCURVE",
 "172 212 CURVE SMOOTH",
@@ -15563,10 +15537,10 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"216 557 LINE",
 "519 662 LINE",
 "508 695 LINE",
-"204 590 LINE"
+"204 590 LINE",
+"216 557 LINE"
 );
 }
 );
@@ -15636,7 +15610,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"339 -11 LINE SMOOTH",
 "493 -11 OFFCURVE",
 "622 107 OFFCURVE",
 "622 301 CURVE SMOOTH",
@@ -15662,7 +15635,6 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"347 24 LINE SMOOTH",
 "268 24 OFFCURVE",
 "240 75 OFFCURVE",
 "240 217 CURVE SMOOTH",
@@ -15683,10 +15655,10 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"266 527 LINE",
 "609 672 LINE",
 "588 715 LINE",
-"244 570 LINE"
+"244 570 LINE",
+"266 527 LINE"
 );
 }
 );
@@ -15731,7 +15703,7 @@ unicode = 010F;
 },
 {
 glyphname = dcroat;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 components = (
@@ -15744,10 +15716,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"263 576 LINE",
 "558 576 LINE",
 "558 611 LINE",
-"263 611 LINE"
+"263 611 LINE",
+"263 576 LINE"
 );
 }
 );
@@ -15764,10 +15736,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"253 567 LINE",
 "611 567 LINE",
 "611 611 LINE",
-"253 611 LINE"
+"253 611 LINE",
+"253 567 LINE"
 );
 }
 );
@@ -15813,8 +15785,86 @@ rightKerningGroup = d;
 unicode = 1E0D;
 },
 {
+glyphname = dz;
+lastChange = "2016-08-18 21:45:32 +0000";
+layers = (
+{
+components = (
+{
+name = d;
+},
+{
+name = z;
+transform = "{1, 0, 0, 1, 568, 0}";
+}
+);
+layerId = UUID0;
+width = 1048;
+},
+{
+components = (
+{
+name = d;
+},
+{
+name = z;
+transform = "{1, 0, 0, 1, 631, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 1107;
+}
+);
+leftKerningGroup = d;
+rightKerningGroup = z;
+unicode = 01F3;
+},
+{
+glyphname = dzcaron;
+lastChange = "2016-08-18 21:39:28 +0000";
+layers = (
+{
+components = (
+{
+name = d;
+},
+{
+name = caron;
+transform = "{1, 0, 0, 1, 628, 0}";
+},
+{
+name = z;
+transform = "{1, 0, 0, 1, 554, 0}";
+}
+);
+layerId = UUID0;
+width = 1034;
+},
+{
+components = (
+{
+name = d;
+},
+{
+name = caron;
+transform = "{1, 0, 0, 1, 630, 0}";
+},
+{
+name = z;
+transform = "{1, 0, 0, 1, 568, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 1044;
+}
+);
+leftKerningGroup = d;
+rightKerningGroup = z;
+unicode = 01C6;
+},
+{
 glyphname = e;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -15822,20 +15872,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"344 287 LINE",
-"133 287 LINE",
-"133 262 LINE",
-"460 262 LINE",
-"460 268 LINE SMOOTH",
-"460 382 OFFCURVE",
-"377 462 OFFCURVE",
-"269 462 CURVE SMOOTH",
-"131 462 OFFCURVE",
-"41 347 OFFCURVE",
-"41 225 CURVE SMOOTH",
-"41 103 OFFCURVE",
-"145 -12 OFFCURVE",
-"274 -12 CURVE SMOOTH",
 "365 -12 OFFCURVE",
 "436 45 OFFCURVE",
 "463 139 CURVE",
@@ -15851,7 +15887,21 @@ nodes = (
 "264 435 CURVE SMOOTH",
 "317 435 OFFCURVE",
 "344 404 OFFCURVE",
-"344 344 CURVE SMOOTH"
+"344 344 CURVE SMOOTH",
+"344 287 LINE",
+"133 287 LINE",
+"133 262 LINE",
+"460 262 LINE",
+"460 268 LINE SMOOTH",
+"460 382 OFFCURVE",
+"377 462 OFFCURVE",
+"269 462 CURVE SMOOTH",
+"131 462 OFFCURVE",
+"41 347 OFFCURVE",
+"41 225 CURVE SMOOTH",
+"41 103 OFFCURVE",
+"145 -12 OFFCURVE",
+"274 -12 CURVE SMOOTH"
 );
 }
 );
@@ -15902,20 +15952,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"358 283 LINE",
-"152 283 LINE",
-"152 253 LINE",
-"499 253 LINE",
-"499 264 LINE SMOOTH",
-"499 386 OFFCURVE",
-"408 462 OFFCURVE",
-"289 462 CURVE SMOOTH",
-"140 462 OFFCURVE",
-"45 344 OFFCURVE",
-"45 228 CURVE SMOOTH",
-"45 103 OFFCURVE",
-"155 -13 OFFCURVE",
-"295 -13 CURVE SMOOTH",
 "395 -13 OFFCURVE",
 "474 46 OFFCURVE",
 "502 138 CURVE",
@@ -15931,7 +15967,21 @@ nodes = (
 "286 430 CURVE SMOOTH",
 "334 430 OFFCURVE",
 "358 401 OFFCURVE",
-"358 344 CURVE SMOOTH"
+"358 344 CURVE SMOOTH",
+"358 283 LINE",
+"152 283 LINE",
+"152 253 LINE",
+"499 253 LINE",
+"499 264 LINE SMOOTH",
+"499 386 OFFCURVE",
+"408 462 OFFCURVE",
+"289 462 CURVE SMOOTH",
+"140 462 OFFCURVE",
+"45 344 OFFCURVE",
+"45 228 CURVE SMOOTH",
+"45 103 OFFCURVE",
+"155 -13 OFFCURVE",
+"295 -13 CURVE SMOOTH"
 );
 }
 );
@@ -15944,13 +15994,12 @@ unicode = 0065;
 },
 {
 glyphname = eacute;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 21:45:32 +0000";
 layers = (
 {
 components = (
 {
 name = e;
-transform = "{1, 0, 0, 1, 3, 0}";
 },
 {
 name = acute;
@@ -15980,13 +16029,12 @@ unicode = 00E9;
 },
 {
 glyphname = ebreve;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 21:45:32 +0000";
 layers = (
 {
 components = (
 {
 name = e;
-transform = "{1, 0, 0, 1, 3, 0}";
 },
 {
 name = breve;
@@ -16016,13 +16064,12 @@ unicode = 0115;
 },
 {
 glyphname = ecaron;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 21:45:32 +0000";
 layers = (
 {
 components = (
 {
 name = e;
-transform = "{1, 0, 0, 1, 3, 0}";
 },
 {
 name = caron;
@@ -16052,13 +16099,12 @@ unicode = 011B;
 },
 {
 glyphname = ecircumflex;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 21:45:32 +0000";
 layers = (
 {
 components = (
 {
 name = e;
-transform = "{1, 0, 0, 1, 3, 0}";
 },
 {
 name = circumflex;
@@ -16088,16 +16134,15 @@ unicode = 00EA;
 },
 {
 glyphname = edblgrave;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 21:39:36 +0000";
 layers = (
 {
 components = (
 {
 name = e;
-transform = "{1, 0, 0, 1, 3, 0}";
 },
 {
-name = uni030F;
+name = dblgravecomb;
 transform = "{1, 0, 0, 1, 20, 0}";
 }
 );
@@ -16110,7 +16155,7 @@ components = (
 name = e;
 },
 {
-name = uni030F;
+name = dblgravecomb;
 transform = "{1, 0, 0, 1, 3, 0}";
 }
 );
@@ -16124,13 +16169,12 @@ unicode = 0205;
 },
 {
 glyphname = edieresis;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 21:45:32 +0000";
 layers = (
 {
 components = (
 {
 name = e;
-transform = "{1, 0, 0, 1, 3, 0}";
 },
 {
 name = dieresis;
@@ -16160,13 +16204,12 @@ unicode = 00EB;
 },
 {
 glyphname = edotaccent;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 21:45:32 +0000";
 layers = (
 {
 components = (
 {
 name = e;
-transform = "{1, 0, 0, 1, 3, 0}";
 },
 {
 name = dotaccent;
@@ -16196,13 +16239,12 @@ unicode = 0117;
 },
 {
 glyphname = edotbelow;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 21:45:32 +0000";
 layers = (
 {
 components = (
 {
 name = e;
-transform = "{1, 0, 0, 1, 3, 0}";
 },
 {
 name = dotbelow;
@@ -16232,13 +16274,12 @@ unicode = 1EB9;
 },
 {
 glyphname = egrave;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 21:45:32 +0000";
 layers = (
 {
 components = (
 {
 name = e;
-transform = "{1, 0, 0, 1, 3, 0}";
 },
 {
 name = grave;
@@ -16268,16 +16309,15 @@ unicode = 00E8;
 },
 {
 glyphname = einvertedbreve;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 21:39:36 +0000";
 layers = (
 {
 components = (
 {
 name = e;
-transform = "{1, 0, 0, 1, 3, 0}";
 },
 {
-name = uni0311;
+name = breveinvertedcomb;
 transform = "{1, 0, 0, 1, 105, 0}";
 }
 );
@@ -16290,7 +16330,7 @@ components = (
 name = e;
 },
 {
-name = uni0311;
+name = breveinvertedcomb;
 transform = "{1, 0, 0, 1, 117, 0}";
 }
 );
@@ -16304,13 +16344,12 @@ unicode = 0207;
 },
 {
 glyphname = emacron;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 21:45:32 +0000";
 layers = (
 {
 components = (
 {
 name = e;
-transform = "{1, 0, 0, 1, 3, 0}";
 },
 {
 name = macron;
@@ -16340,13 +16379,12 @@ unicode = 0113;
 },
 {
 glyphname = eogonek;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 21:45:32 +0000";
 layers = (
 {
 components = (
 {
 name = e;
-transform = "{1, 0, 0, 1, 3, 0}";
 },
 {
 name = ogonek;
@@ -16376,13 +16414,12 @@ unicode = 0119;
 },
 {
 glyphname = etilde;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 21:45:32 +0000";
 layers = (
 {
 components = (
 {
 name = e;
-transform = "{1, 0, 0, 1, 3, 0}";
 },
 {
 name = tilde;
@@ -16411,8 +16448,136 @@ rightKerningGroup = e;
 unicode = 1EBD;
 },
 {
+glyphname = schwa;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"146 152 LINE",
+"357 152 LINE",
+"357 177 LINE",
+"30 177 LINE",
+"30 171 LINE SMOOTH",
+"30 57 OFFCURVE",
+"113 -13 OFFCURVE",
+"221 -13 CURVE SMOOTH",
+"359 -13 OFFCURVE",
+"449 103 OFFCURVE",
+"449 217 CURVE SMOOTH",
+"449 340 OFFCURVE",
+"347 454 OFFCURVE",
+"221 454 CURVE SMOOTH",
+"127 454 OFFCURVE",
+"54 397 OFFCURVE",
+"27 303 CURVE",
+"55 303 LINE",
+"92 392 OFFCURVE",
+"146 424 OFFCURVE",
+"218 424 CURVE SMOOTH",
+"294 424 OFFCURVE",
+"319 383 OFFCURVE",
+"319 221 CURVE SMOOTH",
+"319 63 OFFCURVE",
+"293 14 OFFCURVE",
+"226 14 CURVE SMOOTH",
+"173 14 OFFCURVE",
+"146 45 OFFCURVE",
+"146 105 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"374 -12 OFFCURVE",
+"464 103 OFFCURVE",
+"464 225 CURVE SMOOTH",
+"464 347 OFFCURVE",
+"360 462 OFFCURVE",
+"231 462 CURVE SMOOTH",
+"140 462 OFFCURVE",
+"69 405 OFFCURVE",
+"42 311 CURVE",
+"70 311 LINE",
+"106 400 OFFCURVE",
+"158 432 OFFCURVE",
+"228 432 CURVE SMOOTH",
+"307 432 OFFCURVE",
+"334 387 OFFCURVE",
+"334 225 CURVE SMOOTH",
+"334 67 OFFCURVE",
+"308 15 OFFCURVE",
+"241 15 CURVE SMOOTH",
+"188 15 OFFCURVE",
+"161 46 OFFCURVE",
+"161 106 CURVE SMOOTH",
+"161 163 LINE",
+"372 163 LINE",
+"372 188 LINE",
+"45 188 LINE",
+"45 182 LINE SMOOTH",
+"45 68 OFFCURVE",
+"128 -12 OFFCURVE",
+"236 -12 CURVE SMOOTH"
+);
+}
+);
+width = 508;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"397 -13 OFFCURVE",
+"492 105 OFFCURVE",
+"492 221 CURVE SMOOTH",
+"492 346 OFFCURVE",
+"382 462 OFFCURVE",
+"242 462 CURVE SMOOTH",
+"142 462 OFFCURVE",
+"63 403 OFFCURVE",
+"35 311 CURVE",
+"68 311 LINE",
+"107 396 OFFCURVE",
+"167 427 OFFCURVE",
+"237 427 CURVE SMOOTH",
+"313 427 OFFCURVE",
+"337 389 OFFCURVE",
+"337 227 CURVE SMOOTH",
+"337 69 OFFCURVE",
+"314 19 OFFCURVE",
+"251 19 CURVE SMOOTH",
+"203 19 OFFCURVE",
+"179 48 OFFCURVE",
+"179 105 CURVE",
+"179 166 LINE",
+"385 166 LINE",
+"385 196 LINE",
+"38 196 LINE",
+"38 185 LINE SMOOTH",
+"38 63 OFFCURVE",
+"129 -13 OFFCURVE",
+"248 -13 CURVE SMOOTH"
+);
+}
+);
+width = 537;
+}
+);
+unicode = 0259;
+},
+{
 glyphname = f;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -16471,7 +16636,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"116 0 LINE",
 "226 0 LINE",
 "226 618 LINE SMOOTH",
 "226 704 OFFCURVE",
@@ -16494,25 +16658,26 @@ nodes = (
 "287 765 CURVE SMOOTH",
 "171 765 OFFCURVE",
 "116 672 OFFCURVE",
-"116 478 CURVE SMOOTH"
+"116 478 CURVE SMOOTH",
+"116 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"19 0 LINE",
 "339 0 LINE",
 "339 25 LINE",
-"19 25 LINE"
+"19 25 LINE",
+"19 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"19 425 LINE",
 "349 425 LINE",
 "349 450 LINE",
-"19 450 LINE"
+"19 450 LINE",
+"19 425 LINE"
 );
 }
 );
@@ -16575,7 +16740,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"103 0 LINE",
 "241 0 LINE",
 "241 629 LINE SMOOTH",
 "241 712 OFFCURVE",
@@ -16598,25 +16762,26 @@ nodes = (
 "323 766 CURVE SMOOTH",
 "188 766 OFFCURVE",
 "103 649 OFFCURVE",
-"103 479 CURVE SMOOTH"
+"103 479 CURVE SMOOTH",
+"103 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"23 0 LINE",
 "342 0 LINE",
 "342 30 LINE",
-"23 30 LINE"
+"23 30 LINE",
+"23 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"20 410 LINE",
 "349 410 LINE",
 "349 440 LINE",
-"20 440 LINE"
+"20 440 LINE",
+"20 410 LINE"
 );
 }
 );
@@ -16629,7 +16794,7 @@ unicode = 0066;
 },
 {
 glyphname = g;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -16738,7 +16903,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"240 -326 LINE",
 "379 -326 OFFCURVE",
 "472 -232 OFFCURVE",
 "472 -90 CURVE SMOOTH",
@@ -16795,13 +16959,13 @@ nodes = (
 "43 -181 CURVE SMOOTH",
 "43 -263 OFFCURVE",
 "127 -326 OFFCURVE",
-"240 -326 CURVE SMOOTH"
+"240 -326 CURVE SMOOTH",
+"240 -326 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"249 -296 LINE SMOOTH",
 "171 -296 OFFCURVE",
 "115 -244 OFFCURVE",
 "115 -172 CURVE SMOOTH",
@@ -16814,13 +16978,13 @@ nodes = (
 "431 -132 CURVE SMOOTH",
 "431 -218 OFFCURVE",
 "345 -296 OFFCURVE",
-"249 -296 CURVE SMOOTH"
+"249 -296 CURVE SMOOTH",
+"249 -296 LINE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"241 168 LINE SMOOTH",
 "187 168 OFFCURVE",
 "174 196 OFFCURVE",
 "174 300 CURVE SMOOTH",
@@ -16945,7 +17109,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"264 -324 LINE",
 "405 -324 OFFCURVE",
 "533 -251 OFFCURVE",
 "533 -92 CURVE SMOOTH",
@@ -17002,13 +17165,13 @@ nodes = (
 "40 -181 CURVE SMOOTH",
 "40 -260 OFFCURVE",
 "133 -324 OFFCURVE",
-"264 -324 CURVE SMOOTH"
+"264 -324 CURVE SMOOTH",
+"264 -324 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"283 -289 LINE",
 "197 -289 OFFCURVE",
 "148 -238 OFFCURVE",
 "148 -168 CURVE SMOOTH",
@@ -17021,13 +17184,13 @@ nodes = (
 "477 -124 CURVE SMOOTH",
 "477 -228 OFFCURVE",
 "377 -289 OFFCURVE",
-"283 -289 CURVE SMOOTH"
+"283 -289 CURVE SMOOTH",
+"283 -289 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"273 173 LINE",
 "224 173 OFFCURVE",
 "209 194 OFFCURVE",
 "209 301 CURVE SMOOTH",
@@ -17157,7 +17320,7 @@ unicode = 011D;
 },
 {
 glyphname = gcommaaccent;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 21:39:36 +0000";
 layers = (
 {
 components = (
@@ -17165,7 +17328,7 @@ components = (
 name = g;
 },
 {
-name = commaaccent;
+name = commaaccentcomb;
 transform = "{-1, 0, 0, -1, 331, 457}";
 }
 );
@@ -17178,7 +17341,7 @@ components = (
 name = g;
 },
 {
-name = commaaccent;
+name = commaaccentcomb;
 transform = "{-1, 0, 0, -1, 366, 455}";
 }
 );
@@ -17227,7 +17390,7 @@ unicode = 0121;
 },
 {
 glyphname = h;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -17297,42 +17460,7 @@ paths = (
 {
 closed = 1;
 nodes = (
-"20 729 LINE",
-"209 729 LINE",
-"209 754 LINE",
-"20 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"99 15 LINE",
-"209 15 LINE",
-"209 738 LINE",
-"99 738 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"20 0 LINE",
-"274 0 LINE",
-"274 25 LINE",
-"20 25 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"320 0 LINE",
-"574 0 LINE",
-"574 25 LINE",
-"320 25 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"506 15 LINE",
 "506 353 LINE SMOOTH",
 "506 414 OFFCURVE",
 "449 462 OFFCURVE",
@@ -17348,8 +17476,43 @@ nodes = (
 "373 428 OFFCURVE",
 "396 403 OFFCURVE",
 "396 353 CURVE SMOOTH",
-"396 15 LINE",
-"506 15 LINE"
+"396 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"274 0 LINE",
+"274 25 LINE",
+"20 25 LINE",
+"20 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"574 0 LINE",
+"574 25 LINE",
+"320 25 LINE",
+"320 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"209 15 LINE",
+"209 738 LINE",
+"99 738 LINE",
+"99 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"209 729 LINE",
+"209 754 LINE",
+"20 754 LINE",
+"20 729 LINE"
 );
 }
 );
@@ -17423,42 +17586,7 @@ paths = (
 {
 closed = 1;
 nodes = (
-"20 724 LINE",
-"239 724 LINE",
-"239 754 LINE",
-"20 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"101 15 LINE",
-"239 15 LINE",
-"239 738 LINE",
-"101 738 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"20 0 LINE",
-"304 0 LINE",
-"304 30 LINE",
-"20 30 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"335 0 LINE",
-"604 0 LINE",
-"604 30 LINE",
-"335 30 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"541 15 LINE",
 "541 353 LINE SMOOTH",
 "541 414 OFFCURVE",
 "483 462 OFFCURVE",
@@ -17474,8 +17602,43 @@ nodes = (
 "386 418 OFFCURVE",
 "403 404 OFFCURVE",
 "403 358 CURVE SMOOTH",
-"403 15 LINE",
-"541 15 LINE"
+"403 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"304 0 LINE",
+"304 30 LINE",
+"20 30 LINE",
+"20 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"604 0 LINE",
+"604 30 LINE",
+"335 30 LINE",
+"335 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"239 15 LINE",
+"239 738 LINE",
+"101 738 LINE",
+"101 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"239 724 LINE",
+"239 754 LINE",
+"20 754 LINE",
+"20 724 LINE"
 );
 }
 );
@@ -17488,7 +17651,7 @@ unicode = 0068;
 },
 {
 glyphname = hbar;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 components = (
@@ -17501,10 +17664,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"10 576 LINE",
 "335 576 LINE",
 "335 611 LINE",
-"10 611 LINE"
+"10 611 LINE",
+"10 576 LINE"
 );
 }
 );
@@ -17521,10 +17684,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"20 567 LINE",
 "351 567 LINE",
 "351 611 LINE",
-"20 611 LINE"
+"20 611 LINE",
+"20 567 LINE"
 );
 }
 );
@@ -17606,7 +17769,7 @@ unicode = 1E25;
 },
 {
 glyphname = i;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -17614,37 +17777,33 @@ paths = (
 {
 closed = 1;
 nodes = (
-"25 425 LINE",
-"224 425 LINE",
-"224 450 LINE",
-"25 450 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"114 15 LINE",
 "224 15 LINE",
 "224 434 LINE",
-"114 434 LINE"
+"114 434 LINE",
+"114 15 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"35 0 LINE",
 "304 0 LINE",
 "304 25 LINE",
-"35 25 LINE"
+"35 25 LINE",
+"35 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"100 667 LINE SMOOTH",
-"100 631 OFFCURVE",
-"130 601 OFFCURVE",
-"166 601 CURVE SMOOTH",
+"224 425 LINE",
+"224 450 LINE",
+"25 450 LINE",
+"25 425 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "202 601 OFFCURVE",
 "232 631 OFFCURVE",
 "232 667 CURVE SMOOTH",
@@ -17653,7 +17812,10 @@ nodes = (
 "166 733 CURVE SMOOTH",
 "130 733 OFFCURVE",
 "100 703 OFFCURVE",
-"100 667 CURVE SMOOTH"
+"100 667 CURVE SMOOTH",
+"100 631 OFFCURVE",
+"130 601 OFFCURVE",
+"166 601 CURVE SMOOTH"
 );
 }
 );
@@ -17713,37 +17875,33 @@ paths = (
 {
 closed = 1;
 nodes = (
-"20 420 LINE",
-"239 420 LINE",
-"239 450 LINE",
-"20 450 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"101 15 LINE",
 "239 15 LINE",
 "239 434 LINE",
-"101 434 LINE"
+"101 434 LINE",
+"101 15 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"20 0 LINE",
 "304 0 LINE",
 "304 30 LINE",
-"20 30 LINE"
+"20 30 LINE",
+"20 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"87 653 LINE SMOOTH",
-"87 610 OFFCURVE",
-"124 573 OFFCURVE",
-"167 573 CURVE SMOOTH",
+"239 420 LINE",
+"239 450 LINE",
+"20 450 LINE",
+"20 420 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "211 573 OFFCURVE",
 "248 610 OFFCURVE",
 "248 653 CURVE SMOOTH",
@@ -17752,7 +17910,10 @@ nodes = (
 "167 734 CURVE SMOOTH",
 "124 734 OFFCURVE",
 "87 697 OFFCURVE",
-"87 653 CURVE SMOOTH"
+"87 653 CURVE SMOOTH",
+"87 610 OFFCURVE",
+"124 573 OFFCURVE",
+"167 573 CURVE SMOOTH"
 );
 }
 );
@@ -17764,8 +17925,8 @@ rightKerningGroup = i;
 unicode = 0069;
 },
 {
-glyphname = dotlessi;
-lastChange = "2016-08-16 11:12:00 +0000";
+glyphname = idotless;
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -17773,28 +17934,28 @@ paths = (
 {
 closed = 1;
 nodes = (
-"25 416 LINE",
-"224 416 LINE",
-"224 441 LINE",
-"25 441 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"114 15 LINE",
 "224 15 LINE",
 "224 425 LINE",
-"114 425 LINE"
+"114 425 LINE",
+"114 15 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"35 0 LINE",
 "304 0 LINE",
 "304 25 LINE",
-"35 25 LINE"
+"35 25 LINE",
+"35 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"224 416 LINE",
+"224 441 LINE",
+"25 441 LINE",
+"25 416 LINE"
 );
 }
 );
@@ -17806,28 +17967,28 @@ paths = (
 {
 closed = 1;
 nodes = (
-"20 420 LINE",
-"239 420 LINE",
-"239 450 LINE",
-"20 450 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"101 15 LINE",
 "239 15 LINE",
 "239 434 LINE",
-"101 434 LINE"
+"101 434 LINE",
+"101 15 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"20 0 LINE",
 "304 0 LINE",
 "304 30 LINE",
-"20 30 LINE"
+"20 30 LINE",
+"20 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"239 420 LINE",
+"239 450 LINE",
+"20 450 LINE",
+"20 420 LINE"
 );
 }
 );
@@ -17838,7 +17999,7 @@ unicode = 0131;
 },
 {
 glyphname = iacute;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 21:39:36 +0000";
 layers = (
 {
 components = (
@@ -17847,7 +18008,7 @@ name = acute;
 transform = "{1, 0, 0, 1, 91, 0}";
 },
 {
-name = dotlessi;
+name = idotless;
 }
 );
 layerId = UUID0;
@@ -17860,7 +18021,7 @@ name = acute;
 transform = "{1, 0, 0, 1, 112, 0}";
 },
 {
-name = dotlessi;
+name = idotless;
 }
 );
 layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
@@ -17873,12 +18034,12 @@ unicode = 00ED;
 },
 {
 glyphname = ibreve;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 21:39:36 +0000";
 layers = (
 {
 components = (
 {
-name = dotlessi;
+name = idotless;
 },
 {
 name = breve;
@@ -17891,7 +18052,7 @@ width = 330;
 {
 components = (
 {
-name = dotlessi;
+name = idotless;
 },
 {
 name = breve;
@@ -17908,12 +18069,12 @@ unicode = 012D;
 },
 {
 glyphname = icircumflex;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 21:39:36 +0000";
 layers = (
 {
 components = (
 {
-name = dotlessi;
+name = idotless;
 },
 {
 name = circumflex;
@@ -17926,7 +18087,7 @@ width = 330;
 {
 components = (
 {
-name = dotlessi;
+name = idotless;
 },
 {
 name = circumflex;
@@ -17943,15 +18104,15 @@ unicode = 00EE;
 },
 {
 glyphname = idblgrave;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 21:39:36 +0000";
 layers = (
 {
 components = (
 {
-name = dotlessi;
+name = idotless;
 },
 {
-name = uni030F;
+name = dblgravecomb;
 transform = "{1, 0, 0, 1, -118, 0}";
 }
 );
@@ -17961,10 +18122,10 @@ width = 330;
 {
 components = (
 {
-name = dotlessi;
+name = idotless;
 },
 {
-name = uni030F;
+name = dblgravecomb;
 transform = "{1, 0, 0, 1, -163, 0}";
 }
 );
@@ -17978,12 +18139,12 @@ unicode = 0209;
 },
 {
 glyphname = idieresis;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 21:39:36 +0000";
 layers = (
 {
 components = (
 {
-name = dotlessi;
+name = idotless;
 },
 {
 name = dieresis;
@@ -17996,7 +18157,7 @@ width = 330;
 {
 components = (
 {
-name = dotlessi;
+name = idotless;
 },
 {
 name = dieresis;
@@ -18048,7 +18209,7 @@ unicode = 1ECB;
 },
 {
 glyphname = igrave;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 21:39:36 +0000";
 layers = (
 {
 components = (
@@ -18056,7 +18217,7 @@ components = (
 name = grave;
 },
 {
-name = dotlessi;
+name = idotless;
 }
 );
 layerId = UUID0;
@@ -18069,7 +18230,7 @@ name = grave;
 transform = "{1, 0, 0, 1, -43, 0}";
 },
 {
-name = dotlessi;
+name = idotless;
 }
 );
 layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
@@ -18082,15 +18243,15 @@ unicode = 00EC;
 },
 {
 glyphname = iinvertedbreve;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 21:39:36 +0000";
 layers = (
 {
 components = (
 {
-name = dotlessi;
+name = idotless;
 },
 {
-name = uni0311;
+name = breveinvertedcomb;
 transform = "{1, 0, 0, 1, -1, 0}";
 }
 );
@@ -18100,10 +18261,10 @@ width = 330;
 {
 components = (
 {
-name = dotlessi;
+name = idotless;
 },
 {
-name = uni0311;
+name = breveinvertedcomb;
 transform = "{1, 0, 0, 1, -18, 0}";
 }
 );
@@ -18117,7 +18278,7 @@ unicode = 020B;
 },
 {
 glyphname = ij;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 21:45:32 +0000";
 layers = (
 {
 components = (
@@ -18126,11 +18287,11 @@ name = i;
 },
 {
 name = j;
-transform = "{1, 0, 0, 1, 299, 0}";
+transform = "{1, 0, 0, 1, 310, 0}";
 }
 );
 layerId = UUID0;
-width = 629;
+width = 640;
 },
 {
 components = (
@@ -18152,12 +18313,12 @@ unicode = 0133;
 },
 {
 glyphname = imacron;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 21:39:36 +0000";
 layers = (
 {
 components = (
 {
-name = dotlessi;
+name = idotless;
 },
 {
 name = macron;
@@ -18170,7 +18331,7 @@ width = 330;
 {
 components = (
 {
-name = dotlessi;
+name = idotless;
 },
 {
 name = macron;
@@ -18222,12 +18383,12 @@ unicode = 012F;
 },
 {
 glyphname = itilde;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 21:39:36 +0000";
 layers = (
 {
 components = (
 {
-name = dotlessi;
+name = idotless;
 },
 {
 name = tilde;
@@ -18240,7 +18401,7 @@ width = 330;
 {
 components = (
 {
-name = dotlessi;
+name = idotless;
 },
 {
 name = tilde;
@@ -18257,7 +18418,7 @@ unicode = 0129;
 },
 {
 glyphname = j;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -18317,7 +18478,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"47 -326 LINE",
 "146 -326 OFFCURVE",
 "224 -236 OFFCURVE",
 "224 -47 CURVE SMOOTH",
@@ -18343,16 +18503,13 @@ nodes = (
 "-42 -256 CURVE SMOOTH",
 "-42 -295 OFFCURVE",
 "-11 -326 OFFCURVE",
-"47 -326 CURVE SMOOTH"
+"47 -326 CURVE SMOOTH",
+"47 -326 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"99 667 LINE SMOOTH",
-"99 631 OFFCURVE",
-"129 601 OFFCURVE",
-"165 601 CURVE SMOOTH",
 "201 601 OFFCURVE",
 "231 631 OFFCURVE",
 "231 667 CURVE SMOOTH",
@@ -18361,7 +18518,10 @@ nodes = (
 "165 733 CURVE SMOOTH",
 "129 733 OFFCURVE",
 "99 703 OFFCURVE",
-"99 667 CURVE SMOOTH"
+"99 667 CURVE SMOOTH",
+"99 631 OFFCURVE",
+"129 601 OFFCURVE",
+"165 601 CURVE SMOOTH"
 );
 }
 );
@@ -18425,7 +18585,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"43 -322 LINE",
 "156 -322 OFFCURVE",
 "239 -205 OFFCURVE",
 "239 -35 CURVE SMOOTH",
@@ -18451,16 +18610,13 @@ nodes = (
 "-80 -225 CURVE SMOOTH",
 "-80 -278 OFFCURVE",
 "-26 -322 OFFCURVE",
-"43 -322 CURVE SMOOTH"
+"43 -322 CURVE SMOOTH",
+"43 -322 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"87 653 LINE SMOOTH",
-"87 610 OFFCURVE",
-"124 573 OFFCURVE",
-"167 573 CURVE SMOOTH",
 "211 573 OFFCURVE",
 "248 610 OFFCURVE",
 "248 653 CURVE SMOOTH",
@@ -18469,7 +18625,10 @@ nodes = (
 "167 734 CURVE SMOOTH",
 "124 734 OFFCURVE",
 "87 697 OFFCURVE",
-"87 653 CURVE SMOOTH"
+"87 653 CURVE SMOOTH",
+"87 610 OFFCURVE",
+"124 573 OFFCURVE",
+"167 573 CURVE SMOOTH"
 );
 }
 );
@@ -18481,8 +18640,8 @@ rightKerningGroup = j;
 unicode = 006A;
 },
 {
-glyphname = dotlessj;
-lastChange = "2016-08-16 11:12:00 +0000";
+glyphname = jdotless;
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -18525,7 +18684,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"47 -326 LINE SMOOTH",
 "146 -326 OFFCURVE",
 "224 -236 OFFCURVE",
 "224 -47 CURVE SMOOTH",
@@ -18551,7 +18709,8 @@ nodes = (
 "-42 -256 CURVE SMOOTH",
 "-42 -295 OFFCURVE",
 "-11 -326 OFFCURVE",
-"47 -326 CURVE SMOOTH"
+"47 -326 CURVE SMOOTH",
+"47 -326 LINE SMOOTH"
 );
 }
 );
@@ -18605,7 +18764,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"43 -322 LINE SMOOTH",
 "156 -322 OFFCURVE",
 "239 -205 OFFCURVE",
 "239 -35 CURVE SMOOTH",
@@ -18631,7 +18789,8 @@ nodes = (
 "-80 -225 CURVE SMOOTH",
 "-80 -278 OFFCURVE",
 "-26 -322 OFFCURVE",
-"43 -322 CURVE SMOOTH"
+"43 -322 CURVE SMOOTH",
+"43 -322 LINE SMOOTH"
 );
 }
 );
@@ -18642,12 +18801,12 @@ unicode = 0237;
 },
 {
 glyphname = jcircumflex;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 21:39:36 +0000";
 layers = (
 {
 components = (
 {
-name = dotlessj;
+name = jdotless;
 },
 {
 name = circumflex;
@@ -18660,7 +18819,7 @@ width = 330;
 {
 components = (
 {
-name = dotlessj;
+name = jdotless;
 },
 {
 name = circumflex;
@@ -18677,7 +18836,7 @@ unicode = 0135;
 },
 {
 glyphname = k;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -18752,64 +18911,64 @@ paths = (
 {
 closed = 1;
 nodes = (
-"12 729 LINE",
-"201 729 LINE",
-"201 754 LINE",
-"12 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"91 15 LINE",
-"201 15 LINE",
-"201 738 LINE",
-"91 738 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"12 0 LINE",
-"256 0 LINE",
-"256 25 LINE",
-"12 25 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"318 0 LINE",
-"564 0 LINE",
-"564 25 LINE",
-"318 25 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"386 15 LINE",
 "529 15 LINE",
 "300 306 LINE",
+"208 249 LINE",
+"386 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"256 0 LINE",
+"256 25 LINE",
+"12 25 LINE",
+"12 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"564 0 LINE",
+"564 25 LINE",
+"318 25 LINE",
+"318 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"201 15 LINE",
+"201 738 LINE",
+"91 738 LINE",
+"91 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"251 249 LINE",
+"434 433 LINE",
+"391 433 LINE",
 "208 249 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"285 425 LINE",
 "517 425 LINE",
 "517 450 LINE",
-"285 450 LINE"
+"285 450 LINE",
+"285 425 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"208 249 LINE",
-"251 249 LINE",
-"434 433 LINE",
-"391 433 LINE"
+"201 729 LINE",
+"201 754 LINE",
+"12 754 LINE",
+"12 729 LINE"
 );
 }
 );
@@ -18889,64 +19048,64 @@ paths = (
 {
 closed = 1;
 nodes = (
-"20 724 LINE",
-"239 724 LINE",
-"239 754 LINE",
-"20 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"101 15 LINE",
-"239 15 LINE",
-"239 738 LINE",
-"101 738 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"20 0 LINE",
-"304 0 LINE",
-"304 30 LINE",
-"20 30 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"339 0 LINE",
-"628 0 LINE",
-"628 30 LINE",
-"339 30 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"413 15 LINE",
 "581 15 LINE",
 "352 321 LINE",
-"247 254 LINE"
+"247 254 LINE",
+"413 15 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"332 420 LINE",
+"304 0 LINE",
+"304 30 LINE",
+"20 30 LINE",
+"20 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"628 0 LINE",
+"628 30 LINE",
+"339 30 LINE",
+"339 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"239 15 LINE",
+"239 738 LINE",
+"101 738 LINE",
+"101 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"492 432 LINE",
+"441 432 LINE",
+"247 254 LINE",
+"286 249 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"239 724 LINE",
+"239 754 LINE",
+"20 754 LINE",
+"20 724 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "565 420 LINE",
 "565 450 LINE",
-"332 450 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"247 254 LINE",
-"286 249 LINE",
-"492 432 LINE",
-"441 432 LINE"
+"332 450 LINE",
+"332 420 LINE"
 );
 }
 );
@@ -18959,7 +19118,7 @@ unicode = 006B;
 },
 {
 glyphname = kcommaaccent;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 21:39:36 +0000";
 layers = (
 {
 components = (
@@ -18967,7 +19126,7 @@ components = (
 name = k;
 },
 {
-name = commaaccent;
+name = commaaccentcomb;
 transform = "{1, 0, 0, 1, 198, 0}";
 }
 );
@@ -18980,7 +19139,7 @@ components = (
 name = k;
 },
 {
-name = commaaccent;
+name = commaaccentcomb;
 transform = "{1, 0, 0, 1, 229, 0}";
 }
 );
@@ -18994,7 +19153,7 @@ unicode = 0137;
 },
 {
 glyphname = kgreenlandic;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -19069,64 +19228,64 @@ paths = (
 {
 closed = 1;
 nodes = (
-"12 425 LINE",
-"201 425 LINE",
-"201 450 LINE",
-"12 450 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"91 15 LINE",
-"201 15 LINE",
-"201 434 LINE",
-"91 434 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"12 0 LINE",
-"256 0 LINE",
-"256 25 LINE",
-"12 25 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"318 0 LINE",
-"564 0 LINE",
-"564 25 LINE",
-"318 25 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"386 15 LINE",
 "529 15 LINE",
 "300 306 LINE",
+"208 249 LINE",
+"386 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"256 0 LINE",
+"256 25 LINE",
+"12 25 LINE",
+"12 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"201 15 LINE",
+"201 434 LINE",
+"91 434 LINE",
+"91 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"564 0 LINE",
+"564 25 LINE",
+"318 25 LINE",
+"318 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"201 425 LINE",
+"201 450 LINE",
+"12 450 LINE",
+"12 425 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"251 249 LINE",
+"434 433 LINE",
+"391 433 LINE",
 "208 249 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"285 425 LINE",
 "517 425 LINE",
 "517 450 LINE",
-"285 450 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"208 249 LINE",
-"251 249 LINE",
-"434 433 LINE",
-"391 433 LINE"
+"285 450 LINE",
+"285 425 LINE"
 );
 }
 );
@@ -19206,64 +19365,64 @@ paths = (
 {
 closed = 1;
 nodes = (
-"20 420 LINE",
-"239 420 LINE",
-"239 450 LINE",
-"20 450 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"101 15 LINE",
-"239 15 LINE",
-"239 434 LINE",
-"101 434 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"20 0 LINE",
-"304 0 LINE",
-"304 30 LINE",
-"20 30 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"339 0 LINE",
-"628 0 LINE",
-"628 30 LINE",
-"339 30 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"413 15 LINE",
 "581 15 LINE",
 "352 321 LINE",
-"247 254 LINE"
+"247 254 LINE",
+"413 15 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"332 420 LINE",
+"304 0 LINE",
+"304 30 LINE",
+"20 30 LINE",
+"20 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"239 15 LINE",
+"239 434 LINE",
+"101 434 LINE",
+"101 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"628 0 LINE",
+"628 30 LINE",
+"339 30 LINE",
+"339 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"239 420 LINE",
+"239 450 LINE",
+"20 450 LINE",
+"20 420 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"492 432 LINE",
+"441 432 LINE",
+"247 254 LINE",
+"286 249 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "565 420 LINE",
 "565 450 LINE",
-"332 450 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"247 254 LINE",
-"286 249 LINE",
-"492 432 LINE",
-"441 432 LINE"
+"332 450 LINE",
+"332 420 LINE"
 );
 }
 );
@@ -19275,7 +19434,7 @@ unicode = 0138;
 },
 {
 glyphname = l;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -19347,28 +19506,28 @@ paths = (
 {
 closed = 1;
 nodes = (
-"13 729 LINE",
-"202 729 LINE",
-"202 754 LINE",
-"13 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"92 15 LINE",
 "202 15 LINE",
 "202 738 LINE",
-"92 738 LINE"
+"92 738 LINE",
+"92 15 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"13 0 LINE",
 "282 0 LINE",
 "282 25 LINE",
-"13 25 LINE"
+"13 25 LINE",
+"13 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"202 729 LINE",
+"202 754 LINE",
+"13 754 LINE",
+"13 729 LINE"
 );
 }
 );
@@ -19472,28 +19631,28 @@ paths = (
 {
 closed = 1;
 nodes = (
-"20 724 LINE",
-"239 724 LINE",
-"239 754 LINE",
-"20 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"101 15 LINE",
 "239 15 LINE",
 "239 738 LINE",
-"101 738 LINE"
+"101 738 LINE",
+"101 15 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"20 0 LINE",
 "314 0 LINE",
 "314 30 LINE",
-"20 30 LINE"
+"20 30 LINE",
+"20 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"239 724 LINE",
+"239 754 LINE",
+"20 754 LINE",
+"20 724 LINE"
 );
 }
 );
@@ -19506,7 +19665,7 @@ unicode = 006C;
 },
 {
 glyphname = lacute;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:29:55 +0000";
 layers = (
 {
 components = (
@@ -19514,7 +19673,7 @@ components = (
 name = l;
 },
 {
-name = acute.cap;
+name = acute.case;
 transform = "{1, 0, 0, 1, -6, 0}";
 }
 );
@@ -19527,7 +19686,7 @@ components = (
 name = l;
 },
 {
-name = acute.cap;
+name = acute.case;
 transform = "{1, 0, 0, 1, 11, 0}";
 }
 );
@@ -19575,7 +19734,7 @@ unicode = 013E;
 },
 {
 glyphname = lcommaaccent;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 21:39:36 +0000";
 layers = (
 {
 components = (
@@ -19583,7 +19742,7 @@ components = (
 name = l;
 },
 {
-name = commaaccent;
+name = commaaccentcomb;
 transform = "{1, 0, 0, 1, 57, 0}";
 }
 );
@@ -19596,7 +19755,7 @@ components = (
 name = l;
 },
 {
-name = commaaccent;
+name = commaaccentcomb;
 transform = "{1, 0, 0, 1, 74, 0}";
 }
 );
@@ -19643,8 +19802,43 @@ leftKerningGroup = l;
 unicode = 0140;
 },
 {
+glyphname = lj;
+lastChange = "2016-08-18 21:45:32 +0000";
+layers = (
+{
+components = (
+{
+name = l;
+},
+{
+name = j;
+transform = "{1, 0, 0, 1, 296, 0}";
+}
+);
+layerId = UUID0;
+width = 626;
+},
+{
+components = (
+{
+name = l;
+},
+{
+name = j;
+transform = "{1, 0, 0, 1, 329, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 647;
+}
+);
+leftKerningGroup = l;
+rightKerningGroup = j;
+unicode = 01C9;
+},
+{
 glyphname = lslash;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 components = (
@@ -19657,10 +19851,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"-10 287 LINE",
 "298 448 LINE",
 "298 488 LINE",
-"-10 327 LINE"
+"-10 327 LINE",
+"-10 287 LINE"
 );
 }
 );
@@ -19677,10 +19871,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"20 287 LINE",
 "328 448 LINE",
 "328 502 LINE",
-"20 341 LINE"
+"20 341 LINE",
+"20 287 LINE"
 );
 }
 );
@@ -19691,7 +19885,7 @@ unicode = 0142;
 },
 {
 glyphname = m;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -19699,73 +19893,7 @@ paths = (
 {
 closed = 1;
 nodes = (
-"27 425 LINE",
-"216 425 LINE",
-"216 450 LINE",
-"27 450 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"106 15 LINE",
-"216 15 LINE",
-"216 434 LINE",
-"106 434 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"27 0 LINE",
-"281 0 LINE",
-"281 25 LINE",
-"27 25 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"315 0 LINE",
-"569 0 LINE",
-"569 25 LINE",
-"315 25 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"501 353 LINE SMOOTH",
-"501 414 OFFCURVE",
-"446 462 OFFCURVE",
-"369 462 CURVE SMOOTH",
-"294 462 OFFCURVE",
-"247 422 OFFCURVE",
-"220 367 CURVE",
-"196 367 LINE",
-"216 222 LINE",
-"216 339 OFFCURVE",
-"269 428 OFFCURVE",
-"334 428 CURVE SMOOTH",
-"370 428 OFFCURVE",
-"391 403 OFFCURVE",
-"391 353 CURVE SMOOTH",
-"391 15 LINE",
-"501 15 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"600 0 LINE",
-"854 0 LINE",
-"854 25 LINE",
-"600 25 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"786 15 LINE",
 "786 353 LINE SMOOTH",
 "786 414 OFFCURVE",
 "731 462 OFFCURVE",
@@ -19781,8 +19909,74 @@ nodes = (
 "655 428 OFFCURVE",
 "676 403 OFFCURVE",
 "676 353 CURVE SMOOTH",
-"676 15 LINE",
-"786 15 LINE"
+"676 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"281 0 LINE",
+"281 25 LINE",
+"27 25 LINE",
+"27 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"216 15 LINE",
+"216 434 LINE",
+"106 434 LINE",
+"106 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"569 0 LINE",
+"569 25 LINE",
+"315 25 LINE",
+"315 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"216 425 LINE",
+"216 450 LINE",
+"27 450 LINE",
+"27 425 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"501 15 LINE",
+"501 353 LINE SMOOTH",
+"501 414 OFFCURVE",
+"446 462 OFFCURVE",
+"369 462 CURVE SMOOTH",
+"294 462 OFFCURVE",
+"247 422 OFFCURVE",
+"220 367 CURVE",
+"196 367 LINE",
+"216 222 LINE",
+"216 339 OFFCURVE",
+"269 428 OFFCURVE",
+"334 428 CURVE SMOOTH",
+"370 428 OFFCURVE",
+"391 403 OFFCURVE",
+"391 353 CURVE SMOOTH",
+"391 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"854 0 LINE",
+"854 25 LINE",
+"600 25 LINE",
+"600 0 LINE"
 );
 }
 );
@@ -19887,73 +20081,7 @@ paths = (
 {
 closed = 1;
 nodes = (
-"20 420 LINE",
-"239 420 LINE",
-"239 450 LINE",
-"20 450 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"101 15 LINE",
-"239 15 LINE",
-"239 434 LINE",
-"101 434 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"20 0 LINE",
-"304 0 LINE",
-"304 30 LINE",
-"20 30 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"330 0 LINE",
-"599 0 LINE",
-"599 30 LINE",
-"330 30 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"536 353 LINE SMOOTH",
-"536 414 OFFCURVE",
-"477 462 OFFCURVE",
-"391 462 CURVE SMOOTH",
-"316 462 OFFCURVE",
-"268 426 OFFCURVE",
-"243 367 CURVE",
-"219 367 LINE",
-"239 212 LINE",
-"239 329 OFFCURVE",
-"290 418 OFFCURVE",
-"353 418 CURVE SMOOTH",
-"381 418 OFFCURVE",
-"398 401 OFFCURVE",
-"398 368 CURVE SMOOTH",
-"398 15 LINE",
-"536 15 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"626 0 LINE",
-"895 0 LINE",
-"895 30 LINE",
-"626 30 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"832 15 LINE",
 "832 353 LINE SMOOTH",
 "832 414 OFFCURVE",
 "773 462 OFFCURVE",
@@ -19969,8 +20097,74 @@ nodes = (
 "677 418 OFFCURVE",
 "694 401 OFFCURVE",
 "694 368 CURVE SMOOTH",
-"694 15 LINE",
-"832 15 LINE"
+"694 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"304 0 LINE",
+"304 30 LINE",
+"20 30 LINE",
+"20 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"239 15 LINE",
+"239 434 LINE",
+"101 434 LINE",
+"101 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"599 0 LINE",
+"599 30 LINE",
+"330 30 LINE",
+"330 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"239 420 LINE",
+"239 450 LINE",
+"20 450 LINE",
+"20 420 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"536 15 LINE",
+"536 353 LINE SMOOTH",
+"536 414 OFFCURVE",
+"477 462 OFFCURVE",
+"391 462 CURVE SMOOTH",
+"316 462 OFFCURVE",
+"268 426 OFFCURVE",
+"243 367 CURVE",
+"219 367 LINE",
+"239 212 LINE",
+"239 329 OFFCURVE",
+"290 418 OFFCURVE",
+"353 418 CURVE SMOOTH",
+"381 418 OFFCURVE",
+"398 401 OFFCURVE",
+"398 368 CURVE SMOOTH",
+"398 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"895 0 LINE",
+"895 30 LINE",
+"626 30 LINE",
+"626 0 LINE"
 );
 }
 );
@@ -19981,7 +20175,7 @@ unicode = 006D;
 },
 {
 glyphname = n;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -19989,42 +20183,7 @@ paths = (
 {
 closed = 1;
 nodes = (
-"28 425 LINE",
-"217 425 LINE",
-"217 450 LINE",
-"28 450 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"107 15 LINE",
-"217 15 LINE",
-"217 434 LINE",
-"107 434 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"28 0 LINE",
-"282 0 LINE",
-"282 25 LINE",
-"28 25 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"322 0 LINE",
-"576 0 LINE",
-"576 25 LINE",
-"322 25 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"508 15 LINE",
 "508 353 LINE SMOOTH",
 "508 414 OFFCURVE",
 "452 462 OFFCURVE",
@@ -20040,8 +20199,43 @@ nodes = (
 "376 428 OFFCURVE",
 "398 403 OFFCURVE",
 "398 353 CURVE SMOOTH",
-"398 15 LINE",
-"508 15 LINE"
+"398 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"282 0 LINE",
+"282 25 LINE",
+"28 25 LINE",
+"28 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"217 15 LINE",
+"217 434 LINE",
+"107 434 LINE",
+"107 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"576 0 LINE",
+"576 25 LINE",
+"322 25 LINE",
+"322 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"217 425 LINE",
+"217 450 LINE",
+"28 450 LINE",
+"28 425 LINE"
 );
 }
 );
@@ -20115,42 +20309,7 @@ paths = (
 {
 closed = 1;
 nodes = (
-"20 420 LINE",
-"239 420 LINE",
-"239 450 LINE",
-"20 450 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"101 15 LINE",
-"239 15 LINE",
-"239 434 LINE",
-"101 434 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"20 0 LINE",
-"304 0 LINE",
-"304 30 LINE",
-"20 30 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"335 0 LINE",
-"604 0 LINE",
-"604 30 LINE",
-"335 30 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"541 15 LINE",
 "541 353 LINE SMOOTH",
 "541 414 OFFCURVE",
 "482 462 OFFCURVE",
@@ -20166,8 +20325,43 @@ nodes = (
 "386 418 OFFCURVE",
 "403 401 OFFCURVE",
 "403 368 CURVE SMOOTH",
-"403 15 LINE",
-"541 15 LINE"
+"403 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"304 0 LINE",
+"304 30 LINE",
+"20 30 LINE",
+"20 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"239 15 LINE",
+"239 434 LINE",
+"101 434 LINE",
+"101 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"604 0 LINE",
+"604 30 LINE",
+"335 30 LINE",
+"335 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"239 420 LINE",
+"239 450 LINE",
+"20 450 LINE",
+"20 420 LINE"
 );
 }
 );
@@ -20215,7 +20409,7 @@ unicode = 0144;
 },
 {
 glyphname = napostrophe;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 21:39:36 +0000";
 layers = (
 {
 components = (
@@ -20223,7 +20417,7 @@ components = (
 name = n;
 },
 {
-name = apostrophe;
+name = quoteright;
 transform = "{1, 0, 0, 1, -60, 0}";
 }
 );
@@ -20236,7 +20430,7 @@ components = (
 name = n;
 },
 {
-name = apostrophe;
+name = quoteright;
 transform = "{1, 0, 0, 1, -78, 0}";
 }
 );
@@ -20284,7 +20478,7 @@ unicode = 0148;
 },
 {
 glyphname = ncommaaccent;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 21:39:36 +0000";
 layers = (
 {
 components = (
@@ -20292,7 +20486,7 @@ components = (
 name = n;
 },
 {
-name = commaaccent;
+name = commaaccentcomb;
 transform = "{1, 0, 0, 1, 224, 0}";
 }
 );
@@ -20305,7 +20499,7 @@ components = (
 name = n;
 },
 {
-name = commaaccent;
+name = commaaccentcomb;
 transform = "{1, 0, 0, 1, 229, 0}";
 }
 );
@@ -20354,7 +20548,7 @@ unicode = 1E45;
 },
 {
 glyphname = eng;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -20418,6 +20612,19 @@ paths = (
 {
 closed = 1;
 nodes = (
+"430 -326 OFFCURVE",
+"508 -236 OFFCURVE",
+"508 -47 CURVE SMOOTH",
+"508 353 LINE SMOOTH",
+"508 414 OFFCURVE",
+"452 462 OFFCURVE",
+"373 462 CURVE SMOOTH",
+"296 462 OFFCURVE",
+"249 422 OFFCURVE",
+"221 367 CURVE",
+"217 367 LINE",
+"217 450 LINE",
+"28 450 LINE",
 "28 425 LINE",
 "107 425 LINE",
 "107 25 LINE",
@@ -20451,20 +20658,7 @@ nodes = (
 "242 -256 CURVE SMOOTH",
 "242 -295 OFFCURVE",
 "273 -326 OFFCURVE",
-"331 -326 CURVE SMOOTH",
-"430 -326 OFFCURVE",
-"508 -236 OFFCURVE",
-"508 -47 CURVE SMOOTH",
-"508 353 LINE SMOOTH",
-"508 414 OFFCURVE",
-"452 462 OFFCURVE",
-"373 462 CURVE SMOOTH",
-"296 462 OFFCURVE",
-"249 422 OFFCURVE",
-"221 367 CURVE",
-"217 367 LINE",
-"217 450 LINE",
-"28 450 LINE"
+"331 -326 CURVE SMOOTH"
 );
 }
 );
@@ -20532,6 +20726,19 @@ paths = (
 {
 closed = 1;
 nodes = (
+"458 -322 OFFCURVE",
+"541 -205 OFFCURVE",
+"541 -35 CURVE SMOOTH",
+"541 353 LINE SMOOTH",
+"541 414 OFFCURVE",
+"482 462 OFFCURVE",
+"396 462 CURVE SMOOTH",
+"318 462 OFFCURVE",
+"269 426 OFFCURVE",
+"243 367 CURVE",
+"239 367 LINE",
+"239 450 LINE",
+"20 450 LINE",
 "20 420 LINE",
 "101 420 LINE",
 "101 30 LINE",
@@ -20565,20 +20772,7 @@ nodes = (
 "222 -225 CURVE SMOOTH",
 "222 -278 OFFCURVE",
 "276 -322 OFFCURVE",
-"345 -322 CURVE SMOOTH",
-"458 -322 OFFCURVE",
-"541 -205 OFFCURVE",
-"541 -35 CURVE SMOOTH",
-"541 353 LINE SMOOTH",
-"541 414 OFFCURVE",
-"482 462 OFFCURVE",
-"396 462 CURVE SMOOTH",
-"318 462 OFFCURVE",
-"269 426 OFFCURVE",
-"243 367 CURVE",
-"239 367 LINE",
-"239 450 LINE",
-"20 450 LINE"
+"345 -322 CURVE SMOOTH"
 );
 }
 );
@@ -20587,6 +20781,41 @@ width = 614;
 );
 leftKerningGroup = n;
 unicode = 014B;
+},
+{
+glyphname = nj;
+lastChange = "2016-08-18 21:45:33 +0000";
+layers = (
+{
+components = (
+{
+name = n;
+},
+{
+name = j;
+transform = "{1, 0, 0, 1, 596, 0}";
+}
+);
+layerId = UUID0;
+width = 926;
+},
+{
+components = (
+{
+name = n;
+},
+{
+name = j;
+transform = "{1, 0, 0, 1, 614, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 932;
+}
+);
+leftKerningGroup = n;
+rightKerningGroup = j;
+unicode = 01CC;
 },
 {
 glyphname = ntilde;
@@ -20625,7 +20854,7 @@ unicode = 00F1;
 },
 {
 glyphname = o;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -20633,10 +20862,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"46 225 LINE SMOOTH",
-"46 105 OFFCURVE",
-"151 -12 OFFCURVE",
-"281 -12 CURVE SMOOTH",
 "411 -12 OFFCURVE",
 "516 105 OFFCURVE",
 "516 225 CURVE SMOOTH",
@@ -20645,13 +20870,18 @@ nodes = (
 "281 462 CURVE SMOOTH",
 "151 462 OFFCURVE",
 "46 345 OFFCURVE",
-"46 225 CURVE SMOOTH"
+"46 225 CURVE SMOOTH",
+"46 105 OFFCURVE",
+"151 -12 OFFCURVE",
+"281 -12 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"176 225 LINE",
+"205 18 OFFCURVE",
+"176 57 OFFCURVE",
+"176 225 CURVE SMOOTH",
 "176 393 OFFCURVE",
 "205 432 OFFCURVE",
 "281 432 CURVE SMOOTH",
@@ -20660,10 +20890,7 @@ nodes = (
 "386 225 CURVE SMOOTH",
 "386 57 OFFCURVE",
 "357 18 OFFCURVE",
-"281 18 CURVE SMOOTH",
-"205 18 OFFCURVE",
-"176 57 OFFCURVE",
-"176 225 CURVE SMOOTH"
+"281 18 CURVE SMOOTH"
 );
 }
 );
@@ -20713,10 +20940,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"45 224 LINE SMOOTH",
-"45 84 OFFCURVE",
-"156 -13 OFFCURVE",
-"294 -13 CURVE SMOOTH",
 "432 -13 OFFCURVE",
 "544 84 OFFCURVE",
 "544 224 CURVE SMOOTH",
@@ -20725,13 +20948,18 @@ nodes = (
 "294 462 CURVE SMOOTH",
 "156 462 OFFCURVE",
 "45 364 OFFCURVE",
-"45 224 CURVE SMOOTH"
+"45 224 CURVE SMOOTH",
+"45 84 OFFCURVE",
+"156 -13 OFFCURVE",
+"294 -13 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"200 224 LINE SMOOTH",
+"224 22 OFFCURVE",
+"200 58 OFFCURVE",
+"200 224 CURVE SMOOTH",
 "200 390 OFFCURVE",
 "224 427 OFFCURVE",
 "294 427 CURVE SMOOTH",
@@ -20740,10 +20968,7 @@ nodes = (
 "389 224 CURVE SMOOTH",
 "389 58 OFFCURVE",
 "364 22 OFFCURVE",
-"294 22 CURVE SMOOTH",
-"224 22 OFFCURVE",
-"200 58 OFFCURVE",
-"200 224 CURVE SMOOTH"
+"294 22 CURVE SMOOTH"
 );
 }
 );
@@ -20861,7 +21086,7 @@ unicode = 00F4;
 },
 {
 glyphname = odblgrave;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 21:39:36 +0000";
 layers = (
 {
 components = (
@@ -20869,7 +21094,7 @@ components = (
 name = o;
 },
 {
-name = uni030F;
+name = dblgravecomb;
 transform = "{1, 0, 0, 1, 23, 0}";
 }
 );
@@ -20882,7 +21107,7 @@ components = (
 name = o;
 },
 {
-name = uni030F;
+name = dblgravecomb;
 transform = "{1, 0, 0, 1, 21, 0}";
 }
 );
@@ -21036,7 +21261,7 @@ unicode = 0151;
 },
 {
 glyphname = oinvertedbreve;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 21:39:36 +0000";
 layers = (
 {
 components = (
@@ -21044,7 +21269,7 @@ components = (
 name = o;
 },
 {
-name = uni0311;
+name = breveinvertedcomb;
 transform = "{1, 0, 0, 1, 118, 0}";
 }
 );
@@ -21057,7 +21282,7 @@ components = (
 name = o;
 },
 {
-name = uni0311;
+name = breveinvertedcomb;
 transform = "{1, 0, 0, 1, 124, 0}";
 }
 );
@@ -21141,7 +21366,7 @@ unicode = 01EB;
 },
 {
 glyphname = oslash;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 16:44:19 +0000";
 layers = (
 {
 background = {
@@ -21196,7 +21421,15 @@ paths = (
 {
 closed = 1;
 nodes = (
-"281 -12 LINE SMOOTH",
+"117 -53 LINE",
+"504 483 LINE",
+"466 483 LINE",
+"79 -53 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "411 -12 OFFCURVE",
 "516 105 OFFCURVE",
 "516 225 CURVE SMOOTH",
@@ -21214,16 +21447,6 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"117 -53 LINE",
-"504 483 LINE",
-"466 483 LINE",
-"79 -53 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"281 18 LINE SMOOTH",
 "205 18 OFFCURVE",
 "176 57 OFFCURVE",
 "176 225 CURVE SMOOTH",
@@ -21294,7 +21517,15 @@ paths = (
 {
 closed = 1;
 nodes = (
-"294 -13 LINE SMOOTH",
+"106 -53 LINE",
+"533 483 LINE",
+"475 483 LINE",
+"48 -53 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "432 -13 OFFCURVE",
 "544 84 OFFCURVE",
 "544 224 CURVE SMOOTH",
@@ -21312,16 +21543,6 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"106 -53 LINE",
-"533 483 LINE",
-"475 483 LINE",
-"48 -53 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"294 22 LINE SMOOTH",
 "224 22 OFFCURVE",
 "200 58 OFFCURVE",
 "200 224 CURVE SMOOTH",
@@ -21412,7 +21633,7 @@ unicode = 00F5;
 },
 {
 glyphname = oe;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -21493,10 +21714,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"46 225 LINE SMOOTH",
-"46 105 OFFCURVE",
-"151 -12 OFFCURVE",
-"281 -12 CURVE SMOOTH",
 "411 -12 OFFCURVE",
 "516 105 OFFCURVE",
 "516 225 CURVE SMOOTH",
@@ -21505,13 +21722,18 @@ nodes = (
 "281 462 CURVE SMOOTH",
 "151 462 OFFCURVE",
 "46 345 OFFCURVE",
-"46 225 CURVE SMOOTH"
+"46 225 CURVE SMOOTH",
+"46 105 OFFCURVE",
+"151 -12 OFFCURVE",
+"281 -12 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"176 225 LINE",
+"205 18 OFFCURVE",
+"176 57 OFFCURVE",
+"176 225 CURVE SMOOTH",
 "176 393 OFFCURVE",
 "205 432 OFFCURVE",
 "281 432 CURVE SMOOTH",
@@ -21520,29 +21742,12 @@ nodes = (
 "386 225 CURVE SMOOTH",
 "386 57 OFFCURVE",
 "357 18 OFFCURVE",
-"281 18 CURVE SMOOTH",
-"205 18 OFFCURVE",
-"176 57 OFFCURVE",
-"176 225 CURVE SMOOTH"
+"281 18 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"693 287 LINE",
-"482 287 LINE",
-"482 262 LINE",
-"809 262 LINE",
-"809 268 LINE SMOOTH",
-"809 382 OFFCURVE",
-"726 462 OFFCURVE",
-"618 462 CURVE SMOOTH",
-"480 462 OFFCURVE",
-"390 347 OFFCURVE",
-"390 225 CURVE SMOOTH",
-"390 103 OFFCURVE",
-"494 -12 OFFCURVE",
-"623 -12 CURVE SMOOTH",
 "714 -12 OFFCURVE",
 "785 45 OFFCURVE",
 "812 139 CURVE",
@@ -21558,7 +21763,21 @@ nodes = (
 "613 435 CURVE SMOOTH",
 "666 435 OFFCURVE",
 "693 404 OFFCURVE",
-"693 344 CURVE SMOOTH"
+"693 344 CURVE SMOOTH",
+"693 287 LINE",
+"482 287 LINE",
+"482 262 LINE",
+"809 262 LINE",
+"809 268 LINE SMOOTH",
+"809 382 OFFCURVE",
+"726 462 OFFCURVE",
+"618 462 CURVE SMOOTH",
+"480 462 OFFCURVE",
+"390 347 OFFCURVE",
+"390 225 CURVE SMOOTH",
+"390 103 OFFCURVE",
+"494 -12 OFFCURVE",
+"623 -12 CURVE SMOOTH"
 );
 }
 );
@@ -21643,10 +21862,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"45 224 LINE SMOOTH",
-"45 84 OFFCURVE",
-"156 -12 OFFCURVE",
-"294 -12 CURVE SMOOTH",
 "432 -12 OFFCURVE",
 "540 84 OFFCURVE",
 "540 224 CURVE SMOOTH",
@@ -21655,13 +21870,18 @@ nodes = (
 "294 462 CURVE SMOOTH",
 "156 462 OFFCURVE",
 "45 364 OFFCURVE",
-"45 224 CURVE SMOOTH"
+"45 224 CURVE SMOOTH",
+"45 84 OFFCURVE",
+"156 -12 OFFCURVE",
+"294 -12 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"200 224 LINE SMOOTH",
+"224 23 OFFCURVE",
+"200 58 OFFCURVE",
+"200 224 CURVE SMOOTH",
 "200 390 OFFCURVE",
 "224 427 OFFCURVE",
 "294 427 CURVE SMOOTH",
@@ -21670,29 +21890,12 @@ nodes = (
 "389 224 CURVE SMOOTH",
 "389 58 OFFCURVE",
 "364 23 OFFCURVE",
-"294 23 CURVE SMOOTH",
-"224 23 OFFCURVE",
-"200 58 OFFCURVE",
-"200 224 CURVE SMOOTH"
+"294 23 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"702 283 LINE",
-"496 283 LINE",
-"496 253 LINE",
-"843 253 LINE",
-"843 264 LINE SMOOTH",
-"843 386 OFFCURVE",
-"752 462 OFFCURVE",
-"633 462 CURVE SMOOTH",
-"484 462 OFFCURVE",
-"393 344 OFFCURVE",
-"393 228 CURVE SMOOTH",
-"393 103 OFFCURVE",
-"499 -12 OFFCURVE",
-"639 -12 CURVE SMOOTH",
 "739 -12 OFFCURVE",
 "818 46 OFFCURVE",
 "846 138 CURVE",
@@ -21708,7 +21911,21 @@ nodes = (
 "630 430 CURVE SMOOTH",
 "678 430 OFFCURVE",
 "702 401 OFFCURVE",
-"702 344 CURVE SMOOTH"
+"702 344 CURVE SMOOTH",
+"702 283 LINE",
+"496 283 LINE",
+"496 253 LINE",
+"843 253 LINE",
+"843 264 LINE SMOOTH",
+"843 386 OFFCURVE",
+"752 462 OFFCURVE",
+"633 462 CURVE SMOOTH",
+"484 462 OFFCURVE",
+"393 344 OFFCURVE",
+"393 228 CURVE SMOOTH",
+"393 103 OFFCURVE",
+"499 -12 OFFCURVE",
+"639 -12 CURVE SMOOTH"
 );
 }
 );
@@ -21721,7 +21938,7 @@ unicode = 0153;
 },
 {
 glyphname = p;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -21793,42 +22010,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"9 425 LINE",
-"198 425 LINE",
-"198 450 LINE",
-"9 450 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"88 -299 LINE",
-"198 -299 LINE",
-"198 434 LINE",
-"88 434 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"19 -314 LINE",
-"298 -314 LINE",
-"298 -289 LINE",
-"19 -289 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"324 22 LINE SMOOTH",
-"252 22 OFFCURVE",
-"198 80 OFFCURVE",
-"198 210 CURVE",
-"178 58 LINE",
-"202 58 LINE",
-"224 18 OFFCURVE",
-"273 -12 OFFCURVE",
-"335 -12 CURVE SMOOTH",
 "435 -12 OFFCURVE",
 "529 83 OFFCURVE",
 "529 225 CURVE SMOOTH",
@@ -21848,7 +22029,42 @@ nodes = (
 "401 224 CURVE SMOOTH",
 "401 59 OFFCURVE",
 "380 22 OFFCURVE",
-"324 22 CURVE SMOOTH"
+"324 22 CURVE SMOOTH",
+"252 22 OFFCURVE",
+"198 80 OFFCURVE",
+"198 210 CURVE",
+"178 58 LINE",
+"202 58 LINE",
+"224 18 OFFCURVE",
+"273 -12 OFFCURVE",
+"335 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"298 -314 LINE",
+"298 -289 LINE",
+"19 -289 LINE",
+"19 -314 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"198 -299 LINE",
+"198 434 LINE",
+"88 434 LINE",
+"88 -299 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"198 425 LINE",
+"198 450 LINE",
+"9 450 LINE",
+"9 425 LINE"
 );
 }
 );
@@ -21924,42 +22140,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"20 420 LINE",
-"239 420 LINE",
-"239 450 LINE",
-"20 450 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"101 -299 LINE",
-"239 -299 LINE",
-"239 434 LINE",
-"101 434 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"27 -314 LINE",
-"339 -314 LINE",
-"339 -284 LINE",
-"27 -284 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"355 27 LINE SMOOTH",
-"289 27 OFFCURVE",
-"239 83 OFFCURVE",
-"239 210 CURVE",
-"219 58 LINE",
-"243 58 LINE",
-"265 18 OFFCURVE",
-"314 -12 OFFCURVE",
-"376 -12 CURVE SMOOTH",
 "486 -12 OFFCURVE",
 "585 83 OFFCURVE",
 "585 225 CURVE SMOOTH",
@@ -21979,7 +22159,42 @@ nodes = (
 "430 223 CURVE SMOOTH",
 "430 64 OFFCURVE",
 "409 27 OFFCURVE",
-"355 27 CURVE SMOOTH"
+"355 27 CURVE SMOOTH",
+"289 27 OFFCURVE",
+"239 83 OFFCURVE",
+"239 210 CURVE",
+"219 58 LINE",
+"243 58 LINE",
+"265 18 OFFCURVE",
+"314 -12 OFFCURVE",
+"376 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"339 -314 LINE",
+"339 -284 LINE",
+"27 -284 LINE",
+"27 -314 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"239 -299 LINE",
+"239 434 LINE",
+"101 434 LINE",
+"101 -299 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"239 420 LINE",
+"239 450 LINE",
+"20 450 LINE",
+"20 420 LINE"
 );
 }
 );
@@ -21990,7 +22205,7 @@ unicode = 0070;
 },
 {
 glyphname = thorn;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -22050,7 +22265,14 @@ paths = (
 {
 closed = 1;
 nodes = (
-"330 -12 LINE",
+"294 -314 LINE",
+"294 -289 LINE",
+"193 -289 LINE",
+"193 58 LINE",
+"197 58 LINE",
+"219 18 OFFCURVE",
+"268 -12 OFFCURVE",
+"330 -12 CURVE SMOOTH",
 "430 -12 OFFCURVE",
 "524 83 OFFCURVE",
 "524 225 CURVE SMOOTH",
@@ -22067,21 +22289,12 @@ nodes = (
 "83 729 LINE",
 "83 -289 LINE",
 "15 -289 LINE",
-"15 -314 LINE",
-"294 -314 LINE",
-"294 -289 LINE",
-"193 -289 LINE",
-"193 58 LINE",
-"197 58 LINE",
-"219 18 OFFCURVE",
-"268 -12 OFFCURVE",
-"330 -12 CURVE SMOOTH"
+"15 -314 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"319 22 LINE SMOOTH",
 "250 22 OFFCURVE",
 "193 77 OFFCURVE",
 "193 200 CURVE SMOOTH",
@@ -22158,7 +22371,14 @@ paths = (
 {
 closed = 1;
 nodes = (
-"376 -12 LINE",
+"330 -314 LINE",
+"330 -284 LINE",
+"239 -284 LINE",
+"239 58 LINE",
+"243 58 LINE",
+"265 18 OFFCURVE",
+"314 -12 OFFCURVE",
+"376 -12 CURVE SMOOTH",
 "486 -12 OFFCURVE",
 "585 83 OFFCURVE",
 "585 225 CURVE SMOOTH",
@@ -22175,21 +22395,12 @@ nodes = (
 "101 724 LINE",
 "101 -284 LINE",
 "26 -284 LINE",
-"26 -314 LINE",
-"330 -314 LINE",
-"330 -284 LINE",
-"239 -284 LINE",
-"239 58 LINE",
-"243 58 LINE",
-"265 18 OFFCURVE",
-"314 -12 OFFCURVE",
-"376 -12 CURVE SMOOTH"
+"26 -314 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"354 27 LINE SMOOTH",
 "288 27 OFFCURVE",
 "239 85 OFFCURVE",
 "239 210 CURVE SMOOTH",
@@ -22213,7 +22424,7 @@ unicode = 00FE;
 },
 {
 glyphname = q;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -22285,34 +22496,14 @@ paths = (
 {
 closed = 1;
 nodes = (
-"570 450 LINE",
-"381 450 LINE",
-"381 425 LINE",
-"570 425 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"491 442 LINE",
-"381 442 LINE",
-"381 -299 LINE",
-"491 -299 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"570 -289 LINE",
-"291 -289 LINE",
-"291 -314 LINE",
-"570 -314 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"255 22 LINE",
+"306 -12 OFFCURVE",
+"355 18 OFFCURVE",
+"377 58 CURVE",
+"401 58 LINE",
+"381 210 LINE",
+"381 80 OFFCURVE",
+"327 22 OFFCURVE",
+"255 22 CURVE SMOOTH",
 "199 22 OFFCURVE",
 "178 59 OFFCURVE",
 "178 224 CURVE SMOOTH",
@@ -22332,15 +22523,34 @@ nodes = (
 "50 225 CURVE SMOOTH",
 "50 83 OFFCURVE",
 "144 -12 OFFCURVE",
-"244 -12 CURVE SMOOTH",
-"306 -12 OFFCURVE",
-"355 18 OFFCURVE",
-"377 58 CURVE",
-"401 58 LINE",
-"381 210 LINE",
-"381 80 OFFCURVE",
-"327 22 OFFCURVE",
-"255 22 CURVE SMOOTH"
+"244 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"570 -314 LINE",
+"570 -289 LINE",
+"291 -289 LINE",
+"291 -314 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"491 -299 LINE",
+"491 442 LINE",
+"381 442 LINE",
+"381 -299 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"570 425 LINE",
+"570 450 LINE",
+"381 450 LINE",
+"381 425 LINE"
 );
 }
 );
@@ -22416,34 +22626,14 @@ paths = (
 {
 closed = 1;
 nodes = (
-"611 450 LINE",
-"392 450 LINE",
-"392 420 LINE",
-"611 420 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"530 442 LINE",
-"392 442 LINE",
-"392 -299 LINE",
-"530 -299 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"611 -284 LINE",
-"297 -284 LINE",
-"297 -314 LINE",
-"611 -314 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"275 27 LINE SMOOTH",
+"317 -12 OFFCURVE",
+"366 18 OFFCURVE",
+"388 58 CURVE",
+"412 58 LINE",
+"392 210 LINE",
+"392 83 OFFCURVE",
+"342 27 OFFCURVE",
+"275 27 CURVE SMOOTH",
 "221 27 OFFCURVE",
 "200 64 OFFCURVE",
 "200 223 CURVE SMOOTH",
@@ -22463,15 +22653,34 @@ nodes = (
 "45 225 CURVE SMOOTH",
 "45 83 OFFCURVE",
 "144 -12 OFFCURVE",
-"255 -12 CURVE SMOOTH",
-"317 -12 OFFCURVE",
-"366 18 OFFCURVE",
-"388 58 CURVE",
-"412 58 LINE",
-"392 210 LINE",
-"392 83 OFFCURVE",
-"342 27 OFFCURVE",
-"275 27 CURVE SMOOTH"
+"255 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"611 -314 LINE",
+"611 -284 LINE",
+"297 -284 LINE",
+"297 -314 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"530 -299 LINE",
+"530 442 LINE",
+"392 442 LINE",
+"392 -299 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"611 420 LINE",
+"611 450 LINE",
+"392 450 LINE",
+"392 420 LINE"
 );
 }
 );
@@ -22482,7 +22691,7 @@ unicode = 0071;
 },
 {
 glyphname = r;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -22546,11 +22755,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"28 425 LINE",
-"107 425 LINE",
-"107 25 LINE",
-"28 25 LINE",
-"28 0 LINE",
 "307 0 LINE",
 "307 25 LINE",
 "217 25 LINE",
@@ -22578,7 +22782,12 @@ nodes = (
 "221 371 CURVE",
 "217 371 LINE",
 "217 450 LINE",
-"28 450 LINE"
+"28 450 LINE",
+"28 425 LINE",
+"107 425 LINE",
+"107 25 LINE",
+"28 25 LINE",
+"28 0 LINE"
 );
 }
 );
@@ -22649,11 +22858,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"20 420 LINE",
-"101 420 LINE",
-"101 30 LINE",
-"20 30 LINE",
-"20 0 LINE",
 "304 0 LINE",
 "304 30 LINE",
 "239 30 LINE",
@@ -22681,7 +22885,12 @@ nodes = (
 "243 373 CURVE",
 "239 373 LINE",
 "239 450 LINE",
-"20 450 LINE"
+"20 450 LINE",
+"20 420 LINE",
+"101 420 LINE",
+"101 30 LINE",
+"20 30 LINE",
+"20 0 LINE"
 );
 }
 );
@@ -22764,7 +22973,7 @@ unicode = 0159;
 },
 {
 glyphname = rcommaaccent;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 21:39:36 +0000";
 layers = (
 {
 components = (
@@ -22772,7 +22981,7 @@ components = (
 name = r;
 },
 {
-name = commaaccent;
+name = commaaccentcomb;
 transform = "{1, 0, 0, 1, 81, 0}";
 }
 );
@@ -22785,7 +22994,7 @@ components = (
 name = r;
 },
 {
-name = commaaccent;
+name = commaaccentcomb;
 transform = "{1, 0, 0, 1, 84, 0}";
 }
 );
@@ -22799,7 +23008,7 @@ unicode = 0157;
 },
 {
 glyphname = rdblgrave;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 21:39:36 +0000";
 layers = (
 {
 components = (
@@ -22807,7 +23016,7 @@ components = (
 name = r;
 },
 {
-name = uni030F;
+name = dblgravecomb;
 transform = "{1, 0, 0, 1, -28, 0}";
 }
 );
@@ -22820,7 +23029,7 @@ components = (
 name = r;
 },
 {
-name = uni030F;
+name = dblgravecomb;
 transform = "{1, 0, 0, 1, -32, 0}";
 }
 );
@@ -22869,7 +23078,7 @@ unicode = 1E5B;
 },
 {
 glyphname = rinvertedbreve;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 21:39:36 +0000";
 layers = (
 {
 components = (
@@ -22877,7 +23086,7 @@ components = (
 name = r;
 },
 {
-name = uni0311;
+name = breveinvertedcomb;
 transform = "{1, 0, 0, 1, 66, 0}";
 }
 );
@@ -22890,7 +23099,7 @@ components = (
 name = r;
 },
 {
-name = uni0311;
+name = breveinvertedcomb;
 transform = "{1, 0, 0, 1, 75, 0}";
 }
 );
@@ -22904,7 +23113,7 @@ unicode = 0213;
 },
 {
 glyphname = s;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 16:45:05 +0000";
 layers = (
 {
 background = {
@@ -22967,7 +23176,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"239 -12 LINE",
 "332 -12 OFFCURVE",
 "393 47 OFFCURVE",
 "393 139 CURVE SMOOTH",
@@ -23080,7 +23288,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"229 -12 LINE SMOOTH",
 "328 -12 OFFCURVE",
 "393 40 OFFCURVE",
 "393 144 CURVE SMOOTH",
@@ -23208,6 +23415,41 @@ rightKerningGroup = s;
 unicode = 0161;
 },
 {
+glyphname = scedilla;
+lastChange = "2016-08-18 21:39:28 +0000";
+layers = (
+{
+components = (
+{
+name = s;
+},
+{
+name = cedilla;
+transform = "{1, 0, 0, 1, 97, 0}";
+}
+);
+layerId = UUID0;
+width = 438;
+},
+{
+components = (
+{
+name = s;
+},
+{
+name = cedilla;
+transform = "{1, 0, 0, 1, 99, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 429;
+}
+);
+leftKerningGroup = s;
+rightKerningGroup = s;
+unicode = 015F;
+},
+{
 glyphname = scircumflex;
 lastChange = "2016-08-16 11:12:00 +0000";
 layers = (
@@ -23241,6 +23483,41 @@ width = 429;
 leftKerningGroup = s;
 rightKerningGroup = s;
 unicode = 015D;
+},
+{
+glyphname = scommaaccent;
+lastChange = "2016-08-18 21:39:36 +0000";
+layers = (
+{
+components = (
+{
+name = s;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 131, 0}";
+}
+);
+layerId = UUID0;
+width = 438;
+},
+{
+components = (
+{
+name = s;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 125, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 429;
+}
+);
+leftKerningGroup = s;
+rightKerningGroup = s;
+unicode = 0219;
 },
 {
 glyphname = sdotbelow;
@@ -23279,7 +23556,7 @@ unicode = 1E63;
 },
 {
 glyphname = germandbls;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -23287,6 +23564,26 @@ paths = (
 {
 closed = 1;
 nodes = (
+"435 -6 OFFCURVE",
+"526 80 OFFCURVE",
+"526 218 CURVE SMOOTH",
+"526 350 OFFCURVE",
+"443 427 OFFCURVE",
+"345 435 CURVE",
+"345 439 LINE",
+"418 457 OFFCURVE",
+"481 499 OFFCURVE",
+"481 596 CURVE SMOOTH",
+"481 704 OFFCURVE",
+"404 763 OFFCURVE",
+"288 763 CURVE SMOOTH",
+"157 763 OFFCURVE",
+"92 687 OFFCURVE",
+"92 550 CURVE SMOOTH",
+"92 25 LINE",
+"7 25 LINE",
+"7 0 LINE",
+"202 0 LINE",
 "202 615 LINE SMOOTH",
 "202 694 OFFCURVE",
 "220 736 OFFCURVE",
@@ -23320,27 +23617,7 @@ nodes = (
 "238 72 CURVE SMOOTH",
 "238 29 OFFCURVE",
 "278 -6 OFFCURVE",
-"339 -6 CURVE SMOOTH",
-"435 -6 OFFCURVE",
-"526 80 OFFCURVE",
-"526 218 CURVE SMOOTH",
-"526 350 OFFCURVE",
-"443 427 OFFCURVE",
-"345 435 CURVE",
-"345 439 LINE",
-"418 457 OFFCURVE",
-"481 499 OFFCURVE",
-"481 596 CURVE SMOOTH",
-"481 704 OFFCURVE",
-"404 763 OFFCURVE",
-"288 763 CURVE SMOOTH",
-"157 763 OFFCURVE",
-"92 687 OFFCURVE",
-"92 550 CURVE SMOOTH",
-"92 25 LINE",
-"7 25 LINE",
-"7 0 LINE",
-"202 0 LINE"
+"339 -6 CURVE SMOOTH"
 );
 }
 );
@@ -23352,6 +23629,26 @@ paths = (
 {
 closed = 1;
 nodes = (
+"521 -6 OFFCURVE",
+"623 80 OFFCURVE",
+"623 221 CURVE SMOOTH",
+"623 345 OFFCURVE",
+"543 427 OFFCURVE",
+"442 435 CURVE",
+"442 439 LINE",
+"515 457 OFFCURVE",
+"578 500 OFFCURVE",
+"578 595 CURVE SMOOTH",
+"578 704 OFFCURVE",
+"495 763 OFFCURVE",
+"355 763 CURVE SMOOTH",
+"197 763 OFFCURVE",
+"115 687 OFFCURVE",
+"115 550 CURVE SMOOTH",
+"115 30 LINE",
+"20 30 LINE",
+"20 0 LINE",
+"273 0 LINE",
 "273 615 LINE SMOOTH",
 "273 693 OFFCURVE",
 "291 731 OFFCURVE",
@@ -23385,27 +23682,7 @@ nodes = (
 "309 78 CURVE SMOOTH",
 "309 33 OFFCURVE",
 "345 -6 OFFCURVE",
-"416 -6 CURVE SMOOTH",
-"521 -6 OFFCURVE",
-"623 80 OFFCURVE",
-"623 221 CURVE SMOOTH",
-"623 345 OFFCURVE",
-"543 427 OFFCURVE",
-"442 435 CURVE",
-"442 439 LINE",
-"515 457 OFFCURVE",
-"578 500 OFFCURVE",
-"578 595 CURVE SMOOTH",
-"578 704 OFFCURVE",
-"495 763 OFFCURVE",
-"355 763 CURVE SMOOTH",
-"197 763 OFFCURVE",
-"115 687 OFFCURVE",
-"115 550 CURVE SMOOTH",
-"115 30 LINE",
-"20 30 LINE",
-"20 0 LINE",
-"273 0 LINE"
+"416 -6 CURVE SMOOTH"
 );
 }
 );
@@ -23415,136 +23692,8 @@ width = 669;
 unicode = 00DF;
 },
 {
-glyphname = schwa;
-lastChange = "2016-08-16 11:12:00 +0000";
-layers = (
-{
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"146 152 LINE",
-"357 152 LINE",
-"357 177 LINE",
-"30 177 LINE",
-"30 171 LINE SMOOTH",
-"30 57 OFFCURVE",
-"113 -13 OFFCURVE",
-"221 -13 CURVE SMOOTH",
-"359 -13 OFFCURVE",
-"449 103 OFFCURVE",
-"449 217 CURVE SMOOTH",
-"449 340 OFFCURVE",
-"347 454 OFFCURVE",
-"221 454 CURVE SMOOTH",
-"127 454 OFFCURVE",
-"54 397 OFFCURVE",
-"27 303 CURVE",
-"55 303 LINE",
-"92 392 OFFCURVE",
-"146 424 OFFCURVE",
-"218 424 CURVE SMOOTH",
-"294 424 OFFCURVE",
-"319 383 OFFCURVE",
-"319 221 CURVE SMOOTH",
-"319 63 OFFCURVE",
-"293 14 OFFCURVE",
-"226 14 CURVE SMOOTH",
-"173 14 OFFCURVE",
-"146 45 OFFCURVE",
-"146 105 CURVE SMOOTH"
-);
-}
-);
-};
-layerId = UUID0;
-paths = (
-{
-closed = 1;
-nodes = (
-"161 163 LINE",
-"372 163 LINE",
-"372 188 LINE",
-"45 188 LINE",
-"45 182 LINE SMOOTH",
-"45 68 OFFCURVE",
-"128 -12 OFFCURVE",
-"236 -12 CURVE SMOOTH",
-"374 -12 OFFCURVE",
-"464 103 OFFCURVE",
-"464 225 CURVE SMOOTH",
-"464 347 OFFCURVE",
-"360 462 OFFCURVE",
-"231 462 CURVE SMOOTH",
-"140 462 OFFCURVE",
-"69 405 OFFCURVE",
-"42 311 CURVE",
-"70 311 LINE",
-"106 400 OFFCURVE",
-"158 432 OFFCURVE",
-"228 432 CURVE SMOOTH",
-"307 432 OFFCURVE",
-"334 387 OFFCURVE",
-"334 225 CURVE SMOOTH",
-"334 67 OFFCURVE",
-"308 15 OFFCURVE",
-"241 15 CURVE SMOOTH",
-"188 15 OFFCURVE",
-"161 46 OFFCURVE",
-"161 106 CURVE SMOOTH"
-);
-}
-);
-width = 508;
-},
-{
-layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
-paths = (
-{
-closed = 1;
-nodes = (
-"179 166 LINE",
-"385 166 LINE",
-"385 196 LINE",
-"38 196 LINE",
-"38 185 LINE SMOOTH",
-"38 63 OFFCURVE",
-"129 -13 OFFCURVE",
-"248 -13 CURVE SMOOTH",
-"397 -13 OFFCURVE",
-"492 105 OFFCURVE",
-"492 221 CURVE SMOOTH",
-"492 346 OFFCURVE",
-"382 462 OFFCURVE",
-"242 462 CURVE SMOOTH",
-"142 462 OFFCURVE",
-"63 403 OFFCURVE",
-"35 311 CURVE",
-"68 311 LINE",
-"107 396 OFFCURVE",
-"167 427 OFFCURVE",
-"237 427 CURVE SMOOTH",
-"313 427 OFFCURVE",
-"337 389 OFFCURVE",
-"337 227 CURVE SMOOTH",
-"337 69 OFFCURVE",
-"314 19 OFFCURVE",
-"251 19 CURVE SMOOTH",
-"203 19 OFFCURVE",
-"179 48 OFFCURVE",
-"179 105 CURVE"
-);
-}
-);
-width = 537;
-}
-);
-unicode = 0259;
-},
-{
 glyphname = t;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 16:45:14 +0000";
 layers = (
 {
 background = {
@@ -23586,7 +23735,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"196 -13 LINE",
 "263 -13 OFFCURVE",
 "301 12 OFFCURVE",
 "335 85 CURVE",
@@ -23657,7 +23805,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"206 -13 LINE SMOOTH",
 "281 -13 OFFCURVE",
 "325 12 OFFCURVE",
 "361 85 CURVE",
@@ -23695,7 +23842,7 @@ unicode = 0074;
 },
 {
 glyphname = tbar;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 components = (
@@ -23708,10 +23855,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"20 277 LINE",
 "313 277 LINE",
 "313 312 LINE",
-"20 312 LINE"
+"20 312 LINE",
+"20 277 LINE"
 );
 }
 );
@@ -23728,10 +23875,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"20 268 LINE",
 "323 268 LINE",
 "323 312 LINE",
-"20 312 LINE"
+"20 312 LINE",
+"20 268 LINE"
 );
 }
 );
@@ -23775,6 +23922,76 @@ leftKerningGroup = t;
 unicode = 0165;
 },
 {
+glyphname = tcedilla;
+lastChange = "2016-08-18 21:39:28 +0000";
+layers = (
+{
+components = (
+{
+name = t;
+},
+{
+name = cedilla;
+transform = "{1, 0, 0, 1, 72, 0}";
+}
+);
+layerId = UUID0;
+width = 354;
+},
+{
+components = (
+{
+name = t;
+},
+{
+name = cedilla;
+transform = "{1, 0, 0, 1, 69, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 354;
+}
+);
+leftKerningGroup = t;
+rightKerningGroup = t;
+unicode = 0163;
+},
+{
+glyphname = tcommaaccent;
+lastChange = "2016-08-18 21:39:36 +0000";
+layers = (
+{
+components = (
+{
+name = t;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 100, 0}";
+}
+);
+layerId = UUID0;
+width = 354;
+},
+{
+components = (
+{
+name = t;
+},
+{
+name = commaaccentcomb;
+transform = "{1, 0, 0, 1, 110, 0}";
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 354;
+}
+);
+leftKerningGroup = t;
+rightKerningGroup = t;
+unicode = 021B;
+},
+{
 glyphname = tdotbelow;
 lastChange = "2016-08-16 11:12:00 +0000";
 layers = (
@@ -23811,7 +24028,7 @@ unicode = 1E6D;
 },
 {
 glyphname = u;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -23819,46 +24036,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"557 25 LINE",
-"368 25 LINE",
-"368 0 LINE",
-"557 0 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"478 435 LINE",
-"368 435 LINE",
-"368 16 LINE",
-"478 16 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"478 450 LINE",
-"286 450 LINE",
-"286 425 LINE",
-"478 425 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"195 450 LINE",
-"7 450 LINE",
-"7 425 LINE",
-"195 425 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"85 97 LINE SMOOTH",
-"85 36 OFFCURVE",
-"139 -12 OFFCURVE",
-"216 -12 CURVE SMOOTH",
 "290 -12 OFFCURVE",
 "335 26 OFFCURVE",
 "364 78 CURVE",
@@ -23871,7 +24048,47 @@ nodes = (
 "195 50 OFFCURVE",
 "195 100 CURVE SMOOTH",
 "195 435 LINE",
-"85 435 LINE"
+"85 435 LINE",
+"85 97 LINE SMOOTH",
+"85 36 OFFCURVE",
+"139 -12 OFFCURVE",
+"216 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"557 0 LINE",
+"557 25 LINE",
+"368 25 LINE",
+"368 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"195 425 LINE",
+"195 450 LINE",
+"7 450 LINE",
+"7 425 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"478 16 LINE",
+"478 435 LINE",
+"368 435 LINE",
+"368 16 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"478 425 LINE",
+"478 450 LINE",
+"286 450 LINE",
+"286 425 LINE"
 );
 }
 );
@@ -23945,46 +24162,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"603 30 LINE",
-"386 30 LINE",
-"386 0 LINE",
-"603 0 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"524 435 LINE",
-"386 435 LINE",
-"386 15 LINE",
-"524 15 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"524 450 LINE",
-"304 450 LINE",
-"304 420 LINE",
-"524 420 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"226 450 LINE",
-"10 450 LINE",
-"10 420 LINE",
-"226 420 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"88 98 LINE SMOOTH",
-"88 37 OFFCURVE",
-"140 -13 OFFCURVE",
-"222 -13 CURVE SMOOTH",
 "292 -13 OFFCURVE",
 "358 24 OFFCURVE",
 "382 79 CURVE",
@@ -23997,7 +24174,47 @@ nodes = (
 "226 56 OFFCURVE",
 "226 111 CURVE SMOOTH",
 "226 435 LINE",
-"88 435 LINE"
+"88 435 LINE",
+"88 98 LINE SMOOTH",
+"88 37 OFFCURVE",
+"140 -13 OFFCURVE",
+"222 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"603 0 LINE",
+"603 30 LINE",
+"386 30 LINE",
+"386 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"226 420 LINE",
+"226 450 LINE",
+"10 450 LINE",
+"10 420 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"524 15 LINE",
+"524 435 LINE",
+"386 435 LINE",
+"386 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"524 420 LINE",
+"524 450 LINE",
+"304 450 LINE",
+"304 420 LINE"
 );
 }
 );
@@ -24115,7 +24332,7 @@ unicode = 00FB;
 },
 {
 glyphname = udblgrave;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 21:39:36 +0000";
 layers = (
 {
 components = (
@@ -24123,7 +24340,7 @@ components = (
 name = u;
 },
 {
-name = uni030F;
+name = dblgravecomb;
 transform = "{1, 0, 0, 1, 23, 0}";
 }
 );
@@ -24136,7 +24353,7 @@ components = (
 name = u;
 },
 {
-name = uni030F;
+name = dblgravecomb;
 transform = "{1, 0, 0, 1, -7, 0}";
 }
 );
@@ -24290,7 +24507,7 @@ unicode = 0171;
 },
 {
 glyphname = uinvertedbreve;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 21:39:36 +0000";
 layers = (
 {
 components = (
@@ -24298,7 +24515,7 @@ components = (
 name = u;
 },
 {
-name = uni0311;
+name = breveinvertedcomb;
 transform = "{1, 0, 0, 1, 105, 0}";
 }
 );
@@ -24311,7 +24528,7 @@ components = (
 name = u;
 },
 {
-name = uni0311;
+name = breveinvertedcomb;
 transform = "{1, 0, 0, 1, 125, 0}";
 }
 );
@@ -24357,294 +24574,6 @@ width = 613;
 leftKerningGroup = u;
 rightKerningGroup = u;
 unicode = 016B;
-},
-{
-glyphname = uni015F;
-lastChange = "2016-08-16 11:12:00 +0000";
-layers = (
-{
-components = (
-{
-name = s;
-},
-{
-name = cedilla;
-transform = "{1, 0, 0, 1, 97, 0}";
-}
-);
-layerId = UUID0;
-width = 438;
-},
-{
-components = (
-{
-name = s;
-},
-{
-name = cedilla;
-transform = "{1, 0, 0, 1, 99, 0}";
-}
-);
-layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
-width = 429;
-}
-);
-leftKerningGroup = s;
-rightKerningGroup = s;
-unicode = 015F;
-},
-{
-glyphname = uni0163;
-lastChange = "2016-08-16 11:12:00 +0000";
-layers = (
-{
-components = (
-{
-name = t;
-},
-{
-name = cedilla;
-transform = "{1, 0, 0, 1, 72, 0}";
-}
-);
-layerId = UUID0;
-width = 354;
-},
-{
-components = (
-{
-name = t;
-},
-{
-name = cedilla;
-transform = "{1, 0, 0, 1, 69, 0}";
-}
-);
-layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
-width = 354;
-}
-);
-leftKerningGroup = t;
-rightKerningGroup = t;
-unicode = 0163;
-},
-{
-glyphname = uni01C6;
-lastChange = "2016-08-16 11:12:00 +0000";
-layers = (
-{
-components = (
-{
-name = d;
-},
-{
-name = caron;
-transform = "{1, 0, 0, 1, 628, 0}";
-},
-{
-name = z;
-transform = "{1, 0, 0, 1, 554, 0}";
-}
-);
-layerId = UUID0;
-width = 1034;
-},
-{
-components = (
-{
-name = d;
-},
-{
-name = caron;
-transform = "{1, 0, 0, 1, 630, 0}";
-},
-{
-name = z;
-transform = "{1, 0, 0, 1, 568, 0}";
-}
-);
-layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
-width = 1044;
-}
-);
-leftKerningGroup = d;
-rightKerningGroup = z;
-unicode = 01C6;
-},
-{
-glyphname = uni01C9;
-lastChange = "2016-08-16 11:12:00 +0000";
-layers = (
-{
-components = (
-{
-name = l;
-},
-{
-name = j;
-transform = "{1, 0, 0, 1, 288, 0}";
-}
-);
-layerId = UUID0;
-width = 618;
-},
-{
-components = (
-{
-name = l;
-},
-{
-name = j;
-transform = "{1, 0, 0, 1, 329, 0}";
-}
-);
-layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
-width = 647;
-}
-);
-leftKerningGroup = l;
-rightKerningGroup = j;
-unicode = 01C9;
-},
-{
-glyphname = uni01CC;
-lastChange = "2016-08-16 11:12:00 +0000";
-layers = (
-{
-components = (
-{
-name = n;
-},
-{
-name = j;
-transform = "{1, 0, 0, 1, 572, 0}";
-}
-);
-layerId = UUID0;
-width = 902;
-},
-{
-components = (
-{
-name = n;
-},
-{
-name = j;
-transform = "{1, 0, 0, 1, 614, 0}";
-}
-);
-layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
-width = 932;
-}
-);
-leftKerningGroup = n;
-rightKerningGroup = j;
-unicode = 01CC;
-},
-{
-glyphname = uni01F3;
-lastChange = "2016-08-16 11:12:00 +0000";
-layers = (
-{
-components = (
-{
-name = d;
-},
-{
-name = z;
-transform = "{1, 0, 0, 1, 554, 0}";
-}
-);
-layerId = UUID0;
-width = 1034;
-},
-{
-components = (
-{
-name = d;
-},
-{
-name = z;
-transform = "{1, 0, 0, 1, 631, 0}";
-}
-);
-layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
-width = 1107;
-}
-);
-leftKerningGroup = d;
-rightKerningGroup = z;
-unicode = 01F3;
-},
-{
-glyphname = uni0219;
-lastChange = "2016-08-16 11:12:00 +0000";
-layers = (
-{
-components = (
-{
-name = s;
-},
-{
-name = commaaccent;
-transform = "{1, 0, 0, 1, 131, 0}";
-}
-);
-layerId = UUID0;
-width = 438;
-},
-{
-components = (
-{
-name = s;
-},
-{
-name = commaaccent;
-transform = "{1, 0, 0, 1, 125, 0}";
-}
-);
-layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
-width = 429;
-}
-);
-leftKerningGroup = s;
-rightKerningGroup = s;
-unicode = 0219;
-},
-{
-glyphname = uni021B;
-lastChange = "2016-08-16 11:12:00 +0000";
-layers = (
-{
-components = (
-{
-name = t;
-},
-{
-name = commaaccent;
-transform = "{1, 0, 0, 1, 100, 0}";
-}
-);
-layerId = UUID0;
-width = 354;
-},
-{
-components = (
-{
-name = t;
-},
-{
-name = commaaccent;
-transform = "{1, 0, 0, 1, 110, 0}";
-}
-);
-layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
-width = 354;
-}
-);
-leftKerningGroup = t;
-rightKerningGroup = t;
-unicode = 021B;
 },
 {
 glyphname = uogonek;
@@ -24753,7 +24682,7 @@ unicode = 0169;
 },
 {
 glyphname = v;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -24761,38 +24690,38 @@ paths = (
 {
 closed = 1;
 nodes = (
-"-13 425 LINE",
-"231 425 LINE",
-"231 450 LINE",
-"-13 450 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"241 -12 LINE",
 "294 135 LINE",
 "289 135 LINE",
 "162 447 LINE",
-"41 441 LINE"
+"41 441 LINE",
+"241 -12 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"327 425 LINE",
-"506 425 LINE",
-"506 450 LINE",
-"327 450 LINE"
+"231 425 LINE",
+"231 450 LINE",
+"-13 450 LINE",
+"-13 425 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"241 -12 LINE",
 "270 -12 LINE",
 "435 433 LINE",
-"399 433 LINE"
+"399 433 LINE",
+"241 -12 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"506 425 LINE",
+"506 450 LINE",
+"327 450 LINE",
+"327 425 LINE"
 );
 }
 );
@@ -24845,38 +24774,38 @@ paths = (
 {
 closed = 1;
 nodes = (
-"-15 420 LINE",
-"253 420 LINE",
-"253 450 LINE",
-"-15 450 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"234 -13 LINE",
 "309 167 LINE",
 "304 167 LINE",
 "187 440 LINE",
-"31 440 LINE"
+"31 440 LINE",
+"234 -13 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"323 420 LINE",
-"511 420 LINE",
-"511 450 LINE",
-"323 450 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"234 -13 LINE",
 "263 -13 LINE",
 "450 432 LINE",
-"414 432 LINE"
+"414 432 LINE",
+"234 -13 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"253 420 LINE",
+"253 450 LINE",
+"-15 450 LINE",
+"-15 420 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"511 420 LINE",
+"511 450 LINE",
+"323 450 LINE",
+"323 420 LINE"
 );
 }
 );
@@ -24887,7 +24816,7 @@ unicode = 0076;
 },
 {
 glyphname = w;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -24945,7 +24874,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"204 -12 LINE",
 "233 -12 LINE",
 "348 295 LINE",
 "352 295 LINE",
@@ -24968,7 +24896,8 @@ nodes = (
 "230 450 LINE",
 "-12 450 LINE",
 "-12 425 LINE",
-"50 425 LINE"
+"50 425 LINE",
+"204 -12 LINE"
 );
 }
 );
@@ -25041,7 +24970,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"205 -13 LINE",
 "234 -13 LINE",
 "340 266 LINE",
 "344 266 LINE",
@@ -25064,7 +24992,8 @@ nodes = (
 "253 450 LINE",
 "-15 450 LINE",
 "-15 420 LINE",
-"39 420 LINE"
+"39 420 LINE",
+"205 -13 LINE"
 );
 }
 );
@@ -25217,7 +25146,7 @@ unicode = 1E81;
 },
 {
 glyphname = x;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -25225,64 +25154,64 @@ paths = (
 {
 closed = 1;
 nodes = (
-"309 425 LINE",
-"497 425 LINE",
-"497 450 LINE",
-"309 450 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"248 249 LINE",
-"269 228 LINE",
-"416 432 LINE",
-"380 432 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"189 25 LINE",
-"-9 25 LINE",
-"-9 0 LINE",
-"189 0 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"235 202 LINE",
-"217 226 LINE",
-"67 18 LINE",
-"103 18 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"-11 425 LINE",
-"237 425 LINE",
-"237 450 LINE",
-"-11 450 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"274 0 LINE",
-"522 0 LINE",
-"522 25 LINE",
-"274 25 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"340 15 LINE",
 "477 15 LINE",
 "166 440 LINE",
-"33 440 LINE"
+"33 440 LINE",
+"340 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"189 0 LINE",
+"189 25 LINE",
+"-9 25 LINE",
+"-9 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"103 18 LINE",
+"235 202 LINE",
+"217 226 LINE",
+"67 18 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"522 0 LINE",
+"522 25 LINE",
+"274 25 LINE",
+"274 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"237 425 LINE",
+"237 450 LINE",
+"-11 450 LINE",
+"-11 425 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"416 432 LINE",
+"380 432 LINE",
+"248 249 LINE",
+"269 228 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"497 425 LINE",
+"497 450 LINE",
+"309 450 LINE",
+"309 425 LINE"
 );
 }
 );
@@ -25361,64 +25290,64 @@ paths = (
 {
 closed = 1;
 nodes = (
-"370 420 LINE",
-"558 420 LINE",
-"558 450 LINE",
-"370 450 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"287 248 LINE",
-"308 227 LINE",
-"499 431 LINE",
-"463 431 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"205 30 LINE",
-"7 30 LINE",
-"7 0 LINE",
-"205 0 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"266 182 LINE",
-"248 206 LINE",
-"68 18 LINE",
-"104 18 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"15 420 LINE",
-"293 420 LINE",
-"293 450 LINE",
-"15 450 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"285 0 LINE",
-"573 0 LINE",
-"573 30 LINE",
-"285 30 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"361 15 LINE",
 "531 15 LINE",
 "222 440 LINE",
-"49 440 LINE"
+"49 440 LINE",
+"361 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"205 0 LINE",
+"205 30 LINE",
+"7 30 LINE",
+"7 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"104 18 LINE",
+"266 182 LINE",
+"248 206 LINE",
+"68 18 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"573 0 LINE",
+"573 30 LINE",
+"285 30 LINE",
+"285 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"293 420 LINE",
+"293 450 LINE",
+"15 450 LINE",
+"15 420 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"499 431 LINE",
+"463 431 LINE",
+"287 248 LINE",
+"308 227 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"558 420 LINE",
+"558 450 LINE",
+"370 450 LINE",
+"370 420 LINE"
 );
 }
 );
@@ -25429,7 +25358,7 @@ unicode = 0078;
 },
 {
 glyphname = y;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -25491,34 +25420,11 @@ paths = (
 {
 closed = 1;
 nodes = (
-"-11 425 LINE",
-"237 425 LINE",
-"237 450 LINE",
-"-11 450 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"238 15 LINE",
-"291 159 LINE",
-"285 159 LINE",
-"162 446 LINE",
-"41 440 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"309 425 LINE",
-"497 425 LINE",
-"497 450 LINE",
-"309 450 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"112 -326 OFFCURVE",
+"148 -306 OFFCURVE",
+"182 -216 CURVE SMOOTH",
+"422 432 LINE",
+"386 432 LINE",
 "149 -228 LINE SMOOTH",
 "145 -240 OFFCURVE",
 "139 -251 OFFCURVE",
@@ -25531,12 +25437,35 @@ nodes = (
 "12 -266 CURVE SMOOTH",
 "12 -291 OFFCURVE",
 "26 -326 OFFCURVE",
-"76 -326 CURVE SMOOTH",
-"112 -326 OFFCURVE",
-"148 -306 OFFCURVE",
-"182 -216 CURVE SMOOTH",
-"422 432 LINE",
-"386 432 LINE"
+"76 -326 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"291 159 LINE",
+"285 159 LINE",
+"162 446 LINE",
+"41 440 LINE",
+"238 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"237 425 LINE",
+"237 450 LINE",
+"-11 450 LINE",
+"-11 425 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"497 425 LINE",
+"497 450 LINE",
+"309 450 LINE",
+"309 425 LINE"
 );
 }
 );
@@ -25603,34 +25532,11 @@ paths = (
 {
 closed = 1;
 nodes = (
-"-15 420 LINE",
-"276 420 LINE",
-"276 450 LINE",
-"-15 450 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"244 -3 LINE",
-"313 176 LINE",
-"308 176 LINE",
-"187 440 LINE",
-"28 440 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"336 420 LINE",
-"511 420 LINE",
-"511 450 LINE",
-"336 450 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"109 -323 OFFCURVE",
+"147 -305 OFFCURVE",
+"181 -223 CURVE SMOOTH",
+"456 433 LINE",
+"415 433 LINE",
 "156 -205 LINE SMOOTH",
 "148 -223 OFFCURVE",
 "142 -230 OFFCURVE",
@@ -25643,12 +25549,35 @@ nodes = (
 "-7 -252 CURVE SMOOTH",
 "-7 -283 OFFCURVE",
 "11 -323 OFFCURVE",
-"70 -323 CURVE SMOOTH",
-"109 -323 OFFCURVE",
-"147 -305 OFFCURVE",
-"181 -223 CURVE SMOOTH",
-"456 433 LINE",
-"415 433 LINE"
+"70 -323 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"313 176 LINE",
+"308 176 LINE",
+"187 440 LINE",
+"28 440 LINE",
+"244 -3 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"276 420 LINE",
+"276 450 LINE",
+"-15 450 LINE",
+"-15 420 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"511 420 LINE",
+"511 450 LINE",
+"336 450 LINE",
+"336 420 LINE"
 );
 }
 );
@@ -25836,7 +25765,7 @@ unicode = 1EF9;
 },
 {
 glyphname = z;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -25844,31 +25773,18 @@ paths = (
 {
 closed = 1;
 nodes = (
+"161 15 LINE",
 "422 415 LINE",
 "408 440 LINE",
 "314 440 LINE",
 "46 35 LINE",
-"49 15 LINE",
-"161 15 LINE"
+"49 15 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"68 275 LINE",
-"93 275 LINE",
-"95 357 OFFCURVE",
-"144 425 OFFCURVE",
-"231 425 CURVE SMOOTH",
-"414 425 LINE",
-"422 415 LINE",
-"422 450 LINE",
-"68 450 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"431 0 LINE",
 "431 185 LINE",
 "406 185 LINE",
 "405 169 LINE SMOOTH",
@@ -25877,8 +25793,21 @@ nodes = (
 "268 25 CURVE SMOOTH",
 "54 25 LINE",
 "46 35 LINE",
-"46 0 LINE",
-"431 0 LINE"
+"46 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"93 275 LINE",
+"95 357 OFFCURVE",
+"144 425 OFFCURVE",
+"231 425 CURVE SMOOTH",
+"414 425 LINE",
+"422 415 LINE",
+"422 450 LINE",
+"68 450 LINE",
+"68 275 LINE"
 );
 }
 );
@@ -25934,31 +25863,18 @@ paths = (
 {
 closed = 1;
 nodes = (
+"175 15 LINE",
 "446 416 LINE",
 "432 441 LINE",
 "303 441 LINE",
 "25 35 LINE",
-"28 15 LINE",
-"175 15 LINE"
+"28 15 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"57 275 LINE",
-"87 275 LINE",
-"89 354 OFFCURVE",
-"138 420 OFFCURVE",
-"225 420 CURVE SMOOTH",
-"438 420 LINE",
-"446 416 LINE",
-"446 450 LINE",
-"57 450 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"440 0 LINE",
 "440 185 LINE",
 "410 185 LINE",
 "409 169 LINE SMOOTH",
@@ -25967,8 +25883,21 @@ nodes = (
 "272 30 CURVE SMOOTH",
 "33 30 LINE",
 "25 35 LINE",
-"25 0 LINE",
-"440 0 LINE"
+"25 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"87 275 LINE",
+"89 354 OFFCURVE",
+"138 420 OFFCURVE",
+"225 420 CURVE SMOOTH",
+"438 420 LINE",
+"446 416 LINE",
+"446 450 LINE",
+"57 450 LINE",
+"57 275 LINE"
 );
 }
 );
@@ -26121,7 +26050,7 @@ unicode = 1E93;
 },
 {
 glyphname = f_f;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:28:22 +0000";
 layers = (
 {
 background = {
@@ -26218,36 +26147,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"116 0 LINE",
-"226 0 LINE",
-"226 585 LINE SMOOTH",
-"226 671 OFFCURVE",
-"242 705 OFFCURVE",
-"282 705 CURVE SMOOTH",
-"298 705 OFFCURVE",
-"305 700 OFFCURVE",
-"305 688 CURVE SMOOTH",
-"305 671 OFFCURVE",
-"291 665 OFFCURVE",
-"291 641 CURVE SMOOTH",
-"291 613 OFFCURVE",
-"311 594 OFFCURVE",
-"341 594 CURVE SMOOTH",
-"374 594 OFFCURVE",
-"397 617 OFFCURVE",
-"397 652 CURVE SMOOTH",
-"397 700 OFFCURVE",
-"355 732 OFFCURVE",
-"287 732 CURVE SMOOTH",
-"171 732 OFFCURVE",
-"116 639 OFFCURVE",
-"116 445 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"400 0 LINE",
 "510 0 LINE",
 "510 618 LINE SMOOTH",
 "510 704 OFFCURVE",
@@ -26270,34 +26169,64 @@ nodes = (
 "571 765 CURVE SMOOTH",
 "455 765 OFFCURVE",
 "400 672 OFFCURVE",
-"400 478 CURVE SMOOTH"
+"400 478 CURVE SMOOTH",
+"400 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"19 0 LINE",
 "289 0 LINE",
 "289 25 LINE",
-"19 25 LINE"
+"19 25 LINE",
+"19 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"343 0 LINE",
 "623 0 LINE",
 "623 25 LINE",
-"343 25 LINE"
+"343 25 LINE",
+"343 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"19 425 LINE",
+"226 0 LINE",
+"226 585 LINE SMOOTH",
+"226 671 OFFCURVE",
+"242 705 OFFCURVE",
+"282 705 CURVE SMOOTH",
+"298 705 OFFCURVE",
+"305 700 OFFCURVE",
+"305 688 CURVE SMOOTH",
+"305 671 OFFCURVE",
+"291 665 OFFCURVE",
+"291 641 CURVE SMOOTH",
+"291 613 OFFCURVE",
+"311 594 OFFCURVE",
+"341 594 CURVE SMOOTH",
+"374 594 OFFCURVE",
+"397 617 OFFCURVE",
+"397 652 CURVE SMOOTH",
+"397 700 OFFCURVE",
+"355 732 OFFCURVE",
+"287 732 CURVE SMOOTH",
+"171 732 OFFCURVE",
+"116 639 OFFCURVE",
+"116 445 CURVE SMOOTH",
+"116 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "633 425 LINE",
 "633 450 LINE",
-"19 450 LINE"
+"19 450 LINE",
+"19 425 LINE"
 );
 }
 );
@@ -26398,36 +26327,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"103 0 LINE",
-"241 0 LINE",
-"241 596 LINE SMOOTH",
-"241 679 OFFCURVE",
-"276 701 OFFCURVE",
-"317 701 CURVE SMOOTH",
-"340 701 OFFCURVE",
-"350 694 OFFCURVE",
-"350 682 CURVE SMOOTH",
-"350 664 OFFCURVE",
-"326 660 OFFCURVE",
-"326 626 CURVE SMOOTH",
-"326 588 OFFCURVE",
-"355 570 OFFCURVE",
-"387 570 CURVE SMOOTH",
-"427 570 OFFCURVE",
-"456 597 OFFCURVE",
-"456 637 CURVE SMOOTH",
-"456 689 OFFCURVE",
-"405 733 OFFCURVE",
-"323 733 CURVE SMOOTH",
-"188 733 OFFCURVE",
-"103 616 OFFCURVE",
-"103 446 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"415 0 LINE",
 "553 0 LINE",
 "553 629 LINE SMOOTH",
 "553 712 OFFCURVE",
@@ -26450,34 +26349,64 @@ nodes = (
 "635 766 CURVE SMOOTH",
 "500 766 OFFCURVE",
 "415 649 OFFCURVE",
-"415 479 CURVE SMOOTH"
+"415 479 CURVE SMOOTH",
+"415 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"23 0 LINE",
 "314 0 LINE",
 "314 30 LINE",
-"23 30 LINE"
+"23 30 LINE",
+"23 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"338 0 LINE",
 "654 0 LINE",
 "654 30 LINE",
-"338 30 LINE"
+"338 30 LINE",
+"338 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"20 420 LINE",
+"241 0 LINE",
+"241 596 LINE SMOOTH",
+"241 679 OFFCURVE",
+"276 701 OFFCURVE",
+"317 701 CURVE SMOOTH",
+"340 701 OFFCURVE",
+"350 694 OFFCURVE",
+"350 682 CURVE SMOOTH",
+"350 664 OFFCURVE",
+"326 660 OFFCURVE",
+"326 626 CURVE SMOOTH",
+"326 588 OFFCURVE",
+"355 570 OFFCURVE",
+"387 570 CURVE SMOOTH",
+"427 570 OFFCURVE",
+"456 597 OFFCURVE",
+"456 637 CURVE SMOOTH",
+"456 689 OFFCURVE",
+"405 733 OFFCURVE",
+"323 733 CURVE SMOOTH",
+"188 733 OFFCURVE",
+"103 616 OFFCURVE",
+"103 446 CURVE SMOOTH",
+"103 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "661 420 LINE",
 "661 450 LINE",
-"20 450 LINE"
+"20 450 LINE",
+"20 420 LINE"
 );
 }
 );
@@ -26486,11 +26415,10 @@ width = 658;
 );
 leftKerningGroup = f;
 rightKerningGroup = f;
-unicode = FB00;
 },
 {
 glyphname = f_f_i;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:28:22 +0000";
 layers = (
 {
 background = {
@@ -26605,63 +26533,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"19 0 LINE",
-"299 0 LINE",
-"299 25 LINE",
-"19 25 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"333 0 LINE",
-"574 0 LINE",
-"574 25 LINE",
-"333 25 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"612 0 LINE",
-"871 0 LINE",
-"871 25 LINE",
-"612 25 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"116 10 LINE",
-"226 10 LINE",
-"226 565 LINE SMOOTH",
-"226 666 OFFCURVE",
-"245 705 OFFCURVE",
-"292 705 CURVE SMOOTH",
-"314 705 OFFCURVE",
-"325 697 OFFCURVE",
-"325 680 CURVE SMOOTH",
-"325 660 OFFCURVE",
-"311 655 OFFCURVE",
-"311 631 CURVE SMOOTH",
-"311 603 OFFCURVE",
-"331 584 OFFCURVE",
-"361 584 CURVE SMOOTH",
-"394 584 OFFCURVE",
-"417 606 OFFCURVE",
-"417 643 CURVE SMOOTH",
-"417 695 OFFCURVE",
-"372 732 OFFCURVE",
-"297 732 CURVE SMOOTH",
-"174 732 OFFCURVE",
-"116 633 OFFCURVE",
-"116 425 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"400 10 LINE",
 "510 10 LINE",
 "510 588 LINE SMOOTH",
 "510 696 OFFCURVE",
@@ -26684,25 +26555,82 @@ nodes = (
 "622 765 CURVE SMOOTH",
 "479 765 OFFCURVE",
 "400 663 OFFCURVE",
-"400 448 CURVE SMOOTH"
+"400 448 CURVE SMOOTH",
+"400 10 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"19 425 LINE",
+"299 0 LINE",
+"299 25 LINE",
+"19 25 LINE",
+"19 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"574 0 LINE",
+"574 25 LINE",
+"333 25 LINE",
+"333 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"226 10 LINE",
+"226 565 LINE SMOOTH",
+"226 666 OFFCURVE",
+"245 705 OFFCURVE",
+"292 705 CURVE SMOOTH",
+"314 705 OFFCURVE",
+"325 697 OFFCURVE",
+"325 680 CURVE SMOOTH",
+"325 660 OFFCURVE",
+"311 655 OFFCURVE",
+"311 631 CURVE SMOOTH",
+"311 603 OFFCURVE",
+"331 584 OFFCURVE",
+"361 584 CURVE SMOOTH",
+"394 584 OFFCURVE",
+"417 606 OFFCURVE",
+"417 643 CURVE SMOOTH",
+"417 695 OFFCURVE",
+"372 732 OFFCURVE",
+"297 732 CURVE SMOOTH",
+"174 732 OFFCURVE",
+"116 633 OFFCURVE",
+"116 425 CURVE SMOOTH",
+"116 10 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"871 0 LINE",
+"871 25 LINE",
+"612 25 LINE",
+"612 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "791 425 LINE",
 "791 450 LINE",
-"19 450 LINE"
+"19 450 LINE",
+"19 425 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"681 15 LINE",
 "791 15 LINE",
 "791 435 LINE",
-"681 435 LINE"
+"681 435 LINE",
+"681 15 LINE"
 );
 }
 );
@@ -26821,63 +26749,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"23 0 LINE",
-"312 0 LINE",
-"312 30 LINE",
-"23 30 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"341 0 LINE",
-"618 0 LINE",
-"618 30 LINE",
-"341 30 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"650 0 LINE",
-"910 0 LINE",
-"910 30 LINE",
-"650 30 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"103 10 LINE",
-"241 10 LINE",
-"241 596 LINE SMOOTH",
-"241 679 OFFCURVE",
-"276 701 OFFCURVE",
-"317 701 CURVE SMOOTH",
-"340 701 OFFCURVE",
-"350 694 OFFCURVE",
-"350 682 CURVE SMOOTH",
-"350 664 OFFCURVE",
-"326 660 OFFCURVE",
-"326 626 CURVE SMOOTH",
-"326 588 OFFCURVE",
-"355 570 OFFCURVE",
-"387 570 CURVE SMOOTH",
-"427 570 OFFCURVE",
-"456 597 OFFCURVE",
-"456 637 CURVE SMOOTH",
-"456 689 OFFCURVE",
-"405 733 OFFCURVE",
-"323 733 CURVE SMOOTH",
-"188 733 OFFCURVE",
-"103 616 OFFCURVE",
-"103 446 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"415 10 LINE",
 "553 10 LINE",
 "553 609 LINE SMOOTH",
 "553 709 OFFCURVE",
@@ -26900,25 +26771,82 @@ nodes = (
 "665 766 CURVE SMOOTH",
 "512 766 OFFCURVE",
 "415 649 OFFCURVE",
-"415 479 CURVE SMOOTH"
+"415 479 CURVE SMOOTH",
+"415 10 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"20 420 LINE",
+"312 0 LINE",
+"312 30 LINE",
+"23 30 LINE",
+"23 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"618 0 LINE",
+"618 30 LINE",
+"341 30 LINE",
+"341 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"241 10 LINE",
+"241 596 LINE SMOOTH",
+"241 679 OFFCURVE",
+"276 701 OFFCURVE",
+"317 701 CURVE SMOOTH",
+"340 701 OFFCURVE",
+"350 694 OFFCURVE",
+"350 682 CURVE SMOOTH",
+"350 664 OFFCURVE",
+"326 660 OFFCURVE",
+"326 626 CURVE SMOOTH",
+"326 588 OFFCURVE",
+"355 570 OFFCURVE",
+"387 570 CURVE SMOOTH",
+"427 570 OFFCURVE",
+"456 597 OFFCURVE",
+"456 637 CURVE SMOOTH",
+"456 689 OFFCURVE",
+"405 733 OFFCURVE",
+"323 733 CURVE SMOOTH",
+"188 733 OFFCURVE",
+"103 616 OFFCURVE",
+"103 446 CURVE SMOOTH",
+"103 10 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"910 0 LINE",
+"910 30 LINE",
+"650 30 LINE",
+"650 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "845 420 LINE",
 "845 450 LINE",
-"20 450 LINE"
+"20 450 LINE",
+"20 420 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"707 15 LINE",
 "845 15 LINE",
 "845 434 LINE",
-"707 434 LINE"
+"707 434 LINE",
+"707 15 LINE"
 );
 }
 );
@@ -26927,11 +26855,10 @@ width = 925;
 );
 leftKerningGroup = f;
 rightKerningGroup = i;
-unicode = FB03;
 },
 {
 glyphname = f_f_l;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:28:22 +0000";
 layers = (
 {
 background = {
@@ -27046,36 +26973,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"116 0 LINE",
-"226 0 LINE",
-"226 565 LINE SMOOTH",
-"226 665 OFFCURVE",
-"245 705 OFFCURVE",
-"292 705 CURVE SMOOTH",
-"315 705 OFFCURVE",
-"325 697 OFFCURVE",
-"325 678 CURVE SMOOTH",
-"325 661 OFFCURVE",
-"311 655 OFFCURVE",
-"311 631 CURVE SMOOTH",
-"311 603 OFFCURVE",
-"331 584 OFFCURVE",
-"361 584 CURVE SMOOTH",
-"394 584 OFFCURVE",
-"417 607 OFFCURVE",
-"417 642 CURVE SMOOTH",
-"417 696 OFFCURVE",
-"371 732 OFFCURVE",
-"297 732 CURVE SMOOTH",
-"174 732 OFFCURVE",
-"116 633 OFFCURVE",
-"116 425 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"400 0 LINE",
 "510 0 LINE",
 "510 588 LINE SMOOTH",
 "510 695 OFFCURVE",
@@ -27098,52 +26995,82 @@ nodes = (
 "612 765 CURVE SMOOTH",
 "477 765 OFFCURVE",
 "400 663 OFFCURVE",
-"400 448 CURVE SMOOTH"
+"400 448 CURVE SMOOTH",
+"400 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"681 15 LINE",
-"791 15 LINE",
-"791 766 LINE",
-"681 718 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"19 425 LINE",
-"633 425 LINE",
-"633 450 LINE",
-"19 450 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"19 0 LINE",
 "304 0 LINE",
 "304 25 LINE",
-"19 25 LINE"
+"19 25 LINE",
+"19 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"318 0 LINE",
 "581 0 LINE",
 "581 25 LINE",
-"318 25 LINE"
+"318 25 LINE",
+"318 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"600 0 LINE",
+"226 0 LINE",
+"226 565 LINE SMOOTH",
+"226 665 OFFCURVE",
+"245 705 OFFCURVE",
+"292 705 CURVE SMOOTH",
+"315 705 OFFCURVE",
+"325 697 OFFCURVE",
+"325 678 CURVE SMOOTH",
+"325 661 OFFCURVE",
+"311 655 OFFCURVE",
+"311 631 CURVE SMOOTH",
+"311 603 OFFCURVE",
+"331 584 OFFCURVE",
+"361 584 CURVE SMOOTH",
+"394 584 OFFCURVE",
+"417 607 OFFCURVE",
+"417 642 CURVE SMOOTH",
+"417 696 OFFCURVE",
+"371 732 OFFCURVE",
+"297 732 CURVE SMOOTH",
+"174 732 OFFCURVE",
+"116 633 OFFCURVE",
+"116 425 CURVE SMOOTH",
+"116 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "871 0 LINE",
 "871 25 LINE",
-"600 25 LINE"
+"600 25 LINE",
+"600 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"633 425 LINE",
+"633 450 LINE",
+"19 450 LINE",
+"19 425 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"791 15 LINE",
+"791 766 LINE",
+"681 718 LINE",
+"681 15 LINE"
 );
 }
 );
@@ -27262,36 +27189,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"103 0 LINE",
-"241 0 LINE",
-"241 596 LINE SMOOTH",
-"241 679 OFFCURVE",
-"276 701 OFFCURVE",
-"317 701 CURVE SMOOTH",
-"340 701 OFFCURVE",
-"350 694 OFFCURVE",
-"350 682 CURVE SMOOTH",
-"350 664 OFFCURVE",
-"326 660 OFFCURVE",
-"326 626 CURVE SMOOTH",
-"326 588 OFFCURVE",
-"355 570 OFFCURVE",
-"387 570 CURVE SMOOTH",
-"427 570 OFFCURVE",
-"456 597 OFFCURVE",
-"456 637 CURVE SMOOTH",
-"456 689 OFFCURVE",
-"405 733 OFFCURVE",
-"323 733 CURVE SMOOTH",
-"188 733 OFFCURVE",
-"103 616 OFFCURVE",
-"103 446 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"413 0 LINE",
 "551 0 LINE",
 "551 628 LINE SMOOTH",
 "551 711 OFFCURVE",
@@ -27314,52 +27211,82 @@ nodes = (
 "643 765 CURVE SMOOTH",
 "502 765 OFFCURVE",
 "413 648 OFFCURVE",
-"413 478 CURVE SMOOTH"
+"413 478 CURVE SMOOTH",
+"413 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"716 15 LINE",
-"854 15 LINE",
-"854 754 LINE",
-"716 730 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"20 420 LINE",
-"791 420 LINE",
-"791 450 LINE",
-"20 450 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"23 0 LINE",
 "312 0 LINE",
 "312 30 LINE",
-"23 30 LINE"
+"23 30 LINE",
+"23 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"333 0 LINE",
 "624 0 LINE",
 "624 30 LINE",
-"333 30 LINE"
+"333 30 LINE",
+"333 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"645 0 LINE",
+"241 0 LINE",
+"241 596 LINE SMOOTH",
+"241 679 OFFCURVE",
+"276 701 OFFCURVE",
+"317 701 CURVE SMOOTH",
+"340 701 OFFCURVE",
+"350 694 OFFCURVE",
+"350 682 CURVE SMOOTH",
+"350 664 OFFCURVE",
+"326 660 OFFCURVE",
+"326 626 CURVE SMOOTH",
+"326 588 OFFCURVE",
+"355 570 OFFCURVE",
+"387 570 CURVE SMOOTH",
+"427 570 OFFCURVE",
+"456 597 OFFCURVE",
+"456 637 CURVE SMOOTH",
+"456 689 OFFCURVE",
+"405 733 OFFCURVE",
+"323 733 CURVE SMOOTH",
+"188 733 OFFCURVE",
+"103 616 OFFCURVE",
+"103 446 CURVE SMOOTH",
+"103 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "929 0 LINE",
 "929 30 LINE",
-"645 30 LINE"
+"645 30 LINE",
+"645 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"791 420 LINE",
+"791 450 LINE",
+"20 450 LINE",
+"20 420 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"854 15 LINE",
+"854 754 LINE",
+"716 730 LINE",
+"716 15 LINE"
 );
 }
 );
@@ -27368,11 +27295,10 @@ width = 944;
 );
 leftKerningGroup = f;
 rightKerningGroup = l;
-unicode = FB04;
 },
 {
 glyphname = f_i;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:28:22 +0000";
 layers = (
 {
 background = {
@@ -27449,7 +27375,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"116 0 LINE",
 "226 0 LINE",
 "226 588 LINE SMOOTH",
 "226 696 OFFCURVE",
@@ -27472,43 +27397,44 @@ nodes = (
 "338 765 CURVE SMOOTH",
 "195 765 OFFCURVE",
 "116 663 OFFCURVE",
-"116 448 CURVE SMOOTH"
+"116 448 CURVE SMOOTH",
+"116 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"19 0 LINE",
 "280 0 LINE",
 "280 25 LINE",
-"19 25 LINE"
+"19 25 LINE",
+"19 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"19 425 LINE",
-"507 425 LINE",
-"507 450 LINE",
-"19 450 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"397 15 LINE",
-"507 15 LINE",
-"507 435 LINE",
-"397 435 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"318 0 LINE",
 "587 0 LINE",
 "587 25 LINE",
-"318 25 LINE"
+"318 25 LINE",
+"318 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"507 15 LINE",
+"507 435 LINE",
+"397 435 LINE",
+"397 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"507 425 LINE",
+"507 450 LINE",
+"19 450 LINE",
+"19 425 LINE"
 );
 }
 );
@@ -27589,7 +27515,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"103 10 LINE",
 "241 10 LINE",
 "241 609 LINE SMOOTH",
 "241 709 OFFCURVE",
@@ -27612,43 +27537,44 @@ nodes = (
 "353 766 CURVE SMOOTH",
 "200 766 OFFCURVE",
 "103 649 OFFCURVE",
-"103 479 CURVE SMOOTH"
+"103 479 CURVE SMOOTH",
+"103 10 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"23 0 LINE",
 "302 0 LINE",
 "302 30 LINE",
-"23 30 LINE"
+"23 30 LINE",
+"23 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"20 420 LINE",
-"533 420 LINE",
-"533 450 LINE",
-"20 450 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"395 15 LINE",
-"533 15 LINE",
-"533 434 LINE",
-"395 434 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"334 0 LINE",
 "598 0 LINE",
 "598 30 LINE",
-"334 30 LINE"
+"334 30 LINE",
+"334 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"533 15 LINE",
+"533 434 LINE",
+"395 434 LINE",
+"395 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"533 420 LINE",
+"533 450 LINE",
+"20 450 LINE",
+"20 420 LINE"
 );
 }
 );
@@ -27657,11 +27583,10 @@ width = 613;
 );
 leftKerningGroup = f;
 rightKerningGroup = i;
-unicode = FB01;
 },
 {
 glyphname = f_l;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:28:22 +0000";
 layers = (
 {
 background = {
@@ -27738,7 +27663,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"116 0 LINE",
 "226 0 LINE",
 "226 588 LINE SMOOTH",
 "226 695 OFFCURVE",
@@ -27761,43 +27685,44 @@ nodes = (
 "328 765 CURVE SMOOTH",
 "193 765 OFFCURVE",
 "116 663 OFFCURVE",
-"116 448 CURVE SMOOTH"
+"116 448 CURVE SMOOTH",
+"116 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"19 0 LINE",
 "280 0 LINE",
 "280 25 LINE",
-"19 25 LINE"
+"19 25 LINE",
+"19 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"19 425 LINE",
-"349 425 LINE",
-"349 450 LINE",
-"19 450 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"397 15 LINE",
-"507 15 LINE",
-"507 766 LINE",
-"397 718 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"318 0 LINE",
 "587 0 LINE",
 "587 25 LINE",
-"318 25 LINE"
+"318 25 LINE",
+"318 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"349 425 LINE",
+"349 450 LINE",
+"19 450 LINE",
+"19 425 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"507 15 LINE",
+"507 766 LINE",
+"397 718 LINE",
+"397 15 LINE"
 );
 }
 );
@@ -27878,7 +27803,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"103 0 LINE",
 "241 0 LINE",
 "241 628 LINE SMOOTH",
 "241 711 OFFCURVE",
@@ -27901,43 +27825,44 @@ nodes = (
 "333 765 CURVE SMOOTH",
 "192 765 OFFCURVE",
 "103 648 OFFCURVE",
-"103 478 CURVE SMOOTH"
+"103 478 CURVE SMOOTH",
+"103 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"23 0 LINE",
 "314 0 LINE",
 "314 30 LINE",
-"23 30 LINE"
+"23 30 LINE",
+"23 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"20 420 LINE",
-"481 420 LINE",
-"481 450 LINE",
-"20 450 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"406 15 LINE",
-"544 15 LINE",
-"544 754 LINE",
-"406 730 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"335 0 LINE",
 "619 0 LINE",
 "619 30 LINE",
-"335 30 LINE"
+"335 30 LINE",
+"335 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"481 420 LINE",
+"481 450 LINE",
+"20 450 LINE",
+"20 420 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"544 15 LINE",
+"544 754 LINE",
+"406 730 LINE",
+"406 15 LINE"
 );
 }
 );
@@ -27946,11 +27871,10 @@ width = 634;
 );
 leftKerningGroup = f;
 rightKerningGroup = l;
-unicode = FB02;
 },
 {
 glyphname = ordfeminine;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -27958,32 +27882,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"191 563 LINE SMOOTH",
-"191 524 OFFCURVE",
-"166 505 OFFCURVE",
-"140 505 CURVE SMOOTH",
-"116 505 OFFCURVE",
-"101 521 OFFCURVE",
-"101 550 CURVE SMOOTH",
-"101 584 OFFCURVE",
-"126 607 OFFCURVE",
-"191 607 CURVE"
-);
-},
-{
-closed = 1;
-nodes = (
-"143 735 LINE SMOOTH",
-"174 735 OFFCURVE",
-"191 727 OFFCURVE",
-"191 712 CURVE SMOOTH",
-"191 634 LINE",
-"74 634 OFFCURVE",
-"15 590 OFFCURVE",
-"15 532 CURVE SMOOTH",
-"15 486 OFFCURVE",
-"50 458 OFFCURVE",
-"95 458 CURVE SMOOTH",
 "133 458 OFFCURVE",
 "174 478 OFFCURVE",
 "191 507 CURVE",
@@ -28019,7 +27917,32 @@ nodes = (
 "98 711 CURVE SMOOTH",
 "98 723 OFFCURVE",
 "113 735 OFFCURVE",
-"143 735 CURVE SMOOTH"
+"143 735 CURVE SMOOTH",
+"174 735 OFFCURVE",
+"191 727 OFFCURVE",
+"191 712 CURVE SMOOTH",
+"191 634 LINE",
+"74 634 OFFCURVE",
+"15 590 OFFCURVE",
+"15 532 CURVE SMOOTH",
+"15 486 OFFCURVE",
+"50 458 OFFCURVE",
+"95 458 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"116 505 OFFCURVE",
+"101 521 OFFCURVE",
+"101 550 CURVE SMOOTH",
+"101 584 OFFCURVE",
+"126 607 OFFCURVE",
+"191 607 CURVE",
+"191 563 LINE SMOOTH",
+"191 524 OFFCURVE",
+"166 505 OFFCURVE",
+"140 505 CURVE SMOOTH"
 );
 }
 );
@@ -28031,32 +27954,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"186 563 LINE SMOOTH",
-"186 524 OFFCURVE",
-"165 505 OFFCURVE",
-"145 505 CURVE SMOOTH",
-"121 505 OFFCURVE",
-"106 521 OFFCURVE",
-"106 550 CURVE SMOOTH",
-"106 584 OFFCURVE",
-"129 607 OFFCURVE",
-"186 607 CURVE"
-);
-},
-{
-closed = 1;
-nodes = (
-"143 735 LINE SMOOTH",
-"171 735 OFFCURVE",
-"186 727 OFFCURVE",
-"186 712 CURVE SMOOTH",
-"186 634 LINE",
-"69 634 OFFCURVE",
-"10 590 OFFCURVE",
-"10 532 CURVE SMOOTH",
-"10 486 OFFCURVE",
-"47 458 OFFCURVE",
-"95 458 CURVE SMOOTH",
 "131 458 OFFCURVE",
 "170 478 OFFCURVE",
 "186 507 CURVE",
@@ -28092,7 +27989,32 @@ nodes = (
 "103 711 CURVE SMOOTH",
 "103 723 OFFCURVE",
 "116 735 OFFCURVE",
-"143 735 CURVE SMOOTH"
+"143 735 CURVE SMOOTH",
+"171 735 OFFCURVE",
+"186 727 OFFCURVE",
+"186 712 CURVE SMOOTH",
+"186 634 LINE",
+"69 634 OFFCURVE",
+"10 590 OFFCURVE",
+"10 532 CURVE SMOOTH",
+"10 486 OFFCURVE",
+"47 458 OFFCURVE",
+"95 458 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"121 505 OFFCURVE",
+"106 521 OFFCURVE",
+"106 550 CURVE SMOOTH",
+"106 584 OFFCURVE",
+"129 607 OFFCURVE",
+"186 607 CURVE",
+"186 563 LINE SMOOTH",
+"186 524 OFFCURVE",
+"165 505 OFFCURVE",
+"145 505 CURVE SMOOTH"
 );
 }
 );
@@ -28103,7 +28025,7 @@ unicode = 00AA;
 },
 {
 glyphname = ordmasculine;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -28111,10 +28033,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"15 611 LINE SMOOTH",
-"15 533 OFFCURVE",
-"83 457 OFFCURVE",
-"168 457 CURVE SMOOTH",
 "254 457 OFFCURVE",
 "323 533 OFFCURVE",
 "323 611 CURVE SMOOTH",
@@ -28123,13 +28041,18 @@ nodes = (
 "168 764 CURVE SMOOTH",
 "83 764 OFFCURVE",
 "15 688 OFFCURVE",
-"15 611 CURVE SMOOTH"
+"15 611 CURVE SMOOTH",
+"15 533 OFFCURVE",
+"83 457 OFFCURVE",
+"168 457 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"110 611 LINE",
+"125 487 OFFCURVE",
+"110 509 OFFCURVE",
+"110 611 CURVE SMOOTH",
 "110 712 OFFCURVE",
 "125 735 OFFCURVE",
 "168 735 CURVE SMOOTH",
@@ -28138,10 +28061,7 @@ nodes = (
 "227 611 CURVE SMOOTH",
 "227 509 OFFCURVE",
 "212 487 OFFCURVE",
-"168 487 CURVE SMOOTH",
-"125 487 OFFCURVE",
-"110 509 OFFCURVE",
-"110 611 CURVE SMOOTH"
+"168 487 CURVE SMOOTH"
 );
 }
 );
@@ -28153,10 +28073,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"10 611 LINE SMOOTH",
-"10 533 OFFCURVE",
-"80 457 OFFCURVE",
-"168 457 CURVE SMOOTH",
 "257 457 OFFCURVE",
 "328 533 OFFCURVE",
 "328 611 CURVE SMOOTH",
@@ -28165,13 +28081,18 @@ nodes = (
 "168 764 CURVE SMOOTH",
 "80 764 OFFCURVE",
 "10 688 OFFCURVE",
-"10 611 CURVE SMOOTH"
+"10 611 CURVE SMOOTH",
+"10 533 OFFCURVE",
+"80 457 OFFCURVE",
+"168 457 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"115 611 LINE",
+"129 487 OFFCURVE",
+"115 509 OFFCURVE",
+"115 611 CURVE SMOOTH",
 "115 712 OFFCURVE",
 "129 735 OFFCURVE",
 "168 735 CURVE SMOOTH",
@@ -28180,10 +28101,7 @@ nodes = (
 "222 611 CURVE SMOOTH",
 "222 509 OFFCURVE",
 "208 487 OFFCURVE",
-"168 487 CURVE SMOOTH",
-"129 487 OFFCURVE",
-"115 509 OFFCURVE",
-"115 611 CURVE SMOOTH"
+"168 487 CURVE SMOOTH"
 );
 }
 );
@@ -28193,8 +28111,8 @@ width = 338;
 unicode = 00BA;
 },
 {
-glyphname = uni0394;
-lastChange = "2016-08-16 11:12:00 +0000";
+glyphname = Delta;
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -28213,9 +28131,9 @@ nodes = (
 {
 closed = 1;
 nodes = (
+"283 570 LINE",
 "482 37 LINE",
-"71 37 LINE",
-"283 570 LINE"
+"71 37 LINE"
 );
 }
 );
@@ -28238,9 +28156,9 @@ nodes = (
 {
 closed = 1;
 nodes = (
+"304 527 LINE",
 "495 73 LINE",
-"119 73 LINE",
-"304 527 LINE"
+"119 73 LINE"
 );
 }
 );
@@ -28250,8 +28168,8 @@ width = 727;
 unicode = 0394;
 },
 {
-glyphname = uni03A9;
-lastChange = "2016-08-16 11:12:00 +0000";
+glyphname = Omega;
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -28259,6 +28177,22 @@ paths = (
 {
 closed = 1;
 nodes = (
+"332 0 LINE",
+"342 23 LINE",
+"254 156 OFFCURVE",
+"219 257 OFFCURVE",
+"219 412 CURVE SMOOTH",
+"219 636 OFFCURVE",
+"292 702 OFFCURVE",
+"377 702 CURVE SMOOTH",
+"468 702 OFFCURVE",
+"542 625 OFFCURVE",
+"542 408 CURVE SMOOTH",
+"542 267 OFFCURVE",
+"511 160 OFFCURVE",
+"418 23 CURVE",
+"427 0 LINE",
+"698 0 LINE",
 "727 174 LINE",
 "704 174 LINE",
 "683 109 OFFCURVE",
@@ -28282,23 +28216,7 @@ nodes = (
 "81 112 OFFCURVE",
 "59 174 CURVE",
 "35 174 LINE",
-"60 0 LINE",
-"332 0 LINE",
-"342 23 LINE",
-"254 156 OFFCURVE",
-"219 257 OFFCURVE",
-"219 412 CURVE SMOOTH",
-"219 636 OFFCURVE",
-"292 702 OFFCURVE",
-"377 702 CURVE SMOOTH",
-"468 702 OFFCURVE",
-"542 625 OFFCURVE",
-"542 408 CURVE SMOOTH",
-"542 267 OFFCURVE",
-"511 160 OFFCURVE",
-"418 23 CURVE",
-"427 0 LINE",
-"698 0 LINE"
+"60 0 LINE"
 );
 }
 );
@@ -28310,6 +28228,22 @@ paths = (
 {
 closed = 1;
 nodes = (
+"353 0 LINE",
+"363 26 LINE",
+"314 132 OFFCURVE",
+"251 268 OFFCURVE",
+"251 399 CURVE SMOOTH",
+"251 626 OFFCURVE",
+"311 694 OFFCURVE",
+"403 694 CURVE SMOOTH",
+"494 694 OFFCURVE",
+"560 615 OFFCURVE",
+"560 402 CURVE SMOOTH",
+"560 267 OFFCURVE",
+"488 123 OFFCURVE",
+"446 26 CURVE",
+"456 0 LINE",
+"744 0 LINE",
 "776 189 LINE",
 "735 189 LINE",
 "712 127 OFFCURVE",
@@ -28333,23 +28267,7 @@ nodes = (
 "99 128 OFFCURVE",
 "75 189 CURVE",
 "36 189 LINE",
-"63 0 LINE",
-"353 0 LINE",
-"363 26 LINE",
-"314 132 OFFCURVE",
-"251 268 OFFCURVE",
-"251 399 CURVE SMOOTH",
-"251 626 OFFCURVE",
-"311 694 OFFCURVE",
-"403 694 CURVE SMOOTH",
-"494 694 OFFCURVE",
-"560 615 OFFCURVE",
-"560 402 CURVE SMOOTH",
-"560 267 OFFCURVE",
-"488 123 OFFCURVE",
-"446 26 CURVE",
-"456 0 LINE",
-"744 0 LINE"
+"63 0 LINE"
 );
 }
 );
@@ -28359,8 +28277,8 @@ width = 812;
 unicode = 03A9;
 },
 {
-glyphname = uni03BC;
-lastChange = "2016-08-16 11:12:00 +0000";
+glyphname = mu;
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -28449,46 +28367,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"557 25 LINE",
-"368 25 LINE",
-"368 0 LINE",
-"557 0 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"478 435 LINE",
-"368 435 LINE",
-"368 16 LINE",
-"478 16 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"478 450 LINE",
-"286 450 LINE",
-"286 425 LINE",
-"478 425 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"195 450 LINE",
-"7 450 LINE",
-"7 425 LINE",
-"195 425 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"85 97 LINE SMOOTH",
-"85 36 OFFCURVE",
-"139 -12 OFFCURVE",
-"216 -12 CURVE SMOOTH",
 "290 -12 OFFCURVE",
 "335 26 OFFCURVE",
 "364 78 CURVE",
@@ -28501,26 +28379,66 @@ nodes = (
 "195 50 OFFCURVE",
 "195 100 CURVE SMOOTH",
 "195 435 LINE",
-"85 435 LINE"
+"85 435 LINE",
+"85 97 LINE SMOOTH",
+"85 36 OFFCURVE",
+"139 -12 OFFCURVE",
+"216 -12 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"85 101 LINE",
-"80 -72 OFFCURVE",
-"49 -124 OFFCURVE",
-"49 -190 CURVE SMOOTH",
-"49 -230 OFFCURVE",
-"65 -254 OFFCURVE",
-"100 -254 CURVE SMOOTH",
 "136 -254 OFFCURVE",
 "153 -227 OFFCURVE",
 "153 -188 CURVE SMOOTH",
 "153 -140 OFFCURVE",
 "117 -103 OFFCURVE",
 "109 28 CURVE",
-"113 28 LINE"
+"113 28 LINE",
+"85 101 LINE",
+"80 -72 OFFCURVE",
+"49 -124 OFFCURVE",
+"49 -190 CURVE SMOOTH",
+"49 -230 OFFCURVE",
+"65 -254 OFFCURVE",
+"100 -254 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"557 0 LINE",
+"557 25 LINE",
+"368 25 LINE",
+"368 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"195 425 LINE",
+"195 450 LINE",
+"7 450 LINE",
+"7 425 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"478 16 LINE",
+"478 435 LINE",
+"368 435 LINE",
+"368 16 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"478 425 LINE",
+"478 450 LINE",
+"286 450 LINE",
+"286 425 LINE"
 );
 }
 );
@@ -28613,46 +28531,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"603 30 LINE",
-"386 30 LINE",
-"386 0 LINE",
-"603 0 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"524 435 LINE",
-"386 435 LINE",
-"386 15 LINE",
-"524 15 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"524 450 LINE",
-"304 450 LINE",
-"304 420 LINE",
-"524 420 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"226 450 LINE",
-"10 450 LINE",
-"10 420 LINE",
-"226 420 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"88 98 LINE SMOOTH",
-"88 37 OFFCURVE",
-"140 -13 OFFCURVE",
-"222 -13 CURVE SMOOTH",
 "292 -13 OFFCURVE",
 "358 24 OFFCURVE",
 "382 79 CURVE",
@@ -28665,26 +28543,66 @@ nodes = (
 "226 56 OFFCURVE",
 "226 111 CURVE SMOOTH",
 "226 435 LINE",
-"88 435 LINE"
+"88 435 LINE",
+"88 98 LINE SMOOTH",
+"88 37 OFFCURVE",
+"140 -13 OFFCURVE",
+"222 -13 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"88 101 LINE",
-"83 -78 OFFCURVE",
-"54 -140 OFFCURVE",
-"54 -198 CURVE SMOOTH",
-"54 -251 OFFCURVE",
-"78 -277 OFFCURVE",
-"114 -277 CURVE SMOOTH",
 "153 -277 OFFCURVE",
 "178 -246 OFFCURVE",
 "178 -203 CURVE SMOOTH",
 "178 -152 OFFCURVE",
 "152 -119 OFFCURVE",
 "134 10 CURVE",
-"138 10 LINE"
+"138 10 LINE",
+"88 101 LINE",
+"83 -78 OFFCURVE",
+"54 -140 OFFCURVE",
+"54 -198 CURVE SMOOTH",
+"54 -251 OFFCURVE",
+"78 -277 OFFCURVE",
+"114 -277 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"603 0 LINE",
+"603 30 LINE",
+"386 30 LINE",
+"386 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"226 420 LINE",
+"226 450 LINE",
+"10 450 LINE",
+"10 420 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"524 15 LINE",
+"524 435 LINE",
+"386 435 LINE",
+"386 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"524 420 LINE",
+"524 450 LINE",
+"304 450 LINE",
+"304 420 LINE"
 );
 }
 );
@@ -28695,7 +28613,7 @@ unicode = 03BC;
 },
 {
 glyphname = pi;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -28703,22 +28621,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"567 496 LINE",
-"550 472 OFFCURVE",
-"534 465 OFFCURVE",
-"489 465 CURVE SMOOTH",
-"208 465 LINE SMOOTH",
-"124 465 OFFCURVE",
-"79 438 OFFCURVE",
-"19 362 CURVE",
-"36 340 LINE",
-"80 369 OFFCURVE",
-"105 377 OFFCURVE",
-"168 377 CURVE",
-"168 272 OFFCURVE",
-"145 116 OFFCURVE",
-"70 9 CURVE",
-"78 -13 LINE",
 "98 -12 OFFCURVE",
 "126 -5 OFFCURVE",
 "151 6 CURVE",
@@ -28747,7 +28649,25 @@ nodes = (
 "471 324 OFFCURVE",
 "476 377 CURVE",
 "531 377 LINE",
-"582 490 LINE"
+"582 490 LINE",
+"567 496 LINE",
+"550 472 OFFCURVE",
+"534 465 OFFCURVE",
+"489 465 CURVE SMOOTH",
+"395 465 OFFCURVE",
+"302 465 OFFCURVE",
+"208 465 CURVE SMOOTH",
+"124 465 OFFCURVE",
+"79 438 OFFCURVE",
+"19 362 CURVE",
+"36 340 LINE",
+"80 369 OFFCURVE",
+"105 377 OFFCURVE",
+"168 377 CURVE",
+"168 272 OFFCURVE",
+"145 116 OFFCURVE",
+"70 9 CURVE",
+"78 -13 LINE"
 );
 }
 );
@@ -28759,24 +28679,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"592 509 LINE",
-"572 476 OFFCURVE",
-"559 474 OFFCURVE",
-"511 474 CURVE SMOOTH",
-"452 474 OFFCURVE",
-"285 477 OFFCURVE",
-"242 477 CURVE SMOOTH",
-"126 477 OFFCURVE",
-"94 455 OFFCURVE",
-"22 361 CURVE",
-"41 325 LINE",
-"90 354 OFFCURVE",
-"118 363 OFFCURVE",
-"180 363 CURVE",
-"180 266 OFFCURVE",
-"153 118 OFFCURVE",
-"77 12 CURVE",
-"86 -14 LINE",
 "109 -12 OFFCURVE",
 "137 -6 OFFCURVE",
 "167 6 CURVE",
@@ -28805,7 +28707,25 @@ nodes = (
 "509 295 OFFCURVE",
 "515 363 CURVE",
 "583 363 LINE",
-"626 500 LINE"
+"626 500 LINE",
+"592 509 LINE",
+"572 476 OFFCURVE",
+"559 474 OFFCURVE",
+"511 474 CURVE SMOOTH",
+"452 474 OFFCURVE",
+"285 477 OFFCURVE",
+"242 477 CURVE SMOOTH",
+"126 477 OFFCURVE",
+"94 455 OFFCURVE",
+"22 361 CURVE",
+"41 325 LINE",
+"90 354 OFFCURVE",
+"118 363 OFFCURVE",
+"180 363 CURVE",
+"180 266 OFFCURVE",
+"153 118 OFFCURVE",
+"77 12 CURVE",
+"86 -14 LINE"
 );
 }
 );
@@ -28816,7 +28736,7 @@ unicode = 03C0;
 },
 {
 glyphname = zero;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -28862,10 +28782,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"47 360 LINE SMOOTH",
-"47 152 OFFCURVE",
-"169 -12 OFFCURVE",
-"331 -12 CURVE SMOOTH",
 "494 -12 OFFCURVE",
 "616 152 OFFCURVE",
 "616 360 CURVE SMOOTH",
@@ -28874,13 +28790,18 @@ nodes = (
 "331 732 CURVE SMOOTH",
 "169 732 OFFCURVE",
 "47 567 OFFCURVE",
-"47 360 CURVE SMOOTH"
+"47 360 CURVE SMOOTH",
+"47 152 OFFCURVE",
+"169 -12 OFFCURVE",
+"331 -12 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"197 360 LINE SMOOTH",
+"228 18 OFFCURVE",
+"197 81 OFFCURVE",
+"197 360 CURVE SMOOTH",
 "197 638 OFFCURVE",
 "228 702 OFFCURVE",
 "331 702 CURVE SMOOTH",
@@ -28889,10 +28810,7 @@ nodes = (
 "466 360 CURVE SMOOTH",
 "466 81 OFFCURVE",
 "433 18 OFFCURVE",
-"331 18 CURVE SMOOTH",
-"228 18 OFFCURVE",
-"197 81 OFFCURVE",
-"197 360 CURVE SMOOTH"
+"331 18 CURVE SMOOTH"
 );
 }
 );
@@ -28942,10 +28860,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"44 360 LINE SMOOTH",
-"44 142 OFFCURVE",
-"182 -12 OFFCURVE",
-"363 -12 CURVE SMOOTH",
 "544 -12 OFFCURVE",
 "683 142 OFFCURVE",
 "683 360 CURVE SMOOTH",
@@ -28954,13 +28868,18 @@ nodes = (
 "363 733 CURVE SMOOTH",
 "182 733 OFFCURVE",
 "44 577 OFFCURVE",
-"44 360 CURVE SMOOTH"
+"44 360 CURVE SMOOTH",
+"44 142 OFFCURVE",
+"182 -12 OFFCURVE",
+"363 -12 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"224 360 LINE SMOOTH",
+"256 23 OFFCURVE",
+"224 85 OFFCURVE",
+"224 360 CURVE SMOOTH",
 "224 634 OFFCURVE",
 "256 698 OFFCURVE",
 "363 698 CURVE SMOOTH",
@@ -28969,10 +28888,7 @@ nodes = (
 "503 360 CURVE SMOOTH",
 "503 85 OFFCURVE",
 "465 23 OFFCURVE",
-"363 23 CURVE SMOOTH",
-"256 23 OFFCURVE",
-"224 85 OFFCURVE",
-"224 360 CURVE SMOOTH"
+"363 23 CURVE SMOOTH"
 );
 }
 );
@@ -28983,7 +28899,7 @@ unicode = 0030;
 },
 {
 glyphname = one;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -29010,16 +28926,16 @@ paths = (
 {
 closed = 1;
 nodes = (
-"11 691 LINE",
-"161 691 LINE",
-"161 25 LINE",
-"11 25 LINE",
-"11 0 LINE",
 "420 0 LINE",
 "420 25 LINE",
 "280 25 LINE",
 "280 716 LINE",
-"11 716 LINE"
+"11 716 LINE",
+"11 691 LINE",
+"161 691 LINE",
+"161 25 LINE",
+"11 25 LINE",
+"11 0 LINE"
 );
 }
 );
@@ -29050,16 +28966,16 @@ paths = (
 {
 closed = 1;
 nodes = (
-"8 686 LINE",
-"166 686 LINE",
-"166 30 LINE",
-"8 30 LINE",
-"8 0 LINE",
 "472 0 LINE",
 "472 30 LINE",
 "324 30 LINE",
 "324 716 LINE",
-"8 716 LINE"
+"8 716 LINE",
+"8 686 LINE",
+"166 686 LINE",
+"166 30 LINE",
+"8 30 LINE",
+"8 0 LINE"
 );
 }
 );
@@ -29070,7 +28986,7 @@ unicode = 0031;
 },
 {
 glyphname = two;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -29131,6 +29047,8 @@ paths = (
 {
 closed = 1;
 nodes = (
+"515 0 LINE",
+"515 200 LINE",
 "490 200 LINE",
 "490 105 OFFCURVE",
 "476 96 OFFCURVE",
@@ -29172,9 +29090,7 @@ nodes = (
 "352 372 OFFCURVE",
 "250 277 CURVE SMOOTH",
 "35 77 LINE",
-"35 0 LINE",
-"515 0 LINE",
-"515 200 LINE"
+"35 0 LINE"
 );
 }
 );
@@ -29239,6 +29155,8 @@ paths = (
 {
 closed = 1;
 nodes = (
+"572 0 LINE",
+"572 245 LINE",
 "542 245 LINE",
 "542 148 OFFCURVE",
 "528 139 OFFCURVE",
@@ -29280,9 +29198,7 @@ nodes = (
 "371 365 OFFCURVE",
 "264 280 CURVE SMOOTH",
 "32 97 LINE",
-"32 0 LINE",
-"572 0 LINE",
-"572 245 LINE"
+"32 0 LINE"
 );
 }
 );
@@ -29293,7 +29209,7 @@ unicode = 0032;
 },
 {
 glyphname = three;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -29380,6 +29296,12 @@ paths = (
 {
 closed = 1;
 nodes = (
+"410 -12 OFFCURVE",
+"511 91 OFFCURVE",
+"511 200 CURVE SMOOTH",
+"511 299 OFFCURVE",
+"428 379 OFFCURVE",
+"304 394 CURVE",
 "206 371 LINE",
 "325 371 OFFCURVE",
 "371 311 OFFCURVE",
@@ -29401,28 +29323,21 @@ nodes = (
 "26 123 CURVE SMOOTH",
 "26 44 OFFCURVE",
 "112 -12 OFFCURVE",
-"238 -12 CURVE SMOOTH",
-"410 -12 OFFCURVE",
-"511 91 OFFCURVE",
-"511 200 CURVE SMOOTH",
-"511 299 OFFCURVE",
-"428 379 OFFCURVE",
-"304 394 CURVE"
+"238 -12 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"128 371 LINE",
 "304 371 LINE",
 "304 401 LINE",
-"128 401 LINE"
+"128 401 LINE",
+"128 371 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"245 390 LINE",
 "381 404 OFFCURVE",
 "468 480 OFFCURVE",
 "468 570 CURVE SMOOTH",
@@ -29449,7 +29364,8 @@ nodes = (
 "338 572 CURVE SMOOTH",
 "338 465 OFFCURVE",
 "295 401 OFFCURVE",
-"187 401 CURVE"
+"187 401 CURVE",
+"245 390 LINE"
 );
 }
 );
@@ -29540,6 +29456,12 @@ paths = (
 {
 closed = 1;
 nodes = (
+"446 -12 OFFCURVE",
+"565 91 OFFCURVE",
+"565 204 CURVE SMOOTH",
+"565 323 OFFCURVE",
+"456 388 OFFCURVE",
+"312 396 CURVE",
 "204 371 LINE",
 "331 371 OFFCURVE",
 "379 311 OFFCURVE",
@@ -29561,28 +29483,21 @@ nodes = (
 "24 132 CURVE SMOOTH",
 "24 44 OFFCURVE",
 "111 -12 OFFCURVE",
-"253 -12 CURVE SMOOTH",
-"446 -12 OFFCURVE",
-"565 91 OFFCURVE",
-"565 204 CURVE SMOOTH",
-"565 323 OFFCURVE",
-"456 388 OFFCURVE",
-"312 396 CURVE"
+"253 -12 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"137 371 LINE",
 "312 371 LINE",
 "312 406 LINE",
-"137 406 LINE"
+"137 406 LINE",
+"137 371 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"252 395 LINE",
 "445 409 OFFCURVE",
 "530 476 OFFCURVE",
 "530 568 CURVE SMOOTH",
@@ -29609,7 +29524,8 @@ nodes = (
 "355 576 CURVE SMOOTH",
 "355 468 OFFCURVE",
 "308 406 OFFCURVE",
-"184 406 CURVE"
+"184 406 CURVE",
+"252 395 LINE"
 );
 }
 );
@@ -29620,7 +29536,7 @@ unicode = 0033;
 },
 {
 glyphname = four;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -29666,16 +29582,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"56 227 LINE",
-"56 231 LINE",
-"308 599 LINE",
-"312 599 LINE",
-"312 227 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"517 0 LINE",
+"517 25 LINE",
+"432 25 LINE",
+"432 200 LINE",
 "539 200 LINE",
 "539 118 LINE",
 "565 118 LINE",
@@ -29690,11 +29600,17 @@ nodes = (
 "313 200 LINE",
 "313 25 LINE",
 "214 25 LINE",
-"214 0 LINE",
-"517 0 LINE",
-"517 25 LINE",
-"432 25 LINE",
-"432 200 LINE"
+"214 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"56 231 LINE",
+"308 599 LINE",
+"312 599 LINE",
+"312 227 LINE",
+"56 227 LINE"
 );
 }
 );
@@ -29744,16 +29660,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"61 232 LINE",
-"61 236 LINE",
-"315 588 LINE",
-"319 588 LINE",
-"319 232 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"573 0 LINE",
+"573 30 LINE",
+"477 30 LINE",
+"477 200 LINE",
 "602 200 LINE",
 "602 118 LINE",
 "633 118 LINE",
@@ -29768,11 +29678,17 @@ nodes = (
 "319 200 LINE",
 "319 30 LINE",
 "211 30 LINE",
-"211 0 LINE",
-"573 0 LINE",
-"573 30 LINE",
-"477 30 LINE",
-"477 200 LINE"
+"211 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"61 236 LINE",
+"315 588 LINE",
+"319 588 LINE",
+"319 232 LINE",
+"61 232 LINE"
 );
 }
 );
@@ -29783,7 +29699,7 @@ unicode = 0034;
 },
 {
 glyphname = five;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -29857,30 +29773,12 @@ paths = (
 {
 closed = 1;
 nodes = (
-"145 620 LINE",
-"447 620 LINE",
-"483 748 LINE",
-"458 748 LINE",
-"444 722 OFFCURVE",
-"430 716 OFFCURVE",
-"386 716 CURVE SMOOTH",
-"120 716 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"83 387 LINE",
-"99 377 LINE",
-"118 396 LINE",
-"155 716 LINE",
-"120 716 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"237 437 LINE SMOOTH",
+"393 -12 OFFCURVE",
+"517 87 OFFCURVE",
+"517 222 CURVE SMOOTH",
+"517 346 OFFCURVE",
+"412 437 OFFCURVE",
+"237 437 CURVE SMOOTH",
 "169 437 OFFCURVE",
 "120 423 OFFCURVE",
 "106 415 CURVE",
@@ -29908,13 +29806,30 @@ nodes = (
 "32 123 CURVE SMOOTH",
 "32 42 OFFCURVE",
 "123 -12 OFFCURVE",
-"239 -12 CURVE SMOOTH",
-"393 -12 OFFCURVE",
-"517 87 OFFCURVE",
-"517 222 CURVE SMOOTH",
-"517 346 OFFCURVE",
-"412 437 OFFCURVE",
-"237 437 CURVE SMOOTH"
+"239 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"118 396 LINE",
+"155 716 LINE",
+"120 716 LINE",
+"83 387 LINE",
+"99 377 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"447 620 LINE",
+"483 748 LINE",
+"458 748 LINE",
+"444 722 OFFCURVE",
+"430 716 OFFCURVE",
+"386 716 CURVE SMOOTH",
+"120 716 LINE",
+"145 620 LINE"
 );
 }
 );
@@ -29992,30 +29907,12 @@ paths = (
 {
 closed = 1;
 nodes = (
-"144 577 LINE",
-"516 577 LINE",
-"552 754 LINE",
-"522 754 LINE",
-"509 722 OFFCURVE",
-"496 716 OFFCURVE",
-"455 716 CURVE SMOOTH",
-"119 716 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"85 382 LINE",
-"102 371 LINE",
-"126 410 LINE",
-"154 716 LINE",
-"114 716 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"295 447 LINE SMOOTH",
+"445 -12 OFFCURVE",
+"589 76 OFFCURVE",
+"589 224 CURVE SMOOTH",
+"589 345 OFFCURVE",
+"494 447 OFFCURVE",
+"295 447 CURVE SMOOTH",
 "214 447 OFFCURVE",
 "131 430 OFFCURVE",
 "113 420 CURVE",
@@ -30043,13 +29940,30 @@ nodes = (
 "29 129 CURVE SMOOTH",
 "29 47 OFFCURVE",
 "116 -12 OFFCURVE",
-"266 -12 CURVE SMOOTH",
-"445 -12 OFFCURVE",
-"589 76 OFFCURVE",
-"589 224 CURVE SMOOTH",
-"589 345 OFFCURVE",
-"494 447 OFFCURVE",
-"295 447 CURVE SMOOTH"
+"266 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"126 410 LINE",
+"154 716 LINE",
+"114 716 LINE",
+"85 382 LINE",
+"102 371 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"516 577 LINE",
+"552 754 LINE",
+"522 754 LINE",
+"509 722 OFFCURVE",
+"496 716 OFFCURVE",
+"455 716 CURVE SMOOTH",
+"119 716 LINE",
+"144 577 LINE"
 );
 }
 );
@@ -30060,7 +29974,7 @@ unicode = 0035;
 },
 {
 glyphname = six;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -30117,13 +30031,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"514 752 LINE",
-"271 743 OFFCURVE",
-"49 544 OFFCURVE",
-"49 290 CURVE SMOOTH",
-"49 107 OFFCURVE",
-"164 -12 OFFCURVE",
-"310 -12 CURVE SMOOTH",
 "448 -12 OFFCURVE",
 "576 93 OFFCURVE",
 "576 238 CURVE SMOOTH",
@@ -30136,13 +30043,22 @@ nodes = (
 "201 426 LINE",
 "224 593 OFFCURVE",
 "342 710 OFFCURVE",
-"514 723 CURVE"
+"514 723 CURVE",
+"514 752 LINE",
+"271 743 OFFCURVE",
+"49 544 OFFCURVE",
+"49 290 CURVE SMOOTH",
+"49 107 OFFCURVE",
+"164 -12 OFFCURVE",
+"310 -12 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"187 221 LINE",
+"219 18 OFFCURVE",
+"187 55 OFFCURVE",
+"187 221 CURVE",
 "187 262 OFFCURVE",
 "189 320 OFFCURVE",
 "197 368 CURVE",
@@ -30154,10 +30070,7 @@ nodes = (
 "431 231 CURVE SMOOTH",
 "431 59 OFFCURVE",
 "401 18 OFFCURVE",
-"308 18 CURVE SMOOTH",
-"219 18 OFFCURVE",
-"187 55 OFFCURVE",
-"187 221 CURVE"
+"308 18 CURVE SMOOTH"
 );
 }
 );
@@ -30218,13 +30131,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"523 754 LINE",
-"270 745 OFFCURVE",
-"46 530 OFFCURVE",
-"46 291 CURVE SMOOTH",
-"46 107 OFFCURVE",
-"170 -12 OFFCURVE",
-"325 -12 CURVE SMOOTH",
 "470 -12 OFFCURVE",
 "603 93 OFFCURVE",
 "603 236 CURVE SMOOTH",
@@ -30237,13 +30143,22 @@ nodes = (
 "233 421 LINE",
 "255 574 OFFCURVE",
 "359 703 OFFCURVE",
-"523 720 CURVE"
+"523 720 CURVE",
+"523 754 LINE",
+"270 745 OFFCURVE",
+"46 530 OFFCURVE",
+"46 291 CURVE SMOOTH",
+"46 107 OFFCURVE",
+"170 -12 OFFCURVE",
+"325 -12 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"214 221 LINE SMOOTH",
+"243 23 OFFCURVE",
+"214 71 OFFCURVE",
+"214 221 CURVE SMOOTH",
 "214 258 OFFCURVE",
 "214 310 OFFCURVE",
 "224 353 CURVE",
@@ -30255,10 +30170,7 @@ nodes = (
 "428 224 CURVE SMOOTH",
 "428 73 OFFCURVE",
 "402 23 OFFCURVE",
-"322 23 CURVE SMOOTH",
-"243 23 OFFCURVE",
-"214 71 OFFCURVE",
-"214 221 CURVE SMOOTH"
+"322 23 CURVE SMOOTH"
 );
 }
 );
@@ -30269,7 +30181,7 @@ unicode = 0036;
 },
 {
 glyphname = seven;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -30311,6 +30223,18 @@ paths = (
 {
 closed = 1;
 nodes = (
+"311 -12 OFFCURVE",
+"339 10 OFFCURVE",
+"339 56 CURVE SMOOTH",
+"339 106 OFFCURVE",
+"307 113 OFFCURVE",
+"307 197 CURVE SMOOTH",
+"307 250 OFFCURVE",
+"318 312 OFFCURVE",
+"362 408 CURVE SMOOTH",
+"497 704 LINE",
+"497 716 LINE",
+"86 716 LINE",
 "40 518 LINE",
 "65 518 LINE",
 "97 606 OFFCURVE",
@@ -30323,19 +30247,7 @@ nodes = (
 "192 76 CURVE SMOOTH",
 "192 15 OFFCURVE",
 "222 -12 OFFCURVE",
-"269 -12 CURVE SMOOTH",
-"311 -12 OFFCURVE",
-"339 10 OFFCURVE",
-"339 56 CURVE SMOOTH",
-"339 106 OFFCURVE",
-"307 113 OFFCURVE",
-"307 197 CURVE SMOOTH",
-"307 250 OFFCURVE",
-"318 312 OFFCURVE",
-"362 408 CURVE SMOOTH",
-"497 704 LINE",
-"497 716 LINE",
-"86 716 LINE"
+"269 -12 CURVE SMOOTH"
 );
 }
 );
@@ -30381,6 +30293,18 @@ paths = (
 {
 closed = 1;
 nodes = (
+"352 -12 OFFCURVE",
+"398 14 OFFCURVE",
+"398 72 CURVE SMOOTH",
+"398 121 OFFCURVE",
+"366 167 OFFCURVE",
+"366 238 CURVE SMOOTH",
+"366 284 OFFCURVE",
+"384 340 OFFCURVE",
+"429 418 CURVE SMOOTH",
+"573 666 LINE",
+"573 716 LINE",
+"104 716 LINE",
 "38 468 LINE",
 "73 468 LINE",
 "105 562 OFFCURVE",
@@ -30393,19 +30317,7 @@ nodes = (
 "201 77 CURVE SMOOTH",
 "201 22 OFFCURVE",
 "233 -12 OFFCURVE",
-"296 -12 CURVE SMOOTH",
-"352 -12 OFFCURVE",
-"398 14 OFFCURVE",
-"398 72 CURVE SMOOTH",
-"398 121 OFFCURVE",
-"366 167 OFFCURVE",
-"366 238 CURVE SMOOTH",
-"366 284 OFFCURVE",
-"384 340 OFFCURVE",
-"429 418 CURVE SMOOTH",
-"573 666 LINE",
-"573 716 LINE",
-"104 716 LINE"
+"296 -12 CURVE SMOOTH"
 );
 }
 );
@@ -30416,7 +30328,7 @@ unicode = 0037;
 },
 {
 glyphname = eight;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -30499,64 +30411,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"182 190 LINE SMOOTH",
-"182 300 OFFCURVE",
-"215 361 OFFCURVE",
-"306 361 CURVE SMOOTH",
-"397 361 OFFCURVE",
-"431 300 OFFCURVE",
-"431 190 CURVE SMOOTH",
-"431 67 OFFCURVE",
-"397 18 OFFCURVE",
-"306 18 CURVE SMOOTH",
-"215 18 OFFCURVE",
-"182 67 OFFCURVE",
-"182 190 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"541 555 LINE SMOOTH",
-"541 653 OFFCURVE",
-"463 732 OFFCURVE",
-"307 732 CURVE SMOOTH",
-"151 732 OFFCURVE",
-"72 653 OFFCURVE",
-"72 555 CURVE SMOOTH",
-"72 443 OFFCURVE",
-"177 371 OFFCURVE",
-"307 371 CURVE SMOOTH",
-"437 371 OFFCURVE",
-"541 443 OFFCURVE",
-"541 555 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"411 550 LINE SMOOTH",
-"411 445 OFFCURVE",
-"383 386 OFFCURVE",
-"307 386 CURVE SMOOTH",
-"231 386 OFFCURVE",
-"202 445 OFFCURVE",
-"202 550 CURVE SMOOTH",
-"202 659 OFFCURVE",
-"231 702 OFFCURVE",
-"307 702 CURVE SMOOTH",
-"383 702 OFFCURVE",
-"411 659 OFFCURVE",
-"411 550 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"42 190 LINE SMOOTH",
-"42 77 OFFCURVE",
-"128 -12 OFFCURVE",
-"306 -12 CURVE SMOOTH",
 "484 -12 OFFCURVE",
 "571 77 OFFCURVE",
 "571 190 CURVE SMOOTH",
@@ -30568,7 +30422,61 @@ nodes = (
 "240 374 LINE",
 "125 351 OFFCURVE",
 "42 270 OFFCURVE",
-"42 190 CURVE SMOOTH"
+"42 190 CURVE SMOOTH",
+"42 77 OFFCURVE",
+"128 -12 OFFCURVE",
+"306 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"215 18 OFFCURVE",
+"182 67 OFFCURVE",
+"182 190 CURVE SMOOTH",
+"182 300 OFFCURVE",
+"215 361 OFFCURVE",
+"306 361 CURVE SMOOTH",
+"397 361 OFFCURVE",
+"431 300 OFFCURVE",
+"431 190 CURVE SMOOTH",
+"431 67 OFFCURVE",
+"397 18 OFFCURVE",
+"306 18 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"231 386 OFFCURVE",
+"202 445 OFFCURVE",
+"202 550 CURVE SMOOTH",
+"202 659 OFFCURVE",
+"231 702 OFFCURVE",
+"307 702 CURVE SMOOTH",
+"383 702 OFFCURVE",
+"411 659 OFFCURVE",
+"411 550 CURVE SMOOTH",
+"411 445 OFFCURVE",
+"383 386 OFFCURVE",
+"307 386 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"437 371 OFFCURVE",
+"541 443 OFFCURVE",
+"541 555 CURVE SMOOTH",
+"541 653 OFFCURVE",
+"463 732 OFFCURVE",
+"307 732 CURVE SMOOTH",
+"151 732 OFFCURVE",
+"72 653 OFFCURVE",
+"72 555 CURVE SMOOTH",
+"72 443 OFFCURVE",
+"177 371 OFFCURVE",
+"307 371 CURVE SMOOTH"
 );
 }
 );
@@ -30655,64 +30563,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"209 185 LINE SMOOTH",
-"209 298 OFFCURVE",
-"237 356 OFFCURVE",
-"318 356 CURVE SMOOTH",
-"400 356 OFFCURVE",
-"428 296 OFFCURVE",
-"428 185 CURVE SMOOTH",
-"428 66 OFFCURVE",
-"396 18 OFFCURVE",
-"318 18 CURVE SMOOTH",
-"240 18 OFFCURVE",
-"209 66 OFFCURVE",
-"209 185 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"573 554 LINE SMOOTH",
-"573 649 OFFCURVE",
-"491 732 OFFCURVE",
-"318 732 CURVE SMOOTH",
-"149 732 OFFCURVE",
-"64 653 OFFCURVE",
-"64 555 CURVE SMOOTH",
-"64 443 OFFCURVE",
-"177 371 OFFCURVE",
-"319 371 CURVE SMOOTH",
-"461 371 OFFCURVE",
-"573 443 OFFCURVE",
-"573 554 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"408 551 LINE SMOOTH",
-"408 448 OFFCURVE",
-"385 391 OFFCURVE",
-"319 391 CURVE SMOOTH",
-"253 391 OFFCURVE",
-"229 448 OFFCURVE",
-"229 551 CURVE SMOOTH",
-"229 654 OFFCURVE",
-"253 697 OFFCURVE",
-"319 697 CURVE SMOOTH",
-"385 697 OFFCURVE",
-"408 654 OFFCURVE",
-"408 551 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"34 180 LINE SMOOTH",
-"34 73 OFFCURVE",
-"126 -12 OFFCURVE",
-"318 -12 CURVE SMOOTH",
 "510 -12 OFFCURVE",
 "603 73 OFFCURVE",
 "603 180 CURVE SMOOTH",
@@ -30724,7 +30574,61 @@ nodes = (
 "252 374 LINE",
 "125 350 OFFCURVE",
 "34 285 OFFCURVE",
-"34 180 CURVE SMOOTH"
+"34 180 CURVE SMOOTH",
+"34 73 OFFCURVE",
+"126 -12 OFFCURVE",
+"318 -12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"240 18 OFFCURVE",
+"209 66 OFFCURVE",
+"209 185 CURVE SMOOTH",
+"209 298 OFFCURVE",
+"237 356 OFFCURVE",
+"318 356 CURVE SMOOTH",
+"400 356 OFFCURVE",
+"428 296 OFFCURVE",
+"428 185 CURVE SMOOTH",
+"428 66 OFFCURVE",
+"396 18 OFFCURVE",
+"318 18 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"253 391 OFFCURVE",
+"229 448 OFFCURVE",
+"229 551 CURVE SMOOTH",
+"229 654 OFFCURVE",
+"253 697 OFFCURVE",
+"319 697 CURVE SMOOTH",
+"385 697 OFFCURVE",
+"408 654 OFFCURVE",
+"408 551 CURVE SMOOTH",
+"408 448 OFFCURVE",
+"385 391 OFFCURVE",
+"319 391 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"461 371 OFFCURVE",
+"573 443 OFFCURVE",
+"573 554 CURVE SMOOTH",
+"573 649 OFFCURVE",
+"491 732 OFFCURVE",
+"318 732 CURVE SMOOTH",
+"149 732 OFFCURVE",
+"64 653 OFFCURVE",
+"64 555 CURVE SMOOTH",
+"64 443 OFFCURVE",
+"177 371 OFFCURVE",
+"319 371 CURVE SMOOTH"
 );
 }
 );
@@ -30735,7 +30639,7 @@ unicode = 0038;
 },
 {
 glyphname = nine;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -30792,7 +30696,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"106 -32 LINE",
 "349 -23 OFFCURVE",
 "571 176 OFFCURVE",
 "571 430 CURVE SMOOTH",
@@ -30811,19 +30714,13 @@ nodes = (
 "419 294 LINE",
 "396 127 OFFCURVE",
 "278 11 OFFCURVE",
-"106 -3 CURVE"
+"106 -3 CURVE",
+"106 -32 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"433 499 LINE SMOOTH",
-"433 458 OFFCURVE",
-"431 400 OFFCURVE",
-"423 352 CURVE",
-"395 307 OFFCURVE",
-"349 276 OFFCURVE",
-"288 276 CURVE SMOOTH",
 "219 276 OFFCURVE",
 "189 316 OFFCURVE",
 "189 489 CURVE SMOOTH",
@@ -30832,7 +30729,13 @@ nodes = (
 "312 702 CURVE SMOOTH",
 "401 702 OFFCURVE",
 "433 665 OFFCURVE",
-"433 499 CURVE SMOOTH"
+"433 499 CURVE SMOOTH",
+"433 458 OFFCURVE",
+"431 400 OFFCURVE",
+"423 352 CURVE",
+"395 307 OFFCURVE",
+"349 276 OFFCURVE",
+"288 276 CURVE SMOOTH"
 );
 }
 );
@@ -30893,7 +30796,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"104 -11 LINE",
 "357 -2 OFFCURVE",
 "589 188 OFFCURVE",
 "589 430 CURVE SMOOTH",
@@ -30912,19 +30814,13 @@ nodes = (
 "402 300 LINE",
 "380 145 OFFCURVE",
 "268 39 OFFCURVE",
-"104 23 CURVE"
+"104 23 CURVE",
+"104 -11 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"421 500 LINE",
-"421 463 OFFCURVE",
-"421 411 OFFCURVE",
-"411 368 CURVE",
-"389 329 OFFCURVE",
-"351 297 OFFCURVE",
-"296 297 CURVE SMOOTH",
 "238 297 OFFCURVE",
 "207 333 OFFCURVE",
 "207 497 CURVE SMOOTH",
@@ -30933,7 +30829,13 @@ nodes = (
 "313 699 CURVE SMOOTH",
 "392 699 OFFCURVE",
 "421 650 OFFCURVE",
-"421 500 CURVE"
+"421 500 CURVE",
+"421 463 OFFCURVE",
+"421 411 OFFCURVE",
+"411 368 CURVE",
+"389 329 OFFCURVE",
+"351 297 OFFCURVE",
+"296 297 CURVE SMOOTH"
 );
 }
 );
@@ -30944,7 +30846,7 @@ unicode = 0039;
 },
 {
 glyphname = zero.denominator;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:28:22 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -30952,10 +30854,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"24 197 LINE SMOOTH",
-"24 75 OFFCURVE",
-"101 -8 OFFCURVE",
-"203 -8 CURVE SMOOTH",
 "305 -8 OFFCURVE",
 "383 75 OFFCURVE",
 "383 197 CURVE SMOOTH",
@@ -30964,13 +30862,18 @@ nodes = (
 "203 403 CURVE SMOOTH",
 "101 403 OFFCURVE",
 "24 319 OFFCURVE",
-"24 197 CURVE SMOOTH"
+"24 197 CURVE SMOOTH",
+"24 75 OFFCURVE",
+"101 -8 OFFCURVE",
+"203 -8 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"126 197 LINE SMOOTH",
+"144 13 OFFCURVE",
+"126 47 OFFCURVE",
+"126 197 CURVE SMOOTH",
 "126 348 OFFCURVE",
 "144 383 OFFCURVE",
 "203 383 CURVE SMOOTH",
@@ -30979,10 +30882,7 @@ nodes = (
 "280 197 CURVE SMOOTH",
 "280 47 OFFCURVE",
 "259 13 OFFCURVE",
-"203 13 CURVE SMOOTH",
-"144 13 OFFCURVE",
-"126 47 OFFCURVE",
-"126 197 CURVE SMOOTH"
+"203 13 CURVE SMOOTH"
 );
 }
 );
@@ -31032,10 +30932,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"23 197 LINE SMOOTH",
-"23 74 OFFCURVE",
-"104 -8 OFFCURVE",
-"209 -8 CURVE SMOOTH",
 "314 -8 OFFCURVE",
 "396 74 OFFCURVE",
 "396 197 CURVE SMOOTH",
@@ -31044,13 +30940,18 @@ nodes = (
 "209 403 CURVE SMOOTH",
 "104 403 OFFCURVE",
 "23 319 OFFCURVE",
-"23 197 CURVE SMOOTH"
+"23 197 CURVE SMOOTH",
+"23 74 OFFCURVE",
+"104 -8 OFFCURVE",
+"209 -8 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"131 197 LINE SMOOTH",
+"149 13 OFFCURVE",
+"131 46 OFFCURVE",
+"131 197 CURVE SMOOTH",
 "131 347 OFFCURVE",
 "149 382 OFFCURVE",
 "209 382 CURVE SMOOTH",
@@ -31059,10 +30960,7 @@ nodes = (
 "287 197 CURVE SMOOTH",
 "287 46 OFFCURVE",
 "265 13 OFFCURVE",
-"209 13 CURVE SMOOTH",
-"149 13 OFFCURVE",
-"131 46 OFFCURVE",
-"131 197 CURVE SMOOTH"
+"209 13 CURVE SMOOTH"
 );
 }
 );
@@ -31072,7 +30970,7 @@ width = 419;
 },
 {
 glyphname = one.denominator;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:28:22 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -31080,16 +30978,16 @@ paths = (
 {
 closed = 1;
 nodes = (
-"4 377 LINE",
-"91 377 LINE",
-"91 17 LINE",
-"4 17 LINE",
-"4 0 LINE",
 "266 0 LINE",
 "266 17 LINE",
 "184 17 LINE",
 "184 395 LINE",
-"4 395 LINE"
+"4 395 LINE",
+"4 377 LINE",
+"91 377 LINE",
+"91 17 LINE",
+"4 17 LINE",
+"4 0 LINE"
 );
 }
 );
@@ -31101,16 +30999,16 @@ paths = (
 {
 closed = 1;
 nodes = (
-"3 377 LINE",
-"92 377 LINE",
-"92 18 LINE",
-"3 18 LINE",
-"3 0 LINE",
 "275 0 LINE",
 "275 18 LINE",
 "192 18 LINE",
 "192 395 LINE",
-"3 395 LINE"
+"3 395 LINE",
+"3 377 LINE",
+"92 377 LINE",
+"92 18 LINE",
+"3 18 LINE",
+"3 0 LINE"
 );
 }
 );
@@ -31120,7 +31018,7 @@ width = 279;
 },
 {
 glyphname = two.denominator;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:28:22 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -31128,6 +31026,8 @@ paths = (
 {
 closed = 1;
 nodes = (
+"321 0 LINE",
+"321 143 LINE",
 "304 143 LINE",
 "304 90 OFFCURVE",
 "296 85 OFFCURVE",
@@ -31169,9 +31069,7 @@ nodes = (
 "206 200 OFFCURVE",
 "146 155 CURVE SMOOTH",
 "17 57 LINE",
-"17 0 LINE",
-"321 0 LINE",
-"321 143 LINE"
+"17 0 LINE"
 );
 }
 );
@@ -31183,6 +31081,8 @@ paths = (
 {
 closed = 1;
 nodes = (
+"332 0 LINE",
+"332 147 LINE",
 "314 147 LINE",
 "314 93 OFFCURVE",
 "306 88 OFFCURVE",
@@ -31224,9 +31124,7 @@ nodes = (
 "210 199 OFFCURVE",
 "149 155 CURVE SMOOTH",
 "16 59 LINE",
-"16 0 LINE",
-"332 0 LINE",
-"332 147 LINE"
+"16 0 LINE"
 );
 }
 );
@@ -31236,7 +31134,7 @@ width = 360;
 },
 {
 glyphname = three.denominator;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:28:22 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -31244,6 +31142,12 @@ paths = (
 {
 closed = 1;
 nodes = (
+"249 -8 OFFCURVE",
+"317 50 OFFCURVE",
+"317 113 CURVE SMOOTH",
+"317 183 OFFCURVE",
+"253 216 OFFCURVE",
+"172 219 CURVE",
 "111 204 LINE",
 "182 204 OFFCURVE",
 "208 171 OFFCURVE",
@@ -31265,28 +31169,21 @@ nodes = (
 "13 73 CURVE SMOOTH",
 "13 23 OFFCURVE",
 "61 -8 OFFCURVE",
-"141 -8 CURVE SMOOTH",
-"249 -8 OFFCURVE",
-"317 50 OFFCURVE",
-"317 113 CURVE SMOOTH",
-"317 183 OFFCURVE",
-"253 216 OFFCURVE",
-"172 219 CURVE"
+"141 -8 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"76 204 LINE",
 "172 204 LINE",
 "172 225 LINE",
-"76 225 LINE"
+"76 225 LINE",
+"76 204 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"139 219 LINE",
 "253 226 OFFCURVE",
 "299 262 OFFCURVE",
 "299 313 CURVE SMOOTH",
@@ -31313,7 +31210,8 @@ nodes = (
 "197 318 CURVE SMOOTH",
 "197 258 OFFCURVE",
 "170 225 OFFCURVE",
-"100 225 CURVE"
+"100 225 CURVE",
+"139 219 LINE"
 );
 }
 );
@@ -31325,6 +31223,12 @@ paths = (
 {
 closed = 1;
 nodes = (
+"256 -8 OFFCURVE",
+"327 49 OFFCURVE",
+"327 113 CURVE SMOOTH",
+"327 183 OFFCURVE",
+"258 215 OFFCURVE",
+"173 218 CURVE",
 "111 204 LINE",
 "183 204 OFFCURVE",
 "210 171 OFFCURVE",
@@ -31346,28 +31250,21 @@ nodes = (
 "12 74 CURVE SMOOTH",
 "12 23 OFFCURVE",
 "60 -8 OFFCURVE",
-"143 -8 CURVE SMOOTH",
-"256 -8 OFFCURVE",
-"327 49 OFFCURVE",
-"327 113 CURVE SMOOTH",
-"327 183 OFFCURVE",
-"258 215 OFFCURVE",
-"173 218 CURVE"
+"143 -8 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"78 204 LINE",
 "173 204 LINE",
 "173 224 LINE",
-"78 224 LINE"
+"78 224 LINE",
+"78 204 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"140 218 LINE",
 "265 226 OFFCURVE",
 "310 261 OFFCURVE",
 "310 312 CURVE SMOOTH",
@@ -31394,7 +31291,8 @@ nodes = (
 "200 318 CURVE SMOOTH",
 "200 258 OFFCURVE",
 "173 224 OFFCURVE",
-"99 224 CURVE"
+"99 224 CURVE",
+"140 218 LINE"
 );
 }
 );
@@ -31404,7 +31302,7 @@ width = 346;
 },
 {
 glyphname = four.denominator;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:28:22 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -31412,16 +31310,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"36 129 LINE",
-"36 133 LINE",
-"171 320 LINE",
-"175 320 LINE",
-"175 129 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"322 0 LINE",
+"322 17 LINE",
+"267 17 LINE",
+"267 110 LINE",
 "338 110 LINE",
 "338 65 LINE",
 "356 65 LINE",
@@ -31436,11 +31328,17 @@ nodes = (
 "175 110 LINE",
 "175 17 LINE",
 "115 17 LINE",
-"115 0 LINE",
-"322 0 LINE",
-"322 17 LINE",
-"267 17 LINE",
-"267 110 LINE"
+"115 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"36 133 LINE",
+"171 320 LINE",
+"175 320 LINE",
+"175 129 LINE",
+"36 129 LINE"
 );
 }
 );
@@ -31452,16 +31350,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"34 129 LINE",
-"34 133 LINE",
-"172 318 LINE",
-"176 318 LINE",
-"176 129 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"332 0 LINE",
+"332 18 LINE",
+"276 18 LINE",
+"276 110 LINE",
 "350 110 LINE",
 "350 65 LINE",
 "369 65 LINE",
@@ -31476,11 +31368,17 @@ nodes = (
 "176 110 LINE",
 "176 18 LINE",
 "114 18 LINE",
-"114 0 LINE",
-"332 0 LINE",
-"332 18 LINE",
-"276 18 LINE",
-"276 110 LINE"
+"114 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"34 133 LINE",
+"172 318 LINE",
+"176 318 LINE",
+"176 129 LINE",
+"34 129 LINE"
 );
 }
 );
@@ -31490,7 +31388,7 @@ width = 391;
 },
 {
 glyphname = five.denominator;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:28:22 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -31498,30 +31396,12 @@ paths = (
 {
 closed = 1;
 nodes = (
-"79 310 LINE",
-"292 310 LINE",
-"312 417 LINE",
-"295 417 LINE",
-"288 398 OFFCURVE",
-"281 395 OFFCURVE",
-"259 395 CURVE SMOOTH",
-"65 395 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"47 209 LINE",
-"56 202 LINE",
-"70 228 LINE",
-"84 395 LINE",
-"61 395 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"170 247 LINE SMOOTH",
+"251 -8 OFFCURVE",
+"333 39 OFFCURVE",
+"333 123 CURVE SMOOTH",
+"333 189 OFFCURVE",
+"282 247 OFFCURVE",
+"170 247 CURVE SMOOTH",
 "124 247 OFFCURVE",
 "73 237 OFFCURVE",
 "63 231 CURVE",
@@ -31549,13 +31429,30 @@ nodes = (
 "15 71 CURVE SMOOTH",
 "15 26 OFFCURVE",
 "62 -8 OFFCURVE",
-"149 -8 CURVE SMOOTH",
-"251 -8 OFFCURVE",
-"333 39 OFFCURVE",
-"333 123 CURVE SMOOTH",
-"333 189 OFFCURVE",
-"282 247 OFFCURVE",
-"170 247 CURVE SMOOTH"
+"149 -8 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"70 228 LINE",
+"84 395 LINE",
+"61 395 LINE",
+"47 209 LINE",
+"56 202 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"292 310 LINE",
+"312 417 LINE",
+"295 417 LINE",
+"288 398 OFFCURVE",
+"281 395 OFFCURVE",
+"259 395 CURVE SMOOTH",
+"65 395 LINE",
+"79 310 LINE"
 );
 }
 );
@@ -31567,30 +31464,12 @@ paths = (
 {
 closed = 1;
 nodes = (
-"78 306 LINE",
-"305 306 LINE",
-"325 418 LINE",
-"307 418 LINE",
-"300 398 OFFCURVE",
-"293 395 OFFCURVE",
-"272 395 CURVE SMOOTH",
-"65 395 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"47 208 LINE",
-"57 202 LINE",
-"71 229 LINE",
-"84 395 LINE",
-"60 395 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"181 248 LINE SMOOTH",
+"261 -8 OFFCURVE",
+"346 38 OFFCURVE",
+"346 123 CURVE SMOOTH",
+"346 189 OFFCURVE",
+"298 248 OFFCURVE",
+"181 248 CURVE SMOOTH",
 "132 248 OFFCURVE",
 "75 238 OFFCURVE",
 "64 232 CURVE",
@@ -31618,13 +31497,30 @@ nodes = (
 "15 72 CURVE SMOOTH",
 "15 26 OFFCURVE",
 "61 -8 OFFCURVE",
-"154 -8 CURVE SMOOTH",
-"261 -8 OFFCURVE",
-"346 38 OFFCURVE",
-"346 123 CURVE SMOOTH",
-"346 189 OFFCURVE",
-"298 248 OFFCURVE",
-"181 248 CURVE SMOOTH"
+"154 -8 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"71 229 LINE",
+"84 395 LINE",
+"60 395 LINE",
+"47 208 LINE",
+"57 202 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"305 306 LINE",
+"325 418 LINE",
+"307 418 LINE",
+"300 398 OFFCURVE",
+"293 395 OFFCURVE",
+"272 395 CURVE SMOOTH",
+"65 395 LINE",
+"78 306 LINE"
 );
 }
 );
@@ -31634,7 +31530,7 @@ width = 362;
 },
 {
 glyphname = six.denominator;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:28:22 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -31642,13 +31538,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"287 415 LINE",
-"147 410 OFFCURVE",
-"25 288 OFFCURVE",
-"25 160 CURVE SMOOTH",
-"25 58 OFFCURVE",
-"94 -8 OFFCURVE",
-"180 -8 CURVE SMOOTH",
 "260 -8 OFFCURVE",
 "334 50 OFFCURVE",
 "334 129 CURVE SMOOTH",
@@ -31661,13 +31550,22 @@ nodes = (
 "132 230 LINE",
 "144 312 OFFCURVE",
 "199 385 OFFCURVE",
-"287 395 CURVE"
+"287 395 CURVE",
+"287 415 LINE",
+"147 410 OFFCURVE",
+"25 288 OFFCURVE",
+"25 160 CURVE SMOOTH",
+"25 58 OFFCURVE",
+"94 -8 OFFCURVE",
+"180 -8 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"121 121 LINE SMOOTH",
+"136 13 OFFCURVE",
+"121 41 OFFCURVE",
+"121 121 CURVE SMOOTH",
 "121 140 OFFCURVE",
 "121 168 OFFCURVE",
 "126 191 CURVE",
@@ -31679,10 +31577,7 @@ nodes = (
 "233 121 CURVE SMOOTH",
 "233 42 OFFCURVE",
 "220 13 OFFCURVE",
-"178 13 CURVE SMOOTH",
-"136 13 OFFCURVE",
-"121 41 OFFCURVE",
-"121 121 CURVE SMOOTH"
+"178 13 CURVE SMOOTH"
 );
 }
 );
@@ -31694,13 +31589,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"288 416 LINE",
-"147 411 OFFCURVE",
-"24 288 OFFCURVE",
-"24 160 CURVE SMOOTH",
-"24 58 OFFCURVE",
-"95 -8 OFFCURVE",
-"182 -8 CURVE SMOOTH",
 "264 -8 OFFCURVE",
 "338 50 OFFCURVE",
 "338 129 CURVE SMOOTH",
@@ -31713,13 +31601,22 @@ nodes = (
 "138 230 LINE",
 "150 311 OFFCURVE",
 "202 385 OFFCURVE",
-"288 395 CURVE"
+"288 395 CURVE",
+"288 416 LINE",
+"147 411 OFFCURVE",
+"24 288 OFFCURVE",
+"24 160 CURVE SMOOTH",
+"24 58 OFFCURVE",
+"95 -8 OFFCURVE",
+"182 -8 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"126 121 LINE SMOOTH",
+"141 13 OFFCURVE",
+"126 42 OFFCURVE",
+"126 121 CURVE SMOOTH",
 "126 140 OFFCURVE",
 "126 167 OFFCURVE",
 "131 190 CURVE",
@@ -31731,10 +31628,7 @@ nodes = (
 "233 121 CURVE SMOOTH",
 "233 43 OFFCURVE",
 "220 13 OFFCURVE",
-"181 13 CURVE SMOOTH",
-"141 13 OFFCURVE",
-"126 42 OFFCURVE",
-"126 121 CURVE SMOOTH"
+"181 13 CURVE SMOOTH"
 );
 }
 );
@@ -31744,7 +31638,7 @@ width = 352;
 },
 {
 glyphname = seven.denominator;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:28:22 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -31752,6 +31646,18 @@ paths = (
 {
 closed = 1;
 nodes = (
+"199 -8 OFFCURVE",
+"226 7 OFFCURVE",
+"226 42 CURVE SMOOTH",
+"226 69 OFFCURVE",
+"209 101 OFFCURVE",
+"209 138 CURVE SMOOTH",
+"209 162 OFFCURVE",
+"220 192 OFFCURVE",
+"245 231 CURVE SMOOTH",
+"325 359 LINE",
+"325 395 LINE",
+"60 395 LINE",
 "20 248 LINE",
 "41 248 LINE",
 "59 300 OFFCURVE",
@@ -31764,19 +31670,7 @@ nodes = (
 "111 42 CURVE SMOOTH",
 "111 12 OFFCURVE",
 "129 -8 OFFCURVE",
-"166 -8 CURVE SMOOTH",
-"199 -8 OFFCURVE",
-"226 7 OFFCURVE",
-"226 42 CURVE SMOOTH",
-"226 69 OFFCURVE",
-"209 101 OFFCURVE",
-"209 138 CURVE SMOOTH",
-"209 162 OFFCURVE",
-"220 192 OFFCURVE",
-"245 231 CURVE SMOOTH",
-"325 359 LINE",
-"325 395 LINE",
-"60 395 LINE"
+"166 -8 CURVE SMOOTH"
 );
 }
 );
@@ -31788,6 +31682,18 @@ paths = (
 {
 closed = 1;
 nodes = (
+"206 -8 OFFCURVE",
+"237 8 OFFCURVE",
+"237 43 CURVE SMOOTH",
+"237 70 OFFCURVE",
+"220 105 OFFCURVE",
+"220 141 CURVE SMOOTH",
+"220 165 OFFCURVE",
+"232 194 OFFCURVE",
+"257 232 CURVE SMOOTH",
+"339 357 LINE",
+"339 395 LINE",
+"63 395 LINE",
 "20 244 LINE",
 "43 244 LINE",
 "60 298 OFFCURVE",
@@ -31800,19 +31706,7 @@ nodes = (
 "113 42 CURVE SMOOTH",
 "113 13 OFFCURVE",
 "131 -8 OFFCURVE",
-"171 -8 CURVE SMOOTH",
-"206 -8 OFFCURVE",
-"237 8 OFFCURVE",
-"237 43 CURVE SMOOTH",
-"237 70 OFFCURVE",
-"220 105 OFFCURVE",
-"220 141 CURVE SMOOTH",
-"220 165 OFFCURVE",
-"232 194 OFFCURVE",
-"257 232 CURVE SMOOTH",
-"339 357 LINE",
-"339 395 LINE",
-"63 395 LINE"
+"171 -8 CURVE SMOOTH"
 );
 }
 );
@@ -31822,7 +31716,7 @@ width = 351;
 },
 {
 glyphname = eight.denominator;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:28:22 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -31830,64 +31724,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"118 100 LINE SMOOTH",
-"118 163 OFFCURVE",
-"133 195 OFFCURVE",
-"176 195 CURVE SMOOTH",
-"219 195 OFFCURVE",
-"233 161 OFFCURVE",
-"233 100 CURVE SMOOTH",
-"233 35 OFFCURVE",
-"216 9 OFFCURVE",
-"176 9 CURVE SMOOTH",
-"135 9 OFFCURVE",
-"118 35 OFFCURVE",
-"118 100 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"318 304 LINE SMOOTH",
-"318 356 OFFCURVE",
-"273 403 OFFCURVE",
-"175 403 CURVE SMOOTH",
-"81 403 OFFCURVE",
-"34 359 OFFCURVE",
-"34 305 CURVE SMOOTH",
-"34 243 OFFCURVE",
-"97 205 OFFCURVE",
-"176 205 CURVE SMOOTH",
-"256 205 OFFCURVE",
-"318 243 OFFCURVE",
-"318 304 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"223 303 LINE SMOOTH",
-"223 246 OFFCURVE",
-"211 216 OFFCURVE",
-"176 216 CURVE SMOOTH",
-"142 216 OFFCURVE",
-"129 246 OFFCURVE",
-"129 303 CURVE SMOOTH",
-"129 359 OFFCURVE",
-"142 383 OFFCURVE",
-"176 383 CURVE SMOOTH",
-"211 383 OFFCURVE",
-"223 359 OFFCURVE",
-"223 303 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"17 96 LINE SMOOTH",
-"17 38 OFFCURVE",
-"69 -8 OFFCURVE",
-"176 -8 CURVE SMOOTH",
 "283 -8 OFFCURVE",
 "334 38 OFFCURVE",
 "334 96 CURVE SMOOTH",
@@ -31899,7 +31735,61 @@ nodes = (
 "140 205 LINE",
 "68 192 OFFCURVE",
 "17 159 OFFCURVE",
-"17 96 CURVE SMOOTH"
+"17 96 CURVE SMOOTH",
+"17 38 OFFCURVE",
+"69 -8 OFFCURVE",
+"176 -8 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"135 9 OFFCURVE",
+"118 35 OFFCURVE",
+"118 100 CURVE SMOOTH",
+"118 163 OFFCURVE",
+"133 195 OFFCURVE",
+"176 195 CURVE SMOOTH",
+"219 195 OFFCURVE",
+"233 161 OFFCURVE",
+"233 100 CURVE SMOOTH",
+"233 35 OFFCURVE",
+"216 9 OFFCURVE",
+"176 9 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"142 216 OFFCURVE",
+"129 246 OFFCURVE",
+"129 303 CURVE SMOOTH",
+"129 359 OFFCURVE",
+"142 383 OFFCURVE",
+"176 383 CURVE SMOOTH",
+"211 383 OFFCURVE",
+"223 359 OFFCURVE",
+"223 303 CURVE SMOOTH",
+"223 246 OFFCURVE",
+"211 216 OFFCURVE",
+"176 216 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"256 205 OFFCURVE",
+"318 243 OFFCURVE",
+"318 304 CURVE SMOOTH",
+"318 356 OFFCURVE",
+"273 403 OFFCURVE",
+"175 403 CURVE SMOOTH",
+"81 403 OFFCURVE",
+"34 359 OFFCURVE",
+"34 305 CURVE SMOOTH",
+"34 243 OFFCURVE",
+"97 205 OFFCURVE",
+"176 205 CURVE SMOOTH"
 );
 }
 );
@@ -31911,64 +31801,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"123 100 LINE SMOOTH",
-"123 163 OFFCURVE",
-"137 194 OFFCURVE",
-"178 194 CURVE SMOOTH",
-"219 194 OFFCURVE",
-"233 161 OFFCURVE",
-"233 100 CURVE SMOOTH",
-"233 35 OFFCURVE",
-"216 9 OFFCURVE",
-"178 9 CURVE SMOOTH",
-"140 9 OFFCURVE",
-"123 35 OFFCURVE",
-"123 100 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"324 304 LINE SMOOTH",
-"324 356 OFFCURVE",
-"278 403 OFFCURVE",
-"177 403 CURVE SMOOTH",
-"81 403 OFFCURVE",
-"32 359 OFFCURVE",
-"32 305 CURVE SMOOTH",
-"32 243 OFFCURVE",
-"97 205 OFFCURVE",
-"178 205 CURVE SMOOTH",
-"260 205 OFFCURVE",
-"324 243 OFFCURVE",
-"324 304 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"222 303 LINE SMOOTH",
-"222 247 OFFCURVE",
-"211 216 OFFCURVE",
-"178 216 CURVE SMOOTH",
-"146 216 OFFCURVE",
-"134 247 OFFCURVE",
-"134 303 CURVE SMOOTH",
-"134 359 OFFCURVE",
-"146 382 OFFCURVE",
-"178 382 CURVE SMOOTH",
-"211 382 OFFCURVE",
-"222 359 OFFCURVE",
-"222 303 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"16 96 LINE SMOOTH",
-"16 38 OFFCURVE",
-"68 -8 OFFCURVE",
-"178 -8 CURVE SMOOTH",
 "287 -8 OFFCURVE",
 "340 38 OFFCURVE",
 "340 96 CURVE SMOOTH",
@@ -31980,7 +31812,61 @@ nodes = (
 "142 204 LINE",
 "68 191 OFFCURVE",
 "16 160 OFFCURVE",
-"16 96 CURVE SMOOTH"
+"16 96 CURVE SMOOTH",
+"16 38 OFFCURVE",
+"68 -8 OFFCURVE",
+"178 -8 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"140 9 OFFCURVE",
+"123 35 OFFCURVE",
+"123 100 CURVE SMOOTH",
+"123 163 OFFCURVE",
+"137 194 OFFCURVE",
+"178 194 CURVE SMOOTH",
+"219 194 OFFCURVE",
+"233 161 OFFCURVE",
+"233 100 CURVE SMOOTH",
+"233 35 OFFCURVE",
+"216 9 OFFCURVE",
+"178 9 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"146 216 OFFCURVE",
+"134 247 OFFCURVE",
+"134 303 CURVE SMOOTH",
+"134 359 OFFCURVE",
+"146 382 OFFCURVE",
+"178 382 CURVE SMOOTH",
+"211 382 OFFCURVE",
+"222 359 OFFCURVE",
+"222 303 CURVE SMOOTH",
+"222 247 OFFCURVE",
+"211 216 OFFCURVE",
+"178 216 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"260 205 OFFCURVE",
+"324 243 OFFCURVE",
+"324 304 CURVE SMOOTH",
+"324 356 OFFCURVE",
+"278 403 OFFCURVE",
+"177 403 CURVE SMOOTH",
+"81 403 OFFCURVE",
+"32 359 OFFCURVE",
+"32 305 CURVE SMOOTH",
+"32 243 OFFCURVE",
+"97 205 OFFCURVE",
+"178 205 CURVE SMOOTH"
 );
 }
 );
@@ -31990,7 +31876,7 @@ width = 356;
 },
 {
 glyphname = nine.denominator;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:28:22 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -31998,7 +31884,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"57 -4 LINE",
 "196 1 OFFCURVE",
 "325 104 OFFCURVE",
 "325 235 CURVE SMOOTH",
@@ -32017,19 +31902,13 @@ nodes = (
 "217 164 LINE",
 "205 81 OFFCURVE",
 "145 25 OFFCURVE",
-"57 16 CURVE"
+"57 16 CURVE",
+"57 -4 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"228 274 LINE SMOOTH",
-"228 254 OFFCURVE",
-"228 227 OFFCURVE",
-"223 204 CURVE",
-"212 183 OFFCURVE",
-"192 166 OFFCURVE",
-"163 166 CURVE SMOOTH",
 "133 166 OFFCURVE",
 "116 185 OFFCURVE",
 "116 273 CURVE SMOOTH",
@@ -32038,7 +31917,13 @@ nodes = (
 "171 383 CURVE SMOOTH",
 "213 383 OFFCURVE",
 "228 353 OFFCURVE",
-"228 274 CURVE SMOOTH"
+"228 274 CURVE SMOOTH",
+"228 254 OFFCURVE",
+"228 227 OFFCURVE",
+"223 204 CURVE",
+"212 183 OFFCURVE",
+"192 166 OFFCURVE",
+"163 166 CURVE SMOOTH"
 );
 }
 );
@@ -32050,7 +31935,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"56 -3 LINE",
 "198 2 OFFCURVE",
 "328 105 OFFCURVE",
 "328 235 CURVE SMOOTH",
@@ -32069,19 +31953,13 @@ nodes = (
 "214 165 LINE",
 "202 83 OFFCURVE",
 "143 27 OFFCURVE",
-"56 17 CURVE"
+"56 17 CURVE",
+"56 -3 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"226 274 LINE SMOOTH",
-"226 255 OFFCURVE",
-"225 228 OFFCURVE",
-"220 205 CURVE",
-"210 185 OFFCURVE",
-"192 167 OFFCURVE",
-"164 167 CURVE SMOOTH",
 "136 167 OFFCURVE",
 "119 186 OFFCURVE",
 "119 274 CURVE SMOOTH",
@@ -32090,7 +31968,13 @@ nodes = (
 "171 383 CURVE SMOOTH",
 "211 383 OFFCURVE",
 "226 353 OFFCURVE",
-"226 274 CURVE SMOOTH"
+"226 274 CURVE SMOOTH",
+"226 255 OFFCURVE",
+"225 228 OFFCURVE",
+"220 205 CURVE",
+"210 185 OFFCURVE",
+"192 167 OFFCURVE",
+"164 167 CURVE SMOOTH"
 );
 }
 );
@@ -32100,7 +31984,7 @@ width = 352;
 },
 {
 glyphname = zero.numerator;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:28:22 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -32108,10 +31992,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"24 556 LINE SMOOTH",
-"24 434 OFFCURVE",
-"101 351 OFFCURVE",
-"203 351 CURVE SMOOTH",
 "305 351 OFFCURVE",
 "383 434 OFFCURVE",
 "383 556 CURVE SMOOTH",
@@ -32120,13 +32000,18 @@ nodes = (
 "203 762 CURVE SMOOTH",
 "101 762 OFFCURVE",
 "24 678 OFFCURVE",
-"24 556 CURVE SMOOTH"
+"24 556 CURVE SMOOTH",
+"24 434 OFFCURVE",
+"101 351 OFFCURVE",
+"203 351 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"126 556 LINE SMOOTH",
+"144 372 OFFCURVE",
+"126 406 OFFCURVE",
+"126 556 CURVE SMOOTH",
 "126 707 OFFCURVE",
 "144 742 OFFCURVE",
 "203 742 CURVE SMOOTH",
@@ -32135,10 +32020,7 @@ nodes = (
 "280 556 CURVE SMOOTH",
 "280 406 OFFCURVE",
 "259 372 OFFCURVE",
-"203 372 CURVE SMOOTH",
-"144 372 OFFCURVE",
-"126 406 OFFCURVE",
-"126 556 CURVE SMOOTH"
+"203 372 CURVE SMOOTH"
 );
 }
 );
@@ -32188,10 +32070,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"23 556 LINE SMOOTH",
-"23 433 OFFCURVE",
-"104 351 OFFCURVE",
-"209 351 CURVE SMOOTH",
 "314 351 OFFCURVE",
 "396 433 OFFCURVE",
 "396 556 CURVE SMOOTH",
@@ -32200,13 +32078,18 @@ nodes = (
 "209 762 CURVE SMOOTH",
 "104 762 OFFCURVE",
 "23 678 OFFCURVE",
-"23 556 CURVE SMOOTH"
+"23 556 CURVE SMOOTH",
+"23 433 OFFCURVE",
+"104 351 OFFCURVE",
+"209 351 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"131 556 LINE SMOOTH",
+"149 372 OFFCURVE",
+"131 405 OFFCURVE",
+"131 556 CURVE SMOOTH",
 "131 706 OFFCURVE",
 "149 741 OFFCURVE",
 "209 741 CURVE SMOOTH",
@@ -32215,10 +32098,7 @@ nodes = (
 "287 556 CURVE SMOOTH",
 "287 405 OFFCURVE",
 "265 372 OFFCURVE",
-"209 372 CURVE SMOOTH",
-"149 372 OFFCURVE",
-"131 405 OFFCURVE",
-"131 556 CURVE SMOOTH"
+"209 372 CURVE SMOOTH"
 );
 }
 );
@@ -32228,7 +32108,7 @@ width = 419;
 },
 {
 glyphname = one.numerator;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:28:22 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -32236,16 +32116,16 @@ paths = (
 {
 closed = 1;
 nodes = (
-"4 736 LINE",
-"91 736 LINE",
-"91 376 LINE",
-"4 376 LINE",
-"4 359 LINE",
 "266 359 LINE",
 "266 376 LINE",
 "184 376 LINE",
 "184 754 LINE",
-"4 754 LINE"
+"4 754 LINE",
+"4 736 LINE",
+"91 736 LINE",
+"91 376 LINE",
+"4 376 LINE",
+"4 359 LINE"
 );
 }
 );
@@ -32257,16 +32137,16 @@ paths = (
 {
 closed = 1;
 nodes = (
-"3 736 LINE",
-"92 736 LINE",
-"92 377 LINE",
-"3 377 LINE",
-"3 359 LINE",
 "275 359 LINE",
 "275 377 LINE",
 "192 377 LINE",
 "192 754 LINE",
-"3 754 LINE"
+"3 754 LINE",
+"3 736 LINE",
+"92 736 LINE",
+"92 377 LINE",
+"3 377 LINE",
+"3 359 LINE"
 );
 }
 );
@@ -32276,7 +32156,7 @@ width = 279;
 },
 {
 glyphname = two.numerator;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:28:22 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -32284,6 +32164,8 @@ paths = (
 {
 closed = 1;
 nodes = (
+"321 359 LINE",
+"321 502 LINE",
 "304 502 LINE",
 "304 449 OFFCURVE",
 "296 444 OFFCURVE",
@@ -32325,9 +32207,7 @@ nodes = (
 "206 559 OFFCURVE",
 "146 514 CURVE SMOOTH",
 "17 416 LINE",
-"17 359 LINE",
-"321 359 LINE",
-"321 502 LINE"
+"17 359 LINE"
 );
 }
 );
@@ -32339,6 +32219,8 @@ paths = (
 {
 closed = 1;
 nodes = (
+"332 359 LINE",
+"332 506 LINE",
 "314 506 LINE",
 "314 452 OFFCURVE",
 "306 447 OFFCURVE",
@@ -32380,9 +32262,7 @@ nodes = (
 "210 558 OFFCURVE",
 "149 514 CURVE SMOOTH",
 "16 418 LINE",
-"16 359 LINE",
-"332 359 LINE",
-"332 506 LINE"
+"16 359 LINE"
 );
 }
 );
@@ -32392,7 +32272,7 @@ width = 360;
 },
 {
 glyphname = three.numerator;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:28:22 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -32400,6 +32280,12 @@ paths = (
 {
 closed = 1;
 nodes = (
+"249 351 OFFCURVE",
+"317 409 OFFCURVE",
+"317 472 CURVE SMOOTH",
+"317 542 OFFCURVE",
+"253 575 OFFCURVE",
+"172 578 CURVE",
 "111 563 LINE",
 "182 563 OFFCURVE",
 "208 530 OFFCURVE",
@@ -32421,28 +32307,21 @@ nodes = (
 "13 432 CURVE SMOOTH",
 "13 382 OFFCURVE",
 "61 351 OFFCURVE",
-"141 351 CURVE SMOOTH",
-"249 351 OFFCURVE",
-"317 409 OFFCURVE",
-"317 472 CURVE SMOOTH",
-"317 542 OFFCURVE",
-"253 575 OFFCURVE",
-"172 578 CURVE"
+"141 351 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"76 563 LINE",
 "172 563 LINE",
 "172 584 LINE",
-"76 584 LINE"
+"76 584 LINE",
+"76 563 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"139 578 LINE",
 "253 585 OFFCURVE",
 "299 621 OFFCURVE",
 "299 672 CURVE SMOOTH",
@@ -32469,7 +32348,8 @@ nodes = (
 "197 677 CURVE SMOOTH",
 "197 617 OFFCURVE",
 "170 584 OFFCURVE",
-"100 584 CURVE"
+"100 584 CURVE",
+"139 578 LINE"
 );
 }
 );
@@ -32481,6 +32361,12 @@ paths = (
 {
 closed = 1;
 nodes = (
+"256 351 OFFCURVE",
+"327 408 OFFCURVE",
+"327 472 CURVE SMOOTH",
+"327 542 OFFCURVE",
+"258 574 OFFCURVE",
+"173 577 CURVE",
 "111 563 LINE",
 "183 563 OFFCURVE",
 "210 530 OFFCURVE",
@@ -32502,28 +32388,21 @@ nodes = (
 "12 433 CURVE SMOOTH",
 "12 382 OFFCURVE",
 "60 351 OFFCURVE",
-"143 351 CURVE SMOOTH",
-"256 351 OFFCURVE",
-"327 408 OFFCURVE",
-"327 472 CURVE SMOOTH",
-"327 542 OFFCURVE",
-"258 574 OFFCURVE",
-"173 577 CURVE"
+"143 351 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"78 563 LINE",
 "173 563 LINE",
 "173 583 LINE",
-"78 583 LINE"
+"78 583 LINE",
+"78 563 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"140 577 LINE",
 "265 585 OFFCURVE",
 "310 620 OFFCURVE",
 "310 671 CURVE SMOOTH",
@@ -32550,7 +32429,8 @@ nodes = (
 "200 677 CURVE SMOOTH",
 "200 617 OFFCURVE",
 "173 583 OFFCURVE",
-"99 583 CURVE"
+"99 583 CURVE",
+"140 577 LINE"
 );
 }
 );
@@ -32560,7 +32440,7 @@ width = 346;
 },
 {
 glyphname = four.numerator;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:28:22 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -32568,16 +32448,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"36 488 LINE",
-"36 492 LINE",
-"171 679 LINE",
-"175 679 LINE",
-"175 488 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"322 359 LINE",
+"322 376 LINE",
+"267 376 LINE",
+"267 469 LINE",
 "338 469 LINE",
 "338 424 LINE",
 "356 424 LINE",
@@ -32592,11 +32466,17 @@ nodes = (
 "175 469 LINE",
 "175 376 LINE",
 "115 376 LINE",
-"115 359 LINE",
-"322 359 LINE",
-"322 376 LINE",
-"267 376 LINE",
-"267 469 LINE"
+"115 359 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"36 492 LINE",
+"171 679 LINE",
+"175 679 LINE",
+"175 488 LINE",
+"36 488 LINE"
 );
 }
 );
@@ -32608,16 +32488,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"34 488 LINE",
-"34 492 LINE",
-"172 677 LINE",
-"176 677 LINE",
-"176 488 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"332 359 LINE",
+"332 377 LINE",
+"276 377 LINE",
+"276 469 LINE",
 "350 469 LINE",
 "350 424 LINE",
 "369 424 LINE",
@@ -32632,11 +32506,17 @@ nodes = (
 "176 469 LINE",
 "176 377 LINE",
 "114 377 LINE",
-"114 359 LINE",
-"332 359 LINE",
-"332 377 LINE",
-"276 377 LINE",
-"276 469 LINE"
+"114 359 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"34 492 LINE",
+"172 677 LINE",
+"176 677 LINE",
+"176 488 LINE",
+"34 488 LINE"
 );
 }
 );
@@ -32646,7 +32526,7 @@ width = 391;
 },
 {
 glyphname = five.numerator;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:28:22 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -32654,30 +32534,12 @@ paths = (
 {
 closed = 1;
 nodes = (
-"79 669 LINE",
-"292 669 LINE",
-"312 776 LINE",
-"295 776 LINE",
-"288 757 OFFCURVE",
-"281 754 OFFCURVE",
-"259 754 CURVE SMOOTH",
-"65 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"47 568 LINE",
-"56 561 LINE",
-"70 587 LINE",
-"84 754 LINE",
-"61 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"170 606 LINE SMOOTH",
+"251 351 OFFCURVE",
+"333 398 OFFCURVE",
+"333 482 CURVE SMOOTH",
+"333 548 OFFCURVE",
+"282 606 OFFCURVE",
+"170 606 CURVE SMOOTH",
 "124 606 OFFCURVE",
 "73 596 OFFCURVE",
 "63 590 CURVE",
@@ -32705,13 +32567,30 @@ nodes = (
 "15 430 CURVE SMOOTH",
 "15 385 OFFCURVE",
 "62 351 OFFCURVE",
-"149 351 CURVE SMOOTH",
-"251 351 OFFCURVE",
-"333 398 OFFCURVE",
-"333 482 CURVE SMOOTH",
-"333 548 OFFCURVE",
-"282 606 OFFCURVE",
-"170 606 CURVE SMOOTH"
+"149 351 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"70 587 LINE",
+"84 754 LINE",
+"61 754 LINE",
+"47 568 LINE",
+"56 561 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"292 669 LINE",
+"312 776 LINE",
+"295 776 LINE",
+"288 757 OFFCURVE",
+"281 754 OFFCURVE",
+"259 754 CURVE SMOOTH",
+"65 754 LINE",
+"79 669 LINE"
 );
 }
 );
@@ -32723,30 +32602,12 @@ paths = (
 {
 closed = 1;
 nodes = (
-"78 665 LINE",
-"305 665 LINE",
-"325 777 LINE",
-"307 777 LINE",
-"300 757 OFFCURVE",
-"293 754 OFFCURVE",
-"272 754 CURVE SMOOTH",
-"65 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"47 567 LINE",
-"57 561 LINE",
-"71 588 LINE",
-"84 754 LINE",
-"60 754 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"181 607 LINE SMOOTH",
+"261 351 OFFCURVE",
+"346 397 OFFCURVE",
+"346 482 CURVE SMOOTH",
+"346 548 OFFCURVE",
+"298 607 OFFCURVE",
+"181 607 CURVE SMOOTH",
 "132 607 OFFCURVE",
 "75 597 OFFCURVE",
 "64 591 CURVE",
@@ -32774,13 +32635,30 @@ nodes = (
 "15 431 CURVE SMOOTH",
 "15 385 OFFCURVE",
 "61 351 OFFCURVE",
-"154 351 CURVE SMOOTH",
-"261 351 OFFCURVE",
-"346 397 OFFCURVE",
-"346 482 CURVE SMOOTH",
-"346 548 OFFCURVE",
-"298 607 OFFCURVE",
-"181 607 CURVE SMOOTH"
+"154 351 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"71 588 LINE",
+"84 754 LINE",
+"60 754 LINE",
+"47 567 LINE",
+"57 561 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"305 665 LINE",
+"325 777 LINE",
+"307 777 LINE",
+"300 757 OFFCURVE",
+"293 754 OFFCURVE",
+"272 754 CURVE SMOOTH",
+"65 754 LINE",
+"78 665 LINE"
 );
 }
 );
@@ -32790,7 +32668,7 @@ width = 362;
 },
 {
 glyphname = six.numerator;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:28:22 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -32798,13 +32676,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"287 774 LINE",
-"147 769 OFFCURVE",
-"25 647 OFFCURVE",
-"25 519 CURVE SMOOTH",
-"25 417 OFFCURVE",
-"94 351 OFFCURVE",
-"180 351 CURVE SMOOTH",
 "260 351 OFFCURVE",
 "334 409 OFFCURVE",
 "334 488 CURVE SMOOTH",
@@ -32817,13 +32688,22 @@ nodes = (
 "132 589 LINE",
 "144 671 OFFCURVE",
 "199 744 OFFCURVE",
-"287 754 CURVE"
+"287 754 CURVE",
+"287 774 LINE",
+"147 769 OFFCURVE",
+"25 647 OFFCURVE",
+"25 519 CURVE SMOOTH",
+"25 417 OFFCURVE",
+"94 351 OFFCURVE",
+"180 351 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"121 480 LINE SMOOTH",
+"136 372 OFFCURVE",
+"121 400 OFFCURVE",
+"121 480 CURVE SMOOTH",
 "121 499 OFFCURVE",
 "121 527 OFFCURVE",
 "126 550 CURVE",
@@ -32835,10 +32715,7 @@ nodes = (
 "233 480 CURVE SMOOTH",
 "233 401 OFFCURVE",
 "220 372 OFFCURVE",
-"178 372 CURVE SMOOTH",
-"136 372 OFFCURVE",
-"121 400 OFFCURVE",
-"121 480 CURVE SMOOTH"
+"178 372 CURVE SMOOTH"
 );
 }
 );
@@ -32850,13 +32727,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"288 775 LINE",
-"147 770 OFFCURVE",
-"24 647 OFFCURVE",
-"24 519 CURVE SMOOTH",
-"24 417 OFFCURVE",
-"95 351 OFFCURVE",
-"182 351 CURVE SMOOTH",
 "264 351 OFFCURVE",
 "338 409 OFFCURVE",
 "338 488 CURVE SMOOTH",
@@ -32869,13 +32739,22 @@ nodes = (
 "138 589 LINE",
 "150 670 OFFCURVE",
 "202 744 OFFCURVE",
-"288 754 CURVE"
+"288 754 CURVE",
+"288 775 LINE",
+"147 770 OFFCURVE",
+"24 647 OFFCURVE",
+"24 519 CURVE SMOOTH",
+"24 417 OFFCURVE",
+"95 351 OFFCURVE",
+"182 351 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"126 480 LINE SMOOTH",
+"141 372 OFFCURVE",
+"126 401 OFFCURVE",
+"126 480 CURVE SMOOTH",
 "126 499 OFFCURVE",
 "126 526 OFFCURVE",
 "131 549 CURVE",
@@ -32887,10 +32766,7 @@ nodes = (
 "233 480 CURVE SMOOTH",
 "233 402 OFFCURVE",
 "220 372 OFFCURVE",
-"181 372 CURVE SMOOTH",
-"141 372 OFFCURVE",
-"126 401 OFFCURVE",
-"126 480 CURVE SMOOTH"
+"181 372 CURVE SMOOTH"
 );
 }
 );
@@ -32900,7 +32776,7 @@ width = 352;
 },
 {
 glyphname = seven.numerator;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:28:22 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -32908,6 +32784,18 @@ paths = (
 {
 closed = 1;
 nodes = (
+"199 351 OFFCURVE",
+"226 366 OFFCURVE",
+"226 401 CURVE SMOOTH",
+"226 428 OFFCURVE",
+"209 460 OFFCURVE",
+"209 497 CURVE SMOOTH",
+"209 521 OFFCURVE",
+"220 551 OFFCURVE",
+"245 590 CURVE SMOOTH",
+"325 718 LINE",
+"325 754 LINE",
+"60 754 LINE",
 "20 607 LINE",
 "41 607 LINE",
 "59 659 OFFCURVE",
@@ -32920,19 +32808,7 @@ nodes = (
 "111 401 CURVE SMOOTH",
 "111 371 OFFCURVE",
 "129 351 OFFCURVE",
-"166 351 CURVE SMOOTH",
-"199 351 OFFCURVE",
-"226 366 OFFCURVE",
-"226 401 CURVE SMOOTH",
-"226 428 OFFCURVE",
-"209 460 OFFCURVE",
-"209 497 CURVE SMOOTH",
-"209 521 OFFCURVE",
-"220 551 OFFCURVE",
-"245 590 CURVE SMOOTH",
-"325 718 LINE",
-"325 754 LINE",
-"60 754 LINE"
+"166 351 CURVE SMOOTH"
 );
 }
 );
@@ -32944,6 +32820,18 @@ paths = (
 {
 closed = 1;
 nodes = (
+"206 351 OFFCURVE",
+"237 367 OFFCURVE",
+"237 402 CURVE SMOOTH",
+"237 429 OFFCURVE",
+"220 464 OFFCURVE",
+"220 500 CURVE SMOOTH",
+"220 524 OFFCURVE",
+"232 553 OFFCURVE",
+"257 591 CURVE SMOOTH",
+"339 716 LINE",
+"339 754 LINE",
+"63 754 LINE",
 "20 603 LINE",
 "43 603 LINE",
 "60 657 OFFCURVE",
@@ -32956,19 +32844,7 @@ nodes = (
 "113 401 CURVE SMOOTH",
 "113 372 OFFCURVE",
 "131 351 OFFCURVE",
-"171 351 CURVE SMOOTH",
-"206 351 OFFCURVE",
-"237 367 OFFCURVE",
-"237 402 CURVE SMOOTH",
-"237 429 OFFCURVE",
-"220 464 OFFCURVE",
-"220 500 CURVE SMOOTH",
-"220 524 OFFCURVE",
-"232 553 OFFCURVE",
-"257 591 CURVE SMOOTH",
-"339 716 LINE",
-"339 754 LINE",
-"63 754 LINE"
+"171 351 CURVE SMOOTH"
 );
 }
 );
@@ -32978,7 +32854,7 @@ width = 351;
 },
 {
 glyphname = eight.numerator;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:28:22 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -32986,64 +32862,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"118 459 LINE SMOOTH",
-"118 522 OFFCURVE",
-"133 554 OFFCURVE",
-"176 554 CURVE SMOOTH",
-"219 554 OFFCURVE",
-"233 520 OFFCURVE",
-"233 459 CURVE SMOOTH",
-"233 394 OFFCURVE",
-"216 368 OFFCURVE",
-"176 368 CURVE SMOOTH",
-"135 368 OFFCURVE",
-"118 394 OFFCURVE",
-"118 459 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"318 663 LINE SMOOTH",
-"318 715 OFFCURVE",
-"273 762 OFFCURVE",
-"175 762 CURVE SMOOTH",
-"81 762 OFFCURVE",
-"34 718 OFFCURVE",
-"34 664 CURVE SMOOTH",
-"34 602 OFFCURVE",
-"97 564 OFFCURVE",
-"176 564 CURVE SMOOTH",
-"256 564 OFFCURVE",
-"318 602 OFFCURVE",
-"318 663 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"223 662 LINE SMOOTH",
-"223 605 OFFCURVE",
-"211 575 OFFCURVE",
-"176 575 CURVE SMOOTH",
-"142 575 OFFCURVE",
-"129 605 OFFCURVE",
-"129 662 CURVE SMOOTH",
-"129 718 OFFCURVE",
-"142 742 OFFCURVE",
-"176 742 CURVE SMOOTH",
-"211 742 OFFCURVE",
-"223 718 OFFCURVE",
-"223 662 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"17 455 LINE SMOOTH",
-"17 397 OFFCURVE",
-"69 351 OFFCURVE",
-"176 351 CURVE SMOOTH",
 "283 351 OFFCURVE",
 "334 397 OFFCURVE",
 "334 455 CURVE SMOOTH",
@@ -33055,7 +32873,61 @@ nodes = (
 "140 564 LINE",
 "68 551 OFFCURVE",
 "17 518 OFFCURVE",
-"17 455 CURVE SMOOTH"
+"17 455 CURVE SMOOTH",
+"17 397 OFFCURVE",
+"69 351 OFFCURVE",
+"176 351 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"135 368 OFFCURVE",
+"118 394 OFFCURVE",
+"118 459 CURVE SMOOTH",
+"118 522 OFFCURVE",
+"133 554 OFFCURVE",
+"176 554 CURVE SMOOTH",
+"219 554 OFFCURVE",
+"233 520 OFFCURVE",
+"233 459 CURVE SMOOTH",
+"233 394 OFFCURVE",
+"216 368 OFFCURVE",
+"176 368 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"142 575 OFFCURVE",
+"129 605 OFFCURVE",
+"129 662 CURVE SMOOTH",
+"129 718 OFFCURVE",
+"142 742 OFFCURVE",
+"176 742 CURVE SMOOTH",
+"211 742 OFFCURVE",
+"223 718 OFFCURVE",
+"223 662 CURVE SMOOTH",
+"223 605 OFFCURVE",
+"211 575 OFFCURVE",
+"176 575 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"256 564 OFFCURVE",
+"318 602 OFFCURVE",
+"318 663 CURVE SMOOTH",
+"318 715 OFFCURVE",
+"273 762 OFFCURVE",
+"175 762 CURVE SMOOTH",
+"81 762 OFFCURVE",
+"34 718 OFFCURVE",
+"34 664 CURVE SMOOTH",
+"34 602 OFFCURVE",
+"97 564 OFFCURVE",
+"176 564 CURVE SMOOTH"
 );
 }
 );
@@ -33067,64 +32939,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"123 459 LINE SMOOTH",
-"123 522 OFFCURVE",
-"137 553 OFFCURVE",
-"178 553 CURVE SMOOTH",
-"219 553 OFFCURVE",
-"233 520 OFFCURVE",
-"233 459 CURVE SMOOTH",
-"233 394 OFFCURVE",
-"216 368 OFFCURVE",
-"178 368 CURVE SMOOTH",
-"140 368 OFFCURVE",
-"123 394 OFFCURVE",
-"123 459 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"324 663 LINE SMOOTH",
-"324 715 OFFCURVE",
-"278 762 OFFCURVE",
-"177 762 CURVE SMOOTH",
-"81 762 OFFCURVE",
-"32 718 OFFCURVE",
-"32 664 CURVE SMOOTH",
-"32 602 OFFCURVE",
-"97 564 OFFCURVE",
-"178 564 CURVE SMOOTH",
-"260 564 OFFCURVE",
-"324 602 OFFCURVE",
-"324 663 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"222 662 LINE SMOOTH",
-"222 606 OFFCURVE",
-"211 575 OFFCURVE",
-"178 575 CURVE SMOOTH",
-"146 575 OFFCURVE",
-"134 606 OFFCURVE",
-"134 662 CURVE SMOOTH",
-"134 718 OFFCURVE",
-"146 741 OFFCURVE",
-"178 741 CURVE SMOOTH",
-"211 741 OFFCURVE",
-"222 718 OFFCURVE",
-"222 662 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"16 455 LINE SMOOTH",
-"16 397 OFFCURVE",
-"68 351 OFFCURVE",
-"178 351 CURVE SMOOTH",
 "287 351 OFFCURVE",
 "340 397 OFFCURVE",
 "340 455 CURVE SMOOTH",
@@ -33136,7 +32950,61 @@ nodes = (
 "142 563 LINE",
 "68 550 OFFCURVE",
 "16 519 OFFCURVE",
-"16 455 CURVE SMOOTH"
+"16 455 CURVE SMOOTH",
+"16 397 OFFCURVE",
+"68 351 OFFCURVE",
+"178 351 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"140 368 OFFCURVE",
+"123 394 OFFCURVE",
+"123 459 CURVE SMOOTH",
+"123 522 OFFCURVE",
+"137 553 OFFCURVE",
+"178 553 CURVE SMOOTH",
+"219 553 OFFCURVE",
+"233 520 OFFCURVE",
+"233 459 CURVE SMOOTH",
+"233 394 OFFCURVE",
+"216 368 OFFCURVE",
+"178 368 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"146 575 OFFCURVE",
+"134 606 OFFCURVE",
+"134 662 CURVE SMOOTH",
+"134 718 OFFCURVE",
+"146 741 OFFCURVE",
+"178 741 CURVE SMOOTH",
+"211 741 OFFCURVE",
+"222 718 OFFCURVE",
+"222 662 CURVE SMOOTH",
+"222 606 OFFCURVE",
+"211 575 OFFCURVE",
+"178 575 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"260 564 OFFCURVE",
+"324 602 OFFCURVE",
+"324 663 CURVE SMOOTH",
+"324 715 OFFCURVE",
+"278 762 OFFCURVE",
+"177 762 CURVE SMOOTH",
+"81 762 OFFCURVE",
+"32 718 OFFCURVE",
+"32 664 CURVE SMOOTH",
+"32 602 OFFCURVE",
+"97 564 OFFCURVE",
+"178 564 CURVE SMOOTH"
 );
 }
 );
@@ -33146,7 +33014,7 @@ width = 356;
 },
 {
 glyphname = nine.numerator;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:28:22 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -33154,7 +33022,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"57 355 LINE",
 "196 360 OFFCURVE",
 "325 463 OFFCURVE",
 "325 594 CURVE SMOOTH",
@@ -33173,19 +33040,13 @@ nodes = (
 "217 523 LINE",
 "205 440 OFFCURVE",
 "145 384 OFFCURVE",
-"57 375 CURVE"
+"57 375 CURVE",
+"57 355 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"228 633 LINE SMOOTH",
-"228 613 OFFCURVE",
-"228 586 OFFCURVE",
-"223 563 CURVE",
-"212 542 OFFCURVE",
-"192 525 OFFCURVE",
-"163 525 CURVE SMOOTH",
 "133 525 OFFCURVE",
 "116 544 OFFCURVE",
 "116 632 CURVE SMOOTH",
@@ -33194,7 +33055,13 @@ nodes = (
 "171 742 CURVE SMOOTH",
 "213 742 OFFCURVE",
 "228 712 OFFCURVE",
-"228 633 CURVE SMOOTH"
+"228 633 CURVE SMOOTH",
+"228 613 OFFCURVE",
+"228 586 OFFCURVE",
+"223 563 CURVE",
+"212 542 OFFCURVE",
+"192 525 OFFCURVE",
+"163 525 CURVE SMOOTH"
 );
 }
 );
@@ -33206,7 +33073,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"56 356 LINE",
 "198 361 OFFCURVE",
 "328 464 OFFCURVE",
 "328 594 CURVE SMOOTH",
@@ -33225,19 +33091,13 @@ nodes = (
 "214 524 LINE",
 "202 442 OFFCURVE",
 "143 386 OFFCURVE",
-"56 376 CURVE"
+"56 376 CURVE",
+"56 356 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"226 633 LINE SMOOTH",
-"226 614 OFFCURVE",
-"225 587 OFFCURVE",
-"220 564 CURVE",
-"210 544 OFFCURVE",
-"192 526 OFFCURVE",
-"164 526 CURVE SMOOTH",
 "136 526 OFFCURVE",
 "119 545 OFFCURVE",
 "119 633 CURVE SMOOTH",
@@ -33246,7 +33106,13 @@ nodes = (
 "171 742 CURVE SMOOTH",
 "211 742 OFFCURVE",
 "226 712 OFFCURVE",
-"226 633 CURVE SMOOTH"
+"226 633 CURVE SMOOTH",
+"226 614 OFFCURVE",
+"225 587 OFFCURVE",
+"220 564 CURVE",
+"210 544 OFFCURVE",
+"192 526 OFFCURVE",
+"164 526 CURVE SMOOTH"
 );
 }
 );
@@ -33256,7 +33122,7 @@ width = 352;
 },
 {
 glyphname = zeroinferior;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -33264,10 +33130,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"24 97 LINE SMOOTH",
-"24 -25 OFFCURVE",
-"101 -108 OFFCURVE",
-"203 -108 CURVE SMOOTH",
 "305 -108 OFFCURVE",
 "383 -25 OFFCURVE",
 "383 97 CURVE SMOOTH",
@@ -33276,13 +33138,18 @@ nodes = (
 "203 303 CURVE SMOOTH",
 "101 303 OFFCURVE",
 "24 219 OFFCURVE",
-"24 97 CURVE SMOOTH"
+"24 97 CURVE SMOOTH",
+"24 -25 OFFCURVE",
+"101 -108 OFFCURVE",
+"203 -108 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"126 97 LINE SMOOTH",
+"144 -87 OFFCURVE",
+"126 -53 OFFCURVE",
+"126 97 CURVE SMOOTH",
 "126 248 OFFCURVE",
 "144 283 OFFCURVE",
 "203 283 CURVE SMOOTH",
@@ -33291,10 +33158,7 @@ nodes = (
 "280 97 CURVE SMOOTH",
 "280 -53 OFFCURVE",
 "259 -87 OFFCURVE",
-"203 -87 CURVE SMOOTH",
-"144 -87 OFFCURVE",
-"126 -53 OFFCURVE",
-"126 97 CURVE SMOOTH"
+"203 -87 CURVE SMOOTH"
 );
 }
 );
@@ -33344,10 +33208,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"23 97 LINE SMOOTH",
-"23 -26 OFFCURVE",
-"104 -108 OFFCURVE",
-"209 -108 CURVE SMOOTH",
 "314 -108 OFFCURVE",
 "396 -26 OFFCURVE",
 "396 97 CURVE SMOOTH",
@@ -33356,13 +33216,18 @@ nodes = (
 "209 303 CURVE SMOOTH",
 "104 303 OFFCURVE",
 "23 219 OFFCURVE",
-"23 97 CURVE SMOOTH"
+"23 97 CURVE SMOOTH",
+"23 -26 OFFCURVE",
+"104 -108 OFFCURVE",
+"209 -108 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"131 97 LINE SMOOTH",
+"149 -87 OFFCURVE",
+"131 -54 OFFCURVE",
+"131 97 CURVE SMOOTH",
 "131 247 OFFCURVE",
 "149 282 OFFCURVE",
 "209 282 CURVE SMOOTH",
@@ -33371,10 +33236,7 @@ nodes = (
 "287 97 CURVE SMOOTH",
 "287 -54 OFFCURVE",
 "265 -87 OFFCURVE",
-"209 -87 CURVE SMOOTH",
-"149 -87 OFFCURVE",
-"131 -54 OFFCURVE",
-"131 97 CURVE SMOOTH"
+"209 -87 CURVE SMOOTH"
 );
 }
 );
@@ -33385,7 +33247,7 @@ unicode = 2080;
 },
 {
 glyphname = oneinferior;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -33393,16 +33255,16 @@ paths = (
 {
 closed = 1;
 nodes = (
-"4 277 LINE",
-"91 277 LINE",
-"91 -83 LINE",
-"4 -83 LINE",
-"4 -100 LINE",
 "266 -100 LINE",
 "266 -83 LINE",
 "184 -83 LINE",
 "184 295 LINE",
-"4 295 LINE"
+"4 295 LINE",
+"4 277 LINE",
+"91 277 LINE",
+"91 -83 LINE",
+"4 -83 LINE",
+"4 -100 LINE"
 );
 }
 );
@@ -33414,16 +33276,16 @@ paths = (
 {
 closed = 1;
 nodes = (
-"3 277 LINE",
-"92 277 LINE",
-"92 -82 LINE",
-"3 -82 LINE",
-"3 -100 LINE",
 "275 -100 LINE",
 "275 -82 LINE",
 "192 -82 LINE",
 "192 295 LINE",
-"3 295 LINE"
+"3 295 LINE",
+"3 277 LINE",
+"92 277 LINE",
+"92 -82 LINE",
+"3 -82 LINE",
+"3 -100 LINE"
 );
 }
 );
@@ -33434,7 +33296,7 @@ unicode = 2081;
 },
 {
 glyphname = twoinferior;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -33442,6 +33304,8 @@ paths = (
 {
 closed = 1;
 nodes = (
+"321 -100 LINE",
+"321 43 LINE",
 "304 43 LINE",
 "304 -10 OFFCURVE",
 "296 -15 OFFCURVE",
@@ -33483,9 +33347,7 @@ nodes = (
 "206 100 OFFCURVE",
 "146 55 CURVE SMOOTH",
 "17 -43 LINE",
-"17 -100 LINE",
-"321 -100 LINE",
-"321 43 LINE"
+"17 -100 LINE"
 );
 }
 );
@@ -33497,6 +33359,8 @@ paths = (
 {
 closed = 1;
 nodes = (
+"332 -100 LINE",
+"332 47 LINE",
 "314 47 LINE",
 "314 -7 OFFCURVE",
 "306 -12 OFFCURVE",
@@ -33538,9 +33402,7 @@ nodes = (
 "210 99 OFFCURVE",
 "149 55 CURVE SMOOTH",
 "16 -41 LINE",
-"16 -100 LINE",
-"332 -100 LINE",
-"332 47 LINE"
+"16 -100 LINE"
 );
 }
 );
@@ -33551,7 +33413,7 @@ unicode = 2082;
 },
 {
 glyphname = threeinferior;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -33559,6 +33421,12 @@ paths = (
 {
 closed = 1;
 nodes = (
+"249 -108 OFFCURVE",
+"317 -50 OFFCURVE",
+"317 13 CURVE SMOOTH",
+"317 83 OFFCURVE",
+"253 116 OFFCURVE",
+"172 119 CURVE",
 "111 104 LINE",
 "182 104 OFFCURVE",
 "208 71 OFFCURVE",
@@ -33580,28 +33448,21 @@ nodes = (
 "13 -27 CURVE SMOOTH",
 "13 -77 OFFCURVE",
 "61 -108 OFFCURVE",
-"141 -108 CURVE SMOOTH",
-"249 -108 OFFCURVE",
-"317 -50 OFFCURVE",
-"317 13 CURVE SMOOTH",
-"317 83 OFFCURVE",
-"253 116 OFFCURVE",
-"172 119 CURVE"
+"141 -108 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"76 104 LINE",
 "172 104 LINE",
 "172 125 LINE",
-"76 125 LINE"
+"76 125 LINE",
+"76 104 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"139 119 LINE",
 "253 126 OFFCURVE",
 "299 162 OFFCURVE",
 "299 213 CURVE SMOOTH",
@@ -33628,7 +33489,8 @@ nodes = (
 "197 218 CURVE SMOOTH",
 "197 158 OFFCURVE",
 "170 125 OFFCURVE",
-"100 125 CURVE"
+"100 125 CURVE",
+"139 119 LINE"
 );
 }
 );
@@ -33640,6 +33502,12 @@ paths = (
 {
 closed = 1;
 nodes = (
+"256 -108 OFFCURVE",
+"327 -51 OFFCURVE",
+"327 13 CURVE SMOOTH",
+"327 83 OFFCURVE",
+"258 115 OFFCURVE",
+"173 118 CURVE",
 "111 104 LINE",
 "183 104 OFFCURVE",
 "210 71 OFFCURVE",
@@ -33661,28 +33529,21 @@ nodes = (
 "12 -26 CURVE SMOOTH",
 "12 -77 OFFCURVE",
 "60 -108 OFFCURVE",
-"143 -108 CURVE SMOOTH",
-"256 -108 OFFCURVE",
-"327 -51 OFFCURVE",
-"327 13 CURVE SMOOTH",
-"327 83 OFFCURVE",
-"258 115 OFFCURVE",
-"173 118 CURVE"
+"143 -108 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"78 104 LINE",
 "173 104 LINE",
 "173 124 LINE",
-"78 124 LINE"
+"78 124 LINE",
+"78 104 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"140 118 LINE",
 "265 126 OFFCURVE",
 "310 161 OFFCURVE",
 "310 212 CURVE SMOOTH",
@@ -33709,7 +33570,8 @@ nodes = (
 "200 218 CURVE SMOOTH",
 "200 158 OFFCURVE",
 "173 124 OFFCURVE",
-"99 124 CURVE"
+"99 124 CURVE",
+"140 118 LINE"
 );
 }
 );
@@ -33720,7 +33582,7 @@ unicode = 2083;
 },
 {
 glyphname = fourinferior;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -33728,16 +33590,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"36 29 LINE",
-"36 33 LINE",
-"171 220 LINE",
-"175 220 LINE",
-"175 29 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"322 -100 LINE",
+"322 -83 LINE",
+"267 -83 LINE",
+"267 10 LINE",
 "338 10 LINE",
 "338 -35 LINE",
 "356 -35 LINE",
@@ -33752,11 +33608,17 @@ nodes = (
 "175 10 LINE",
 "175 -83 LINE",
 "115 -83 LINE",
-"115 -100 LINE",
-"322 -100 LINE",
-"322 -83 LINE",
-"267 -83 LINE",
-"267 10 LINE"
+"115 -100 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"36 33 LINE",
+"171 220 LINE",
+"175 220 LINE",
+"175 29 LINE",
+"36 29 LINE"
 );
 }
 );
@@ -33768,16 +33630,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"34 29 LINE",
-"34 33 LINE",
-"172 218 LINE",
-"176 218 LINE",
-"176 29 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"332 -100 LINE",
+"332 -82 LINE",
+"276 -82 LINE",
+"276 10 LINE",
 "350 10 LINE",
 "350 -35 LINE",
 "369 -35 LINE",
@@ -33792,11 +33648,17 @@ nodes = (
 "176 10 LINE",
 "176 -82 LINE",
 "114 -82 LINE",
-"114 -100 LINE",
-"332 -100 LINE",
-"332 -82 LINE",
-"276 -82 LINE",
-"276 10 LINE"
+"114 -100 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"34 33 LINE",
+"172 218 LINE",
+"176 218 LINE",
+"176 29 LINE",
+"34 29 LINE"
 );
 }
 );
@@ -33807,7 +33669,7 @@ unicode = 2084;
 },
 {
 glyphname = fiveinferior;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -33815,30 +33677,12 @@ paths = (
 {
 closed = 1;
 nodes = (
-"79 210 LINE",
-"292 210 LINE",
-"312 317 LINE",
-"295 317 LINE",
-"288 298 OFFCURVE",
-"281 295 OFFCURVE",
-"259 295 CURVE SMOOTH",
-"65 295 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"47 109 LINE",
-"56 102 LINE",
-"70 128 LINE",
-"84 295 LINE",
-"61 295 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"170 147 LINE SMOOTH",
+"251 -108 OFFCURVE",
+"333 -61 OFFCURVE",
+"333 23 CURVE SMOOTH",
+"333 89 OFFCURVE",
+"282 147 OFFCURVE",
+"170 147 CURVE SMOOTH",
 "124 147 OFFCURVE",
 "73 137 OFFCURVE",
 "63 131 CURVE",
@@ -33866,13 +33710,30 @@ nodes = (
 "15 -29 CURVE SMOOTH",
 "15 -74 OFFCURVE",
 "62 -108 OFFCURVE",
-"149 -108 CURVE SMOOTH",
-"251 -108 OFFCURVE",
-"333 -61 OFFCURVE",
-"333 23 CURVE SMOOTH",
-"333 89 OFFCURVE",
-"282 147 OFFCURVE",
-"170 147 CURVE SMOOTH"
+"149 -108 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"70 128 LINE",
+"84 295 LINE",
+"61 295 LINE",
+"47 109 LINE",
+"56 102 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"292 210 LINE",
+"312 317 LINE",
+"295 317 LINE",
+"288 298 OFFCURVE",
+"281 295 OFFCURVE",
+"259 295 CURVE SMOOTH",
+"65 295 LINE",
+"79 210 LINE"
 );
 }
 );
@@ -33884,30 +33745,12 @@ paths = (
 {
 closed = 1;
 nodes = (
-"78 206 LINE",
-"305 206 LINE",
-"325 318 LINE",
-"307 318 LINE",
-"300 298 OFFCURVE",
-"293 295 OFFCURVE",
-"272 295 CURVE SMOOTH",
-"65 295 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"47 108 LINE",
-"57 102 LINE",
-"71 129 LINE",
-"84 295 LINE",
-"60 295 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"181 148 LINE SMOOTH",
+"261 -108 OFFCURVE",
+"346 -62 OFFCURVE",
+"346 23 CURVE SMOOTH",
+"346 89 OFFCURVE",
+"298 148 OFFCURVE",
+"181 148 CURVE SMOOTH",
 "132 148 OFFCURVE",
 "75 138 OFFCURVE",
 "64 132 CURVE",
@@ -33935,13 +33778,30 @@ nodes = (
 "15 -28 CURVE SMOOTH",
 "15 -74 OFFCURVE",
 "61 -108 OFFCURVE",
-"154 -108 CURVE SMOOTH",
-"261 -108 OFFCURVE",
-"346 -62 OFFCURVE",
-"346 23 CURVE SMOOTH",
-"346 89 OFFCURVE",
-"298 148 OFFCURVE",
-"181 148 CURVE SMOOTH"
+"154 -108 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"71 129 LINE",
+"84 295 LINE",
+"60 295 LINE",
+"47 108 LINE",
+"57 102 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"305 206 LINE",
+"325 318 LINE",
+"307 318 LINE",
+"300 298 OFFCURVE",
+"293 295 OFFCURVE",
+"272 295 CURVE SMOOTH",
+"65 295 LINE",
+"78 206 LINE"
 );
 }
 );
@@ -33952,7 +33812,7 @@ unicode = 2085;
 },
 {
 glyphname = sixinferior;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -33960,13 +33820,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"287 315 LINE",
-"147 310 OFFCURVE",
-"25 188 OFFCURVE",
-"25 60 CURVE SMOOTH",
-"25 -42 OFFCURVE",
-"94 -108 OFFCURVE",
-"180 -108 CURVE SMOOTH",
 "260 -108 OFFCURVE",
 "334 -50 OFFCURVE",
 "334 29 CURVE SMOOTH",
@@ -33979,13 +33832,22 @@ nodes = (
 "132 130 LINE",
 "144 212 OFFCURVE",
 "199 285 OFFCURVE",
-"287 295 CURVE"
+"287 295 CURVE",
+"287 315 LINE",
+"147 310 OFFCURVE",
+"25 188 OFFCURVE",
+"25 60 CURVE SMOOTH",
+"25 -42 OFFCURVE",
+"94 -108 OFFCURVE",
+"180 -108 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"121 21 LINE SMOOTH",
+"136 -87 OFFCURVE",
+"121 -59 OFFCURVE",
+"121 21 CURVE SMOOTH",
 "121 40 OFFCURVE",
 "121 68 OFFCURVE",
 "126 91 CURVE",
@@ -33997,10 +33859,7 @@ nodes = (
 "233 21 CURVE SMOOTH",
 "233 -58 OFFCURVE",
 "220 -87 OFFCURVE",
-"178 -87 CURVE SMOOTH",
-"136 -87 OFFCURVE",
-"121 -59 OFFCURVE",
-"121 21 CURVE SMOOTH"
+"178 -87 CURVE SMOOTH"
 );
 }
 );
@@ -34012,13 +33871,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"288 316 LINE",
-"147 311 OFFCURVE",
-"24 188 OFFCURVE",
-"24 60 CURVE SMOOTH",
-"24 -42 OFFCURVE",
-"95 -108 OFFCURVE",
-"182 -108 CURVE SMOOTH",
 "264 -108 OFFCURVE",
 "338 -50 OFFCURVE",
 "338 29 CURVE SMOOTH",
@@ -34031,13 +33883,22 @@ nodes = (
 "138 130 LINE",
 "150 211 OFFCURVE",
 "202 285 OFFCURVE",
-"288 295 CURVE"
+"288 295 CURVE",
+"288 316 LINE",
+"147 311 OFFCURVE",
+"24 188 OFFCURVE",
+"24 60 CURVE SMOOTH",
+"24 -42 OFFCURVE",
+"95 -108 OFFCURVE",
+"182 -108 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"126 21 LINE SMOOTH",
+"141 -87 OFFCURVE",
+"126 -58 OFFCURVE",
+"126 21 CURVE SMOOTH",
 "126 40 OFFCURVE",
 "126 67 OFFCURVE",
 "131 90 CURVE",
@@ -34049,10 +33910,7 @@ nodes = (
 "233 21 CURVE SMOOTH",
 "233 -57 OFFCURVE",
 "220 -87 OFFCURVE",
-"181 -87 CURVE SMOOTH",
-"141 -87 OFFCURVE",
-"126 -58 OFFCURVE",
-"126 21 CURVE SMOOTH"
+"181 -87 CURVE SMOOTH"
 );
 }
 );
@@ -34063,7 +33921,7 @@ unicode = 2086;
 },
 {
 glyphname = seveninferior;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -34071,6 +33929,18 @@ paths = (
 {
 closed = 1;
 nodes = (
+"199 -108 OFFCURVE",
+"226 -93 OFFCURVE",
+"226 -58 CURVE SMOOTH",
+"226 -31 OFFCURVE",
+"209 1 OFFCURVE",
+"209 38 CURVE SMOOTH",
+"209 62 OFFCURVE",
+"220 92 OFFCURVE",
+"245 131 CURVE SMOOTH",
+"325 259 LINE",
+"325 295 LINE",
+"60 295 LINE",
 "20 148 LINE",
 "41 148 LINE",
 "59 200 OFFCURVE",
@@ -34083,19 +33953,7 @@ nodes = (
 "111 -58 CURVE SMOOTH",
 "111 -88 OFFCURVE",
 "129 -108 OFFCURVE",
-"166 -108 CURVE SMOOTH",
-"199 -108 OFFCURVE",
-"226 -93 OFFCURVE",
-"226 -58 CURVE SMOOTH",
-"226 -31 OFFCURVE",
-"209 1 OFFCURVE",
-"209 38 CURVE SMOOTH",
-"209 62 OFFCURVE",
-"220 92 OFFCURVE",
-"245 131 CURVE SMOOTH",
-"325 259 LINE",
-"325 295 LINE",
-"60 295 LINE"
+"166 -108 CURVE SMOOTH"
 );
 }
 );
@@ -34107,6 +33965,18 @@ paths = (
 {
 closed = 1;
 nodes = (
+"206 -108 OFFCURVE",
+"237 -92 OFFCURVE",
+"237 -57 CURVE SMOOTH",
+"237 -30 OFFCURVE",
+"220 5 OFFCURVE",
+"220 41 CURVE SMOOTH",
+"220 65 OFFCURVE",
+"232 94 OFFCURVE",
+"257 132 CURVE SMOOTH",
+"339 257 LINE",
+"339 295 LINE",
+"63 295 LINE",
 "20 144 LINE",
 "43 144 LINE",
 "60 198 OFFCURVE",
@@ -34119,19 +33989,7 @@ nodes = (
 "113 -58 CURVE SMOOTH",
 "113 -87 OFFCURVE",
 "131 -108 OFFCURVE",
-"171 -108 CURVE SMOOTH",
-"206 -108 OFFCURVE",
-"237 -92 OFFCURVE",
-"237 -57 CURVE SMOOTH",
-"237 -30 OFFCURVE",
-"220 5 OFFCURVE",
-"220 41 CURVE SMOOTH",
-"220 65 OFFCURVE",
-"232 94 OFFCURVE",
-"257 132 CURVE SMOOTH",
-"339 257 LINE",
-"339 295 LINE",
-"63 295 LINE"
+"171 -108 CURVE SMOOTH"
 );
 }
 );
@@ -34142,7 +34000,7 @@ unicode = 2087;
 },
 {
 glyphname = eightinferior;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -34150,64 +34008,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"118 0 LINE SMOOTH",
-"118 63 OFFCURVE",
-"133 95 OFFCURVE",
-"176 95 CURVE SMOOTH",
-"219 95 OFFCURVE",
-"233 61 OFFCURVE",
-"233 0 CURVE SMOOTH",
-"233 -65 OFFCURVE",
-"216 -91 OFFCURVE",
-"176 -91 CURVE SMOOTH",
-"135 -91 OFFCURVE",
-"118 -65 OFFCURVE",
-"118 0 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"318 204 LINE SMOOTH",
-"318 256 OFFCURVE",
-"273 303 OFFCURVE",
-"175 303 CURVE SMOOTH",
-"81 303 OFFCURVE",
-"34 259 OFFCURVE",
-"34 205 CURVE SMOOTH",
-"34 143 OFFCURVE",
-"97 105 OFFCURVE",
-"176 105 CURVE SMOOTH",
-"256 105 OFFCURVE",
-"318 143 OFFCURVE",
-"318 204 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"223 203 LINE SMOOTH",
-"223 146 OFFCURVE",
-"211 116 OFFCURVE",
-"176 116 CURVE SMOOTH",
-"142 116 OFFCURVE",
-"129 146 OFFCURVE",
-"129 203 CURVE SMOOTH",
-"129 259 OFFCURVE",
-"142 283 OFFCURVE",
-"176 283 CURVE SMOOTH",
-"211 283 OFFCURVE",
-"223 259 OFFCURVE",
-"223 203 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"17 -4 LINE SMOOTH",
-"17 -62 OFFCURVE",
-"69 -108 OFFCURVE",
-"176 -108 CURVE SMOOTH",
 "283 -108 OFFCURVE",
 "334 -62 OFFCURVE",
 "334 -4 CURVE SMOOTH",
@@ -34219,7 +34019,61 @@ nodes = (
 "140 105 LINE",
 "68 92 OFFCURVE",
 "17 59 OFFCURVE",
-"17 -4 CURVE SMOOTH"
+"17 -4 CURVE SMOOTH",
+"17 -62 OFFCURVE",
+"69 -108 OFFCURVE",
+"176 -108 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"135 -91 OFFCURVE",
+"118 -65 OFFCURVE",
+"118 0 CURVE SMOOTH",
+"118 63 OFFCURVE",
+"133 95 OFFCURVE",
+"176 95 CURVE SMOOTH",
+"219 95 OFFCURVE",
+"233 61 OFFCURVE",
+"233 0 CURVE SMOOTH",
+"233 -65 OFFCURVE",
+"216 -91 OFFCURVE",
+"176 -91 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"142 116 OFFCURVE",
+"129 146 OFFCURVE",
+"129 203 CURVE SMOOTH",
+"129 259 OFFCURVE",
+"142 283 OFFCURVE",
+"176 283 CURVE SMOOTH",
+"211 283 OFFCURVE",
+"223 259 OFFCURVE",
+"223 203 CURVE SMOOTH",
+"223 146 OFFCURVE",
+"211 116 OFFCURVE",
+"176 116 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"256 105 OFFCURVE",
+"318 143 OFFCURVE",
+"318 204 CURVE SMOOTH",
+"318 256 OFFCURVE",
+"273 303 OFFCURVE",
+"175 303 CURVE SMOOTH",
+"81 303 OFFCURVE",
+"34 259 OFFCURVE",
+"34 205 CURVE SMOOTH",
+"34 143 OFFCURVE",
+"97 105 OFFCURVE",
+"176 105 CURVE SMOOTH"
 );
 }
 );
@@ -34231,64 +34085,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"123 0 LINE SMOOTH",
-"123 63 OFFCURVE",
-"137 94 OFFCURVE",
-"178 94 CURVE SMOOTH",
-"219 94 OFFCURVE",
-"233 61 OFFCURVE",
-"233 0 CURVE SMOOTH",
-"233 -65 OFFCURVE",
-"216 -91 OFFCURVE",
-"178 -91 CURVE SMOOTH",
-"140 -91 OFFCURVE",
-"123 -65 OFFCURVE",
-"123 0 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"324 204 LINE SMOOTH",
-"324 256 OFFCURVE",
-"278 303 OFFCURVE",
-"177 303 CURVE SMOOTH",
-"81 303 OFFCURVE",
-"32 259 OFFCURVE",
-"32 205 CURVE SMOOTH",
-"32 143 OFFCURVE",
-"97 105 OFFCURVE",
-"178 105 CURVE SMOOTH",
-"260 105 OFFCURVE",
-"324 143 OFFCURVE",
-"324 204 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"222 203 LINE SMOOTH",
-"222 147 OFFCURVE",
-"211 116 OFFCURVE",
-"178 116 CURVE SMOOTH",
-"146 116 OFFCURVE",
-"134 147 OFFCURVE",
-"134 203 CURVE SMOOTH",
-"134 259 OFFCURVE",
-"146 282 OFFCURVE",
-"178 282 CURVE SMOOTH",
-"211 282 OFFCURVE",
-"222 259 OFFCURVE",
-"222 203 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"16 -4 LINE SMOOTH",
-"16 -62 OFFCURVE",
-"68 -108 OFFCURVE",
-"178 -108 CURVE SMOOTH",
 "287 -108 OFFCURVE",
 "340 -62 OFFCURVE",
 "340 -4 CURVE SMOOTH",
@@ -34300,7 +34096,61 @@ nodes = (
 "142 104 LINE",
 "68 91 OFFCURVE",
 "16 60 OFFCURVE",
-"16 -4 CURVE SMOOTH"
+"16 -4 CURVE SMOOTH",
+"16 -62 OFFCURVE",
+"68 -108 OFFCURVE",
+"178 -108 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"140 -91 OFFCURVE",
+"123 -65 OFFCURVE",
+"123 0 CURVE SMOOTH",
+"123 63 OFFCURVE",
+"137 94 OFFCURVE",
+"178 94 CURVE SMOOTH",
+"219 94 OFFCURVE",
+"233 61 OFFCURVE",
+"233 0 CURVE SMOOTH",
+"233 -65 OFFCURVE",
+"216 -91 OFFCURVE",
+"178 -91 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"146 116 OFFCURVE",
+"134 147 OFFCURVE",
+"134 203 CURVE SMOOTH",
+"134 259 OFFCURVE",
+"146 282 OFFCURVE",
+"178 282 CURVE SMOOTH",
+"211 282 OFFCURVE",
+"222 259 OFFCURVE",
+"222 203 CURVE SMOOTH",
+"222 147 OFFCURVE",
+"211 116 OFFCURVE",
+"178 116 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"260 105 OFFCURVE",
+"324 143 OFFCURVE",
+"324 204 CURVE SMOOTH",
+"324 256 OFFCURVE",
+"278 303 OFFCURVE",
+"177 303 CURVE SMOOTH",
+"81 303 OFFCURVE",
+"32 259 OFFCURVE",
+"32 205 CURVE SMOOTH",
+"32 143 OFFCURVE",
+"97 105 OFFCURVE",
+"178 105 CURVE SMOOTH"
 );
 }
 );
@@ -34311,7 +34161,7 @@ unicode = 2088;
 },
 {
 glyphname = nineinferior;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -34319,7 +34169,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"57 -104 LINE",
 "196 -99 OFFCURVE",
 "325 4 OFFCURVE",
 "325 135 CURVE SMOOTH",
@@ -34338,19 +34187,13 @@ nodes = (
 "217 64 LINE",
 "205 -19 OFFCURVE",
 "145 -75 OFFCURVE",
-"57 -84 CURVE"
+"57 -84 CURVE",
+"57 -104 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"228 174 LINE SMOOTH",
-"228 154 OFFCURVE",
-"228 127 OFFCURVE",
-"223 104 CURVE",
-"212 83 OFFCURVE",
-"192 66 OFFCURVE",
-"163 66 CURVE SMOOTH",
 "133 66 OFFCURVE",
 "116 85 OFFCURVE",
 "116 173 CURVE SMOOTH",
@@ -34359,7 +34202,13 @@ nodes = (
 "171 283 CURVE SMOOTH",
 "213 283 OFFCURVE",
 "228 253 OFFCURVE",
-"228 174 CURVE SMOOTH"
+"228 174 CURVE SMOOTH",
+"228 154 OFFCURVE",
+"228 127 OFFCURVE",
+"223 104 CURVE",
+"212 83 OFFCURVE",
+"192 66 OFFCURVE",
+"163 66 CURVE SMOOTH"
 );
 }
 );
@@ -34371,7 +34220,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"56 -103 LINE",
 "198 -98 OFFCURVE",
 "328 5 OFFCURVE",
 "328 135 CURVE SMOOTH",
@@ -34390,19 +34238,13 @@ nodes = (
 "214 65 LINE",
 "202 -17 OFFCURVE",
 "143 -73 OFFCURVE",
-"56 -83 CURVE"
+"56 -83 CURVE",
+"56 -103 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"226 174 LINE SMOOTH",
-"226 155 OFFCURVE",
-"225 128 OFFCURVE",
-"220 105 CURVE",
-"210 85 OFFCURVE",
-"192 67 OFFCURVE",
-"164 67 CURVE SMOOTH",
 "136 67 OFFCURVE",
 "119 86 OFFCURVE",
 "119 174 CURVE SMOOTH",
@@ -34411,7 +34253,13 @@ nodes = (
 "171 283 CURVE SMOOTH",
 "211 283 OFFCURVE",
 "226 253 OFFCURVE",
-"226 174 CURVE SMOOTH"
+"226 174 CURVE SMOOTH",
+"226 155 OFFCURVE",
+"225 128 OFFCURVE",
+"220 105 CURVE",
+"210 85 OFFCURVE",
+"192 67 OFFCURVE",
+"164 67 CURVE SMOOTH"
 );
 }
 );
@@ -34422,7 +34270,7 @@ unicode = 2089;
 },
 {
 glyphname = zerosuperior;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -34430,10 +34278,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"24 656 LINE SMOOTH",
-"24 534 OFFCURVE",
-"101 451 OFFCURVE",
-"203 451 CURVE SMOOTH",
 "305 451 OFFCURVE",
 "383 534 OFFCURVE",
 "383 656 CURVE SMOOTH",
@@ -34442,13 +34286,18 @@ nodes = (
 "203 862 CURVE SMOOTH",
 "101 862 OFFCURVE",
 "24 778 OFFCURVE",
-"24 656 CURVE SMOOTH"
+"24 656 CURVE SMOOTH",
+"24 534 OFFCURVE",
+"101 451 OFFCURVE",
+"203 451 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"126 656 LINE SMOOTH",
+"144 472 OFFCURVE",
+"126 506 OFFCURVE",
+"126 656 CURVE SMOOTH",
 "126 807 OFFCURVE",
 "144 842 OFFCURVE",
 "203 842 CURVE SMOOTH",
@@ -34457,10 +34306,7 @@ nodes = (
 "280 656 CURVE SMOOTH",
 "280 506 OFFCURVE",
 "259 472 OFFCURVE",
-"203 472 CURVE SMOOTH",
-"144 472 OFFCURVE",
-"126 506 OFFCURVE",
-"126 656 CURVE SMOOTH"
+"203 472 CURVE SMOOTH"
 );
 }
 );
@@ -34510,10 +34356,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"23 656 LINE SMOOTH",
-"23 533 OFFCURVE",
-"104 451 OFFCURVE",
-"209 451 CURVE SMOOTH",
 "314 451 OFFCURVE",
 "396 533 OFFCURVE",
 "396 656 CURVE SMOOTH",
@@ -34522,13 +34364,18 @@ nodes = (
 "209 862 CURVE SMOOTH",
 "104 862 OFFCURVE",
 "23 778 OFFCURVE",
-"23 656 CURVE SMOOTH"
+"23 656 CURVE SMOOTH",
+"23 533 OFFCURVE",
+"104 451 OFFCURVE",
+"209 451 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"131 656 LINE SMOOTH",
+"149 472 OFFCURVE",
+"131 505 OFFCURVE",
+"131 656 CURVE SMOOTH",
 "131 806 OFFCURVE",
 "149 841 OFFCURVE",
 "209 841 CURVE SMOOTH",
@@ -34537,10 +34384,7 @@ nodes = (
 "287 656 CURVE SMOOTH",
 "287 505 OFFCURVE",
 "265 472 OFFCURVE",
-"209 472 CURVE SMOOTH",
-"149 472 OFFCURVE",
-"131 505 OFFCURVE",
-"131 656 CURVE SMOOTH"
+"209 472 CURVE SMOOTH"
 );
 }
 );
@@ -34551,7 +34395,7 @@ unicode = 2070;
 },
 {
 glyphname = onesuperior;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -34559,16 +34403,16 @@ paths = (
 {
 closed = 1;
 nodes = (
-"4 836 LINE",
-"91 836 LINE",
-"91 476 LINE",
-"4 476 LINE",
-"4 459 LINE",
 "266 459 LINE",
 "266 476 LINE",
 "184 476 LINE",
 "184 854 LINE",
-"4 854 LINE"
+"4 854 LINE",
+"4 836 LINE",
+"91 836 LINE",
+"91 476 LINE",
+"4 476 LINE",
+"4 459 LINE"
 );
 }
 );
@@ -34580,16 +34424,16 @@ paths = (
 {
 closed = 1;
 nodes = (
-"3 836 LINE",
-"92 836 LINE",
-"92 477 LINE",
-"3 477 LINE",
-"3 459 LINE",
 "275 459 LINE",
 "275 477 LINE",
 "192 477 LINE",
 "192 854 LINE",
-"3 854 LINE"
+"3 854 LINE",
+"3 836 LINE",
+"92 836 LINE",
+"92 477 LINE",
+"3 477 LINE",
+"3 459 LINE"
 );
 }
 );
@@ -34600,7 +34444,7 @@ unicode = 00B9;
 },
 {
 glyphname = twosuperior;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -34608,6 +34452,8 @@ paths = (
 {
 closed = 1;
 nodes = (
+"321 459 LINE",
+"321 602 LINE",
 "304 602 LINE",
 "304 549 OFFCURVE",
 "296 544 OFFCURVE",
@@ -34649,9 +34495,7 @@ nodes = (
 "206 659 OFFCURVE",
 "146 614 CURVE SMOOTH",
 "17 516 LINE",
-"17 459 LINE",
-"321 459 LINE",
-"321 602 LINE"
+"17 459 LINE"
 );
 }
 );
@@ -34663,6 +34507,8 @@ paths = (
 {
 closed = 1;
 nodes = (
+"332 459 LINE",
+"332 606 LINE",
 "314 606 LINE",
 "314 552 OFFCURVE",
 "306 547 OFFCURVE",
@@ -34704,9 +34550,7 @@ nodes = (
 "210 658 OFFCURVE",
 "149 614 CURVE SMOOTH",
 "16 518 LINE",
-"16 459 LINE",
-"332 459 LINE",
-"332 606 LINE"
+"16 459 LINE"
 );
 }
 );
@@ -34717,7 +34561,7 @@ unicode = 00B2;
 },
 {
 glyphname = threesuperior;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -34725,6 +34569,12 @@ paths = (
 {
 closed = 1;
 nodes = (
+"249 451 OFFCURVE",
+"317 509 OFFCURVE",
+"317 572 CURVE SMOOTH",
+"317 642 OFFCURVE",
+"253 675 OFFCURVE",
+"172 678 CURVE",
 "111 663 LINE",
 "182 663 OFFCURVE",
 "208 630 OFFCURVE",
@@ -34746,28 +34596,21 @@ nodes = (
 "13 532 CURVE SMOOTH",
 "13 482 OFFCURVE",
 "61 451 OFFCURVE",
-"141 451 CURVE SMOOTH",
-"249 451 OFFCURVE",
-"317 509 OFFCURVE",
-"317 572 CURVE SMOOTH",
-"317 642 OFFCURVE",
-"253 675 OFFCURVE",
-"172 678 CURVE"
+"141 451 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"76 663 LINE",
 "172 663 LINE",
 "172 684 LINE",
-"76 684 LINE"
+"76 684 LINE",
+"76 663 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"139 678 LINE",
 "253 685 OFFCURVE",
 "299 721 OFFCURVE",
 "299 772 CURVE SMOOTH",
@@ -34794,7 +34637,8 @@ nodes = (
 "197 777 CURVE SMOOTH",
 "197 717 OFFCURVE",
 "170 684 OFFCURVE",
-"100 684 CURVE"
+"100 684 CURVE",
+"139 678 LINE"
 );
 }
 );
@@ -34806,6 +34650,12 @@ paths = (
 {
 closed = 1;
 nodes = (
+"256 451 OFFCURVE",
+"327 508 OFFCURVE",
+"327 572 CURVE SMOOTH",
+"327 642 OFFCURVE",
+"258 674 OFFCURVE",
+"173 677 CURVE",
 "111 663 LINE",
 "183 663 OFFCURVE",
 "210 630 OFFCURVE",
@@ -34827,28 +34677,21 @@ nodes = (
 "12 533 CURVE SMOOTH",
 "12 482 OFFCURVE",
 "60 451 OFFCURVE",
-"143 451 CURVE SMOOTH",
-"256 451 OFFCURVE",
-"327 508 OFFCURVE",
-"327 572 CURVE SMOOTH",
-"327 642 OFFCURVE",
-"258 674 OFFCURVE",
-"173 677 CURVE"
+"143 451 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"78 663 LINE",
 "173 663 LINE",
 "173 683 LINE",
-"78 683 LINE"
+"78 683 LINE",
+"78 663 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"140 677 LINE",
 "265 685 OFFCURVE",
 "310 720 OFFCURVE",
 "310 771 CURVE SMOOTH",
@@ -34875,7 +34718,8 @@ nodes = (
 "200 777 CURVE SMOOTH",
 "200 717 OFFCURVE",
 "173 683 OFFCURVE",
-"99 683 CURVE"
+"99 683 CURVE",
+"140 677 LINE"
 );
 }
 );
@@ -34886,7 +34730,7 @@ unicode = 00B3;
 },
 {
 glyphname = foursuperior;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -34894,16 +34738,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"36 588 LINE",
-"36 592 LINE",
-"171 779 LINE",
-"175 779 LINE",
-"175 588 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"322 459 LINE",
+"322 476 LINE",
+"267 476 LINE",
+"267 569 LINE",
 "338 569 LINE",
 "338 524 LINE",
 "356 524 LINE",
@@ -34918,11 +34756,17 @@ nodes = (
 "175 569 LINE",
 "175 476 LINE",
 "115 476 LINE",
-"115 459 LINE",
-"322 459 LINE",
-"322 476 LINE",
-"267 476 LINE",
-"267 569 LINE"
+"115 459 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"36 592 LINE",
+"171 779 LINE",
+"175 779 LINE",
+"175 588 LINE",
+"36 588 LINE"
 );
 }
 );
@@ -34934,16 +34778,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"34 588 LINE",
-"34 592 LINE",
-"172 777 LINE",
-"176 777 LINE",
-"176 588 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
+"332 459 LINE",
+"332 477 LINE",
+"276 477 LINE",
+"276 569 LINE",
 "350 569 LINE",
 "350 524 LINE",
 "369 524 LINE",
@@ -34958,11 +34796,17 @@ nodes = (
 "176 569 LINE",
 "176 477 LINE",
 "114 477 LINE",
-"114 459 LINE",
-"332 459 LINE",
-"332 477 LINE",
-"276 477 LINE",
-"276 569 LINE"
+"114 459 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"34 592 LINE",
+"172 777 LINE",
+"176 777 LINE",
+"176 588 LINE",
+"34 588 LINE"
 );
 }
 );
@@ -34973,7 +34817,7 @@ unicode = 2074;
 },
 {
 glyphname = fivesuperior;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -34981,30 +34825,12 @@ paths = (
 {
 closed = 1;
 nodes = (
-"79 769 LINE",
-"292 769 LINE",
-"312 876 LINE",
-"295 876 LINE",
-"288 857 OFFCURVE",
-"281 854 OFFCURVE",
-"259 854 CURVE SMOOTH",
-"65 854 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"47 668 LINE",
-"56 661 LINE",
-"70 687 LINE",
-"84 854 LINE",
-"61 854 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"170 706 LINE SMOOTH",
+"251 451 OFFCURVE",
+"333 498 OFFCURVE",
+"333 582 CURVE SMOOTH",
+"333 648 OFFCURVE",
+"282 706 OFFCURVE",
+"170 706 CURVE SMOOTH",
 "124 706 OFFCURVE",
 "73 696 OFFCURVE",
 "63 690 CURVE",
@@ -35032,13 +34858,30 @@ nodes = (
 "15 530 CURVE SMOOTH",
 "15 485 OFFCURVE",
 "62 451 OFFCURVE",
-"149 451 CURVE SMOOTH",
-"251 451 OFFCURVE",
-"333 498 OFFCURVE",
-"333 582 CURVE SMOOTH",
-"333 648 OFFCURVE",
-"282 706 OFFCURVE",
-"170 706 CURVE SMOOTH"
+"149 451 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"70 687 LINE",
+"84 854 LINE",
+"61 854 LINE",
+"47 668 LINE",
+"56 661 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"292 769 LINE",
+"312 876 LINE",
+"295 876 LINE",
+"288 857 OFFCURVE",
+"281 854 OFFCURVE",
+"259 854 CURVE SMOOTH",
+"65 854 LINE",
+"79 769 LINE"
 );
 }
 );
@@ -35050,30 +34893,12 @@ paths = (
 {
 closed = 1;
 nodes = (
-"78 765 LINE",
-"305 765 LINE",
-"325 877 LINE",
-"307 877 LINE",
-"300 857 OFFCURVE",
-"293 854 OFFCURVE",
-"272 854 CURVE SMOOTH",
-"65 854 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"47 667 LINE",
-"57 661 LINE",
-"71 688 LINE",
-"84 854 LINE",
-"60 854 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"181 707 LINE SMOOTH",
+"261 451 OFFCURVE",
+"346 497 OFFCURVE",
+"346 582 CURVE SMOOTH",
+"346 648 OFFCURVE",
+"298 707 OFFCURVE",
+"181 707 CURVE SMOOTH",
 "132 707 OFFCURVE",
 "75 697 OFFCURVE",
 "64 691 CURVE",
@@ -35101,13 +34926,30 @@ nodes = (
 "15 531 CURVE SMOOTH",
 "15 485 OFFCURVE",
 "61 451 OFFCURVE",
-"154 451 CURVE SMOOTH",
-"261 451 OFFCURVE",
-"346 497 OFFCURVE",
-"346 582 CURVE SMOOTH",
-"346 648 OFFCURVE",
-"298 707 OFFCURVE",
-"181 707 CURVE SMOOTH"
+"154 451 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"71 688 LINE",
+"84 854 LINE",
+"60 854 LINE",
+"47 667 LINE",
+"57 661 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"305 765 LINE",
+"325 877 LINE",
+"307 877 LINE",
+"300 857 OFFCURVE",
+"293 854 OFFCURVE",
+"272 854 CURVE SMOOTH",
+"65 854 LINE",
+"78 765 LINE"
 );
 }
 );
@@ -35118,7 +34960,7 @@ unicode = 2075;
 },
 {
 glyphname = sixsuperior;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -35126,13 +34968,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"287 874 LINE",
-"147 869 OFFCURVE",
-"25 747 OFFCURVE",
-"25 619 CURVE SMOOTH",
-"25 517 OFFCURVE",
-"94 451 OFFCURVE",
-"180 451 CURVE SMOOTH",
 "260 451 OFFCURVE",
 "334 509 OFFCURVE",
 "334 588 CURVE SMOOTH",
@@ -35145,13 +34980,22 @@ nodes = (
 "132 689 LINE",
 "144 771 OFFCURVE",
 "199 844 OFFCURVE",
-"287 854 CURVE"
+"287 854 CURVE",
+"287 874 LINE",
+"147 869 OFFCURVE",
+"25 747 OFFCURVE",
+"25 619 CURVE SMOOTH",
+"25 517 OFFCURVE",
+"94 451 OFFCURVE",
+"180 451 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"121 580 LINE SMOOTH",
+"136 472 OFFCURVE",
+"121 500 OFFCURVE",
+"121 580 CURVE SMOOTH",
 "121 599 OFFCURVE",
 "121 627 OFFCURVE",
 "126 650 CURVE",
@@ -35163,10 +35007,7 @@ nodes = (
 "233 580 CURVE SMOOTH",
 "233 501 OFFCURVE",
 "220 472 OFFCURVE",
-"178 472 CURVE SMOOTH",
-"136 472 OFFCURVE",
-"121 500 OFFCURVE",
-"121 580 CURVE SMOOTH"
+"178 472 CURVE SMOOTH"
 );
 }
 );
@@ -35178,13 +35019,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"288 875 LINE",
-"147 870 OFFCURVE",
-"24 747 OFFCURVE",
-"24 619 CURVE SMOOTH",
-"24 517 OFFCURVE",
-"95 451 OFFCURVE",
-"182 451 CURVE SMOOTH",
 "264 451 OFFCURVE",
 "338 509 OFFCURVE",
 "338 588 CURVE SMOOTH",
@@ -35197,13 +35031,22 @@ nodes = (
 "138 689 LINE",
 "150 770 OFFCURVE",
 "202 844 OFFCURVE",
-"288 854 CURVE"
+"288 854 CURVE",
+"288 875 LINE",
+"147 870 OFFCURVE",
+"24 747 OFFCURVE",
+"24 619 CURVE SMOOTH",
+"24 517 OFFCURVE",
+"95 451 OFFCURVE",
+"182 451 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"126 580 LINE SMOOTH",
+"141 472 OFFCURVE",
+"126 501 OFFCURVE",
+"126 580 CURVE SMOOTH",
 "126 599 OFFCURVE",
 "126 626 OFFCURVE",
 "131 649 CURVE",
@@ -35215,10 +35058,7 @@ nodes = (
 "233 580 CURVE SMOOTH",
 "233 502 OFFCURVE",
 "220 472 OFFCURVE",
-"181 472 CURVE SMOOTH",
-"141 472 OFFCURVE",
-"126 501 OFFCURVE",
-"126 580 CURVE SMOOTH"
+"181 472 CURVE SMOOTH"
 );
 }
 );
@@ -35229,7 +35069,7 @@ unicode = 2076;
 },
 {
 glyphname = sevensuperior;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -35237,6 +35077,18 @@ paths = (
 {
 closed = 1;
 nodes = (
+"199 451 OFFCURVE",
+"226 466 OFFCURVE",
+"226 501 CURVE SMOOTH",
+"226 528 OFFCURVE",
+"209 560 OFFCURVE",
+"209 597 CURVE SMOOTH",
+"209 621 OFFCURVE",
+"220 651 OFFCURVE",
+"245 690 CURVE SMOOTH",
+"325 818 LINE",
+"325 854 LINE",
+"60 854 LINE",
 "20 707 LINE",
 "41 707 LINE",
 "59 759 OFFCURVE",
@@ -35249,19 +35101,7 @@ nodes = (
 "111 501 CURVE SMOOTH",
 "111 471 OFFCURVE",
 "129 451 OFFCURVE",
-"166 451 CURVE SMOOTH",
-"199 451 OFFCURVE",
-"226 466 OFFCURVE",
-"226 501 CURVE SMOOTH",
-"226 528 OFFCURVE",
-"209 560 OFFCURVE",
-"209 597 CURVE SMOOTH",
-"209 621 OFFCURVE",
-"220 651 OFFCURVE",
-"245 690 CURVE SMOOTH",
-"325 818 LINE",
-"325 854 LINE",
-"60 854 LINE"
+"166 451 CURVE SMOOTH"
 );
 }
 );
@@ -35273,6 +35113,18 @@ paths = (
 {
 closed = 1;
 nodes = (
+"206 451 OFFCURVE",
+"237 467 OFFCURVE",
+"237 502 CURVE SMOOTH",
+"237 529 OFFCURVE",
+"220 564 OFFCURVE",
+"220 600 CURVE SMOOTH",
+"220 624 OFFCURVE",
+"232 653 OFFCURVE",
+"257 691 CURVE SMOOTH",
+"339 816 LINE",
+"339 854 LINE",
+"63 854 LINE",
 "20 703 LINE",
 "43 703 LINE",
 "60 757 OFFCURVE",
@@ -35285,19 +35137,7 @@ nodes = (
 "113 501 CURVE SMOOTH",
 "113 472 OFFCURVE",
 "131 451 OFFCURVE",
-"171 451 CURVE SMOOTH",
-"206 451 OFFCURVE",
-"237 467 OFFCURVE",
-"237 502 CURVE SMOOTH",
-"237 529 OFFCURVE",
-"220 564 OFFCURVE",
-"220 600 CURVE SMOOTH",
-"220 624 OFFCURVE",
-"232 653 OFFCURVE",
-"257 691 CURVE SMOOTH",
-"339 816 LINE",
-"339 854 LINE",
-"63 854 LINE"
+"171 451 CURVE SMOOTH"
 );
 }
 );
@@ -35308,7 +35148,7 @@ unicode = 2077;
 },
 {
 glyphname = eightsuperior;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -35316,64 +35156,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"118 559 LINE SMOOTH",
-"118 622 OFFCURVE",
-"133 654 OFFCURVE",
-"176 654 CURVE SMOOTH",
-"219 654 OFFCURVE",
-"233 620 OFFCURVE",
-"233 559 CURVE SMOOTH",
-"233 494 OFFCURVE",
-"216 468 OFFCURVE",
-"176 468 CURVE SMOOTH",
-"135 468 OFFCURVE",
-"118 494 OFFCURVE",
-"118 559 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"318 763 LINE SMOOTH",
-"318 815 OFFCURVE",
-"273 862 OFFCURVE",
-"175 862 CURVE SMOOTH",
-"81 862 OFFCURVE",
-"34 818 OFFCURVE",
-"34 764 CURVE SMOOTH",
-"34 702 OFFCURVE",
-"97 664 OFFCURVE",
-"176 664 CURVE SMOOTH",
-"256 664 OFFCURVE",
-"318 702 OFFCURVE",
-"318 763 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"223 762 LINE SMOOTH",
-"223 705 OFFCURVE",
-"211 675 OFFCURVE",
-"176 675 CURVE SMOOTH",
-"142 675 OFFCURVE",
-"129 705 OFFCURVE",
-"129 762 CURVE SMOOTH",
-"129 818 OFFCURVE",
-"142 842 OFFCURVE",
-"176 842 CURVE SMOOTH",
-"211 842 OFFCURVE",
-"223 818 OFFCURVE",
-"223 762 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"17 555 LINE SMOOTH",
-"17 497 OFFCURVE",
-"69 451 OFFCURVE",
-"176 451 CURVE SMOOTH",
 "283 451 OFFCURVE",
 "334 497 OFFCURVE",
 "334 555 CURVE SMOOTH",
@@ -35385,7 +35167,61 @@ nodes = (
 "140 664 LINE",
 "68 651 OFFCURVE",
 "17 618 OFFCURVE",
-"17 555 CURVE SMOOTH"
+"17 555 CURVE SMOOTH",
+"17 497 OFFCURVE",
+"69 451 OFFCURVE",
+"176 451 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"135 468 OFFCURVE",
+"118 494 OFFCURVE",
+"118 559 CURVE SMOOTH",
+"118 622 OFFCURVE",
+"133 654 OFFCURVE",
+"176 654 CURVE SMOOTH",
+"219 654 OFFCURVE",
+"233 620 OFFCURVE",
+"233 559 CURVE SMOOTH",
+"233 494 OFFCURVE",
+"216 468 OFFCURVE",
+"176 468 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"142 675 OFFCURVE",
+"129 705 OFFCURVE",
+"129 762 CURVE SMOOTH",
+"129 818 OFFCURVE",
+"142 842 OFFCURVE",
+"176 842 CURVE SMOOTH",
+"211 842 OFFCURVE",
+"223 818 OFFCURVE",
+"223 762 CURVE SMOOTH",
+"223 705 OFFCURVE",
+"211 675 OFFCURVE",
+"176 675 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"256 664 OFFCURVE",
+"318 702 OFFCURVE",
+"318 763 CURVE SMOOTH",
+"318 815 OFFCURVE",
+"273 862 OFFCURVE",
+"175 862 CURVE SMOOTH",
+"81 862 OFFCURVE",
+"34 818 OFFCURVE",
+"34 764 CURVE SMOOTH",
+"34 702 OFFCURVE",
+"97 664 OFFCURVE",
+"176 664 CURVE SMOOTH"
 );
 }
 );
@@ -35397,64 +35233,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"123 559 LINE SMOOTH",
-"123 622 OFFCURVE",
-"137 653 OFFCURVE",
-"178 653 CURVE SMOOTH",
-"219 653 OFFCURVE",
-"233 620 OFFCURVE",
-"233 559 CURVE SMOOTH",
-"233 494 OFFCURVE",
-"216 468 OFFCURVE",
-"178 468 CURVE SMOOTH",
-"140 468 OFFCURVE",
-"123 494 OFFCURVE",
-"123 559 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"324 763 LINE SMOOTH",
-"324 815 OFFCURVE",
-"278 862 OFFCURVE",
-"177 862 CURVE SMOOTH",
-"81 862 OFFCURVE",
-"32 818 OFFCURVE",
-"32 764 CURVE SMOOTH",
-"32 702 OFFCURVE",
-"97 664 OFFCURVE",
-"178 664 CURVE SMOOTH",
-"260 664 OFFCURVE",
-"324 702 OFFCURVE",
-"324 763 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"222 762 LINE SMOOTH",
-"222 706 OFFCURVE",
-"211 675 OFFCURVE",
-"178 675 CURVE SMOOTH",
-"146 675 OFFCURVE",
-"134 706 OFFCURVE",
-"134 762 CURVE SMOOTH",
-"134 818 OFFCURVE",
-"146 841 OFFCURVE",
-"178 841 CURVE SMOOTH",
-"211 841 OFFCURVE",
-"222 818 OFFCURVE",
-"222 762 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"16 555 LINE SMOOTH",
-"16 497 OFFCURVE",
-"68 451 OFFCURVE",
-"178 451 CURVE SMOOTH",
 "287 451 OFFCURVE",
 "340 497 OFFCURVE",
 "340 555 CURVE SMOOTH",
@@ -35466,7 +35244,61 @@ nodes = (
 "142 663 LINE",
 "68 650 OFFCURVE",
 "16 619 OFFCURVE",
-"16 555 CURVE SMOOTH"
+"16 555 CURVE SMOOTH",
+"16 497 OFFCURVE",
+"68 451 OFFCURVE",
+"178 451 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"140 468 OFFCURVE",
+"123 494 OFFCURVE",
+"123 559 CURVE SMOOTH",
+"123 622 OFFCURVE",
+"137 653 OFFCURVE",
+"178 653 CURVE SMOOTH",
+"219 653 OFFCURVE",
+"233 620 OFFCURVE",
+"233 559 CURVE SMOOTH",
+"233 494 OFFCURVE",
+"216 468 OFFCURVE",
+"178 468 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"146 675 OFFCURVE",
+"134 706 OFFCURVE",
+"134 762 CURVE SMOOTH",
+"134 818 OFFCURVE",
+"146 841 OFFCURVE",
+"178 841 CURVE SMOOTH",
+"211 841 OFFCURVE",
+"222 818 OFFCURVE",
+"222 762 CURVE SMOOTH",
+"222 706 OFFCURVE",
+"211 675 OFFCURVE",
+"178 675 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"260 664 OFFCURVE",
+"324 702 OFFCURVE",
+"324 763 CURVE SMOOTH",
+"324 815 OFFCURVE",
+"278 862 OFFCURVE",
+"177 862 CURVE SMOOTH",
+"81 862 OFFCURVE",
+"32 818 OFFCURVE",
+"32 764 CURVE SMOOTH",
+"32 702 OFFCURVE",
+"97 664 OFFCURVE",
+"178 664 CURVE SMOOTH"
 );
 }
 );
@@ -35477,7 +35309,7 @@ unicode = 2078;
 },
 {
 glyphname = ninesuperior;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -35485,7 +35317,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"57 455 LINE",
 "196 460 OFFCURVE",
 "325 563 OFFCURVE",
 "325 694 CURVE SMOOTH",
@@ -35504,19 +35335,13 @@ nodes = (
 "217 623 LINE",
 "205 540 OFFCURVE",
 "145 484 OFFCURVE",
-"57 475 CURVE"
+"57 475 CURVE",
+"57 455 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"228 733 LINE SMOOTH",
-"228 713 OFFCURVE",
-"228 686 OFFCURVE",
-"223 663 CURVE",
-"212 642 OFFCURVE",
-"192 625 OFFCURVE",
-"163 625 CURVE SMOOTH",
 "133 625 OFFCURVE",
 "116 644 OFFCURVE",
 "116 732 CURVE SMOOTH",
@@ -35525,7 +35350,13 @@ nodes = (
 "171 842 CURVE SMOOTH",
 "213 842 OFFCURVE",
 "228 812 OFFCURVE",
-"228 733 CURVE SMOOTH"
+"228 733 CURVE SMOOTH",
+"228 713 OFFCURVE",
+"228 686 OFFCURVE",
+"223 663 CURVE",
+"212 642 OFFCURVE",
+"192 625 OFFCURVE",
+"163 625 CURVE SMOOTH"
 );
 }
 );
@@ -35537,7 +35368,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"56 456 LINE",
 "198 461 OFFCURVE",
 "328 564 OFFCURVE",
 "328 694 CURVE SMOOTH",
@@ -35556,19 +35386,13 @@ nodes = (
 "214 624 LINE",
 "202 542 OFFCURVE",
 "143 486 OFFCURVE",
-"56 476 CURVE"
+"56 476 CURVE",
+"56 456 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"226 733 LINE SMOOTH",
-"226 714 OFFCURVE",
-"225 687 OFFCURVE",
-"220 664 CURVE",
-"210 644 OFFCURVE",
-"192 626 OFFCURVE",
-"164 626 CURVE SMOOTH",
 "136 626 OFFCURVE",
 "119 645 OFFCURVE",
 "119 733 CURVE SMOOTH",
@@ -35577,7 +35401,13 @@ nodes = (
 "171 842 CURVE SMOOTH",
 "211 842 OFFCURVE",
 "226 812 OFFCURVE",
-"226 733 CURVE SMOOTH"
+"226 733 CURVE SMOOTH",
+"226 714 OFFCURVE",
+"225 687 OFFCURVE",
+"220 664 CURVE",
+"210 644 OFFCURVE",
+"192 626 OFFCURVE",
+"164 626 CURVE SMOOTH"
 );
 }
 );
@@ -35588,7 +35418,7 @@ unicode = 2079;
 },
 {
 glyphname = fraction;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -35596,10 +35426,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"430 753 LINE",
-"0 0 LINE",
 "59 0 LINE",
-"489 753 LINE"
+"489 753 LINE",
+"430 753 LINE",
+"0 0 LINE"
 );
 }
 );
@@ -35611,10 +35441,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"410 753 LINE",
-"0 0 LINE",
 "79 0 LINE",
-"489 753 LINE"
+"489 753 LINE",
+"410 753 LINE",
+"0 0 LINE"
 );
 }
 );
@@ -35625,13 +35455,14 @@ unicode = 2044;
 },
 {
 glyphname = onehalf;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 16:52:41 +0000";
 layers = (
 {
 components = (
 {
+alignment = -1;
 name = fraction;
-transform = "{1, 0, 0, 1, 194, 0}";
+transform = "{1, 0, 0, 1, 215, 0}";
 },
 {
 name = one.numerator;
@@ -35648,8 +35479,9 @@ width = 913;
 {
 components = (
 {
+alignment = -1;
 name = fraction;
-transform = "{1, 0, 0, 1, 194, 0}";
+transform = "{1, 0, 0, 1, 220, 0}";
 },
 {
 name = one.numerator;
@@ -36012,7 +35844,7 @@ unicode = 215E;
 },
 {
 glyphname = asterisk;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -36020,33 +35852,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"30 633 LINE SMOOTH",
-"30 614 OFFCURVE",
-"41 600 OFFCURVE",
-"59 590 CURVE SMOOTH",
-"96 568 OFFCURVE",
-"129 578 OFFCURVE",
-"187 551 CURVE",
-"187 547 LINE",
-"129 520 OFFCURVE",
-"96 530 OFFCURVE",
-"59 508 CURVE SMOOTH",
-"41 498 OFFCURVE",
-"30 484 OFFCURVE",
-"30 465 CURVE SMOOTH",
-"30 443 OFFCURVE",
-"44 419 OFFCURVE",
-"76 419 CURVE SMOOTH",
-"127 419 OFFCURVE",
-"135 480 OFFCURVE",
-"203 522 CURVE",
-"206 520 LINE",
-"200 455 OFFCURVE",
-"175 426 OFFCURVE",
-"175 388 CURVE SMOOTH",
-"175 358 OFFCURVE",
-"190 336 OFFCURVE",
-"221 336 CURVE SMOOTH",
 "254 336 OFFCURVE",
 "269 361 OFFCURVE",
 "269 390 CURVE SMOOTH",
@@ -36098,7 +35903,33 @@ nodes = (
 "76 679 CURVE SMOOTH",
 "44 679 OFFCURVE",
 "30 655 OFFCURVE",
-"30 633 CURVE SMOOTH"
+"30 633 CURVE SMOOTH",
+"30 614 OFFCURVE",
+"41 600 OFFCURVE",
+"59 590 CURVE SMOOTH",
+"96 568 OFFCURVE",
+"129 578 OFFCURVE",
+"187 551 CURVE",
+"187 547 LINE",
+"129 520 OFFCURVE",
+"96 530 OFFCURVE",
+"59 508 CURVE SMOOTH",
+"41 498 OFFCURVE",
+"30 484 OFFCURVE",
+"30 465 CURVE SMOOTH",
+"30 443 OFFCURVE",
+"44 419 OFFCURVE",
+"76 419 CURVE SMOOTH",
+"127 419 OFFCURVE",
+"135 480 OFFCURVE",
+"203 522 CURVE",
+"206 520 LINE",
+"200 455 OFFCURVE",
+"175 426 OFFCURVE",
+"175 388 CURVE SMOOTH",
+"175 358 OFFCURVE",
+"190 336 OFFCURVE",
+"221 336 CURVE SMOOTH"
 );
 }
 );
@@ -36110,33 +35941,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"20 635 LINE SMOOTH",
-"20 611 OFFCURVE",
-"35 591 OFFCURVE",
-"59 580 CURVE SMOOTH",
-"94 564 OFFCURVE",
-"129 577 OFFCURVE",
-"187 551 CURVE",
-"187 547 LINE",
-"129 520 OFFCURVE",
-"94 534 OFFCURVE",
-"59 518 CURVE SMOOTH",
-"35 507 OFFCURVE",
-"20 487 OFFCURVE",
-"20 464 CURVE SMOOTH",
-"20 438 OFFCURVE",
-"38 409 OFFCURVE",
-"74 409 CURVE SMOOTH",
-"129 409 OFFCURVE",
-"134 475 OFFCURVE",
-"203 522 CURVE",
-"206 520 LINE",
-"198 456 OFFCURVE",
-"165 432 OFFCURVE",
-"165 391 CURVE SMOOTH",
-"165 361 OFFCURVE",
-"183 336 OFFCURVE",
-"221 336 CURVE SMOOTH",
 "261 336 OFFCURVE",
 "279 364 OFFCURVE",
 "279 393 CURVE SMOOTH",
@@ -36188,7 +35992,33 @@ nodes = (
 "74 689 CURVE SMOOTH",
 "39 689 OFFCURVE",
 "20 661 OFFCURVE",
-"20 635 CURVE SMOOTH"
+"20 635 CURVE SMOOTH",
+"20 611 OFFCURVE",
+"35 591 OFFCURVE",
+"59 580 CURVE SMOOTH",
+"94 564 OFFCURVE",
+"129 577 OFFCURVE",
+"187 551 CURVE",
+"187 547 LINE",
+"129 520 OFFCURVE",
+"94 534 OFFCURVE",
+"59 518 CURVE SMOOTH",
+"35 507 OFFCURVE",
+"20 487 OFFCURVE",
+"20 464 CURVE SMOOTH",
+"20 438 OFFCURVE",
+"38 409 OFFCURVE",
+"74 409 CURVE SMOOTH",
+"129 409 OFFCURVE",
+"134 475 OFFCURVE",
+"203 522 CURVE",
+"206 520 LINE",
+"198 456 OFFCURVE",
+"165 432 OFFCURVE",
+"165 391 CURVE SMOOTH",
+"165 361 OFFCURVE",
+"183 336 OFFCURVE",
+"221 336 CURVE SMOOTH"
 );
 }
 );
@@ -36199,7 +36029,7 @@ unicode = 002A;
 },
 {
 glyphname = backslash;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -36207,10 +36037,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"-60 753 LINE",
-"150 0 LINE",
 "209 0 LINE",
-"-1 753 LINE"
+"-1 753 LINE",
+"-60 753 LINE",
+"150 0 LINE"
 );
 }
 );
@@ -36222,10 +36052,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"-60 753 LINE",
-"130 0 LINE",
 "209 0 LINE",
-"19 753 LINE"
+"19 753 LINE",
+"-60 753 LINE",
+"130 0 LINE"
 );
 }
 );
@@ -36236,7 +36066,7 @@ unicode = 005C;
 },
 {
 glyphname = periodcentered;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -36244,10 +36074,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"10 250 LINE SMOOTH",
-"10 210 OFFCURVE",
-"43 177 OFFCURVE",
-"83 177 CURVE SMOOTH",
 "123 177 OFFCURVE",
 "156 210 OFFCURVE",
 "156 250 CURVE SMOOTH",
@@ -36256,7 +36082,10 @@ nodes = (
 "83 323 CURVE SMOOTH",
 "43 323 OFFCURVE",
 "10 290 OFFCURVE",
-"10 250 CURVE SMOOTH"
+"10 250 CURVE SMOOTH",
+"10 210 OFFCURVE",
+"43 177 OFFCURVE",
+"83 177 CURVE SMOOTH"
 );
 }
 );
@@ -36268,10 +36097,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"50 254 LINE SMOOTH",
-"50 206 OFFCURVE",
-"89 167 OFFCURVE",
-"137 167 CURVE SMOOTH",
 "185 167 OFFCURVE",
 "224 206 OFFCURVE",
 "224 254 CURVE SMOOTH",
@@ -36280,7 +36105,10 @@ nodes = (
 "137 341 CURVE SMOOTH",
 "89 341 OFFCURVE",
 "50 302 OFFCURVE",
-"50 254 CURVE SMOOTH"
+"50 254 CURVE SMOOTH",
+"50 206 OFFCURVE",
+"89 167 OFFCURVE",
+"137 167 CURVE SMOOTH"
 );
 }
 );
@@ -36291,7 +36119,7 @@ unicode = 00B7;
 },
 {
 glyphname = bullet;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -36299,19 +36127,18 @@ paths = (
 {
 closed = 1;
 nodes = (
-"205 495 LINE SMOOTH",
-"135 495 OFFCURVE",
-"90 443 OFFCURVE",
-"90 380 CURVE SMOOTH",
-"90 317 OFFCURVE",
-"135 265 OFFCURVE",
-"205 265 CURVE SMOOTH",
 "275 265 OFFCURVE",
 "320 317 OFFCURVE",
 "320 380 CURVE SMOOTH",
 "320 443 OFFCURVE",
 "275 495 OFFCURVE",
-"205 495 CURVE SMOOTH"
+"205 495 CURVE SMOOTH",
+"135 495 OFFCURVE",
+"90 443 OFFCURVE",
+"90 380 CURVE SMOOTH",
+"90 317 OFFCURVE",
+"135 265 OFFCURVE",
+"205 265 CURVE SMOOTH"
 );
 }
 );
@@ -36323,19 +36150,18 @@ paths = (
 {
 closed = 1;
 nodes = (
-"205 495 LINE SMOOTH",
-"135 495 OFFCURVE",
-"90 443 OFFCURVE",
-"90 380 CURVE SMOOTH",
-"90 317 OFFCURVE",
-"135 265 OFFCURVE",
-"205 265 CURVE SMOOTH",
 "275 265 OFFCURVE",
 "320 317 OFFCURVE",
 "320 380 CURVE SMOOTH",
 "320 443 OFFCURVE",
 "275 495 OFFCURVE",
-"205 495 CURVE SMOOTH"
+"205 495 CURVE SMOOTH",
+"135 495 OFFCURVE",
+"90 443 OFFCURVE",
+"90 380 CURVE SMOOTH",
+"90 317 OFFCURVE",
+"135 265 OFFCURVE",
+"205 265 CURVE SMOOTH"
 );
 }
 );
@@ -36346,7 +36172,7 @@ unicode = 2022;
 },
 {
 glyphname = colon;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -36392,28 +36218,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"40 61 LINE SMOOTH",
-"40 21 OFFCURVE",
-"73 -12 OFFCURVE",
-"113 -12 CURVE SMOOTH",
-"153 -12 OFFCURVE",
-"186 21 OFFCURVE",
-"186 61 CURVE SMOOTH",
-"186 101 OFFCURVE",
-"153 134 OFFCURVE",
-"113 134 CURVE SMOOTH",
-"73 134 OFFCURVE",
-"40 101 OFFCURVE",
-"40 61 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"40 358 LINE SMOOTH",
-"40 318 OFFCURVE",
-"73 285 OFFCURVE",
-"113 285 CURVE SMOOTH",
 "153 285 OFFCURVE",
 "186 318 OFFCURVE",
 "186 358 CURVE SMOOTH",
@@ -36422,7 +36226,27 @@ nodes = (
 "113 431 CURVE SMOOTH",
 "73 431 OFFCURVE",
 "40 398 OFFCURVE",
-"40 358 CURVE SMOOTH"
+"40 358 CURVE SMOOTH",
+"40 318 OFFCURVE",
+"73 285 OFFCURVE",
+"113 285 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"153 -12 OFFCURVE",
+"186 21 OFFCURVE",
+"186 61 CURVE SMOOTH",
+"186 101 OFFCURVE",
+"153 134 OFFCURVE",
+"113 134 CURVE SMOOTH",
+"73 134 OFFCURVE",
+"40 101 OFFCURVE",
+"40 61 CURVE SMOOTH",
+"40 21 OFFCURVE",
+"73 -12 OFFCURVE",
+"113 -12 CURVE SMOOTH"
 );
 }
 );
@@ -36472,28 +36296,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"50 74 LINE SMOOTH",
-"50 26 OFFCURVE",
-"89 -13 OFFCURVE",
-"137 -13 CURVE SMOOTH",
-"185 -13 OFFCURVE",
-"224 26 OFFCURVE",
-"224 74 CURVE SMOOTH",
-"224 122 OFFCURVE",
-"185 161 OFFCURVE",
-"137 161 CURVE SMOOTH",
-"89 161 OFFCURVE",
-"50 122 OFFCURVE",
-"50 74 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"50 367 LINE SMOOTH",
-"50 319 OFFCURVE",
-"89 280 OFFCURVE",
-"137 280 CURVE SMOOTH",
 "185 280 OFFCURVE",
 "224 319 OFFCURVE",
 "224 367 CURVE SMOOTH",
@@ -36502,7 +36304,27 @@ nodes = (
 "137 454 CURVE SMOOTH",
 "89 454 OFFCURVE",
 "50 415 OFFCURVE",
-"50 367 CURVE SMOOTH"
+"50 367 CURVE SMOOTH",
+"50 319 OFFCURVE",
+"89 280 OFFCURVE",
+"137 280 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"185 -13 OFFCURVE",
+"224 26 OFFCURVE",
+"224 74 CURVE SMOOTH",
+"224 122 OFFCURVE",
+"185 161 OFFCURVE",
+"137 161 CURVE SMOOTH",
+"89 161 OFFCURVE",
+"50 122 OFFCURVE",
+"50 74 CURVE SMOOTH",
+"50 26 OFFCURVE",
+"89 -13 OFFCURVE",
+"137 -13 CURVE SMOOTH"
 );
 }
 );
@@ -36513,7 +36335,7 @@ unicode = 003A;
 },
 {
 glyphname = comma;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -36552,7 +36374,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"55 -165 LINE",
 "144 -128 OFFCURVE",
 "198 -57 OFFCURVE",
 "198 22 CURVE SMOOTH",
@@ -36573,7 +36394,8 @@ nodes = (
 "168 4 CURVE SMOOTH",
 "168 -49 OFFCURVE",
 "120 -108 OFFCURVE",
-"49 -143 CURVE"
+"49 -143 CURVE",
+"55 -165 LINE"
 );
 }
 );
@@ -36616,7 +36438,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"113 -204 LINE",
 "197 -152 OFFCURVE",
 "258 -80 OFFCURVE",
 "258 14 CURVE SMOOTH",
@@ -36637,7 +36458,8 @@ nodes = (
 "209 -7 CURVE SMOOTH",
 "209 -71 OFFCURVE",
 "174 -123 OFFCURVE",
-"96 -183 CURVE"
+"96 -183 CURVE",
+"113 -204 LINE"
 );
 }
 );
@@ -36648,7 +36470,7 @@ unicode = 002C;
 },
 {
 glyphname = ellipsis;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -36656,46 +36478,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"50 60 LINE SMOOTH",
-"50 20 OFFCURVE",
-"83 -13 OFFCURVE",
-"123 -13 CURVE SMOOTH",
-"163 -13 OFFCURVE",
-"196 20 OFFCURVE",
-"196 60 CURVE SMOOTH",
-"196 100 OFFCURVE",
-"163 133 OFFCURVE",
-"123 133 CURVE SMOOTH",
-"83 133 OFFCURVE",
-"50 100 OFFCURVE",
-"50 60 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"296 60 LINE SMOOTH",
-"296 20 OFFCURVE",
-"329 -13 OFFCURVE",
-"369 -13 CURVE SMOOTH",
-"409 -13 OFFCURVE",
-"442 20 OFFCURVE",
-"442 60 CURVE SMOOTH",
-"442 100 OFFCURVE",
-"409 133 OFFCURVE",
-"369 133 CURVE SMOOTH",
-"329 133 OFFCURVE",
-"296 100 OFFCURVE",
-"296 60 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"542 60 LINE SMOOTH",
-"542 20 OFFCURVE",
-"575 -13 OFFCURVE",
-"615 -13 CURVE SMOOTH",
 "655 -13 OFFCURVE",
 "688 20 OFFCURVE",
 "688 60 CURVE SMOOTH",
@@ -36704,7 +36486,44 @@ nodes = (
 "615 133 CURVE SMOOTH",
 "575 133 OFFCURVE",
 "542 100 OFFCURVE",
-"542 60 CURVE SMOOTH"
+"542 60 CURVE SMOOTH",
+"542 20 OFFCURVE",
+"575 -13 OFFCURVE",
+"615 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"163 -13 OFFCURVE",
+"196 20 OFFCURVE",
+"196 60 CURVE SMOOTH",
+"196 100 OFFCURVE",
+"163 133 OFFCURVE",
+"123 133 CURVE SMOOTH",
+"83 133 OFFCURVE",
+"50 100 OFFCURVE",
+"50 60 CURVE SMOOTH",
+"50 20 OFFCURVE",
+"83 -13 OFFCURVE",
+"123 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"409 -13 OFFCURVE",
+"442 20 OFFCURVE",
+"442 60 CURVE SMOOTH",
+"442 100 OFFCURVE",
+"409 133 OFFCURVE",
+"369 133 CURVE SMOOTH",
+"329 133 OFFCURVE",
+"296 100 OFFCURVE",
+"296 60 CURVE SMOOTH",
+"296 20 OFFCURVE",
+"329 -13 OFFCURVE",
+"369 -13 CURVE SMOOTH"
 );
 }
 );
@@ -36716,46 +36535,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"50 74 LINE SMOOTH",
-"50 26 OFFCURVE",
-"89 -13 OFFCURVE",
-"137 -13 CURVE SMOOTH",
-"185 -13 OFFCURVE",
-"224 26 OFFCURVE",
-"224 74 CURVE SMOOTH",
-"224 122 OFFCURVE",
-"185 161 OFFCURVE",
-"137 161 CURVE SMOOTH",
-"89 161 OFFCURVE",
-"50 122 OFFCURVE",
-"50 74 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"324 74 LINE SMOOTH",
-"324 26 OFFCURVE",
-"363 -13 OFFCURVE",
-"411 -13 CURVE SMOOTH",
-"459 -13 OFFCURVE",
-"498 26 OFFCURVE",
-"498 74 CURVE SMOOTH",
-"498 122 OFFCURVE",
-"459 161 OFFCURVE",
-"411 161 CURVE SMOOTH",
-"363 161 OFFCURVE",
-"324 122 OFFCURVE",
-"324 74 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"598 74 LINE SMOOTH",
-"598 26 OFFCURVE",
-"637 -13 OFFCURVE",
-"685 -13 CURVE SMOOTH",
 "733 -13 OFFCURVE",
 "772 26 OFFCURVE",
 "772 74 CURVE SMOOTH",
@@ -36764,7 +36543,44 @@ nodes = (
 "685 161 CURVE SMOOTH",
 "637 161 OFFCURVE",
 "598 122 OFFCURVE",
-"598 74 CURVE SMOOTH"
+"598 74 CURVE SMOOTH",
+"598 26 OFFCURVE",
+"637 -13 OFFCURVE",
+"685 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"185 -13 OFFCURVE",
+"224 26 OFFCURVE",
+"224 74 CURVE SMOOTH",
+"224 122 OFFCURVE",
+"185 161 OFFCURVE",
+"137 161 CURVE SMOOTH",
+"89 161 OFFCURVE",
+"50 122 OFFCURVE",
+"50 74 CURVE SMOOTH",
+"50 26 OFFCURVE",
+"89 -13 OFFCURVE",
+"137 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"459 -13 OFFCURVE",
+"498 26 OFFCURVE",
+"498 74 CURVE SMOOTH",
+"498 122 OFFCURVE",
+"459 161 OFFCURVE",
+"411 161 CURVE SMOOTH",
+"363 161 OFFCURVE",
+"324 122 OFFCURVE",
+"324 74 CURVE SMOOTH",
+"324 26 OFFCURVE",
+"363 -13 OFFCURVE",
+"411 -13 CURVE SMOOTH"
 );
 }
 );
@@ -36775,29 +36591,11 @@ unicode = 2026;
 },
 {
 glyphname = exclam;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
 paths = (
-{
-closed = 1;
-nodes = (
-"54 61 LINE SMOOTH",
-"54 21 OFFCURVE",
-"87 -12 OFFCURVE",
-"127 -12 CURVE SMOOTH",
-"167 -12 OFFCURVE",
-"200 21 OFFCURVE",
-"200 61 CURVE SMOOTH",
-"200 101 OFFCURVE",
-"167 134 OFFCURVE",
-"127 134 CURVE SMOOTH",
-"87 134 OFFCURVE",
-"54 101 OFFCURVE",
-"54 61 CURVE SMOOTH"
-);
-},
 {
 closed = 1;
 nodes = (
@@ -36814,6 +36612,23 @@ nodes = (
 "54 577 OFFCURVE",
 "111 496 OFFCURVE",
 "111 224 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"167 -12 OFFCURVE",
+"200 21 OFFCURVE",
+"200 61 CURVE SMOOTH",
+"200 101 OFFCURVE",
+"167 134 OFFCURVE",
+"127 134 CURVE SMOOTH",
+"87 134 OFFCURVE",
+"54 101 OFFCURVE",
+"54 61 CURVE SMOOTH",
+"54 21 OFFCURVE",
+"87 -12 OFFCURVE",
+"127 -12 CURVE SMOOTH"
 );
 }
 );
@@ -36944,24 +36759,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"66 75 LINE SMOOTH",
-"66 27 OFFCURVE",
-"106 -13 OFFCURVE",
-"154 -13 CURVE SMOOTH",
-"202 -13 OFFCURVE",
-"242 27 OFFCURVE",
-"242 75 CURVE SMOOTH",
-"242 123 OFFCURVE",
-"202 163 OFFCURVE",
-"154 163 CURVE SMOOTH",
-"106 163 OFFCURVE",
-"66 123 OFFCURVE",
-"66 75 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
 "171 224 LINE",
 "171 490 OFFCURVE",
 "241 562 OFFCURVE",
@@ -36976,6 +36773,23 @@ nodes = (
 "134 490 OFFCURVE",
 "134 224 CURVE"
 );
+},
+{
+closed = 1;
+nodes = (
+"202 -13 OFFCURVE",
+"242 27 OFFCURVE",
+"242 75 CURVE SMOOTH",
+"242 123 OFFCURVE",
+"202 163 OFFCURVE",
+"154 163 CURVE SMOOTH",
+"106 163 OFFCURVE",
+"66 123 OFFCURVE",
+"66 75 CURVE SMOOTH",
+"66 27 OFFCURVE",
+"106 -13 OFFCURVE",
+"154 -13 CURVE SMOOTH"
+);
 }
 );
 width = 307;
@@ -36985,7 +36799,7 @@ unicode = 0021;
 },
 {
 glyphname = exclamdown;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -37032,25 +36846,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"54 379 LINE SMOOTH",
-"54 339 OFFCURVE",
-"87 306 OFFCURVE",
-"127 306 CURVE SMOOTH",
-"167 306 OFFCURVE",
-"200 339 OFFCURVE",
-"200 379 CURVE SMOOTH",
-"200 419 OFFCURVE",
-"167 452 OFFCURVE",
-"127 452 CURVE SMOOTH",
-"87 452 OFFCURVE",
-"54 419 OFFCURVE",
-"54 379 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"127 -326 LINE",
 "167 -326 OFFCURVE",
 "200 -308 OFFCURVE",
 "200 -229 CURVE SMOOTH",
@@ -37063,7 +36858,25 @@ nodes = (
 "54 -231 CURVE SMOOTH",
 "54 -301 OFFCURVE",
 "80 -326 OFFCURVE",
-"127 -326 CURVE SMOOTH"
+"127 -326 CURVE SMOOTH",
+"127 -326 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"167 306 OFFCURVE",
+"200 339 OFFCURVE",
+"200 379 CURVE SMOOTH",
+"200 419 OFFCURVE",
+"167 452 OFFCURVE",
+"127 452 CURVE SMOOTH",
+"87 452 OFFCURVE",
+"54 419 OFFCURVE",
+"54 379 CURVE SMOOTH",
+"54 339 OFFCURVE",
+"87 306 OFFCURVE",
+"127 306 CURVE SMOOTH"
 );
 }
 );
@@ -37114,25 +36927,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"65 365 LINE",
-"65 317 OFFCURVE",
-"105 277 OFFCURVE",
-"153 277 CURVE SMOOTH",
-"201 277 OFFCURVE",
-"241 317 OFFCURVE",
-"241 365 CURVE SMOOTH",
-"241 413 OFFCURVE",
-"201 453 OFFCURVE",
-"153 453 CURVE SMOOTH",
-"105 453 OFFCURVE",
-"65 413 OFFCURVE",
-"65 365 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"155 -323 LINE",
 "210 -323 OFFCURVE",
 "242 -289 OFFCURVE",
 "242 -220 CURVE SMOOTH",
@@ -37145,7 +36939,25 @@ nodes = (
 "66 -219 CURVE SMOOTH",
 "66 -296 OFFCURVE",
 "106 -323 OFFCURVE",
-"155 -323 CURVE SMOOTH"
+"155 -323 CURVE SMOOTH",
+"155 -323 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"201 277 OFFCURVE",
+"241 317 OFFCURVE",
+"241 365 CURVE SMOOTH",
+"241 413 OFFCURVE",
+"201 453 OFFCURVE",
+"153 453 CURVE SMOOTH",
+"105 453 OFFCURVE",
+"65 413 OFFCURVE",
+"65 365 CURVE SMOOTH",
+"65 317 OFFCURVE",
+"105 277 OFFCURVE",
+"153 277 CURVE SMOOTH"
 );
 }
 );
@@ -37156,7 +36968,7 @@ unicode = 00A1;
 },
 {
 glyphname = numbersign;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -37204,37 +37016,37 @@ paths = (
 {
 closed = 1;
 nodes = (
-"197 763 LINE",
-"77 0 LINE",
-"125 0 LINE",
-"245 763 LINE"
+"342 0 LINE",
+"462 763 LINE",
+"414 763 LINE",
+"294 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"0 236 LINE",
 "498 236 LINE",
 "498 276 LINE",
-"0 276 LINE"
+"0 276 LINE",
+"0 236 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"414 763 LINE",
-"294 0 LINE",
-"342 0 LINE",
-"462 763 LINE"
+"125 0 LINE",
+"245 763 LINE",
+"197 763 LINE",
+"77 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"49 475 LINE",
 "547 475 LINE",
 "547 515 LINE",
-"49 515 LINE"
+"49 515 LINE",
+"49 475 LINE"
 );
 }
 );
@@ -37286,37 +37098,37 @@ paths = (
 {
 closed = 1;
 nodes = (
-"189 763 LINE",
-"69 0 LINE",
 "133 0 LINE",
-"253 763 LINE"
+"253 763 LINE",
+"189 763 LINE",
+"69 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"0 232 LINE",
 "498 232 LINE",
 "498 281 LINE",
-"0 281 LINE"
+"0 281 LINE",
+"0 232 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"406 763 LINE",
-"286 0 LINE",
 "342 0 LINE",
-"462 763 LINE"
+"462 763 LINE",
+"406 763 LINE",
+"286 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"49 470 LINE",
 "547 470 LINE",
 "547 520 LINE",
-"49 520 LINE"
+"49 520 LINE",
+"49 470 LINE"
 );
 }
 );
@@ -37327,7 +37139,7 @@ unicode = 0023;
 },
 {
 glyphname = period;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -37335,10 +37147,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"40 61 LINE SMOOTH",
-"40 21 OFFCURVE",
-"73 -12 OFFCURVE",
-"113 -12 CURVE SMOOTH",
 "153 -12 OFFCURVE",
 "186 21 OFFCURVE",
 "186 61 CURVE SMOOTH",
@@ -37347,7 +37155,10 @@ nodes = (
 "113 134 CURVE SMOOTH",
 "73 134 OFFCURVE",
 "40 101 OFFCURVE",
-"40 61 CURVE SMOOTH"
+"40 61 CURVE SMOOTH",
+"40 21 OFFCURVE",
+"73 -12 OFFCURVE",
+"113 -12 CURVE SMOOTH"
 );
 }
 );
@@ -37398,10 +37209,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"50 74 LINE SMOOTH",
-"50 26 OFFCURVE",
-"89 -13 OFFCURVE",
-"137 -13 CURVE SMOOTH",
 "185 -13 OFFCURVE",
 "224 26 OFFCURVE",
 "224 74 CURVE SMOOTH",
@@ -37410,7 +37217,10 @@ nodes = (
 "137 161 CURVE SMOOTH",
 "89 161 OFFCURVE",
 "50 122 OFFCURVE",
-"50 74 CURVE SMOOTH"
+"50 74 CURVE SMOOTH",
+"50 26 OFFCURVE",
+"89 -13 OFFCURVE",
+"137 -13 CURVE SMOOTH"
 );
 }
 );
@@ -37421,7 +37231,7 @@ unicode = 002E;
 },
 {
 glyphname = question;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -37429,25 +37239,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"105 61 LINE SMOOTH",
-"105 21 OFFCURVE",
-"138 -12 OFFCURVE",
-"178 -12 CURVE SMOOTH",
-"218 -12 OFFCURVE",
-"251 21 OFFCURVE",
-"251 61 CURVE SMOOTH",
-"251 101 OFFCURVE",
-"218 134 OFFCURVE",
-"178 134 CURVE SMOOTH",
-"138 134 OFFCURVE",
-"105 101 OFFCURVE",
-"105 61 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"152 222 LINE",
 "182 222 LINE",
 "182 376 OFFCURVE",
 "382 399 OFFCURVE",
@@ -37479,6 +37270,23 @@ nodes = (
 "143 292 OFFCURVE",
 "143 260 OFFCURVE",
 "152 222 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"218 -12 OFFCURVE",
+"251 21 OFFCURVE",
+"251 61 CURVE SMOOTH",
+"251 101 OFFCURVE",
+"218 134 OFFCURVE",
+"178 134 CURVE SMOOTH",
+"138 134 OFFCURVE",
+"105 101 OFFCURVE",
+"105 61 CURVE SMOOTH",
+"105 21 OFFCURVE",
+"138 -12 OFFCURVE",
+"178 -12 CURVE SMOOTH"
 );
 }
 );
@@ -37675,25 +37483,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"88 74 LINE SMOOTH",
-"88 27 OFFCURVE",
-"128 -13 OFFCURVE",
-"175 -13 CURVE SMOOTH",
-"223 -13 OFFCURVE",
-"263 27 OFFCURVE",
-"263 74 CURVE SMOOTH",
-"263 122 OFFCURVE",
-"223 162 OFFCURVE",
-"175 162 CURVE SMOOTH",
-"128 162 OFFCURVE",
-"88 122 OFFCURVE",
-"88 74 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"152 224 LINE",
 "182 224 LINE",
 "182 361 OFFCURVE",
 "430 367 OFFCURVE",
@@ -37726,6 +37515,23 @@ nodes = (
 "149 249 OFFCURVE",
 "152 224 CURVE"
 );
+},
+{
+closed = 1;
+nodes = (
+"223 -13 OFFCURVE",
+"263 27 OFFCURVE",
+"263 74 CURVE SMOOTH",
+"263 122 OFFCURVE",
+"223 162 OFFCURVE",
+"175 162 CURVE SMOOTH",
+"128 162 OFFCURVE",
+"88 122 OFFCURVE",
+"88 74 CURVE SMOOTH",
+"88 27 OFFCURVE",
+"128 -13 OFFCURVE",
+"175 -13 CURVE SMOOTH"
+);
 }
 );
 width = 470;
@@ -37735,7 +37541,7 @@ unicode = 003F;
 },
 {
 glyphname = questiondown;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -37800,14 +37606,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"262 230 LINE",
-"232 230 LINE",
-"232 76 OFFCURVE",
-"32 53 OFFCURVE",
-"32 -115 CURVE SMOOTH",
-"32 -238 OFFCURVE",
-"108 -314 OFFCURVE",
-"223 -314 CURVE SMOOTH",
 "321 -314 OFFCURVE",
 "390 -245 OFFCURVE",
 "390 -175 CURVE SMOOTH",
@@ -37831,13 +37629,22 @@ nodes = (
 "271 145 CURVE SMOOTH",
 "271 160 OFFCURVE",
 "271 192 OFFCURVE",
-"262 230 CURVE"
+"262 230 CURVE",
+"232 230 LINE",
+"232 76 OFFCURVE",
+"32 53 OFFCURVE",
+"32 -115 CURVE SMOOTH",
+"32 -238 OFFCURVE",
+"108 -314 OFFCURVE",
+"223 -314 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"309 389 LINE SMOOTH",
+"276 316 OFFCURVE",
+"309 349 OFFCURVE",
+"309 389 CURVE SMOOTH",
 "309 429 OFFCURVE",
 "276 462 OFFCURVE",
 "236 462 CURVE SMOOTH",
@@ -37846,10 +37653,7 @@ nodes = (
 "163 389 CURVE SMOOTH",
 "163 349 OFFCURVE",
 "196 316 OFFCURVE",
-"236 316 CURVE SMOOTH",
-"276 316 OFFCURVE",
-"309 349 OFFCURVE",
-"309 389 CURVE SMOOTH"
+"236 316 CURVE SMOOTH"
 );
 }
 );
@@ -37918,14 +37722,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"318 216 LINE",
-"288 216 LINE",
-"288 79 OFFCURVE",
-"40 73 OFFCURVE",
-"40 -129 CURVE SMOOTH",
-"40 -235 OFFCURVE",
-"125 -314 OFFCURVE",
-"255 -314 CURVE SMOOTH",
 "357 -314 OFFCURVE",
 "425 -244 OFFCURVE",
 "425 -166 CURVE SMOOTH",
@@ -37949,13 +37745,22 @@ nodes = (
 "322 149 CURVE SMOOTH",
 "322 165 OFFCURVE",
 "321 191 OFFCURVE",
-"318 216 CURVE"
+"318 216 CURVE",
+"288 216 LINE",
+"288 79 OFFCURVE",
+"40 73 OFFCURVE",
+"40 -129 CURVE SMOOTH",
+"40 -235 OFFCURVE",
+"125 -314 OFFCURVE",
+"255 -314 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"382 375 LINE SMOOTH",
+"342 287 OFFCURVE",
+"382 327 OFFCURVE",
+"382 375 CURVE SMOOTH",
 "382 422 OFFCURVE",
 "342 462 OFFCURVE",
 "295 462 CURVE SMOOTH",
@@ -37964,10 +37769,7 @@ nodes = (
 "207 375 CURVE SMOOTH",
 "207 327 OFFCURVE",
 "247 287 OFFCURVE",
-"295 287 CURVE SMOOTH",
-"342 287 OFFCURVE",
-"382 327 OFFCURVE",
-"382 375 CURVE SMOOTH"
+"295 287 CURVE SMOOTH"
 );
 }
 );
@@ -37986,24 +37788,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"125 463 LINE",
-"125 627 OFFCURVE",
-"174 647 OFFCURVE",
-"174 704 CURVE SMOOTH",
-"174 745 OFFCURVE",
-"145 763 OFFCURVE",
-"112 763 CURVE SMOOTH",
-"79 763 OFFCURVE",
-"50 745 OFFCURVE",
-"50 704 CURVE SMOOTH",
-"50 647 OFFCURVE",
-"99 627 OFFCURVE",
-"99 463 CURVE"
-);
-},
-{
-closed = 1;
-nodes = (
 "296 463 LINE",
 "296 627 OFFCURVE",
 "345 647 OFFCURVE",
@@ -38018,6 +37802,24 @@ nodes = (
 "270 627 OFFCURVE",
 "270 463 CURVE"
 );
+},
+{
+closed = 1;
+nodes = (
+"125 463 LINE",
+"125 627 OFFCURVE",
+"174 647 OFFCURVE",
+"174 704 CURVE SMOOTH",
+"174 745 OFFCURVE",
+"145 763 OFFCURVE",
+"112 763 CURVE SMOOTH",
+"79 763 OFFCURVE",
+"50 745 OFFCURVE",
+"50 704 CURVE SMOOTH",
+"50 647 OFFCURVE",
+"99 627 OFFCURVE",
+"99 463 CURVE"
+);
 }
 );
 width = 395;
@@ -38025,24 +37827,6 @@ width = 395;
 {
 layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
 paths = (
-{
-closed = 1;
-nodes = (
-"135 403 LINE",
-"135 595 OFFCURVE",
-"204 619 OFFCURVE",
-"204 684 CURVE SMOOTH",
-"204 739 OFFCURVE",
-"165 763 OFFCURVE",
-"122 763 CURVE SMOOTH",
-"79 763 OFFCURVE",
-"40 739 OFFCURVE",
-"40 684 CURVE SMOOTH",
-"40 619 OFFCURVE",
-"109 595 OFFCURVE",
-"109 403 CURVE"
-);
-},
 {
 closed = 1;
 nodes = (
@@ -38059,6 +37843,24 @@ nodes = (
 "243 619 OFFCURVE",
 "312 595 OFFCURVE",
 "312 403 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"135 403 LINE",
+"135 595 OFFCURVE",
+"204 619 OFFCURVE",
+"204 684 CURVE SMOOTH",
+"204 739 OFFCURVE",
+"165 763 OFFCURVE",
+"122 763 CURVE SMOOTH",
+"79 763 OFFCURVE",
+"40 739 OFFCURVE",
+"40 684 CURVE SMOOTH",
+"40 619 OFFCURVE",
+"109 595 OFFCURVE",
+"109 403 CURVE"
 );
 }
 );
@@ -38155,7 +37957,7 @@ unicode = 0027;
 },
 {
 glyphname = semicolon;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -38238,7 +38040,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"55 -165 LINE",
 "144 -128 OFFCURVE",
 "198 -57 OFFCURVE",
 "198 22 CURVE SMOOTH",
@@ -38259,16 +38060,13 @@ nodes = (
 "168 4 CURVE SMOOTH",
 "168 -49 OFFCURVE",
 "120 -108 OFFCURVE",
-"49 -143 CURVE"
+"49 -143 CURVE",
+"55 -165 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"43 358 LINE SMOOTH",
-"43 318 OFFCURVE",
-"76 285 OFFCURVE",
-"116 285 CURVE SMOOTH",
 "156 285 OFFCURVE",
 "189 318 OFFCURVE",
 "189 358 CURVE SMOOTH",
@@ -38277,7 +38075,10 @@ nodes = (
 "116 431 CURVE SMOOTH",
 "76 431 OFFCURVE",
 "43 398 OFFCURVE",
-"43 358 CURVE SMOOTH"
+"43 358 CURVE SMOOTH",
+"43 318 OFFCURVE",
+"76 285 OFFCURVE",
+"116 285 CURVE SMOOTH"
 );
 }
 );
@@ -38398,7 +38199,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"113 -204 LINE",
 "197 -152 OFFCURVE",
 "258 -80 OFFCURVE",
 "258 14 CURVE SMOOTH",
@@ -38419,16 +38219,13 @@ nodes = (
 "209 -7 CURVE SMOOTH",
 "209 -71 OFFCURVE",
 "174 -123 OFFCURVE",
-"96 -183 CURVE"
+"96 -183 CURVE",
+"113 -204 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"50 367 LINE SMOOTH",
-"50 319 OFFCURVE",
-"89 280 OFFCURVE",
-"137 280 CURVE SMOOTH",
 "185 280 OFFCURVE",
 "224 319 OFFCURVE",
 "224 367 CURVE SMOOTH",
@@ -38437,7 +38234,10 @@ nodes = (
 "137 454 CURVE SMOOTH",
 "89 454 OFFCURVE",
 "50 415 OFFCURVE",
-"50 367 CURVE SMOOTH"
+"50 367 CURVE SMOOTH",
+"50 319 OFFCURVE",
+"89 280 OFFCURVE",
+"137 280 CURVE SMOOTH"
 );
 }
 );
@@ -38448,7 +38248,7 @@ unicode = 003B;
 },
 {
 glyphname = slash;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -38456,10 +38256,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"190 753 LINE",
-"-20 0 LINE",
 "39 0 LINE",
-"249 753 LINE"
+"249 753 LINE",
+"190 753 LINE",
+"-20 0 LINE"
 );
 }
 );
@@ -38471,10 +38271,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"170 753 LINE",
-"-20 0 LINE",
 "59 0 LINE",
-"249 753 LINE"
+"249 753 LINE",
+"170 753 LINE",
+"-20 0 LINE"
 );
 }
 );
@@ -38485,7 +38285,7 @@ unicode = 002F;
 },
 {
 glyphname = underscore;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -38506,10 +38306,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"0 -114 LINE",
 "538 -114 LINE",
 "538 -70 LINE",
-"0 -70 LINE"
+"0 -70 LINE",
+"0 -114 LINE"
 );
 }
 );
@@ -38534,10 +38334,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"0 -124 LINE",
 "584 -124 LINE",
 "584 -70 LINE",
-"0 -70 LINE"
+"0 -70 LINE",
+"0 -124 LINE"
 );
 }
 );
@@ -38548,7 +38348,7 @@ unicode = 005F;
 },
 {
 glyphname = braceleft;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -38556,14 +38356,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"54 323 LINE",
-"106 323 OFFCURVE",
-"120 295 OFFCURVE",
-"120 201 CURVE SMOOTH",
-"120 59 LINE SMOOTH",
-"120 -94 OFFCURVE",
-"146 -123 OFFCURVE",
-"319 -123 CURVE",
 "319 -98 LINE",
 "248 -98 OFFCURVE",
 "229 -69 OFFCURVE",
@@ -38587,7 +38379,15 @@ nodes = (
 "120 462 LINE SMOOTH",
 "120 368 OFFCURVE",
 "106 340 OFFCURVE",
-"54 340 CURVE"
+"54 340 CURVE",
+"54 323 LINE",
+"106 323 OFFCURVE",
+"120 295 OFFCURVE",
+"120 201 CURVE SMOOTH",
+"120 59 LINE SMOOTH",
+"120 -94 OFFCURVE",
+"146 -123 OFFCURVE",
+"319 -123 CURVE"
 );
 }
 );
@@ -38640,14 +38440,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"10 320 LINE",
-"62 320 OFFCURVE",
-"76 293 OFFCURVE",
-"76 203 CURVE SMOOTH",
-"76 61 LINE SMOOTH",
-"76 -92 OFFCURVE",
-"104 -121 OFFCURVE",
-"295 -121 CURVE",
 "295 -91 LINE",
 "228 -91 OFFCURVE",
 "210 -62 OFFCURVE",
@@ -38671,7 +38463,15 @@ nodes = (
 "76 464 LINE SMOOTH",
 "76 374 OFFCURVE",
 "62 347 OFFCURVE",
-"10 347 CURVE"
+"10 347 CURVE",
+"10 320 LINE",
+"62 320 OFFCURVE",
+"76 293 OFFCURVE",
+"76 203 CURVE SMOOTH",
+"76 61 LINE SMOOTH",
+"76 -92 OFFCURVE",
+"104 -121 OFFCURVE",
+"295 -121 CURVE"
 );
 }
 );
@@ -38682,7 +38482,7 @@ unicode = 007B;
 },
 {
 glyphname = braceright;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -38690,6 +38490,13 @@ paths = (
 {
 closed = 1;
 nodes = (
+"166 -123 OFFCURVE",
+"192 -94 OFFCURVE",
+"192 59 CURVE SMOOTH",
+"192 201 LINE SMOOTH",
+"192 295 OFFCURVE",
+"206 323 OFFCURVE",
+"258 323 CURVE",
 "258 340 LINE",
 "206 340 OFFCURVE",
 "192 368 OFFCURVE",
@@ -38714,14 +38521,7 @@ nodes = (
 "83 -69 OFFCURVE",
 "64 -98 OFFCURVE",
 "-7 -98 CURVE",
-"-7 -123 LINE",
-"166 -123 OFFCURVE",
-"192 -94 OFFCURVE",
-"192 59 CURVE SMOOTH",
-"192 201 LINE SMOOTH",
-"192 295 OFFCURVE",
-"206 323 OFFCURVE",
-"258 323 CURVE"
+"-7 -123 LINE"
 );
 }
 );
@@ -38774,6 +38574,13 @@ paths = (
 {
 closed = 1;
 nodes = (
+"197 -121 OFFCURVE",
+"225 -92 OFFCURVE",
+"225 61 CURVE SMOOTH",
+"225 203 LINE SMOOTH",
+"225 293 OFFCURVE",
+"239 320 OFFCURVE",
+"291 320 CURVE",
 "291 347 LINE",
 "239 347 OFFCURVE",
 "225 374 OFFCURVE",
@@ -38798,14 +38605,7 @@ nodes = (
 "91 -62 OFFCURVE",
 "73 -91 OFFCURVE",
 "6 -91 CURVE",
-"6 -121 LINE",
-"197 -121 OFFCURVE",
-"225 -92 OFFCURVE",
-"225 61 CURVE SMOOTH",
-"225 203 LINE SMOOTH",
-"225 293 OFFCURVE",
-"239 320 OFFCURVE",
-"291 320 CURVE"
+"6 -121 LINE"
 );
 }
 );
@@ -38816,7 +38616,7 @@ unicode = 007D;
 },
 {
 glyphname = bracketleft;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -38824,14 +38624,14 @@ paths = (
 {
 closed = 1;
 nodes = (
-"82 -123 LINE",
 "301 -123 LINE",
 "301 -98 LINE",
 "191 -98 LINE",
 "191 763 LINE",
 "301 763 LINE",
 "301 788 LINE",
-"82 788 LINE"
+"82 788 LINE",
+"82 -123 LINE"
 );
 }
 );
@@ -38874,14 +38674,14 @@ paths = (
 {
 closed = 1;
 nodes = (
-"85 -123 LINE",
 "314 -123 LINE",
 "314 -93 LINE",
 "219 -93 LINE",
 "219 758 LINE",
 "314 758 LINE",
 "314 788 LINE",
-"85 788 LINE"
+"85 788 LINE",
+"85 -123 LINE"
 );
 }
 );
@@ -38892,7 +38692,7 @@ unicode = 005B;
 },
 {
 glyphname = bracketright;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -38900,14 +38700,14 @@ paths = (
 {
 closed = 1;
 nodes = (
-"17 -123 LINE",
 "236 -123 LINE",
 "236 788 LINE",
 "17 788 LINE",
 "17 763 LINE",
 "127 763 LINE",
 "127 -98 LINE",
-"17 -98 LINE"
+"17 -98 LINE",
+"17 -123 LINE"
 );
 }
 );
@@ -38950,14 +38750,14 @@ paths = (
 {
 closed = 1;
 nodes = (
-"5 -123 LINE",
 "234 -123 LINE",
 "234 788 LINE",
 "5 788 LINE",
 "5 758 LINE",
 "100 758 LINE",
 "100 -93 LINE",
-"5 -93 LINE"
+"5 -93 LINE",
+"5 -123 LINE"
 );
 }
 );
@@ -38968,7 +38768,7 @@ unicode = 005D;
 },
 {
 glyphname = parenleft;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 16:54:48 +0000";
 layers = (
 {
 background = {
@@ -38999,7 +38799,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"282 -136 LINE",
 "307 -123 LINE",
 "248 -46 OFFCURVE",
 "178 86 OFFCURVE",
@@ -39048,7 +38847,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"262 -136 LINE",
 "287 -123 LINE",
 "190 31 OFFCURVE",
 "180 162 OFFCURVE",
@@ -39073,7 +38871,7 @@ unicode = 0028;
 },
 {
 glyphname = parenright;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -39081,7 +38879,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"27 -136 LINE",
 "172 17 OFFCURVE",
 "239 164 OFFCURVE",
 "239 332 CURVE SMOOTH",
@@ -39094,7 +38891,8 @@ nodes = (
 "131 334 CURVE SMOOTH",
 "131 86 OFFCURVE",
 "61 -46 OFFCURVE",
-"2 -123 CURVE"
+"2 -123 CURVE",
+"27 -136 LINE"
 );
 }
 );
@@ -39106,7 +38904,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"47 -136 LINE",
 "228 38 OFFCURVE",
 "279 188 OFFCURVE",
 "279 332 CURVE SMOOTH",
@@ -39119,7 +38916,8 @@ nodes = (
 "129 324 CURVE SMOOTH",
 "129 163 OFFCURVE",
 "119 31 OFFCURVE",
-"22 -123 CURVE"
+"22 -123 CURVE",
+"47 -136 LINE"
 );
 }
 );
@@ -39130,7 +38928,7 @@ unicode = 0029;
 },
 {
 glyphname = emdash;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -39151,10 +38949,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"0 202 LINE",
 "828 202 LINE",
 "828 246 LINE",
-"0 246 LINE"
+"0 246 LINE",
+"0 202 LINE"
 );
 }
 );
@@ -39179,10 +38977,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"0 192 LINE",
 "875 192 LINE",
 "875 246 LINE",
-"0 246 LINE"
+"0 246 LINE",
+"0 192 LINE"
 );
 }
 );
@@ -39193,7 +38991,7 @@ unicode = 2014;
 },
 {
 glyphname = endash;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -39214,10 +39012,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"0 202 LINE",
 "538 202 LINE",
 "538 246 LINE",
-"0 246 LINE"
+"0 246 LINE",
+"0 202 LINE"
 );
 }
 );
@@ -39242,10 +39040,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"0 192 LINE",
 "584 192 LINE",
 "584 246 LINE",
-"0 246 LINE"
+"0 246 LINE",
+"0 192 LINE"
 );
 }
 );
@@ -39256,7 +39054,7 @@ unicode = 2013;
 },
 {
 glyphname = hyphen;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -39277,10 +39075,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"50 202 LINE",
 "345 202 LINE",
 "345 246 LINE",
-"50 246 LINE"
+"50 246 LINE",
+"50 202 LINE"
 );
 }
 );
@@ -39305,10 +39103,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"50 182 LINE",
 "345 182 LINE",
 "345 246 LINE",
-"50 246 LINE"
+"50 246 LINE",
+"50 182 LINE"
 );
 }
 );
@@ -39318,8 +39116,8 @@ width = 395;
 unicode = 002D;
 },
 {
-glyphname = uni00AD;
-lastChange = "2016-08-16 11:12:00 +0000";
+glyphname = softhyphen;
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -39340,10 +39138,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"50 202 LINE",
 "345 202 LINE",
 "345 246 LINE",
-"50 246 LINE"
+"50 246 LINE",
+"50 202 LINE"
 );
 }
 );
@@ -39368,10 +39166,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"50 182 LINE",
 "345 182 LINE",
 "345 246 LINE",
-"50 246 LINE"
+"50 246 LINE",
+"50 182 LINE"
 );
 }
 );
@@ -39381,161 +39179,12 @@ width = 395;
 unicode = 00AD;
 },
 {
-glyphname = apostrophe;
-lastChange = "2016-08-16 11:12:00 +0000";
-layers = (
-{
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"162 721 OFFCURVE",
-"131 763 OFFCURVE",
-"80 763 CURVE SMOOTH",
-"37 763 OFFCURVE",
-"10 734 OFFCURVE",
-"10 699 CURVE SMOOTH",
-"10 675 OFFCURVE",
-"24 649 OFFCURVE",
-"60 649 CURVE SMOOTH",
-"91 649 OFFCURVE",
-"111 676 OFFCURVE",
-"120 676 CURVE SMOOTH",
-"123 676 OFFCURVE",
-"125 673 OFFCURVE",
-"125 662 CURVE SMOOTH",
-"125 617 OFFCURVE",
-"93 569 OFFCURVE",
-"33 529 CURVE",
-"53 506 LINE",
-"115 544 OFFCURVE",
-"162 600 OFFCURVE",
-"162 667 CURVE SMOOTH"
-);
-}
-);
-};
-layerId = UUID0;
-paths = (
-{
-closed = 1;
-nodes = (
-"162 667 LINE SMOOTH",
-"162 721 OFFCURVE",
-"131 763 OFFCURVE",
-"80 763 CURVE SMOOTH",
-"37 763 OFFCURVE",
-"10 734 OFFCURVE",
-"10 699 CURVE SMOOTH",
-"10 675 OFFCURVE",
-"24 649 OFFCURVE",
-"60 649 CURVE SMOOTH",
-"91 649 OFFCURVE",
-"111 676 OFFCURVE",
-"120 676 CURVE SMOOTH",
-"123 676 OFFCURVE",
-"125 673 OFFCURVE",
-"125 662 CURVE SMOOTH",
-"125 617 OFFCURVE",
-"93 569 OFFCURVE",
-"33 529 CURVE",
-"53 506 LINE",
-"115 544 OFFCURVE",
-"162 600 OFFCURVE",
-"162 667 CURVE SMOOTH"
-);
-}
-);
-width = 172;
-},
-{
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"176 709 OFFCURVE",
-"146 764 OFFCURVE",
-"89 764 CURVE SMOOTH",
-"44 764 OFFCURVE",
-"10 730 OFFCURVE",
-"10 687 CURVE SMOOTH",
-"10 653 OFFCURVE",
-"30 620 OFFCURVE",
-"68 620 CURVE SMOOTH",
-"106 620 OFFCURVE",
-"111 652 OFFCURVE",
-"123 652 CURVE SMOOTH",
-"127 652 OFFCURVE",
-"132 648 OFFCURVE",
-"132 628 CURVE SMOOTH",
-"132 581 OFFCURVE",
-"105 543 OFFCURVE",
-"46 501 CURVE",
-"66 479 LINE",
-"133 524 OFFCURVE",
-"176 573 OFFCURVE",
-"176 647 CURVE SMOOTH"
-);
-}
-);
-};
-layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
-paths = (
-{
-closed = 1;
-nodes = (
-"176 647 LINE SMOOTH",
-"176 709 OFFCURVE",
-"146 764 OFFCURVE",
-"89 764 CURVE SMOOTH",
-"44 764 OFFCURVE",
-"10 730 OFFCURVE",
-"10 687 CURVE SMOOTH",
-"10 653 OFFCURVE",
-"30 620 OFFCURVE",
-"68 620 CURVE SMOOTH",
-"106 620 OFFCURVE",
-"111 652 OFFCURVE",
-"123 652 CURVE SMOOTH",
-"127 652 OFFCURVE",
-"132 648 OFFCURVE",
-"132 628 CURVE SMOOTH",
-"132 581 OFFCURVE",
-"105 543 OFFCURVE",
-"46 501 CURVE",
-"66 479 LINE",
-"133 524 OFFCURVE",
-"176 573 OFFCURVE",
-"176 647 CURVE SMOOTH"
-);
-}
-);
-width = 186;
-}
-);
-unicode = 02BC;
-},
-{
-glyphname = guillemotleft;
-lastChange = "2016-08-16 11:12:00 +0000";
+glyphname = guillemetleft;
+lastChange = "2016-08-18 21:39:28 +0000";
 layers = (
 {
 layerId = UUID0;
 paths = (
-{
-closed = 1;
-nodes = (
-"285 53 LINE",
-"174 220 LINE",
-"285 391 LINE",
-"270 402 LINE",
-"70 231 LINE",
-"70 209 LINE",
-"270 38 LINE"
-);
-},
 {
 closed = 1;
 nodes = (
@@ -39547,6 +39196,18 @@ nodes = (
 "280 209 LINE",
 "480 38 LINE"
 );
+},
+{
+closed = 1;
+nodes = (
+"285 53 LINE",
+"174 220 LINE",
+"285 391 LINE",
+"270 402 LINE",
+"70 231 LINE",
+"70 209 LINE",
+"270 38 LINE"
+);
 }
 );
 width = 555;
@@ -39554,18 +39215,6 @@ width = 555;
 {
 layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
 paths = (
-{
-closed = 1;
-nodes = (
-"265 43 LINE",
-"174 220 LINE",
-"265 401 LINE",
-"250 412 LINE",
-"30 231 LINE",
-"30 209 LINE",
-"250 28 LINE"
-);
-},
 {
 closed = 1;
 nodes = (
@@ -39577,6 +39226,18 @@ nodes = (
 "213 209 LINE",
 "433 28 LINE"
 );
+},
+{
+closed = 1;
+nodes = (
+"265 43 LINE",
+"174 220 LINE",
+"265 401 LINE",
+"250 412 LINE",
+"30 231 LINE",
+"30 209 LINE",
+"250 28 LINE"
+);
 }
 );
 width = 508;
@@ -39585,8 +39246,8 @@ width = 508;
 unicode = 00AB;
 },
 {
-glyphname = guillemotright;
-lastChange = "2016-08-16 11:12:00 +0000";
+glyphname = guillemetright;
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -39622,25 +39283,25 @@ paths = (
 {
 closed = 1;
 nodes = (
-"85 38 LINE",
-"285 209 LINE",
-"285 231 LINE",
-"85 402 LINE",
-"70 391 LINE",
-"181 220 LINE",
-"70 53 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"295 38 LINE",
 "495 209 LINE",
 "495 231 LINE",
 "295 402 LINE",
 "280 391 LINE",
 "391 220 LINE",
-"280 53 LINE"
+"280 53 LINE",
+"295 38 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"285 209 LINE",
+"285 231 LINE",
+"85 402 LINE",
+"70 391 LINE",
+"181 220 LINE",
+"70 53 LINE",
+"85 38 LINE"
 );
 }
 );
@@ -39680,25 +39341,25 @@ paths = (
 {
 closed = 1;
 nodes = (
-"75 28 LINE",
-"295 209 LINE",
-"295 231 LINE",
-"75 412 LINE",
-"60 401 LINE",
-"151 220 LINE",
-"60 43 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"258 28 LINE",
 "478 209 LINE",
 "478 231 LINE",
 "258 412 LINE",
 "243 401 LINE",
 "334 220 LINE",
-"243 43 LINE"
+"243 43 LINE",
+"258 28 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"295 209 LINE",
+"295 231 LINE",
+"75 412 LINE",
+"60 401 LINE",
+"151 220 LINE",
+"60 43 LINE",
+"75 28 LINE"
 );
 }
 );
@@ -39752,7 +39413,7 @@ unicode = 2039;
 },
 {
 glyphname = guilsinglright;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -39760,13 +39421,13 @@ paths = (
 {
 closed = 1;
 nodes = (
-"75 38 LINE",
 "275 209 LINE",
 "275 231 LINE",
 "75 402 LINE",
 "60 391 LINE",
 "171 220 LINE",
-"60 53 LINE"
+"60 53 LINE",
+"75 38 LINE"
 );
 }
 );
@@ -39778,13 +39439,13 @@ paths = (
 {
 closed = 1;
 nodes = (
-"75 28 LINE",
 "295 209 LINE",
 "295 231 LINE",
 "75 412 LINE",
 "60 401 LINE",
 "151 220 LINE",
-"60 43 LINE"
+"60 43 LINE",
+"75 28 LINE"
 );
 }
 );
@@ -39795,7 +39456,7 @@ unicode = 203A;
 },
 {
 glyphname = quotedblbase;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -39861,35 +39522,9 @@ paths = (
 {
 closed = 1;
 nodes = (
-"213 30 LINE SMOOTH",
-"213 95 OFFCURVE",
-"174 145 OFFCURVE",
-"111 145 CURVE SMOOTH",
-"59 145 OFFCURVE",
-"27 111 OFFCURVE",
-"27 70 CURVE SMOOTH",
-"27 40 OFFCURVE",
-"45 10 OFFCURVE",
-"87 10 CURVE SMOOTH",
-"143 10 OFFCURVE",
-"143 64 OFFCURVE",
-"158 64 CURVE SMOOTH",
-"166 64 OFFCURVE",
-"181 47 OFFCURVE",
-"181 20 CURVE SMOOTH",
-"181 -23 OFFCURVE",
-"144 -85 OFFCURVE",
-"78 -132 CURVE",
-"95 -153 LINE",
-"162 -109 OFFCURVE",
-"213 -45 OFFCURVE",
-"213 30 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"459 30 LINE SMOOTH",
+"408 -109 OFFCURVE",
+"459 -45 OFFCURVE",
+"459 30 CURVE SMOOTH",
 "459 95 OFFCURVE",
 "420 145 OFFCURVE",
 "357 145 CURVE SMOOTH",
@@ -39908,10 +39543,34 @@ nodes = (
 "427 -23 OFFCURVE",
 "390 -85 OFFCURVE",
 "324 -132 CURVE",
-"341 -153 LINE",
-"408 -109 OFFCURVE",
-"459 -45 OFFCURVE",
-"459 30 CURVE SMOOTH"
+"341 -153 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"162 -109 OFFCURVE",
+"213 -45 OFFCURVE",
+"213 30 CURVE SMOOTH",
+"213 95 OFFCURVE",
+"174 145 OFFCURVE",
+"111 145 CURVE SMOOTH",
+"59 145 OFFCURVE",
+"27 111 OFFCURVE",
+"27 70 CURVE SMOOTH",
+"27 40 OFFCURVE",
+"45 10 OFFCURVE",
+"87 10 CURVE SMOOTH",
+"143 10 OFFCURVE",
+"143 64 OFFCURVE",
+"158 64 CURVE SMOOTH",
+"166 64 OFFCURVE",
+"181 47 OFFCURVE",
+"181 20 CURVE SMOOTH",
+"181 -23 OFFCURVE",
+"144 -85 OFFCURVE",
+"78 -132 CURVE",
+"95 -153 LINE"
 );
 }
 );
@@ -39981,35 +39640,9 @@ paths = (
 {
 closed = 1;
 nodes = (
-"258 47 LINE SMOOTH",
-"258 128 OFFCURVE",
-"213 192 OFFCURVE",
-"142 192 CURVE SMOOTH",
-"86 192 OFFCURVE",
-"50 152 OFFCURVE",
-"50 100 CURVE SMOOTH",
-"50 59 OFFCURVE",
-"73 20 OFFCURVE",
-"123 20 CURVE SMOOTH",
-"171 20 OFFCURVE",
-"183 56 OFFCURVE",
-"198 56 CURVE SMOOTH",
-"204 56 OFFCURVE",
-"209 50 OFFCURVE",
-"209 26 CURVE SMOOTH",
-"209 -38 OFFCURVE",
-"174 -90 OFFCURVE",
-"96 -150 CURVE",
-"113 -171 LINE",
-"197 -119 OFFCURVE",
-"258 -47 OFFCURVE",
-"258 47 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"511 47 LINE SMOOTH",
+"450 -119 OFFCURVE",
+"511 -47 OFFCURVE",
+"511 47 CURVE SMOOTH",
 "511 128 OFFCURVE",
 "466 192 OFFCURVE",
 "395 192 CURVE SMOOTH",
@@ -40028,10 +39661,34 @@ nodes = (
 "462 -38 OFFCURVE",
 "427 -90 OFFCURVE",
 "349 -150 CURVE",
-"366 -171 LINE",
-"450 -119 OFFCURVE",
-"511 -47 OFFCURVE",
-"511 47 CURVE SMOOTH"
+"366 -171 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"197 -119 OFFCURVE",
+"258 -47 OFFCURVE",
+"258 47 CURVE SMOOTH",
+"258 128 OFFCURVE",
+"213 192 OFFCURVE",
+"142 192 CURVE SMOOTH",
+"86 192 OFFCURVE",
+"50 152 OFFCURVE",
+"50 100 CURVE SMOOTH",
+"50 59 OFFCURVE",
+"73 20 OFFCURVE",
+"123 20 CURVE SMOOTH",
+"171 20 OFFCURVE",
+"183 56 OFFCURVE",
+"198 56 CURVE SMOOTH",
+"204 56 OFFCURVE",
+"209 50 OFFCURVE",
+"209 26 CURVE SMOOTH",
+"209 -38 OFFCURVE",
+"174 -90 OFFCURVE",
+"96 -150 CURVE",
+"113 -171 LINE"
 );
 }
 );
@@ -40042,7 +39699,7 @@ unicode = 201E;
 },
 {
 glyphname = quotedblleft;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -40108,38 +39765,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"27 580 LINE SMOOTH",
-"27 515 OFFCURVE",
-"66 465 OFFCURVE",
-"129 465 CURVE SMOOTH",
-"181 465 OFFCURVE",
-"213 499 OFFCURVE",
-"213 540 CURVE SMOOTH",
-"213 570 OFFCURVE",
-"195 600 OFFCURVE",
-"153 600 CURVE SMOOTH",
-"97 600 OFFCURVE",
-"97 546 OFFCURVE",
-"82 546 CURVE SMOOTH",
-"74 546 OFFCURVE",
-"59 563 OFFCURVE",
-"59 590 CURVE SMOOTH",
-"59 633 OFFCURVE",
-"96 695 OFFCURVE",
-"162 742 CURVE",
-"145 763 LINE",
-"78 719 OFFCURVE",
-"27 655 OFFCURVE",
-"27 580 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"273 580 LINE SMOOTH",
-"273 515 OFFCURVE",
-"312 465 OFFCURVE",
-"375 465 CURVE SMOOTH",
 "427 465 OFFCURVE",
 "459 499 OFFCURVE",
 "459 540 CURVE SMOOTH",
@@ -40158,7 +39783,37 @@ nodes = (
 "391 763 LINE",
 "324 719 OFFCURVE",
 "273 655 OFFCURVE",
-"273 580 CURVE SMOOTH"
+"273 580 CURVE SMOOTH",
+"273 515 OFFCURVE",
+"312 465 OFFCURVE",
+"375 465 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"181 465 OFFCURVE",
+"213 499 OFFCURVE",
+"213 540 CURVE SMOOTH",
+"213 570 OFFCURVE",
+"195 600 OFFCURVE",
+"153 600 CURVE SMOOTH",
+"97 600 OFFCURVE",
+"97 546 OFFCURVE",
+"82 546 CURVE SMOOTH",
+"74 546 OFFCURVE",
+"59 563 OFFCURVE",
+"59 590 CURVE SMOOTH",
+"59 633 OFFCURVE",
+"96 695 OFFCURVE",
+"162 742 CURVE",
+"145 763 LINE",
+"78 719 OFFCURVE",
+"27 655 OFFCURVE",
+"27 580 CURVE SMOOTH",
+"27 515 OFFCURVE",
+"66 465 OFFCURVE",
+"129 465 CURVE SMOOTH"
 );
 }
 );
@@ -40228,38 +39883,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"50 555 LINE SMOOTH",
-"50 474 OFFCURVE",
-"95 410 OFFCURVE",
-"166 410 CURVE SMOOTH",
-"222 410 OFFCURVE",
-"258 450 OFFCURVE",
-"258 502 CURVE SMOOTH",
-"258 543 OFFCURVE",
-"235 582 OFFCURVE",
-"185 582 CURVE SMOOTH",
-"137 582 OFFCURVE",
-"125 546 OFFCURVE",
-"110 546 CURVE SMOOTH",
-"104 546 OFFCURVE",
-"99 552 OFFCURVE",
-"99 576 CURVE SMOOTH",
-"99 640 OFFCURVE",
-"134 692 OFFCURVE",
-"212 752 CURVE",
-"195 773 LINE",
-"111 721 OFFCURVE",
-"50 649 OFFCURVE",
-"50 555 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"303 555 LINE SMOOTH",
-"303 474 OFFCURVE",
-"348 410 OFFCURVE",
-"419 410 CURVE SMOOTH",
 "475 410 OFFCURVE",
 "511 450 OFFCURVE",
 "511 502 CURVE SMOOTH",
@@ -40278,7 +39901,37 @@ nodes = (
 "448 773 LINE",
 "364 721 OFFCURVE",
 "303 649 OFFCURVE",
-"303 555 CURVE SMOOTH"
+"303 555 CURVE SMOOTH",
+"303 474 OFFCURVE",
+"348 410 OFFCURVE",
+"419 410 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"222 410 OFFCURVE",
+"258 450 OFFCURVE",
+"258 502 CURVE SMOOTH",
+"258 543 OFFCURVE",
+"235 582 OFFCURVE",
+"185 582 CURVE SMOOTH",
+"137 582 OFFCURVE",
+"125 546 OFFCURVE",
+"110 546 CURVE SMOOTH",
+"104 546 OFFCURVE",
+"99 552 OFFCURVE",
+"99 576 CURVE SMOOTH",
+"99 640 OFFCURVE",
+"134 692 OFFCURVE",
+"212 752 CURVE",
+"195 773 LINE",
+"111 721 OFFCURVE",
+"50 649 OFFCURVE",
+"50 555 CURVE SMOOTH",
+"50 474 OFFCURVE",
+"95 410 OFFCURVE",
+"166 410 CURVE SMOOTH"
 );
 }
 );
@@ -40289,7 +39942,7 @@ unicode = 201C;
 },
 {
 glyphname = quotedblright;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -40297,35 +39950,9 @@ paths = (
 {
 closed = 1;
 nodes = (
-"213 648 LINE SMOOTH",
-"213 713 OFFCURVE",
-"174 763 OFFCURVE",
-"111 763 CURVE SMOOTH",
-"59 763 OFFCURVE",
-"27 729 OFFCURVE",
-"27 688 CURVE SMOOTH",
-"27 658 OFFCURVE",
-"45 628 OFFCURVE",
-"87 628 CURVE SMOOTH",
-"143 628 OFFCURVE",
-"143 682 OFFCURVE",
-"158 682 CURVE SMOOTH",
-"166 682 OFFCURVE",
-"181 665 OFFCURVE",
-"181 638 CURVE SMOOTH",
-"181 595 OFFCURVE",
-"144 533 OFFCURVE",
-"78 486 CURVE",
-"95 465 LINE",
-"162 509 OFFCURVE",
-"213 573 OFFCURVE",
-"213 648 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"459 648 LINE SMOOTH",
+"408 509 OFFCURVE",
+"459 573 OFFCURVE",
+"459 648 CURVE SMOOTH",
 "459 713 OFFCURVE",
 "420 763 OFFCURVE",
 "357 763 CURVE SMOOTH",
@@ -40344,10 +39971,34 @@ nodes = (
 "427 595 OFFCURVE",
 "390 533 OFFCURVE",
 "324 486 CURVE",
-"341 465 LINE",
-"408 509 OFFCURVE",
-"459 573 OFFCURVE",
-"459 648 CURVE SMOOTH"
+"341 465 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"162 509 OFFCURVE",
+"213 573 OFFCURVE",
+"213 648 CURVE SMOOTH",
+"213 713 OFFCURVE",
+"174 763 OFFCURVE",
+"111 763 CURVE SMOOTH",
+"59 763 OFFCURVE",
+"27 729 OFFCURVE",
+"27 688 CURVE SMOOTH",
+"27 658 OFFCURVE",
+"45 628 OFFCURVE",
+"87 628 CURVE SMOOTH",
+"143 628 OFFCURVE",
+"143 682 OFFCURVE",
+"158 682 CURVE SMOOTH",
+"166 682 OFFCURVE",
+"181 665 OFFCURVE",
+"181 638 CURVE SMOOTH",
+"181 595 OFFCURVE",
+"144 533 OFFCURVE",
+"78 486 CURVE",
+"95 465 LINE"
 );
 }
 );
@@ -40535,35 +40186,9 @@ paths = (
 {
 closed = 1;
 nodes = (
-"258 628 LINE SMOOTH",
-"258 709 OFFCURVE",
-"213 773 OFFCURVE",
-"142 773 CURVE SMOOTH",
-"86 773 OFFCURVE",
-"50 733 OFFCURVE",
-"50 681 CURVE SMOOTH",
-"50 640 OFFCURVE",
-"73 601 OFFCURVE",
-"123 601 CURVE SMOOTH",
-"171 601 OFFCURVE",
-"183 637 OFFCURVE",
-"198 637 CURVE SMOOTH",
-"204 637 OFFCURVE",
-"209 631 OFFCURVE",
-"209 607 CURVE SMOOTH",
-"209 543 OFFCURVE",
-"174 491 OFFCURVE",
-"96 431 CURVE",
-"113 410 LINE",
-"197 462 OFFCURVE",
-"258 534 OFFCURVE",
-"258 628 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"511 628 LINE SMOOTH",
+"450 462 OFFCURVE",
+"511 534 OFFCURVE",
+"511 628 CURVE SMOOTH",
 "511 709 OFFCURVE",
 "466 773 OFFCURVE",
 "395 773 CURVE SMOOTH",
@@ -40582,10 +40207,34 @@ nodes = (
 "462 543 OFFCURVE",
 "427 491 OFFCURVE",
 "349 431 CURVE",
-"366 410 LINE",
-"450 462 OFFCURVE",
-"511 534 OFFCURVE",
-"511 628 CURVE SMOOTH"
+"366 410 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"197 462 OFFCURVE",
+"258 534 OFFCURVE",
+"258 628 CURVE SMOOTH",
+"258 709 OFFCURVE",
+"213 773 OFFCURVE",
+"142 773 CURVE SMOOTH",
+"86 773 OFFCURVE",
+"50 733 OFFCURVE",
+"50 681 CURVE SMOOTH",
+"50 640 OFFCURVE",
+"73 601 OFFCURVE",
+"123 601 CURVE SMOOTH",
+"171 601 OFFCURVE",
+"183 637 OFFCURVE",
+"198 637 CURVE SMOOTH",
+"204 637 OFFCURVE",
+"209 631 OFFCURVE",
+"209 607 CURVE SMOOTH",
+"209 543 OFFCURVE",
+"174 491 OFFCURVE",
+"96 431 CURVE",
+"113 410 LINE"
 );
 }
 );
@@ -40596,7 +40245,7 @@ unicode = 201D;
 },
 {
 glyphname = quoteleft;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -40604,10 +40253,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"27 580 LINE",
-"27 515 OFFCURVE",
-"66 465 OFFCURVE",
-"129 465 CURVE SMOOTH",
 "181 465 OFFCURVE",
 "213 499 OFFCURVE",
 "213 540 CURVE SMOOTH",
@@ -40626,7 +40271,10 @@ nodes = (
 "145 763 LINE",
 "78 719 OFFCURVE",
 "27 655 OFFCURVE",
-"27 580 CURVE"
+"27 580 CURVE",
+"27 515 OFFCURVE",
+"66 465 OFFCURVE",
+"129 465 CURVE SMOOTH"
 );
 }
 );
@@ -40725,10 +40373,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"50 555 LINE",
-"50 474 OFFCURVE",
-"95 410 OFFCURVE",
-"166 410 CURVE SMOOTH",
 "222 410 OFFCURVE",
 "258 450 OFFCURVE",
 "258 502 CURVE SMOOTH",
@@ -40747,7 +40391,10 @@ nodes = (
 "195 773 LINE",
 "111 721 OFFCURVE",
 "50 649 OFFCURVE",
-"50 555 CURVE"
+"50 555 CURVE",
+"50 474 OFFCURVE",
+"95 410 OFFCURVE",
+"166 410 CURVE SMOOTH"
 );
 }
 );
@@ -40758,7 +40405,144 @@ unicode = 2018;
 },
 {
 glyphname = quoteright;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"162 721 OFFCURVE",
+"131 763 OFFCURVE",
+"80 763 CURVE SMOOTH",
+"37 763 OFFCURVE",
+"10 734 OFFCURVE",
+"10 699 CURVE SMOOTH",
+"10 675 OFFCURVE",
+"24 649 OFFCURVE",
+"60 649 CURVE SMOOTH",
+"91 649 OFFCURVE",
+"111 676 OFFCURVE",
+"120 676 CURVE SMOOTH",
+"123 676 OFFCURVE",
+"125 673 OFFCURVE",
+"125 662 CURVE SMOOTH",
+"125 617 OFFCURVE",
+"93 569 OFFCURVE",
+"33 529 CURVE",
+"53 506 LINE",
+"115 544 OFFCURVE",
+"162 600 OFFCURVE",
+"162 667 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"115 544 OFFCURVE",
+"162 600 OFFCURVE",
+"162 667 CURVE SMOOTH",
+"162 667 LINE SMOOTH",
+"162 721 OFFCURVE",
+"131 763 OFFCURVE",
+"80 763 CURVE SMOOTH",
+"37 763 OFFCURVE",
+"10 734 OFFCURVE",
+"10 699 CURVE SMOOTH",
+"10 675 OFFCURVE",
+"24 649 OFFCURVE",
+"60 649 CURVE SMOOTH",
+"91 649 OFFCURVE",
+"111 676 OFFCURVE",
+"120 676 CURVE SMOOTH",
+"123 676 OFFCURVE",
+"125 673 OFFCURVE",
+"125 662 CURVE SMOOTH",
+"125 617 OFFCURVE",
+"93 569 OFFCURVE",
+"33 529 CURVE",
+"53 506 LINE"
+);
+}
+);
+width = 172;
+},
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"176 709 OFFCURVE",
+"146 764 OFFCURVE",
+"89 764 CURVE SMOOTH",
+"44 764 OFFCURVE",
+"10 730 OFFCURVE",
+"10 687 CURVE SMOOTH",
+"10 653 OFFCURVE",
+"30 620 OFFCURVE",
+"68 620 CURVE SMOOTH",
+"106 620 OFFCURVE",
+"111 652 OFFCURVE",
+"123 652 CURVE SMOOTH",
+"127 652 OFFCURVE",
+"132 648 OFFCURVE",
+"132 628 CURVE SMOOTH",
+"132 581 OFFCURVE",
+"105 543 OFFCURVE",
+"46 501 CURVE",
+"66 479 LINE",
+"133 524 OFFCURVE",
+"176 573 OFFCURVE",
+"176 647 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"133 524 OFFCURVE",
+"176 573 OFFCURVE",
+"176 647 CURVE SMOOTH",
+"176 647 LINE SMOOTH",
+"176 709 OFFCURVE",
+"146 764 OFFCURVE",
+"89 764 CURVE SMOOTH",
+"44 764 OFFCURVE",
+"10 730 OFFCURVE",
+"10 687 CURVE SMOOTH",
+"10 653 OFFCURVE",
+"30 620 OFFCURVE",
+"68 620 CURVE SMOOTH",
+"106 620 OFFCURVE",
+"111 652 OFFCURVE",
+"123 652 CURVE SMOOTH",
+"127 652 OFFCURVE",
+"132 648 OFFCURVE",
+"132 628 CURVE SMOOTH",
+"132 581 OFFCURVE",
+"105 543 OFFCURVE",
+"46 501 CURVE",
+"66 479 LINE"
+);
+}
+);
+width = 186;
+}
+);
+unicode = 2019;
+},
+{
+glyphname = quoteright;
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -40766,7 +40550,9 @@ paths = (
 {
 closed = 1;
 nodes = (
-"213 648 LINE SMOOTH",
+"162 509 OFFCURVE",
+"213 573 OFFCURVE",
+"213 648 CURVE SMOOTH",
 "213 713 OFFCURVE",
 "174 763 OFFCURVE",
 "111 763 CURVE SMOOTH",
@@ -40785,10 +40571,7 @@ nodes = (
 "181 595 OFFCURVE",
 "144 533 OFFCURVE",
 "78 486 CURVE",
-"95 465 LINE",
-"162 509 OFFCURVE",
-"213 573 OFFCURVE",
-"213 648 CURVE SMOOTH"
+"95 465 LINE"
 );
 }
 );
@@ -40883,7 +40666,9 @@ paths = (
 {
 closed = 1;
 nodes = (
-"258 618 LINE SMOOTH",
+"197 452 OFFCURVE",
+"258 524 OFFCURVE",
+"258 618 CURVE SMOOTH",
 "258 699 OFFCURVE",
 "213 763 OFFCURVE",
 "142 763 CURVE SMOOTH",
@@ -40902,10 +40687,7 @@ nodes = (
 "209 533 OFFCURVE",
 "174 481 OFFCURVE",
 "96 421 CURVE",
-"113 400 LINE",
-"197 452 OFFCURVE",
-"258 524 OFFCURVE",
-"258 618 CURVE SMOOTH"
+"113 400 LINE"
 );
 }
 );
@@ -40916,7 +40698,7 @@ unicode = 2019;
 },
 {
 glyphname = quotesinglbase;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -40924,7 +40706,9 @@ paths = (
 {
 closed = 1;
 nodes = (
-"213 30 LINE SMOOTH",
+"162 -109 OFFCURVE",
+"213 -45 OFFCURVE",
+"213 30 CURVE SMOOTH",
 "213 95 OFFCURVE",
 "174 145 OFFCURVE",
 "111 145 CURVE SMOOTH",
@@ -40943,10 +40727,7 @@ nodes = (
 "181 -23 OFFCURVE",
 "144 -85 OFFCURVE",
 "78 -132 CURVE",
-"95 -153 LINE",
-"162 -109 OFFCURVE",
-"213 -45 OFFCURVE",
-"213 30 CURVE SMOOTH"
+"95 -153 LINE"
 );
 }
 );
@@ -41041,7 +40822,9 @@ paths = (
 {
 closed = 1;
 nodes = (
-"258 47 LINE SMOOTH",
+"197 -119 OFFCURVE",
+"258 -47 OFFCURVE",
+"258 47 CURVE SMOOTH",
 "258 128 OFFCURVE",
 "213 192 OFFCURVE",
 "142 192 CURVE SMOOTH",
@@ -41060,10 +40843,7 @@ nodes = (
 "209 -38 OFFCURVE",
 "174 -90 OFFCURVE",
 "96 -150 CURVE",
-"113 -171 LINE",
-"197 -119 OFFCURVE",
-"258 -47 OFFCURVE",
-"258 47 CURVE SMOOTH"
+"113 -171 LINE"
 );
 }
 );
@@ -41088,8 +40868,8 @@ width = 160;
 unicode = 0020;
 },
 {
-glyphname = uni00A0;
-lastChange = "2016-08-16 11:12:00 +0000";
+glyphname = nbspace;
+lastChange = "2016-08-18 21:39:28 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -41119,7 +40899,7 @@ unicode = 000D;
 },
 {
 glyphname = .notdef;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:28:22 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -41127,55 +40907,55 @@ paths = (
 {
 closed = 1;
 nodes = (
-"127 -326 LINE",
-"221 -326 LINE",
+"201 899 LINE",
 "221 924 LINE",
-"127 924 LINE"
+"608 -301 LINE",
+"588 -326 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"127 -326 LINE",
 "682 -326 LINE",
 "682 -301 LINE",
-"127 -301 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"127 899 LINE",
-"682 899 LINE",
-"682 924 LINE",
-"127 924 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"588 -326 LINE",
-"682 -326 LINE",
-"682 924 LINE",
-"588 924 LINE"
+"127 -301 LINE",
+"127 -326 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
 "221 -326 LINE",
-"608 899 LINE",
-"588 924 LINE",
-"201 -301 LINE"
+"221 924 LINE",
+"127 924 LINE",
+"127 -326 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"201 899 LINE",
-"588 -326 LINE",
-"608 -301 LINE",
-"221 924 LINE"
+"608 899 LINE",
+"588 924 LINE",
+"201 -301 LINE",
+"221 -326 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"682 -326 LINE",
+"682 924 LINE",
+"588 924 LINE",
+"588 -326 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"682 899 LINE",
+"682 924 LINE",
+"127 924 LINE",
+"127 899 LINE"
 );
 }
 );
@@ -41187,192 +40967,65 @@ paths = (
 {
 closed = 1;
 nodes = (
-"127 -326 LINE",
-"221 -326 LINE",
+"201 899 LINE",
 "221 924 LINE",
-"127 924 LINE"
+"608 -301 LINE",
+"588 -326 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"127 -326 LINE",
 "682 -326 LINE",
 "682 -301 LINE",
-"127 -301 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"127 899 LINE",
-"682 899 LINE",
-"682 924 LINE",
-"127 924 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"588 -326 LINE",
-"682 -326 LINE",
-"682 924 LINE",
-"588 924 LINE"
+"127 -301 LINE",
+"127 -326 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
 "221 -326 LINE",
-"608 899 LINE",
-"588 924 LINE",
-"201 -301 LINE"
+"221 924 LINE",
+"127 924 LINE",
+"127 -326 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"201 899 LINE",
-"588 -326 LINE",
-"608 -301 LINE",
-"221 924 LINE"
+"608 899 LINE",
+"588 924 LINE",
+"201 -301 LINE",
+"221 -326 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"682 -326 LINE",
+"682 924 LINE",
+"588 924 LINE",
+"588 -326 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"682 899 LINE",
+"682 924 LINE",
+"127 924 LINE",
+"127 899 LINE"
 );
 }
 );
 width = 809;
 }
 );
-},
-{
-glyphname = Euro;
-lastChange = "2016-08-16 11:12:00 +0000";
-layers = (
-{
-layerId = UUID0;
-paths = (
-{
-closed = 1;
-nodes = (
-"485 325 LINE",
-"251 325 LINE",
-"251 407 LINE",
-"485 407 LINE",
-"485 451 LINE",
-"251 451 LINE",
-"251 614 OFFCURVE",
-"288 703 OFFCURVE",
-"369 703 CURVE SMOOTH",
-"449 703 OFFCURVE",
-"497 633 OFFCURVE",
-"512 540 CURVE",
-"546 540 LINE",
-"546 733 LINE",
-"521 733 LINE",
-"483 679 LINE",
-"464 703 OFFCURVE",
-"421 734 OFFCURVE",
-"357 734 CURVE SMOOTH",
-"214 734 OFFCURVE",
-"135 587 OFFCURVE",
-"110 451 CURVE",
-"26 451 LINE",
-"26 407 LINE",
-"102 407 LINE",
-"101 392 OFFCURVE",
-"101 375 OFFCURVE",
-"101 360 CURVE SMOOTH",
-"101 325 LINE",
-"26 325 LINE",
-"26 279 LINE",
-"108 279 LINE",
-"130 139 OFFCURVE",
-"209 -13 OFFCURVE",
-"357 -13 CURVE SMOOTH",
-"415 -13 OFFCURVE",
-"461 14 OFFCURVE",
-"481 40 CURVE",
-"521 0 LINE",
-"546 0 LINE",
-"546 179 LINE",
-"512 179 LINE",
-"497 86 OFFCURVE",
-"448 17 OFFCURVE",
-"356 17 CURVE SMOOTH",
-"271 17 OFFCURVE",
-"252 165 OFFCURVE",
-"251 279 CURVE",
-"485 279 LINE"
-);
-}
-);
-width = 581;
-},
-{
-layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
-paths = (
-{
-closed = 1;
-nodes = (
-"525 330 LINE",
-"291 330 LINE",
-"291 402 LINE",
-"525 402 LINE",
-"525 451 LINE",
-"291 451 LINE",
-"291 605 OFFCURVE",
-"328 698 OFFCURVE",
-"422 698 CURVE SMOOTH",
-"506 698 OFFCURVE",
-"555 625 OFFCURVE",
-"572 540 CURVE",
-"606 540 LINE",
-"606 733 LINE",
-"581 733 LINE",
-"543 679 LINE",
-"520 703 OFFCURVE",
-"472 734 OFFCURVE",
-"396 734 CURVE SMOOTH",
-"229 734 OFFCURVE",
-"138 584 OFFCURVE",
-"110 451 CURVE",
-"26 451 LINE",
-"26 402 LINE",
-"102 402 LINE",
-"101 389 OFFCURVE",
-"101 373 OFFCURVE",
-"101 360 CURVE SMOOTH",
-"101 330 LINE",
-"26 330 LINE",
-"26 279 LINE",
-"108 279 LINE",
-"134 139 OFFCURVE",
-"226 -13 OFFCURVE",
-"395 -13 CURVE SMOOTH",
-"466 -13 OFFCURVE",
-"517 14 OFFCURVE",
-"541 40 CURVE",
-"581 0 LINE",
-"606 0 LINE",
-"606 179 LINE",
-"572 179 LINE",
-"556 95 OFFCURVE",
-"503 22 OFFCURVE",
-"423 22 CURVE SMOOTH",
-"310 22 OFFCURVE",
-"292 169 OFFCURVE",
-"291 279 CURVE",
-"525 279 LINE"
-);
-}
-);
-width = 651;
-}
-);
-unicode = 20AC;
 },
 {
 glyphname = cent;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -41432,7 +41085,19 @@ paths = (
 {
 closed = 1;
 nodes = (
-"266 576 LINE SMOOTH",
+"355 136 OFFCURVE",
+"419 201 OFFCURVE",
+"445 297 CURVE",
+"417 297 LINE",
+"381 202 OFFCURVE",
+"335 166 OFFCURVE",
+"262 166 CURVE SMOOTH",
+"185 166 OFFCURVE",
+"157 206 OFFCURVE",
+"157 368 CURVE SMOOTH",
+"157 539 OFFCURVE",
+"188 576 OFFCURVE",
+"266 576 CURVE SMOOTH",
 "307 576 OFFCURVE",
 "329 566 OFFCURVE",
 "329 544 CURVE SMOOTH",
@@ -41453,29 +41118,16 @@ nodes = (
 "27 370 CURVE SMOOTH",
 "27 251 OFFCURVE",
 "132 136 OFFCURVE",
-"259 136 CURVE SMOOTH",
-"355 136 OFFCURVE",
-"419 201 OFFCURVE",
-"445 297 CURVE",
-"417 297 LINE",
-"381 202 OFFCURVE",
-"335 166 OFFCURVE",
-"262 166 CURVE SMOOTH",
-"185 166 OFFCURVE",
-"157 206 OFFCURVE",
-"157 368 CURVE SMOOTH",
-"157 539 OFFCURVE",
-"188 576 OFFCURVE",
-"266 576 CURVE SMOOTH"
+"259 136 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"238 6 LINE",
 "267 6 LINE",
 "267 734 LINE",
-"238 734 LINE"
+"238 734 LINE",
+"238 6 LINE"
 );
 }
 );
@@ -41539,7 +41191,19 @@ paths = (
 {
 closed = 1;
 nodes = (
-"299 570 LINE SMOOTH",
+"395 135 OFFCURVE",
+"463 200 OFFCURVE",
+"490 296 CURVE",
+"457 296 LINE",
+"420 205 OFFCURVE",
+"372 170 OFFCURVE",
+"300 170 CURVE SMOOTH",
+"224 170 OFFCURVE",
+"200 209 OFFCURVE",
+"200 363 CURVE SMOOTH",
+"200 536 OFFCURVE",
+"230 570 OFFCURVE",
+"299 570 CURVE SMOOTH",
 "339 570 OFFCURVE",
 "357 562 OFFCURVE",
 "357 546 CURVE SMOOTH",
@@ -41560,29 +41224,16 @@ nodes = (
 "45 370 CURVE SMOOTH",
 "45 250 OFFCURVE",
 "155 135 OFFCURVE",
-"292 135 CURVE SMOOTH",
-"395 135 OFFCURVE",
-"463 200 OFFCURVE",
-"490 296 CURVE",
-"457 296 LINE",
-"420 205 OFFCURVE",
-"372 170 OFFCURVE",
-"300 170 CURVE SMOOTH",
-"224 170 OFFCURVE",
-"200 209 OFFCURVE",
-"200 363 CURVE SMOOTH",
-"200 536 OFFCURVE",
-"230 570 OFFCURVE",
-"299 570 CURVE SMOOTH"
+"292 135 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"270 6 LINE",
 "299 6 LINE",
 "299 734 LINE",
-"270 734 LINE"
+"270 734 LINE",
+"270 6 LINE"
 );
 }
 );
@@ -41592,8 +41243,8 @@ width = 520;
 unicode = 00A2;
 },
 {
-glyphname = colonmonetary;
-lastChange = "2016-08-16 11:12:00 +0000";
+glyphname = colonsign;
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -41601,16 +41252,19 @@ paths = (
 {
 closed = 1;
 nodes = (
-"236 23 LINE",
-"394 733 LINE",
-"362 733 LINE",
-"204 23 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"266 576 LINE SMOOTH",
+"355 136 OFFCURVE",
+"419 201 OFFCURVE",
+"445 297 CURVE",
+"417 297 LINE",
+"381 202 OFFCURVE",
+"335 166 OFFCURVE",
+"262 166 CURVE SMOOTH",
+"185 166 OFFCURVE",
+"157 206 OFFCURVE",
+"157 368 CURVE SMOOTH",
+"157 529 OFFCURVE",
+"188 576 OFFCURVE",
+"266 576 CURVE SMOOTH",
 "347 576 OFFCURVE",
 "383 515 OFFCURVE",
 "394 445 CURVE",
@@ -41626,20 +41280,7 @@ nodes = (
 "27 370 CURVE SMOOTH",
 "27 251 OFFCURVE",
 "132 136 OFFCURVE",
-"259 136 CURVE SMOOTH",
-"355 136 OFFCURVE",
-"419 201 OFFCURVE",
-"445 297 CURVE",
-"417 297 LINE",
-"381 202 OFFCURVE",
-"335 166 OFFCURVE",
-"262 166 CURVE SMOOTH",
-"185 166 OFFCURVE",
-"157 206 OFFCURVE",
-"157 368 CURVE SMOOTH",
-"157 529 OFFCURVE",
-"188 576 OFFCURVE",
-"266 576 CURVE SMOOTH"
+"259 136 CURVE SMOOTH"
 );
 },
 {
@@ -41649,6 +41290,15 @@ nodes = (
 "320 733 LINE",
 "288 733 LINE",
 "130 23 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"236 23 LINE",
+"394 733 LINE",
+"362 733 LINE",
+"204 23 LINE"
 );
 }
 );
@@ -41660,16 +41310,19 @@ paths = (
 {
 closed = 1;
 nodes = (
-"255 23 LINE",
-"413 733 LINE",
-"381 733 LINE",
-"223 23 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"300 572 LINE SMOOTH",
+"387 137 OFFCURVE",
+"444 201 OFFCURVE",
+"470 298 CURVE",
+"437 298 LINE",
+"404 209 OFFCURVE",
+"366 172 OFFCURVE",
+"297 172 CURVE SMOOTH",
+"224 172 OFFCURVE",
+"200 214 OFFCURVE",
+"200 364 CURVE SMOOTH",
+"200 525 OFFCURVE",
+"228 572 OFFCURVE",
+"300 572 CURVE SMOOTH",
 "393 572 OFFCURVE",
 "422 492 OFFCURVE",
 "422 440 CURVE",
@@ -41685,20 +41338,7 @@ nodes = (
 "45 372 CURVE SMOOTH",
 "45 252 OFFCURVE",
 "157 137 OFFCURVE",
-"289 137 CURVE SMOOTH",
-"387 137 OFFCURVE",
-"444 201 OFFCURVE",
-"470 298 CURVE",
-"437 298 LINE",
-"404 209 OFFCURVE",
-"366 172 OFFCURVE",
-"297 172 CURVE SMOOTH",
-"224 172 OFFCURVE",
-"200 214 OFFCURVE",
-"200 364 CURVE SMOOTH",
-"200 525 OFFCURVE",
-"228 572 OFFCURVE",
-"300 572 CURVE SMOOTH"
+"289 137 CURVE SMOOTH"
 );
 },
 {
@@ -41709,6 +41349,15 @@ nodes = (
 "307 733 LINE",
 "149 23 LINE"
 );
+},
+{
+closed = 1;
+nodes = (
+"255 23 LINE",
+"413 733 LINE",
+"381 733 LINE",
+"223 23 LINE"
+);
 }
 );
 width = 500;
@@ -41718,7 +41367,7 @@ unicode = 20A1;
 },
 {
 glyphname = currency;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -41726,10 +41375,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"100 368 LINE SMOOTH",
-"100 240 OFFCURVE",
-"204 135 OFFCURVE",
-"334 135 CURVE SMOOTH",
 "464 135 OFFCURVE",
 "569 240 OFFCURVE",
 "569 368 CURVE SMOOTH",
@@ -41738,13 +41383,36 @@ nodes = (
 "334 602 CURVE SMOOTH",
 "204 602 OFFCURVE",
 "100 496 OFFCURVE",
-"100 368 CURVE SMOOTH"
+"100 368 CURVE SMOOTH",
+"100 240 OFFCURVE",
+"204 135 OFFCURVE",
+"334 135 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"165 368 LINE",
+"211 235 LINE",
+"194 262 LINE",
+"100 152 LINE",
+"122 135 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"212 500 LINE",
+"122 601 LINE",
+"100 584 LINE",
+"194 474 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"240 200 OFFCURVE",
+"165 275 OFFCURVE",
+"165 368 CURVE SMOOTH",
 "165 461 OFFCURVE",
 "240 537 OFFCURVE",
 "334 537 CURVE SMOOTH",
@@ -41753,28 +41421,7 @@ nodes = (
 "504 368 CURVE SMOOTH",
 "504 275 OFFCURVE",
 "428 200 OFFCURVE",
-"334 200 CURVE SMOOTH",
-"240 200 OFFCURVE",
-"165 275 OFFCURVE",
-"165 368 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"122 135 LINE",
-"211 235 LINE",
-"194 262 LINE",
-"100 152 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"547 601 LINE",
-"457 500 LINE",
-"475 474 LINE",
-"569 584 LINE"
+"334 200 CURVE SMOOTH"
 );
 },
 {
@@ -41789,10 +41436,10 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"100 584 LINE",
-"194 474 LINE",
-"212 500 LINE",
-"122 601 LINE"
+"569 584 LINE",
+"547 601 LINE",
+"457 500 LINE",
+"475 474 LINE"
 );
 }
 );
@@ -41804,10 +41451,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"100 368 LINE SMOOTH",
-"100 240 OFFCURVE",
-"204 135 OFFCURVE",
-"334 135 CURVE SMOOTH",
 "464 135 OFFCURVE",
 "569 240 OFFCURVE",
 "569 368 CURVE SMOOTH",
@@ -41816,13 +41459,36 @@ nodes = (
 "334 602 CURVE SMOOTH",
 "204 602 OFFCURVE",
 "100 496 OFFCURVE",
-"100 368 CURVE SMOOTH"
+"100 368 CURVE SMOOTH",
+"100 240 OFFCURVE",
+"204 135 OFFCURVE",
+"334 135 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"180 368 LINE",
+"231 225 LINE",
+"184 282 LINE",
+"90 172 LINE",
+"142 125 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"232 510 LINE",
+"142 611 LINE",
+"90 564 LINE",
+"184 454 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"248 215 OFFCURVE",
+"180 283 OFFCURVE",
+"180 368 CURVE SMOOTH",
 "180 453 OFFCURVE",
 "248 522 OFFCURVE",
 "334 522 CURVE SMOOTH",
@@ -41831,28 +41497,7 @@ nodes = (
 "489 368 CURVE SMOOTH",
 "489 283 OFFCURVE",
 "420 215 OFFCURVE",
-"334 215 CURVE SMOOTH",
-"248 215 OFFCURVE",
-"180 283 OFFCURVE",
-"180 368 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"142 125 LINE",
-"231 225 LINE",
-"184 282 LINE",
-"90 172 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"527 611 LINE",
-"437 510 LINE",
-"485 454 LINE",
-"579 564 LINE"
+"334 215 CURVE SMOOTH"
 );
 },
 {
@@ -41867,10 +41512,10 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"90 564 LINE",
-"184 454 LINE",
-"232 510 LINE",
-"142 611 LINE"
+"579 564 LINE",
+"527 611 LINE",
+"437 510 LINE",
+"485 454 LINE"
 );
 }
 );
@@ -41881,7 +41526,7 @@ unicode = 00A4;
 },
 {
 glyphname = dollar;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -41889,22 +41534,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"245 17 LINE SMOOTH",
-"148 17 OFFCURVE",
-"90 56 OFFCURVE",
-"90 82 CURVE SMOOTH",
-"90 110 OFFCURVE",
-"157 103 OFFCURVE",
-"157 162 CURVE SMOOTH",
-"157 195 OFFCURVE",
-"135 216 OFFCURVE",
-"97 216 CURVE SMOOTH",
-"49 216 OFFCURVE",
-"23 181 OFFCURVE",
-"23 135 CURVE SMOOTH",
-"23 50 OFFCURVE",
-"112 -13 OFFCURVE",
-"243 -13 CURVE SMOOTH",
 "405 -13 OFFCURVE",
 "499 82 OFFCURVE",
 "499 217 CURVE SMOOTH",
@@ -41943,25 +41572,40 @@ nodes = (
 "440 175 CURVE SMOOTH",
 "440 79 OFFCURVE",
 "368 17 OFFCURVE",
-"245 17 CURVE SMOOTH"
+"245 17 CURVE SMOOTH",
+"148 17 OFFCURVE",
+"90 56 OFFCURVE",
+"90 82 CURVE SMOOTH",
+"90 110 OFFCURVE",
+"157 103 OFFCURVE",
+"157 162 CURVE SMOOTH",
+"157 195 OFFCURVE",
+"135 216 OFFCURVE",
+"97 216 CURVE SMOOTH",
+"49 216 OFFCURVE",
+"23 181 OFFCURVE",
+"23 135 CURVE SMOOTH",
+"23 50 OFFCURVE",
+"112 -13 OFFCURVE",
+"243 -13 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"305 -113 LINE",
-"334 -113 LINE",
-"334 801 LINE",
-"305 801 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"193 -113 LINE",
 "222 -113 LINE",
 "222 801 LINE",
-"193 801 LINE"
+"193 801 LINE",
+"193 -113 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"334 -113 LINE",
+"334 801 LINE",
+"305 801 LINE",
+"305 -113 LINE"
 );
 }
 );
@@ -42412,22 +42056,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"298 26 LINE SMOOTH",
-"181 26 OFFCURVE",
-"107 64 OFFCURVE",
-"107 90 CURVE SMOOTH",
-"107 118 OFFCURVE",
-"191 104 OFFCURVE",
-"191 181 CURVE SMOOTH",
-"191 227 OFFCURVE",
-"160 257 OFFCURVE",
-"114 257 CURVE SMOOTH",
-"56 257 OFFCURVE",
-"23 211 OFFCURVE",
-"23 157 CURVE SMOOTH",
-"23 57 OFFCURVE",
-"138 -10 OFFCURVE",
-"294 -10 CURVE SMOOTH",
 "483 -10 OFFCURVE",
 "586 89 OFFCURVE",
 "586 226 CURVE SMOOTH",
@@ -42466,25 +42094,40 @@ nodes = (
 "514 156 CURVE SMOOTH",
 "514 80 OFFCURVE",
 "437 26 OFFCURVE",
-"298 26 CURVE SMOOTH"
+"298 26 CURVE SMOOTH",
+"181 26 OFFCURVE",
+"107 64 OFFCURVE",
+"107 90 CURVE SMOOTH",
+"107 118 OFFCURVE",
+"191 104 OFFCURVE",
+"191 181 CURVE SMOOTH",
+"191 227 OFFCURVE",
+"160 257 OFFCURVE",
+"114 257 CURVE SMOOTH",
+"56 257 OFFCURVE",
+"23 211 OFFCURVE",
+"23 157 CURVE SMOOTH",
+"23 57 OFFCURVE",
+"138 -10 OFFCURVE",
+"294 -10 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"351 -113 LINE",
-"391 -113 LINE",
-"391 804 LINE",
-"351 804 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"229 -113 LINE",
 "269 -113 LINE",
 "269 804 LINE",
-"229 804 LINE"
+"229 804 LINE",
+"229 -113 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"391 -113 LINE",
+"391 804 LINE",
+"351 804 LINE",
+"351 -113 LINE"
 );
 }
 );
@@ -42494,8 +42137,8 @@ width = 594;
 unicode = 0024;
 },
 {
-glyphname = florin;
-lastChange = "2016-08-16 11:12:00 +0000";
+glyphname = euro;
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -42503,6 +42146,136 @@ paths = (
 {
 closed = 1;
 nodes = (
+"415 -13 OFFCURVE",
+"461 14 OFFCURVE",
+"481 40 CURVE",
+"521 0 LINE",
+"546 0 LINE",
+"546 179 LINE",
+"512 179 LINE",
+"497 86 OFFCURVE",
+"448 17 OFFCURVE",
+"356 17 CURVE SMOOTH",
+"271 17 OFFCURVE",
+"252 165 OFFCURVE",
+"251 279 CURVE",
+"485 279 LINE",
+"485 325 LINE",
+"251 325 LINE",
+"251 407 LINE",
+"485 407 LINE",
+"485 451 LINE",
+"251 451 LINE",
+"251 614 OFFCURVE",
+"288 703 OFFCURVE",
+"369 703 CURVE SMOOTH",
+"449 703 OFFCURVE",
+"497 633 OFFCURVE",
+"512 540 CURVE",
+"546 540 LINE",
+"546 733 LINE",
+"521 733 LINE",
+"483 679 LINE",
+"464 703 OFFCURVE",
+"421 734 OFFCURVE",
+"357 734 CURVE SMOOTH",
+"214 734 OFFCURVE",
+"135 587 OFFCURVE",
+"110 451 CURVE",
+"26 451 LINE",
+"26 407 LINE",
+"102 407 LINE",
+"101 392 OFFCURVE",
+"101 375 OFFCURVE",
+"101 360 CURVE SMOOTH",
+"101 325 LINE",
+"26 325 LINE",
+"26 279 LINE",
+"108 279 LINE",
+"130 139 OFFCURVE",
+"209 -13 OFFCURVE",
+"357 -13 CURVE SMOOTH"
+);
+}
+);
+width = 581;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"466 -13 OFFCURVE",
+"517 14 OFFCURVE",
+"541 40 CURVE",
+"581 0 LINE",
+"606 0 LINE",
+"606 179 LINE",
+"572 179 LINE",
+"556 95 OFFCURVE",
+"503 22 OFFCURVE",
+"423 22 CURVE SMOOTH",
+"310 22 OFFCURVE",
+"292 169 OFFCURVE",
+"291 279 CURVE",
+"525 279 LINE",
+"525 330 LINE",
+"291 330 LINE",
+"291 402 LINE",
+"525 402 LINE",
+"525 451 LINE",
+"291 451 LINE",
+"291 605 OFFCURVE",
+"328 698 OFFCURVE",
+"422 698 CURVE SMOOTH",
+"506 698 OFFCURVE",
+"555 625 OFFCURVE",
+"572 540 CURVE",
+"606 540 LINE",
+"606 733 LINE",
+"581 733 LINE",
+"543 679 LINE",
+"520 703 OFFCURVE",
+"472 734 OFFCURVE",
+"396 734 CURVE SMOOTH",
+"229 734 OFFCURVE",
+"138 584 OFFCURVE",
+"110 451 CURVE",
+"26 451 LINE",
+"26 402 LINE",
+"102 402 LINE",
+"101 389 OFFCURVE",
+"101 373 OFFCURVE",
+"101 360 CURVE SMOOTH",
+"101 330 LINE",
+"26 330 LINE",
+"26 279 LINE",
+"108 279 LINE",
+"134 139 OFFCURVE",
+"226 -13 OFFCURVE",
+"395 -13 CURVE SMOOTH"
+);
+}
+);
+width = 651;
+}
+);
+unicode = 20AC;
+},
+{
+glyphname = florin;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"32 -314 OFFCURVE",
+"144 -249 OFFCURVE",
+"194 45 CURVE SMOOTH",
 "271 501 LINE SMOOTH",
 "300 676 OFFCURVE",
 "335 724 OFFCURVE",
@@ -42543,19 +42316,16 @@ nodes = (
 "-159 -240 CURVE SMOOTH",
 "-159 -292 OFFCURVE",
 "-93 -314 OFFCURVE",
-"-47 -314 CURVE SMOOTH",
-"32 -314 OFFCURVE",
-"144 -249 OFFCURVE",
-"194 45 CURVE SMOOTH"
+"-47 -314 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"41 396 LINE",
 "362 396 LINE",
 "362 440 LINE",
-"41 440 LINE"
+"41 440 LINE",
+"41 396 LINE"
 );
 }
 );
@@ -42567,6 +42337,9 @@ paths = (
 {
 closed = 1;
 nodes = (
+"10 -314 OFFCURVE",
+"144 -250 OFFCURVE",
+"194 45 CURVE SMOOTH",
 "271 501 LINE SMOOTH",
 "300 673 OFFCURVE",
 "334 724 OFFCURVE",
@@ -42607,19 +42380,16 @@ nodes = (
 "-209 -230 CURVE SMOOTH",
 "-209 -289 OFFCURVE",
 "-132 -314 OFFCURVE",
-"-76 -314 CURVE SMOOTH",
-"10 -314 OFFCURVE",
-"144 -250 OFFCURVE",
-"194 45 CURVE SMOOTH"
+"-76 -314 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"21 391 LINE",
 "382 391 LINE",
 "382 440 LINE",
-"21 440 LINE"
+"21 440 LINE",
+"21 391 LINE"
 );
 }
 );
@@ -42630,7 +42400,7 @@ unicode = 0192;
 },
 {
 glyphname = franc;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -42638,15 +42408,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"10 729 LINE",
-"128 729 LINE",
-"128 199 LINE",
-"10 199 LINE",
-"10 155 LINE",
-"128 155 LINE",
-"128 25 LINE",
-"10 25 LINE",
-"10 0 LINE",
 "372 0 LINE",
 "372 25 LINE",
 "262 25 LINE",
@@ -42671,7 +42432,16 @@ nodes = (
 "586 509 CURVE",
 "621 509 LINE",
 "621 754 LINE",
-"10 754 LINE"
+"10 754 LINE",
+"10 729 LINE",
+"128 729 LINE",
+"128 199 LINE",
+"10 199 LINE",
+"10 155 LINE",
+"128 155 LINE",
+"128 25 LINE",
+"10 25 LINE",
+"10 0 LINE"
 );
 }
 );
@@ -42683,15 +42453,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"20 724 LINE",
-"115 724 LINE",
-"115 199 LINE",
-"20 199 LINE",
-"20 150 LINE",
-"115 150 LINE",
-"115 30 LINE",
-"20 30 LINE",
-"20 0 LINE",
 "401 0 LINE",
 "401 30 LINE",
 "273 30 LINE",
@@ -42716,7 +42477,16 @@ nodes = (
 "606 539 CURVE",
 "646 539 LINE",
 "646 754 LINE",
-"20 754 LINE"
+"20 754 LINE",
+"20 724 LINE",
+"115 724 LINE",
+"115 199 LINE",
+"20 199 LINE",
+"20 150 LINE",
+"115 150 LINE",
+"115 30 LINE",
+"20 30 LINE",
+"20 0 LINE"
 );
 }
 );
@@ -42727,7 +42497,7 @@ unicode = 20A3;
 },
 {
 glyphname = lira;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -42735,37 +42505,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"53 58 LINE SMOOTH",
-"53 91 OFFCURVE",
-"80 110 OFFCURVE",
-"109 110 CURVE SMOOTH",
-"134 110 OFFCURVE",
-"172 96 OFFCURVE",
-"191 78 CURVE",
-"178 47 OFFCURVE",
-"140 10 OFFCURVE",
-"102 10 CURVE SMOOTH",
-"75 10 OFFCURVE",
-"53 28 OFFCURVE",
-"53 58 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"201 154 LINE",
-"201 145 OFFCURVE",
-"201 135 OFFCURVE",
-"199 126 CURVE",
-"172 135 OFFCURVE",
-"143 144 OFFCURVE",
-"114 144 CURVE SMOOTH",
-"64 144 OFFCURVE",
-"16 117 OFFCURVE",
-"16 60 CURVE SMOOTH",
-"16 12 OFFCURVE",
-"49 -20 OFFCURVE",
-"102 -20 CURVE SMOOTH",
 "157 -20 OFFCURVE",
 "206 15 OFFCURVE",
 "226 54 CURVE",
@@ -42811,25 +42550,54 @@ nodes = (
 "134 470 CURVE SMOOTH",
 "134 330 OFFCURVE",
 "201 242 OFFCURVE",
-"201 154 CURVE"
+"201 154 CURVE",
+"201 145 OFFCURVE",
+"201 135 OFFCURVE",
+"199 126 CURVE",
+"172 135 OFFCURVE",
+"143 144 OFFCURVE",
+"114 144 CURVE SMOOTH",
+"64 144 OFFCURVE",
+"16 117 OFFCURVE",
+"16 60 CURVE SMOOTH",
+"16 12 OFFCURVE",
+"49 -20 OFFCURVE",
+"102 -20 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"41 396 LINE",
-"415 396 LINE",
-"415 440 LINE",
-"41 440 LINE"
+"75 10 OFFCURVE",
+"53 28 OFFCURVE",
+"53 58 CURVE SMOOTH",
+"53 91 OFFCURVE",
+"80 110 OFFCURVE",
+"109 110 CURVE SMOOTH",
+"134 110 OFFCURVE",
+"172 96 OFFCURVE",
+"191 78 CURVE",
+"178 47 OFFCURVE",
+"140 10 OFFCURVE",
+"102 10 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"41 276 LINE",
 "415 276 LINE",
 "415 320 LINE",
-"41 320 LINE"
+"41 320 LINE",
+"41 276 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"415 396 LINE",
+"415 440 LINE",
+"41 440 LINE",
+"41 396 LINE"
 );
 }
 );
@@ -42943,37 +42711,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"58 58 LINE SMOOTH",
-"58 86 OFFCURVE",
-"79 105 OFFCURVE",
-"110 105 CURVE SMOOTH",
-"129 105 OFFCURVE",
-"160 98 OFFCURVE",
-"176 88 CURVE",
-"165 55 OFFCURVE",
-"135 15 OFFCURVE",
-"101 15 CURVE SMOOTH",
-"79 15 OFFCURVE",
-"58 31 OFFCURVE",
-"58 58 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"186 164 LINE SMOOTH",
-"186 155 OFFCURVE",
-"186 145 OFFCURVE",
-"184 136 CURVE",
-"159 139 OFFCURVE",
-"137 144 OFFCURVE",
-"115 144 CURVE SMOOTH",
-"63 144 OFFCURVE",
-"16 117 OFFCURVE",
-"16 59 CURVE SMOOTH",
-"16 12 OFFCURVE",
-"48 -20 OFFCURVE",
-"104 -20 CURVE SMOOTH",
 "165 -20 OFFCURVE",
 "224 17 OFFCURVE",
 "246 54 CURVE",
@@ -43019,25 +42756,54 @@ nodes = (
 "114 471 CURVE SMOOTH",
 "114 333 OFFCURVE",
 "186 248 OFFCURVE",
-"186 164 CURVE SMOOTH"
+"186 164 CURVE SMOOTH",
+"186 155 OFFCURVE",
+"186 145 OFFCURVE",
+"184 136 CURVE",
+"159 139 OFFCURVE",
+"137 144 OFFCURVE",
+"115 144 CURVE SMOOTH",
+"63 144 OFFCURVE",
+"16 117 OFFCURVE",
+"16 59 CURVE SMOOTH",
+"16 12 OFFCURVE",
+"48 -20 OFFCURVE",
+"104 -20 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"41 395 LINE",
-"435 395 LINE",
-"435 444 LINE",
-"41 444 LINE"
+"79 15 OFFCURVE",
+"58 31 OFFCURVE",
+"58 58 CURVE SMOOTH",
+"58 86 OFFCURVE",
+"79 105 OFFCURVE",
+"110 105 CURVE SMOOTH",
+"129 105 OFFCURVE",
+"160 98 OFFCURVE",
+"176 88 CURVE",
+"165 55 OFFCURVE",
+"135 15 OFFCURVE",
+"101 15 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"41 271 LINE",
 "435 271 LINE",
 "435 320 LINE",
-"41 320 LINE"
+"41 320 LINE",
+"41 271 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"435 395 LINE",
+"435 444 LINE",
+"41 444 LINE",
+"41 395 LINE"
 );
 }
 );
@@ -43047,8 +42813,8 @@ width = 559;
 unicode = 20A4;
 },
 {
-glyphname = sterling;
-lastChange = "2016-08-16 11:12:00 +0000";
+glyphname = liraTurkish;
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -43056,96 +42822,70 @@ paths = (
 {
 closed = 1;
 nodes = (
-"53 58 LINE SMOOTH",
-"53 91 OFFCURVE",
-"80 110 OFFCURVE",
-"109 110 CURVE SMOOTH",
-"134 110 OFFCURVE",
-"172 96 OFFCURVE",
-"191 78 CURVE",
-"178 47 OFFCURVE",
-"140 10 OFFCURVE",
-"102 10 CURVE SMOOTH",
-"75 10 OFFCURVE",
-"53 28 OFFCURVE",
-"53 58 CURVE SMOOTH"
+"266 0 LINE SMOOTH",
+"452 0 OFFCURVE",
+"556 86 OFFCURVE",
+"556 222 CURVE SMOOTH",
+"556 298 OFFCURVE",
+"523 339 OFFCURVE",
+"470 339 CURVE SMOOTH",
+"434 339 OFFCURVE",
+"412 321 OFFCURVE",
+"412 291 CURVE SMOOTH",
+"412 267 OFFCURVE",
+"426 249 OFFCURVE",
+"454 249 CURVE SMOOTH",
+"495 249 OFFCURVE",
+"486 286 OFFCURVE",
+"505 286 CURVE SMOOTH",
+"519 286 OFFCURVE",
+"528 264 OFFCURVE",
+"528 223 CURVE SMOOTH",
+"528 96 OFFCURVE",
+"442 25 OFFCURVE",
+"269 25 CURVE SMOOTH",
+"20 25 LINE",
+"20 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"201 154 LINE",
-"201 145 OFFCURVE",
-"201 135 OFFCURVE",
-"199 126 CURVE",
-"172 135 OFFCURVE",
-"143 144 OFFCURVE",
-"114 144 CURVE SMOOTH",
-"64 144 OFFCURVE",
-"16 117 OFFCURVE",
-"16 60 CURVE SMOOTH",
-"16 12 OFFCURVE",
-"49 -20 OFFCURVE",
-"102 -20 CURVE SMOOTH",
-"157 -20 OFFCURVE",
-"206 15 OFFCURVE",
-"226 54 CURVE",
-"295 -7 OFFCURVE",
-"335 -20 OFFCURVE",
-"379 -20 CURVE SMOOTH",
-"512 -20 OFFCURVE",
-"531 101 OFFCURVE",
-"531 204 CURVE",
-"507 204 LINE",
-"503 113 OFFCURVE",
-"451 79 OFFCURVE",
-"377 79 CURVE SMOOTH",
-"335 79 OFFCURVE",
-"289 90 OFFCURVE",
-"250 111 CURVE",
-"274 167 OFFCURVE",
-"286 225 OFFCURVE",
-"286 286 CURVE SMOOTH",
-"286 398 OFFCURVE",
-"246 485 OFFCURVE",
-"246 571 CURVE SMOOTH",
-"246 649 OFFCURVE",
-"279 703 OFFCURVE",
-"363 703 CURVE SMOOTH",
-"432 703 OFFCURVE",
-"464 666 OFFCURVE",
-"464 643 CURVE SMOOTH",
-"464 612 OFFCURVE",
-"406 616 OFFCURVE",
-"406 568 CURVE SMOOTH",
-"406 540 OFFCURVE",
-"425 519 OFFCURVE",
-"458 519 CURVE SMOOTH",
-"501 519 OFFCURVE",
-"521 553 OFFCURVE",
-"521 596 CURVE SMOOTH",
-"521 679 OFFCURVE",
-"447 733 OFFCURVE",
-"350 733 CURVE SMOOTH",
-"206 733 OFFCURVE",
-"134 615 OFFCURVE",
-"134 470 CURVE SMOOTH",
-"134 330 OFFCURVE",
-"201 242 OFFCURVE",
-"201 154 CURVE"
+"272 15 LINE",
+"272 754 LINE",
+"138 754 LINE",
+"138 15 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"41 355 LINE",
-"415 355 LINE",
-"415 399 LINE",
-"41 399 LINE"
+"470 427 LINE",
+"470 474 LINE",
+"35 318 LINE",
+"35 271 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"470 555 LINE",
+"470 602 LINE",
+"35 446 LINE",
+"35 399 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"393 729 LINE",
+"393 754 LINE",
+"20 754 LINE",
+"20 729 LINE"
 );
 }
 );
-width = 559;
+width = 570;
 },
 {
 layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
@@ -43153,103 +42893,77 @@ paths = (
 {
 closed = 1;
 nodes = (
-"58 58 LINE SMOOTH",
-"58 86 OFFCURVE",
-"79 105 OFFCURVE",
-"110 105 CURVE SMOOTH",
-"129 105 OFFCURVE",
-"160 98 OFFCURVE",
-"176 88 CURVE",
-"165 55 OFFCURVE",
-"135 15 OFFCURVE",
-"101 15 CURVE SMOOTH",
-"79 15 OFFCURVE",
-"58 31 OFFCURVE",
-"58 58 CURVE SMOOTH"
+"266 0 LINE SMOOTH",
+"452 0 OFFCURVE",
+"556 82 OFFCURVE",
+"556 212 CURVE SMOOTH",
+"556 294 OFFCURVE",
+"520 339 OFFCURVE",
+"463 339 CURVE SMOOTH",
+"421 339 OFFCURVE",
+"395 317 OFFCURVE",
+"395 281 CURVE SMOOTH",
+"395 251 OFFCURVE",
+"410 229 OFFCURVE",
+"442 229 CURVE SMOOTH",
+"487 229 OFFCURVE",
+"477 276 OFFCURVE",
+"498 276 CURVE SMOOTH",
+"512 276 OFFCURVE",
+"521 253 OFFCURVE",
+"521 213 CURVE SMOOTH",
+"521 98 OFFCURVE",
+"437 35 OFFCURVE",
+"269 35 CURVE SMOOTH",
+"20 35 LINE",
+"20 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"186 164 LINE",
-"186 155 OFFCURVE",
-"186 145 OFFCURVE",
-"184 136 CURVE",
-"159 139 OFFCURVE",
-"137 144 OFFCURVE",
-"115 144 CURVE SMOOTH",
-"63 144 OFFCURVE",
-"16 117 OFFCURVE",
-"16 59 CURVE SMOOTH",
-"16 12 OFFCURVE",
-"48 -20 OFFCURVE",
-"104 -20 CURVE SMOOTH",
-"165 -20 OFFCURVE",
-"224 17 OFFCURVE",
-"246 54 CURVE",
-"301 -3 OFFCURVE",
-"342 -20 OFFCURVE",
-"386 -20 CURVE SMOOTH",
-"508 -20 OFFCURVE",
-"546 113 OFFCURVE",
-"546 204 CURVE",
-"507 204 LINE",
-"502 122 OFFCURVE",
-"447 99 OFFCURVE",
-"374 99 CURVE SMOOTH",
-"343 99 OFFCURVE",
-"303 103 OFFCURVE",
-"270 111 CURVE",
-"294 167 OFFCURVE",
-"306 225 OFFCURVE",
-"306 286 CURVE SMOOTH",
-"306 397 OFFCURVE",
-"266 486 OFFCURVE",
-"266 569 CURVE SMOOTH",
-"266 644 OFFCURVE",
-"298 698 OFFCURVE",
-"373 698 CURVE SMOOTH",
-"429 698 OFFCURVE",
-"464 667 OFFCURVE",
-"464 643 CURVE SMOOTH",
-"464 611 OFFCURVE",
-"406 614 OFFCURVE",
-"406 563 CURVE SMOOTH",
-"406 532 OFFCURVE",
-"427 509 OFFCURVE",
-"463 509 CURVE SMOOTH",
-"510 509 OFFCURVE",
-"531 548 OFFCURVE",
-"531 593 CURVE SMOOTH",
-"531 681 OFFCURVE",
-"453 733 OFFCURVE",
-"349 733 CURVE SMOOTH",
-"192 733 OFFCURVE",
-"114 614 OFFCURVE",
-"114 471 CURVE SMOOTH",
-"114 333 OFFCURVE",
-"186 248 OFFCURVE",
-"186 164 CURVE"
+"273 20 LINE",
+"273 754 LINE",
+"115 754 LINE",
+"115 20 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"41 355 LINE",
-"435 355 LINE",
-"435 404 LINE",
-"41 404 LINE"
+"470 422 LINE",
+"470 474 LINE",
+"35 318 LINE",
+"35 266 LINE"
 );
-}
-);
-width = 559;
-}
-);
-unicode = 00A3;
 },
 {
-glyphname = uni20A6;
-lastChange = "2016-08-16 11:12:00 +0000";
+closed = 1;
+nodes = (
+"470 555 LINE",
+"470 607 LINE",
+"35 451 LINE",
+"35 399 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"393 724 LINE",
+"393 754 LINE",
+"20 754 LINE",
+"20 724 LINE"
+);
+}
+);
+width = 576;
+}
+);
+unicode = 20BA;
+},
+{
+glyphname = naira;
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 components = (
@@ -43262,19 +42976,19 @@ paths = (
 {
 closed = 1;
 nodes = (
-"20 512 LINE",
 "722 512 LINE",
 "722 556 LINE",
-"20 556 LINE"
+"20 556 LINE",
+"20 512 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"20 386 LINE",
 "722 386 LINE",
 "722 430 LINE",
-"20 430 LINE"
+"20 430 LINE",
+"20 386 LINE"
 );
 }
 );
@@ -43291,19 +43005,19 @@ paths = (
 {
 closed = 1;
 nodes = (
-"20 511 LINE",
-"772 511 LINE",
-"772 559 LINE",
-"20 559 LINE"
+"772 380 LINE",
+"772 429 LINE",
+"20 429 LINE",
+"20 380 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"20 380 LINE",
-"772 380 LINE",
-"772 429 LINE",
-"20 429 LINE"
+"772 511 LINE",
+"772 559 LINE",
+"20 559 LINE",
+"20 511 LINE"
 );
 }
 );
@@ -43313,73 +43027,8 @@ width = 743;
 unicode = 20A6;
 },
 {
-glyphname = uni20A9;
-lastChange = "2016-08-16 11:12:00 +0000";
-layers = (
-{
-components = (
-{
-name = W;
-}
-);
-layerId = UUID0;
-paths = (
-{
-closed = 1;
-nodes = (
-"40 502 LINE",
-"958 502 LINE",
-"958 546 LINE",
-"40 546 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"40 376 LINE",
-"958 376 LINE",
-"958 420 LINE",
-"40 420 LINE"
-);
-}
-);
-width = 907;
-},
-{
-components = (
-{
-name = W;
-}
-);
-layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
-paths = (
-{
-closed = 1;
-nodes = (
-"20 497 LINE",
-"978 497 LINE",
-"978 546 LINE",
-"20 546 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"20 371 LINE",
-"978 371 LINE",
-"978 420 LINE",
-"20 420 LINE"
-);
-}
-);
-width = 998;
-}
-);
-unicode = 20A9;
-},
-{
-glyphname = uni20B9;
-lastChange = "2016-08-16 11:12:00 +0000";
+glyphname = rupeeIndian;
+lastChange = "2016-08-19 17:07:29 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -43435,19 +43084,19 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"47 690 LINE",
-"569 690 LINE",
-"569 734 LINE",
-"47 734 LINE"
+"569 564 LINE",
+"569 608 LINE",
+"47 608 LINE",
+"47 564 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"47 564 LINE",
-"569 564 LINE",
-"569 608 LINE",
-"47 608 LINE"
+"569 690 LINE",
+"569 734 LINE",
+"47 734 LINE",
+"47 690 LINE"
 );
 }
 );
@@ -43507,19 +43156,19 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"47 685 LINE",
-"604 685 LINE",
-"604 734 LINE",
-"47 734 LINE"
+"604 559 LINE",
+"604 608 LINE",
+"47 608 LINE",
+"47 559 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"47 559 LINE",
-"604 559 LINE",
-"604 608 LINE",
-"47 608 LINE"
+"604 685 LINE",
+"604 734 LINE",
+"47 734 LINE",
+"47 685 LINE"
 );
 }
 );
@@ -43529,8 +43178,8 @@ width = 604;
 unicode = 20B9;
 },
 {
-glyphname = uni20BA;
-lastChange = "2016-08-16 11:12:00 +0000";
+glyphname = sterling;
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -43538,71 +43187,94 @@ paths = (
 {
 closed = 1;
 nodes = (
-"138 15 LINE",
-"272 15 LINE",
-"272 754 LINE",
-"138 754 LINE"
+"157 -20 OFFCURVE",
+"206 15 OFFCURVE",
+"226 54 CURVE",
+"295 -7 OFFCURVE",
+"335 -20 OFFCURVE",
+"379 -20 CURVE SMOOTH",
+"512 -20 OFFCURVE",
+"531 101 OFFCURVE",
+"531 204 CURVE",
+"507 204 LINE",
+"503 113 OFFCURVE",
+"451 79 OFFCURVE",
+"377 79 CURVE SMOOTH",
+"335 79 OFFCURVE",
+"289 90 OFFCURVE",
+"250 111 CURVE",
+"274 167 OFFCURVE",
+"286 225 OFFCURVE",
+"286 286 CURVE SMOOTH",
+"286 398 OFFCURVE",
+"246 485 OFFCURVE",
+"246 571 CURVE SMOOTH",
+"246 649 OFFCURVE",
+"279 703 OFFCURVE",
+"363 703 CURVE SMOOTH",
+"432 703 OFFCURVE",
+"464 666 OFFCURVE",
+"464 643 CURVE SMOOTH",
+"464 612 OFFCURVE",
+"406 616 OFFCURVE",
+"406 568 CURVE SMOOTH",
+"406 540 OFFCURVE",
+"425 519 OFFCURVE",
+"458 519 CURVE SMOOTH",
+"501 519 OFFCURVE",
+"521 553 OFFCURVE",
+"521 596 CURVE SMOOTH",
+"521 679 OFFCURVE",
+"447 733 OFFCURVE",
+"350 733 CURVE SMOOTH",
+"206 733 OFFCURVE",
+"134 615 OFFCURVE",
+"134 470 CURVE SMOOTH",
+"134 330 OFFCURVE",
+"201 242 OFFCURVE",
+"201 154 CURVE",
+"201 145 OFFCURVE",
+"201 135 OFFCURVE",
+"199 126 CURVE",
+"172 135 OFFCURVE",
+"143 144 OFFCURVE",
+"114 144 CURVE SMOOTH",
+"64 144 OFFCURVE",
+"16 117 OFFCURVE",
+"16 60 CURVE SMOOTH",
+"16 12 OFFCURVE",
+"49 -20 OFFCURVE",
+"102 -20 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"20 729 LINE",
-"393 729 LINE",
-"393 754 LINE",
-"20 754 LINE"
+"75 10 OFFCURVE",
+"53 28 OFFCURVE",
+"53 58 CURVE SMOOTH",
+"53 91 OFFCURVE",
+"80 110 OFFCURVE",
+"109 110 CURVE SMOOTH",
+"134 110 OFFCURVE",
+"172 96 OFFCURVE",
+"191 78 CURVE",
+"178 47 OFFCURVE",
+"140 10 OFFCURVE",
+"102 10 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"528 223 LINE SMOOTH",
-"528 96 OFFCURVE",
-"442 25 OFFCURVE",
-"269 25 CURVE SMOOTH",
-"20 25 LINE",
-"20 0 LINE",
-"266 0 LINE SMOOTH",
-"452 0 OFFCURVE",
-"556 86 OFFCURVE",
-"556 222 CURVE SMOOTH",
-"556 298 OFFCURVE",
-"523 339 OFFCURVE",
-"470 339 CURVE SMOOTH",
-"434 339 OFFCURVE",
-"412 321 OFFCURVE",
-"412 291 CURVE SMOOTH",
-"412 267 OFFCURVE",
-"426 249 OFFCURVE",
-"454 249 CURVE SMOOTH",
-"495 249 OFFCURVE",
-"486 286 OFFCURVE",
-"505 286 CURVE SMOOTH",
-"519 286 OFFCURVE",
-"528 264 OFFCURVE",
-"528 223 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"35 399 LINE",
-"470 555 LINE",
-"470 602 LINE",
-"35 446 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"35 271 LINE",
-"470 427 LINE",
-"470 474 LINE",
-"35 318 LINE"
+"415 355 LINE",
+"415 399 LINE",
+"41 399 LINE",
+"41 355 LINE"
 );
 }
 );
-width = 570;
+width = 559;
 },
 {
 layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
@@ -43610,78 +43282,166 @@ paths = (
 {
 closed = 1;
 nodes = (
-"115 20 LINE",
-"273 20 LINE",
-"273 754 LINE",
-"115 754 LINE"
+"165 -20 OFFCURVE",
+"224 17 OFFCURVE",
+"246 54 CURVE",
+"301 -3 OFFCURVE",
+"342 -20 OFFCURVE",
+"386 -20 CURVE SMOOTH",
+"508 -20 OFFCURVE",
+"546 113 OFFCURVE",
+"546 204 CURVE",
+"507 204 LINE",
+"502 122 OFFCURVE",
+"447 99 OFFCURVE",
+"374 99 CURVE SMOOTH",
+"343 99 OFFCURVE",
+"303 103 OFFCURVE",
+"270 111 CURVE",
+"294 167 OFFCURVE",
+"306 225 OFFCURVE",
+"306 286 CURVE SMOOTH",
+"306 397 OFFCURVE",
+"266 486 OFFCURVE",
+"266 569 CURVE SMOOTH",
+"266 644 OFFCURVE",
+"298 698 OFFCURVE",
+"373 698 CURVE SMOOTH",
+"429 698 OFFCURVE",
+"464 667 OFFCURVE",
+"464 643 CURVE SMOOTH",
+"464 611 OFFCURVE",
+"406 614 OFFCURVE",
+"406 563 CURVE SMOOTH",
+"406 532 OFFCURVE",
+"427 509 OFFCURVE",
+"463 509 CURVE SMOOTH",
+"510 509 OFFCURVE",
+"531 548 OFFCURVE",
+"531 593 CURVE SMOOTH",
+"531 681 OFFCURVE",
+"453 733 OFFCURVE",
+"349 733 CURVE SMOOTH",
+"192 733 OFFCURVE",
+"114 614 OFFCURVE",
+"114 471 CURVE SMOOTH",
+"114 333 OFFCURVE",
+"186 248 OFFCURVE",
+"186 164 CURVE",
+"186 155 OFFCURVE",
+"186 145 OFFCURVE",
+"184 136 CURVE",
+"159 139 OFFCURVE",
+"137 144 OFFCURVE",
+"115 144 CURVE SMOOTH",
+"63 144 OFFCURVE",
+"16 117 OFFCURVE",
+"16 59 CURVE SMOOTH",
+"16 12 OFFCURVE",
+"48 -20 OFFCURVE",
+"104 -20 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"20 724 LINE",
-"393 724 LINE",
-"393 754 LINE",
-"20 754 LINE"
+"79 15 OFFCURVE",
+"58 31 OFFCURVE",
+"58 58 CURVE SMOOTH",
+"58 86 OFFCURVE",
+"79 105 OFFCURVE",
+"110 105 CURVE SMOOTH",
+"129 105 OFFCURVE",
+"160 98 OFFCURVE",
+"176 88 CURVE",
+"165 55 OFFCURVE",
+"135 15 OFFCURVE",
+"101 15 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"521 213 LINE SMOOTH",
-"521 98 OFFCURVE",
-"437 35 OFFCURVE",
-"269 35 CURVE SMOOTH",
-"20 35 LINE",
-"20 0 LINE",
-"266 0 LINE SMOOTH",
-"452 0 OFFCURVE",
-"556 82 OFFCURVE",
-"556 212 CURVE SMOOTH",
-"556 294 OFFCURVE",
-"520 339 OFFCURVE",
-"463 339 CURVE SMOOTH",
-"421 339 OFFCURVE",
-"395 317 OFFCURVE",
-"395 281 CURVE SMOOTH",
-"395 251 OFFCURVE",
-"410 229 OFFCURVE",
-"442 229 CURVE SMOOTH",
-"487 229 OFFCURVE",
-"477 276 OFFCURVE",
-"498 276 CURVE SMOOTH",
-"512 276 OFFCURVE",
-"521 253 OFFCURVE",
-"521 213 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"35 399 LINE",
-"470 555 LINE",
-"470 607 LINE",
-"35 451 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"35 266 LINE",
-"470 422 LINE",
-"470 474 LINE",
-"35 318 LINE"
+"435 355 LINE",
+"435 404 LINE",
+"41 404 LINE",
+"41 355 LINE"
 );
 }
 );
-width = 576;
+width = 559;
 }
 );
-unicode = 20BA;
+unicode = 00A3;
+},
+{
+glyphname = won;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+components = (
+{
+name = W;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"958 502 LINE",
+"958 546 LINE",
+"40 546 LINE",
+"40 502 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"958 376 LINE",
+"958 420 LINE",
+"40 420 LINE",
+"40 376 LINE"
+);
+}
+);
+width = 907;
+},
+{
+components = (
+{
+name = W;
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"978 497 LINE",
+"978 546 LINE",
+"20 546 LINE",
+"20 497 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"978 371 LINE",
+"978 420 LINE",
+"20 420 LINE",
+"20 371 LINE"
+);
+}
+);
+width = 998;
+}
+);
+unicode = 20A9;
 },
 {
 glyphname = yen;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -43689,6 +43449,12 @@ paths = (
 {
 closed = 1;
 nodes = (
+"577 0 LINE",
+"577 25 LINE",
+"457 25 LINE",
+"457 362 LINE",
+"654 729 LINE",
+"750 729 LINE",
 "750 754 LINE",
 "485 754 LINE",
 "485 729 LINE",
@@ -43704,31 +43470,25 @@ nodes = (
 "323 343 LINE",
 "323 25 LINE",
 "203 25 LINE",
-"203 0 LINE",
-"577 0 LINE",
-"577 25 LINE",
-"457 25 LINE",
-"457 362 LINE",
-"654 729 LINE",
-"750 729 LINE"
+"203 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"141 334 LINE",
-"633 334 LINE",
-"633 378 LINE",
-"141 378 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"141 208 LINE",
 "633 208 LINE",
 "633 252 LINE",
-"141 252 LINE"
+"141 252 LINE",
+"141 208 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"633 334 LINE",
+"633 378 LINE",
+"141 378 LINE",
+"141 334 LINE"
 );
 }
 );
@@ -43740,6 +43500,12 @@ paths = (
 {
 closed = 1;
 nodes = (
+"593 0 LINE",
+"593 30 LINE",
+"475 30 LINE",
+"475 342 LINE",
+"667 724 LINE",
+"756 724 LINE",
 "756 754 LINE",
 "521 754 LINE",
 "521 724 LINE",
@@ -43755,31 +43521,25 @@ nodes = (
 "317 329 LINE",
 "317 30 LINE",
 "202 30 LINE",
-"202 0 LINE",
-"593 0 LINE",
-"593 30 LINE",
-"475 30 LINE",
-"475 342 LINE",
-"667 724 LINE",
-"756 724 LINE"
+"202 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"141 329 LINE",
-"633 329 LINE",
-"633 378 LINE",
-"141 378 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"141 203 LINE",
 "633 203 LINE",
 "633 252 LINE",
-"141 252 LINE"
+"141 252 LINE",
+"141 203 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"633 329 LINE",
+"633 378 LINE",
+"141 378 LINE",
+"141 329 LINE"
 );
 }
 );
@@ -43789,8 +43549,86 @@ width = 766;
 unicode = 00A5;
 },
 {
+glyphname = bulletoperator;
+lastChange = "2016-08-19 17:05:53 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"123 177 OFFCURVE",
+"156 210 OFFCURVE",
+"156 250 CURVE SMOOTH",
+"156 290 OFFCURVE",
+"123 323 OFFCURVE",
+"83 323 CURVE SMOOTH",
+"43 323 OFFCURVE",
+"10 290 OFFCURVE",
+"10 250 CURVE SMOOTH",
+"10 210 OFFCURVE",
+"43 177 OFFCURVE",
+"83 177 CURVE SMOOTH"
+);
+}
+);
+width = 166;
+},
+{
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+paths = (
+{
+closed = 1;
+nodes = (
+"185 167 OFFCURVE",
+"224 206 OFFCURVE",
+"224 254 CURVE SMOOTH",
+"224 302 OFFCURVE",
+"185 341 OFFCURVE",
+"137 341 CURVE SMOOTH",
+"89 341 OFFCURVE",
+"50 302 OFFCURVE",
+"50 254 CURVE SMOOTH",
+"50 206 OFFCURVE",
+"89 167 OFFCURVE",
+"137 167 CURVE SMOOTH"
+);
+}
+);
+width = 274;
+}
+);
+unicode = 2219;
+},
+{
+glyphname = divisionslash;
+lastChange = "2016-08-18 21:39:28 +0000";
+layers = (
+{
+components = (
+{
+name = fraction;
+}
+);
+layerId = UUID0;
+width = 489;
+},
+{
+components = (
+{
+name = fraction;
+}
+);
+layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
+width = 489;
+}
+);
+unicode = 2215;
+},
+{
 glyphname = plus;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -43820,19 +43658,19 @@ paths = (
 {
 closed = 1;
 nodes = (
-"40 321 LINE",
-"538 321 LINE",
-"538 365 LINE",
-"40 365 LINE"
+"311 74 LINE",
+"311 612 LINE",
+"267 612 LINE",
+"267 74 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"311 74 LINE",
-"311 612 LINE",
-"267 612 LINE",
-"267 74 LINE"
+"538 321 LINE",
+"538 365 LINE",
+"40 365 LINE",
+"40 321 LINE"
 );
 }
 );
@@ -43866,19 +43704,19 @@ paths = (
 {
 closed = 1;
 nodes = (
-"40 316 LINE",
-"538 316 LINE",
-"538 370 LINE",
-"40 370 LINE"
+"316 74 LINE",
+"316 612 LINE",
+"262 612 LINE",
+"262 74 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"316 74 LINE",
-"316 612 LINE",
-"262 612 LINE",
-"262 74 LINE"
+"538 316 LINE",
+"538 370 LINE",
+"40 370 LINE",
+"40 316 LINE"
 );
 }
 );
@@ -43889,7 +43727,7 @@ unicode = 002B;
 },
 {
 glyphname = minus;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -43910,10 +43748,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"40 321 LINE",
 "538 321 LINE",
 "538 365 LINE",
-"40 365 LINE"
+"40 365 LINE",
+"40 321 LINE"
 );
 }
 );
@@ -43938,10 +43776,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"40 316 LINE",
 "538 316 LINE",
 "538 370 LINE",
-"40 370 LINE"
+"40 370 LINE",
+"40 316 LINE"
 );
 }
 );
@@ -43952,7 +43790,7 @@ unicode = 2212;
 },
 {
 glyphname = multiply;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -43982,19 +43820,19 @@ paths = (
 {
 closed = 1;
 nodes = (
-"68 532 LINE",
-"478 122 LINE",
 "510 154 LINE",
-"100 564 LINE"
+"100 564 LINE",
+"68 532 LINE",
+"478 122 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"98 124 LINE",
 "508 534 LINE",
 "478 564 LINE",
-"70 156 LINE"
+"70 156 LINE",
+"98 124 LINE"
 );
 }
 );
@@ -44046,19 +43884,19 @@ paths = (
 {
 closed = 1;
 nodes = (
-"61 527 LINE",
-"471 117 LINE",
-"511 164 LINE",
-"101 574 LINE"
+"521 532 LINE",
+"477 575 LINE",
+"67 165 LINE",
+"111 122 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"111 122 LINE",
-"521 532 LINE",
-"477 575 LINE",
-"67 165 LINE"
+"511 164 LINE",
+"101 574 LINE",
+"61 527 LINE",
+"471 117 LINE"
 );
 }
 );
@@ -44069,7 +43907,7 @@ unicode = 00D7;
 },
 {
 glyphname = divide;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -44124,19 +43962,15 @@ paths = (
 {
 closed = 1;
 nodes = (
-"40 321 LINE",
 "538 321 LINE",
 "538 365 LINE",
-"40 365 LINE"
+"40 365 LINE",
+"40 321 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"235 156 LINE SMOOTH",
-"235 124 OFFCURVE",
-"262 97 OFFCURVE",
-"294 97 CURVE SMOOTH",
 "326 97 OFFCURVE",
 "353 124 OFFCURVE",
 "353 156 CURVE SMOOTH",
@@ -44145,16 +43979,15 @@ nodes = (
 "294 215 CURVE SMOOTH",
 "262 215 OFFCURVE",
 "235 188 OFFCURVE",
-"235 156 CURVE SMOOTH"
+"235 156 CURVE SMOOTH",
+"235 124 OFFCURVE",
+"262 97 OFFCURVE",
+"294 97 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"235 530 LINE SMOOTH",
-"235 498 OFFCURVE",
-"262 471 OFFCURVE",
-"294 471 CURVE SMOOTH",
 "326 471 OFFCURVE",
 "353 498 OFFCURVE",
 "353 530 CURVE SMOOTH",
@@ -44163,7 +43996,10 @@ nodes = (
 "294 589 CURVE SMOOTH",
 "262 589 OFFCURVE",
 "235 563 OFFCURVE",
-"235 530 CURVE SMOOTH"
+"235 530 CURVE SMOOTH",
+"235 498 OFFCURVE",
+"262 471 OFFCURVE",
+"294 471 CURVE SMOOTH"
 );
 }
 );
@@ -44222,19 +44058,15 @@ paths = (
 {
 closed = 1;
 nodes = (
-"40 316 LINE",
 "538 316 LINE",
 "538 370 LINE",
-"40 370 LINE"
+"40 370 LINE",
+"40 316 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"217 142 LINE SMOOTH",
-"217 100 OFFCURVE",
-"252 65 OFFCURVE",
-"294 65 CURVE SMOOTH",
 "336 65 OFFCURVE",
 "371 100 OFFCURVE",
 "371 142 CURVE SMOOTH",
@@ -44243,16 +44075,15 @@ nodes = (
 "294 219 CURVE SMOOTH",
 "252 219 OFFCURVE",
 "217 184 OFFCURVE",
-"217 142 CURVE SMOOTH"
+"217 142 CURVE SMOOTH",
+"217 100 OFFCURVE",
+"252 65 OFFCURVE",
+"294 65 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"217 544 LINE SMOOTH",
-"217 502 OFFCURVE",
-"252 467 OFFCURVE",
-"294 467 CURVE SMOOTH",
 "336 467 OFFCURVE",
 "371 502 OFFCURVE",
 "371 544 CURVE SMOOTH",
@@ -44261,7 +44092,10 @@ nodes = (
 "294 621 CURVE SMOOTH",
 "252 621 OFFCURVE",
 "217 586 OFFCURVE",
-"217 544 CURVE SMOOTH"
+"217 544 CURVE SMOOTH",
+"217 502 OFFCURVE",
+"252 467 OFFCURVE",
+"294 467 CURVE SMOOTH"
 );
 }
 );
@@ -44272,7 +44106,7 @@ unicode = 00F7;
 },
 {
 glyphname = equal;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -44302,19 +44136,19 @@ paths = (
 {
 closed = 1;
 nodes = (
-"50 235 LINE",
-"548 235 LINE",
-"548 283 LINE",
-"50 283 LINE"
+"548 402 LINE",
+"548 450 LINE",
+"50 450 LINE",
+"50 402 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"50 402 LINE",
-"548 402 LINE",
-"548 450 LINE",
-"50 450 LINE"
+"548 235 LINE",
+"548 283 LINE",
+"50 283 LINE",
+"50 235 LINE"
 );
 }
 );
@@ -44348,19 +44182,19 @@ paths = (
 {
 closed = 1;
 nodes = (
-"50 224 LINE",
-"548 224 LINE",
-"548 278 LINE",
-"50 278 LINE"
+"548 420 LINE",
+"548 474 LINE",
+"50 474 LINE",
+"50 420 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"50 420 LINE",
-"548 420 LINE",
-"548 474 LINE",
-"50 474 LINE"
+"548 224 LINE",
+"548 278 LINE",
+"50 278 LINE",
+"50 224 LINE"
 );
 }
 );
@@ -44371,7 +44205,7 @@ unicode = 003D;
 },
 {
 glyphname = notequal;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -44410,28 +44244,28 @@ paths = (
 {
 closed = 1;
 nodes = (
-"50 405 LINE",
-"548 405 LINE",
-"548 449 LINE",
-"50 449 LINE"
+"247 72 LINE",
+"396 604 LINE",
+"361 604 LINE",
+"212 72 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"50 239 LINE",
 "548 239 LINE",
 "548 283 LINE",
-"50 283 LINE"
+"50 283 LINE",
+"50 239 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"361 604 LINE",
-"212 72 LINE",
-"247 72 LINE",
-"396 604 LINE"
+"548 405 LINE",
+"548 449 LINE",
+"50 449 LINE",
+"50 405 LINE"
 );
 }
 );
@@ -44474,28 +44308,28 @@ paths = (
 {
 closed = 1;
 nodes = (
-"50 400 LINE",
-"548 400 LINE",
-"548 454 LINE",
-"50 454 LINE"
+"252 72 LINE",
+"401 604 LINE",
+"355 604 LINE",
+"206 72 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"50 234 LINE",
 "548 234 LINE",
 "548 288 LINE",
-"50 288 LINE"
+"50 288 LINE",
+"50 234 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"355 604 LINE",
-"206 72 LINE",
-"252 72 LINE",
-"401 604 LINE"
+"548 400 LINE",
+"548 454 LINE",
+"50 454 LINE",
+"50 400 LINE"
 );
 }
 );
@@ -44506,7 +44340,7 @@ unicode = 2260;
 },
 {
 glyphname = greater;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -44536,19 +44370,19 @@ paths = (
 {
 closed = 1;
 nodes = (
+"528 316 LINE",
 "528 373 LINE",
-"60 607 LINE",
-"60 553 LINE",
-"528 319 LINE"
+"60 139 LINE",
+"60 82 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
 "528 373 LINE",
-"60 139 LINE",
-"60 82 LINE",
-"528 316 LINE"
+"60 607 LINE",
+"60 553 LINE",
+"528 319 LINE"
 );
 }
 );
@@ -44582,19 +44416,19 @@ paths = (
 {
 closed = 1;
 nodes = (
+"528 311 LINE",
 "528 378 LINE",
-"60 612 LINE",
-"60 548 LINE",
-"528 314 LINE"
+"60 144 LINE",
+"60 77 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
 "528 378 LINE",
-"60 144 LINE",
-"60 77 LINE",
-"528 311 LINE"
+"60 612 LINE",
+"60 548 LINE",
+"528 314 LINE"
 );
 }
 );
@@ -44605,7 +44439,7 @@ unicode = 003E;
 },
 {
 glyphname = less;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -44635,19 +44469,19 @@ paths = (
 {
 closed = 1;
 nodes = (
-"60 319 LINE",
-"528 553 LINE",
-"528 607 LINE",
-"60 373 LINE"
+"528 139 LINE",
+"60 373 LINE",
+"60 316 LINE",
+"528 82 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"60 316 LINE",
-"528 82 LINE",
-"528 139 LINE",
-"60 373 LINE"
+"528 553 LINE",
+"528 607 LINE",
+"60 373 LINE",
+"60 319 LINE"
 );
 }
 );
@@ -44681,19 +44515,19 @@ paths = (
 {
 closed = 1;
 nodes = (
-"60 314 LINE",
-"528 548 LINE",
-"528 612 LINE",
-"60 378 LINE"
+"528 144 LINE",
+"60 378 LINE",
+"60 311 LINE",
+"528 77 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"60 311 LINE",
-"528 77 LINE",
-"528 144 LINE",
-"60 378 LINE"
+"528 548 LINE",
+"528 612 LINE",
+"60 378 LINE",
+"60 314 LINE"
 );
 }
 );
@@ -44704,7 +44538,7 @@ unicode = 003C;
 },
 {
 glyphname = greaterequal;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -44743,22 +44577,22 @@ paths = (
 {
 closed = 1;
 nodes = (
+"518 408 LINE",
 "518 465 LINE",
 "50 699 LINE",
 "50 645 LINE",
 "464 438 LINE",
 "50 231 LINE",
-"50 174 LINE",
-"518 408 LINE"
+"50 174 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
+"538 43 LINE",
 "538 87 LINE",
 "40 87 LINE",
-"40 43 LINE",
-"538 43 LINE"
+"40 43 LINE"
 );
 }
 );
@@ -44801,22 +44635,22 @@ paths = (
 {
 closed = 1;
 nodes = (
+"518 402 LINE",
 "518 469 LINE",
 "50 703 LINE",
 "50 639 LINE",
 "454 437 LINE",
 "50 235 LINE",
-"50 168 LINE",
-"518 402 LINE"
+"50 168 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
+"538 38 LINE",
 "538 92 LINE",
 "40 92 LINE",
-"40 38 LINE",
-"538 38 LINE"
+"40 38 LINE"
 );
 }
 );
@@ -44827,7 +44661,7 @@ unicode = 2265;
 },
 {
 glyphname = lessequal;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -44866,28 +44700,28 @@ paths = (
 {
 closed = 1;
 nodes = (
-"60 411 LINE",
-"528 645 LINE",
-"528 699 LINE",
-"60 465 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"60 408 LINE",
-"528 174 LINE",
 "528 231 LINE",
-"60 465 LINE"
+"60 465 LINE",
+"60 408 LINE",
+"528 174 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"40 43 LINE",
 "538 43 LINE",
 "538 87 LINE",
-"40 87 LINE"
+"40 87 LINE",
+"40 43 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"528 645 LINE",
+"528 699 LINE",
+"60 465 LINE",
+"60 411 LINE"
 );
 }
 );
@@ -44930,28 +44764,28 @@ paths = (
 {
 closed = 1;
 nodes = (
-"60 405 LINE",
-"528 639 LINE",
-"528 703 LINE",
-"60 469 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"60 402 LINE",
-"528 168 LINE",
 "528 235 LINE",
-"60 469 LINE"
+"60 469 LINE",
+"60 402 LINE",
+"528 168 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"40 38 LINE",
 "538 38 LINE",
 "538 92 LINE",
-"40 92 LINE"
+"40 92 LINE",
+"40 38 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"528 639 LINE",
+"528 703 LINE",
+"60 469 LINE",
+"60 405 LINE"
 );
 }
 );
@@ -44962,7 +44796,7 @@ unicode = 2264;
 },
 {
 glyphname = plusminus;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -45001,15 +44835,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"40 411 LINE",
-"538 411 LINE",
-"538 455 LINE",
-"40 455 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
 "311 164 LINE",
 "311 702 LINE",
 "267 702 LINE",
@@ -45019,10 +44844,19 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"40 43 LINE",
 "538 43 LINE",
 "538 87 LINE",
-"40 87 LINE"
+"40 87 LINE",
+"40 43 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"538 411 LINE",
+"538 455 LINE",
+"40 455 LINE",
+"40 411 LINE"
 );
 }
 );
@@ -45065,15 +44899,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"40 406 LINE",
-"538 406 LINE",
-"538 460 LINE",
-"40 460 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
 "316 164 LINE",
 "316 702 LINE",
 "262 702 LINE",
@@ -45083,10 +44908,19 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"40 38 LINE",
 "538 38 LINE",
 "538 92 LINE",
-"40 92 LINE"
+"40 92 LINE",
+"40 38 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"538 406 LINE",
+"538 460 LINE",
+"40 460 LINE",
+"40 406 LINE"
 );
 }
 );
@@ -45097,7 +44931,7 @@ unicode = 00B1;
 },
 {
 glyphname = approxequal;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -45159,6 +44993,15 @@ paths = (
 {
 closed = 1;
 nodes = (
+"111 400 OFFCURVE",
+"137 436 OFFCURVE",
+"182 436 CURVE SMOOTH",
+"252 436 OFFCURVE",
+"318 375 OFFCURVE",
+"393 375 CURVE SMOOTH",
+"465 375 OFFCURVE",
+"499 412 OFFCURVE",
+"534 458 CURVE",
 "496 487 LINE",
 "469 455 OFFCURVE",
 "439 423 OFFCURVE",
@@ -45169,21 +45012,21 @@ nodes = (
 "113 484 OFFCURVE",
 "81 445 OFFCURVE",
 "50 397 CURVE",
-"89 366 LINE",
-"111 400 OFFCURVE",
-"137 436 OFFCURVE",
-"182 436 CURVE SMOOTH",
-"252 436 OFFCURVE",
-"318 375 OFFCURVE",
-"393 375 CURVE SMOOTH",
-"465 375 OFFCURVE",
-"499 412 OFFCURVE",
-"534 458 CURVE"
+"89 366 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
+"111 233 OFFCURVE",
+"137 269 OFFCURVE",
+"182 269 CURVE SMOOTH",
+"252 269 OFFCURVE",
+"318 208 OFFCURVE",
+"393 208 CURVE SMOOTH",
+"465 208 OFFCURVE",
+"499 245 OFFCURVE",
+"534 291 CURVE",
 "496 320 LINE",
 "469 288 OFFCURVE",
 "439 256 OFFCURVE",
@@ -45194,16 +45037,7 @@ nodes = (
 "113 317 OFFCURVE",
 "81 278 OFFCURVE",
 "50 230 CURVE",
-"89 199 LINE",
-"111 233 OFFCURVE",
-"137 269 OFFCURVE",
-"182 269 CURVE SMOOTH",
-"252 269 OFFCURVE",
-"318 208 OFFCURVE",
-"393 208 CURVE SMOOTH",
-"465 208 OFFCURVE",
-"499 245 OFFCURVE",
-"534 291 CURVE"
+"89 199 LINE"
 );
 }
 );
@@ -45269,6 +45103,15 @@ paths = (
 {
 closed = 1;
 nodes = (
+"112 399 OFFCURVE",
+"137 436 OFFCURVE",
+"182 436 CURVE SMOOTH",
+"252 436 OFFCURVE",
+"318 375 OFFCURVE",
+"393 375 CURVE SMOOTH",
+"467 375 OFFCURVE",
+"509 419 OFFCURVE",
+"539 458 CURVE",
 "495 503 LINE",
 "462 464 OFFCURVE",
 "439 438 OFFCURVE",
@@ -45279,21 +45122,21 @@ nodes = (
 "111 499 OFFCURVE",
 "72 452 OFFCURVE",
 "44 410 CURVE",
-"90 365 LINE",
-"112 399 OFFCURVE",
-"137 436 OFFCURVE",
-"182 436 CURVE SMOOTH",
-"252 436 OFFCURVE",
-"318 375 OFFCURVE",
-"393 375 CURVE SMOOTH",
-"467 375 OFFCURVE",
-"509 419 OFFCURVE",
-"539 458 CURVE"
+"90 365 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
+"112 219 OFFCURVE",
+"137 256 OFFCURVE",
+"182 256 CURVE SMOOTH",
+"252 256 OFFCURVE",
+"318 195 OFFCURVE",
+"393 195 CURVE SMOOTH",
+"467 195 OFFCURVE",
+"509 239 OFFCURVE",
+"539 278 CURVE",
 "495 323 LINE",
 "462 284 OFFCURVE",
 "439 258 OFFCURVE",
@@ -45304,16 +45147,7 @@ nodes = (
 "111 319 OFFCURVE",
 "72 272 OFFCURVE",
 "44 230 CURVE",
-"90 185 LINE",
-"112 219 OFFCURVE",
-"137 256 OFFCURVE",
-"182 256 CURVE SMOOTH",
-"252 256 OFFCURVE",
-"318 195 OFFCURVE",
-"393 195 CURVE SMOOTH",
-"467 195 OFFCURVE",
-"509 239 OFFCURVE",
-"539 278 CURVE"
+"90 185 LINE"
 );
 }
 );
@@ -45324,7 +45158,7 @@ unicode = 2248;
 },
 {
 glyphname = asciitilde;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -45332,6 +45166,15 @@ paths = (
 {
 closed = 1;
 nodes = (
+"75 260 OFFCURVE",
+"97 291 OFFCURVE",
+"147 291 CURVE SMOOTH",
+"211 291 OFFCURVE",
+"271 230 OFFCURVE",
+"338 230 CURVE SMOOTH",
+"400 230 OFFCURVE",
+"433 274 OFFCURVE",
+"465 320 CURVE",
 "424 345 LINE",
 "400 309 OFFCURVE",
 "379 282 OFFCURVE",
@@ -45342,16 +45185,7 @@ nodes = (
 "78 343 OFFCURVE",
 "41 296 OFFCURVE",
 "10 248 CURVE",
-"50 221 LINE",
-"75 260 OFFCURVE",
-"97 291 OFFCURVE",
-"147 291 CURVE SMOOTH",
-"211 291 OFFCURVE",
-"271 230 OFFCURVE",
-"338 230 CURVE SMOOTH",
-"400 230 OFFCURVE",
-"433 274 OFFCURVE",
-"465 320 CURVE"
+"50 221 LINE"
 );
 }
 );
@@ -45363,6 +45197,15 @@ paths = (
 {
 closed = 1;
 nodes = (
+"75 250 OFFCURVE",
+"97 281 OFFCURVE",
+"147 281 CURVE SMOOTH",
+"211 281 OFFCURVE",
+"271 220 OFFCURVE",
+"338 220 CURVE SMOOTH",
+"405 220 OFFCURVE",
+"440 264 OFFCURVE",
+"475 310 CURVE",
 "424 355 LINE",
 "400 319 OFFCURVE",
 "379 292 OFFCURVE",
@@ -45373,16 +45216,7 @@ nodes = (
 "73 353 OFFCURVE",
 "33 306 OFFCURVE",
 "0 258 CURVE",
-"50 211 LINE",
-"75 250 OFFCURVE",
-"97 281 OFFCURVE",
-"147 281 CURVE SMOOTH",
-"211 281 OFFCURVE",
-"271 220 OFFCURVE",
-"338 220 CURVE SMOOTH",
-"405 220 OFFCURVE",
-"440 264 OFFCURVE",
-"475 310 CURVE"
+"50 211 LINE"
 );
 }
 );
@@ -45393,7 +45227,7 @@ unicode = 007E;
 },
 {
 glyphname = logicalnot;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -45423,19 +45257,19 @@ paths = (
 {
 closed = 1;
 nodes = (
-"20 282 LINE",
 "518 282 LINE",
 "518 326 LINE",
-"20 326 LINE"
+"20 326 LINE",
+"20 282 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"441 307 LINE",
-"441 72 LINE",
 "518 72 LINE",
-"518 307 LINE"
+"518 307 LINE",
+"441 307 LINE",
+"441 72 LINE"
 );
 }
 );
@@ -45469,19 +45303,19 @@ paths = (
 {
 closed = 1;
 nodes = (
-"20 277 LINE",
 "518 277 LINE",
 "518 326 LINE",
-"20 326 LINE"
+"20 326 LINE",
+"20 277 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"425 307 LINE",
-"425 55 LINE",
 "518 55 LINE",
-"518 307 LINE"
+"518 307 LINE",
+"425 307 LINE",
+"425 55 LINE"
 );
 }
 );
@@ -45492,7 +45326,7 @@ unicode = 00AC;
 },
 {
 glyphname = infinity;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -45500,7 +45334,15 @@ paths = (
 {
 closed = 1;
 nodes = (
-"742 296 LINE SMOOTH",
+"290 117 OFFCURVE",
+"346 168 OFFCURVE",
+"396 231 CURVE",
+"462 141 OFFCURVE",
+"520 117 OFFCURVE",
+"573 117 CURVE SMOOTH",
+"661 117 OFFCURVE",
+"742 183 OFFCURVE",
+"742 296 CURVE SMOOTH",
 "742 401 OFFCURVE",
 "672 468 OFFCURVE",
 "581 468 CURVE SMOOTH",
@@ -45515,22 +45357,12 @@ nodes = (
 "47 291 CURVE SMOOTH",
 "47 186 OFFCURVE",
 "122 117 OFFCURVE",
-"212 117 CURVE SMOOTH",
-"290 117 OFFCURVE",
-"346 168 OFFCURVE",
-"396 231 CURVE",
-"462 141 OFFCURVE",
-"520 117 OFFCURVE",
-"573 117 CURVE SMOOTH",
-"661 117 OFFCURVE",
-"742 183 OFFCURVE",
-"742 296 CURVE SMOOTH"
+"212 117 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"219 172 LINE SMOOTH",
 "154 172 OFFCURVE",
 "104 223 OFFCURVE",
 "104 293 CURVE SMOOTH",
@@ -45548,19 +45380,18 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"573 414 LINE SMOOTH",
-"641 414 OFFCURVE",
-"684 358 OFFCURVE",
-"684 294 CURVE SMOOTH",
-"684 238 OFFCURVE",
-"651 172 OFFCURVE",
-"577 172 CURVE SMOOTH",
 "521 172 OFFCURVE",
 "481 210 OFFCURVE",
 "418 294 CURVE",
 "474 374 OFFCURVE",
 "517 414 OFFCURVE",
-"573 414 CURVE SMOOTH"
+"573 414 CURVE SMOOTH",
+"641 414 OFFCURVE",
+"684 358 OFFCURVE",
+"684 294 CURVE SMOOTH",
+"684 238 OFFCURVE",
+"651 172 OFFCURVE",
+"577 172 CURVE SMOOTH"
 );
 }
 );
@@ -45572,7 +45403,15 @@ paths = (
 {
 closed = 1;
 nodes = (
-"766 297 LINE SMOOTH",
+"300 106 OFFCURVE",
+"354 153 OFFCURVE",
+"407 221 CURVE",
+"475 125 OFFCURVE",
+"536 106 OFFCURVE",
+"592 106 CURVE SMOOTH",
+"680 106 OFFCURVE",
+"766 175 OFFCURVE",
+"766 297 CURVE SMOOTH",
 "766 406 OFFCURVE",
 "689 477 OFFCURVE",
 "597 477 CURVE SMOOTH",
@@ -45587,22 +45426,12 @@ nodes = (
 "47 290 CURVE SMOOTH",
 "47 178 OFFCURVE",
 "129 106 OFFCURVE",
-"217 106 CURVE SMOOTH",
-"300 106 OFFCURVE",
-"354 153 OFFCURVE",
-"407 221 CURVE",
-"475 125 OFFCURVE",
-"536 106 OFFCURVE",
-"592 106 CURVE SMOOTH",
-"680 106 OFFCURVE",
-"766 175 OFFCURVE",
-"766 297 CURVE SMOOTH"
+"217 106 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"229 183 LINE SMOOTH",
 "170 183 OFFCURVE",
 "126 232 OFFCURVE",
 "126 289 CURVE SMOOTH",
@@ -45620,19 +45449,18 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"588 401 LINE SMOOTH",
-"649 401 OFFCURVE",
-"687 352 OFFCURVE",
-"687 289 CURVE SMOOTH",
-"687 244 OFFCURVE",
-"653 183 OFFCURVE",
-"594 183 CURVE SMOOTH",
 "541 183 OFFCURVE",
 "509 207 OFFCURVE",
 "446 294 CURVE",
 "511 376 OFFCURVE",
 "544 401 OFFCURVE",
-"588 401 CURVE SMOOTH"
+"588 401 CURVE SMOOTH",
+"649 401 OFFCURVE",
+"687 352 OFFCURVE",
+"687 289 CURVE SMOOTH",
+"687 244 OFFCURVE",
+"653 183 OFFCURVE",
+"594 183 CURVE SMOOTH"
 );
 }
 );
@@ -45643,7 +45471,7 @@ unicode = 221E;
 },
 {
 glyphname = integral;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -45651,7 +45479,9 @@ paths = (
 {
 closed = 1;
 nodes = (
-"276 159 LINE SMOOTH",
+"173 -202 OFFCURVE",
+"276 -138 OFFCURVE",
+"276 159 CURVE SMOOTH",
 "276 261 OFFCURVE",
 "264 560 OFFCURVE",
 "264 658 CURVE SMOOTH",
@@ -45693,10 +45523,7 @@ nodes = (
 "-20 -120 CURVE SMOOTH",
 "-20 -176 OFFCURVE",
 "42 -202 OFFCURVE",
-"93 -202 CURVE SMOOTH",
-"173 -202 OFFCURVE",
-"276 -138 OFFCURVE",
-"276 159 CURVE SMOOTH"
+"93 -202 CURVE SMOOTH"
 );
 }
 );
@@ -45708,7 +45535,9 @@ paths = (
 {
 closed = 1;
 nodes = (
-"291 161 LINE SMOOTH",
+"179 -202 OFFCURVE",
+"291 -140 OFFCURVE",
+"291 161 CURVE SMOOTH",
 "291 259 OFFCURVE",
 "279 560 OFFCURVE",
 "279 659 CURVE SMOOTH",
@@ -45750,10 +45579,7 @@ nodes = (
 "-30 -118 CURVE SMOOTH",
 "-30 -177 OFFCURVE",
 "37 -202 OFFCURVE",
-"92 -202 CURVE SMOOTH",
-"179 -202 OFFCURVE",
-"291 -140 OFFCURVE",
-"291 161 CURVE SMOOTH"
+"92 -202 CURVE SMOOTH"
 );
 }
 );
@@ -45763,8 +45589,8 @@ width = 446;
 unicode = 222B;
 },
 {
-glyphname = Omega;
-lastChange = "2016-08-16 11:12:00 +0000";
+glyphname = Ohm;
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -45772,6 +45598,22 @@ paths = (
 {
 closed = 1;
 nodes = (
+"332 0 LINE",
+"342 23 LINE",
+"254 156 OFFCURVE",
+"219 257 OFFCURVE",
+"219 412 CURVE SMOOTH",
+"219 636 OFFCURVE",
+"292 702 OFFCURVE",
+"377 702 CURVE SMOOTH",
+"468 702 OFFCURVE",
+"542 625 OFFCURVE",
+"542 408 CURVE SMOOTH",
+"542 267 OFFCURVE",
+"511 160 OFFCURVE",
+"418 23 CURVE",
+"427 0 LINE",
+"698 0 LINE",
 "727 174 LINE",
 "704 174 LINE",
 "683 109 OFFCURVE",
@@ -45795,23 +45637,7 @@ nodes = (
 "81 112 OFFCURVE",
 "59 174 CURVE",
 "35 174 LINE",
-"60 0 LINE",
-"332 0 LINE",
-"342 23 LINE",
-"254 156 OFFCURVE",
-"219 257 OFFCURVE",
-"219 412 CURVE SMOOTH",
-"219 636 OFFCURVE",
-"292 702 OFFCURVE",
-"377 702 CURVE SMOOTH",
-"468 702 OFFCURVE",
-"542 625 OFFCURVE",
-"542 408 CURVE SMOOTH",
-"542 267 OFFCURVE",
-"511 160 OFFCURVE",
-"418 23 CURVE",
-"427 0 LINE",
-"698 0 LINE"
+"60 0 LINE"
 );
 }
 );
@@ -45823,6 +45649,22 @@ paths = (
 {
 closed = 1;
 nodes = (
+"353 0 LINE",
+"363 26 LINE",
+"314 132 OFFCURVE",
+"251 268 OFFCURVE",
+"251 399 CURVE SMOOTH",
+"251 626 OFFCURVE",
+"311 694 OFFCURVE",
+"403 694 CURVE SMOOTH",
+"494 694 OFFCURVE",
+"560 615 OFFCURVE",
+"560 402 CURVE SMOOTH",
+"560 267 OFFCURVE",
+"488 123 OFFCURVE",
+"446 26 CURVE",
+"456 0 LINE",
+"744 0 LINE",
 "776 189 LINE",
 "735 189 LINE",
 "712 127 OFFCURVE",
@@ -45846,23 +45688,7 @@ nodes = (
 "99 128 OFFCURVE",
 "75 189 CURVE",
 "36 189 LINE",
-"63 0 LINE",
-"353 0 LINE",
-"363 26 LINE",
-"314 132 OFFCURVE",
-"251 268 OFFCURVE",
-"251 399 CURVE SMOOTH",
-"251 626 OFFCURVE",
-"311 694 OFFCURVE",
-"403 694 CURVE SMOOTH",
-"494 694 OFFCURVE",
-"560 615 OFFCURVE",
-"560 402 CURVE SMOOTH",
-"560 267 OFFCURVE",
-"488 123 OFFCURVE",
-"446 26 CURVE",
-"456 0 LINE",
-"744 0 LINE"
+"63 0 LINE"
 );
 }
 );
@@ -45872,8 +45698,8 @@ width = 812;
 unicode = 2126;
 },
 {
-glyphname = Delta;
-lastChange = "2016-08-16 11:12:00 +0000";
+glyphname = increment;
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -45892,9 +45718,9 @@ nodes = (
 {
 closed = 1;
 nodes = (
+"283 570 LINE",
 "482 37 LINE",
-"71 37 LINE",
-"283 570 LINE"
+"71 37 LINE"
 );
 }
 );
@@ -45917,9 +45743,9 @@ nodes = (
 {
 closed = 1;
 nodes = (
+"304 527 LINE",
 "495 73 LINE",
-"119 73 LINE",
-"304 527 LINE"
+"119 73 LINE"
 );
 }
 );
@@ -45930,7 +45756,7 @@ unicode = 2206;
 },
 {
 glyphname = product;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -45938,11 +45764,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"17 709 LINE",
-"107 709 LINE",
-"107 -54 LINE",
-"17 -54 LINE",
-"17 -79 LINE",
 "321 -79 LINE",
 "321 -54 LINE",
 "241 -54 LINE",
@@ -45957,7 +45778,12 @@ nodes = (
 "604 709 LINE",
 "694 709 LINE",
 "694 734 LINE",
-"17 734 LINE"
+"17 734 LINE",
+"17 709 LINE",
+"107 709 LINE",
+"107 -54 LINE",
+"17 -54 LINE",
+"17 -79 LINE"
 );
 }
 );
@@ -46016,11 +45842,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"31 703 LINE",
-"130 703 LINE",
-"130 -56 LINE",
-"31 -56 LINE",
-"31 -86 LINE",
 "361 -86 LINE",
 "361 -56 LINE",
 "288 -56 LINE",
@@ -46035,7 +45856,12 @@ nodes = (
 "670 703 LINE",
 "769 703 LINE",
 "769 733 LINE",
-"31 733 LINE"
+"31 733 LINE",
+"31 703 LINE",
+"130 703 LINE",
+"130 -56 LINE",
+"31 -56 LINE",
+"31 -86 LINE"
 );
 }
 );
@@ -46046,7 +45872,7 @@ unicode = 220F;
 },
 {
 glyphname = summation;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -46054,6 +45880,7 @@ paths = (
 {
 closed = 1;
 nodes = (
+"511 -87 LINE",
 "558 141 LINE",
 "532 148 LINE",
 "487 31 OFFCURVE",
@@ -46072,8 +45899,7 @@ nodes = (
 "32 709 LINE",
 "255 278 LINE",
 "28 -53 LINE",
-"28 -87 LINE",
-"511 -87 LINE"
+"28 -87 LINE"
 );
 }
 );
@@ -46085,6 +45911,7 @@ paths = (
 {
 closed = 1;
 nodes = (
+"552 -96 LINE",
 "606 149 LINE",
 "560 149 LINE",
 "515 43 OFFCURVE",
@@ -46103,8 +45930,7 @@ nodes = (
 "33 690 LINE",
 "261 264 LINE",
 "28 -56 LINE",
-"28 -96 LINE",
-"552 -96 LINE"
+"28 -96 LINE"
 );
 }
 );
@@ -46115,7 +45941,7 @@ unicode = 2211;
 },
 {
 glyphname = radical;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -46123,6 +45949,7 @@ paths = (
 {
 closed = 1;
 nodes = (
+"377 -172 LINE",
 "558 915 LINE",
 "529 915 LINE",
 "382 56 LINE",
@@ -46131,8 +45958,7 @@ nodes = (
 "34 440 LINE",
 "34 415 LINE",
 "128 415 LINE",
-"363 -175 LINE",
-"377 -172 LINE"
+"363 -175 LINE"
 );
 }
 );
@@ -46144,6 +45970,7 @@ paths = (
 {
 closed = 1;
 nodes = (
+"415 -175 LINE",
 "612 914 LINE",
 "551 914 LINE",
 "405 81 LINE",
@@ -46152,8 +45979,7 @@ nodes = (
 "39 440 LINE",
 "39 405 LINE",
 "137 405 LINE",
-"376 -183 LINE",
-"415 -175 LINE"
+"376 -183 LINE"
 );
 }
 );
@@ -46163,8 +45989,8 @@ width = 617;
 unicode = 221A;
 },
 {
-glyphname = mu;
-lastChange = "2016-08-16 11:12:00 +0000";
+glyphname = micro;
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -46253,46 +46079,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"557 25 LINE",
-"368 25 LINE",
-"368 0 LINE",
-"557 0 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"478 435 LINE",
-"368 435 LINE",
-"368 16 LINE",
-"478 16 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"478 450 LINE",
-"286 450 LINE",
-"286 425 LINE",
-"478 425 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"195 450 LINE",
-"7 450 LINE",
-"7 425 LINE",
-"195 425 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"85 97 LINE SMOOTH",
-"85 36 OFFCURVE",
-"139 -12 OFFCURVE",
-"216 -12 CURVE SMOOTH",
 "290 -12 OFFCURVE",
 "335 26 OFFCURVE",
 "364 78 CURVE",
@@ -46305,26 +46091,66 @@ nodes = (
 "195 50 OFFCURVE",
 "195 100 CURVE SMOOTH",
 "195 435 LINE",
-"85 435 LINE"
+"85 435 LINE",
+"85 97 LINE SMOOTH",
+"85 36 OFFCURVE",
+"139 -12 OFFCURVE",
+"216 -12 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"85 101 LINE",
-"80 -72 OFFCURVE",
-"49 -124 OFFCURVE",
-"49 -190 CURVE SMOOTH",
-"49 -230 OFFCURVE",
-"65 -254 OFFCURVE",
-"100 -254 CURVE SMOOTH",
 "136 -254 OFFCURVE",
 "153 -227 OFFCURVE",
 "153 -188 CURVE SMOOTH",
 "153 -140 OFFCURVE",
 "117 -103 OFFCURVE",
 "109 28 CURVE",
-"113 28 LINE"
+"113 28 LINE",
+"85 101 LINE",
+"80 -72 OFFCURVE",
+"49 -124 OFFCURVE",
+"49 -190 CURVE SMOOTH",
+"49 -230 OFFCURVE",
+"65 -254 OFFCURVE",
+"100 -254 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"557 0 LINE",
+"557 25 LINE",
+"368 25 LINE",
+"368 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"195 425 LINE",
+"195 450 LINE",
+"7 450 LINE",
+"7 425 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"478 16 LINE",
+"478 435 LINE",
+"368 435 LINE",
+"368 16 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"478 425 LINE",
+"478 450 LINE",
+"286 450 LINE",
+"286 425 LINE"
 );
 }
 );
@@ -46417,46 +46243,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"603 30 LINE",
-"386 30 LINE",
-"386 0 LINE",
-"603 0 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"524 435 LINE",
-"386 435 LINE",
-"386 15 LINE",
-"524 15 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"524 450 LINE",
-"304 450 LINE",
-"304 420 LINE",
-"524 420 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"226 450 LINE",
-"10 450 LINE",
-"10 420 LINE",
-"226 420 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"88 98 LINE SMOOTH",
-"88 37 OFFCURVE",
-"140 -13 OFFCURVE",
-"222 -13 CURVE SMOOTH",
 "292 -13 OFFCURVE",
 "358 24 OFFCURVE",
 "382 79 CURVE",
@@ -46469,26 +46255,66 @@ nodes = (
 "226 56 OFFCURVE",
 "226 111 CURVE SMOOTH",
 "226 435 LINE",
-"88 435 LINE"
+"88 435 LINE",
+"88 98 LINE SMOOTH",
+"88 37 OFFCURVE",
+"140 -13 OFFCURVE",
+"222 -13 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"88 101 LINE",
-"83 -78 OFFCURVE",
-"54 -140 OFFCURVE",
-"54 -198 CURVE SMOOTH",
-"54 -251 OFFCURVE",
-"78 -277 OFFCURVE",
-"114 -277 CURVE SMOOTH",
 "153 -277 OFFCURVE",
 "178 -246 OFFCURVE",
 "178 -203 CURVE SMOOTH",
 "178 -152 OFFCURVE",
 "152 -119 OFFCURVE",
 "134 10 CURVE",
-"138 10 LINE"
+"138 10 LINE",
+"88 101 LINE",
+"83 -78 OFFCURVE",
+"54 -140 OFFCURVE",
+"54 -198 CURVE SMOOTH",
+"54 -251 OFFCURVE",
+"78 -277 OFFCURVE",
+"114 -277 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"603 0 LINE",
+"603 30 LINE",
+"386 30 LINE",
+"386 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"226 420 LINE",
+"226 450 LINE",
+"10 450 LINE",
+"10 420 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"524 15 LINE",
+"524 435 LINE",
+"386 435 LINE",
+"386 15 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"524 420 LINE",
+"524 450 LINE",
+"304 450 LINE",
+"304 420 LINE"
 );
 }
 );
@@ -46499,7 +46325,7 @@ unicode = 00B5;
 },
 {
 glyphname = partialdiff;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -46507,13 +46333,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"280 451 LINE SMOOTH",
-"133 451 OFFCURVE",
-"43 319 OFFCURVE",
-"43 193 CURVE SMOOTH",
-"43 67 OFFCURVE",
-"123 -11 OFFCURVE",
-"243 -11 CURVE SMOOTH",
 "404 -11 OFFCURVE",
 "524 129 OFFCURVE",
 "524 391 CURVE SMOOTH",
@@ -46535,13 +46354,24 @@ nodes = (
 "407 390 CURVE",
 "379 429 OFFCURVE",
 "337 451 OFFCURVE",
-"280 451 CURVE SMOOTH"
+"280 451 CURVE SMOOTH",
+"133 451 OFFCURVE",
+"43 319 OFFCURVE",
+"43 193 CURVE SMOOTH",
+"43 67 OFFCURVE",
+"123 -11 OFFCURVE",
+"243 -11 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"308 411 LINE",
+"193 19 OFFCURVE",
+"170 58 OFFCURVE",
+"170 138 CURVE SMOOTH",
+"170 224 OFFCURVE",
+"196 411 OFFCURVE",
+"308 411 CURVE SMOOTH",
 "359 411 OFFCURVE",
 "386 372 OFFCURVE",
 "397 350 CURVE",
@@ -46550,13 +46380,7 @@ nodes = (
 "346 136 CURVE SMOOTH",
 "314 52 OFFCURVE",
 "289 19 OFFCURVE",
-"243 19 CURVE SMOOTH",
-"193 19 OFFCURVE",
-"170 58 OFFCURVE",
-"170 138 CURVE SMOOTH",
-"170 224 OFFCURVE",
-"196 411 OFFCURVE",
-"308 411 CURVE SMOOTH"
+"243 19 CURVE SMOOTH"
 );
 }
 );
@@ -46568,13 +46392,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"291 455 LINE",
-"149 455 OFFCURVE",
-"44 339 OFFCURVE",
-"44 197 CURVE SMOOTH",
-"44 69 OFFCURVE",
-"129 -12 OFFCURVE",
-"259 -12 CURVE SMOOTH",
 "450 -12 OFFCURVE",
 "565 162 OFFCURVE",
 "565 384 CURVE SMOOTH",
@@ -46596,13 +46413,24 @@ nodes = (
 "424 397 CURVE",
 "393 437 OFFCURVE",
 "347 455 OFFCURVE",
-"291 455 CURVE SMOOTH"
+"291 455 CURVE SMOOTH",
+"149 455 OFFCURVE",
+"44 339 OFFCURVE",
+"44 197 CURVE SMOOTH",
+"44 69 OFFCURVE",
+"129 -12 OFFCURVE",
+"259 -12 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"330 399 LINE SMOOTH",
+"218 31 OFFCURVE",
+"196 63 OFFCURVE",
+"196 136 CURVE SMOOTH",
+"196 210 OFFCURVE",
+"219 399 OFFCURVE",
+"330 399 CURVE SMOOTH",
 "376 399 OFFCURVE",
 "401 366 OFFCURVE",
 "413 343 CURVE",
@@ -46611,13 +46439,7 @@ nodes = (
 "360 138 CURVE SMOOTH",
 "335 79 OFFCURVE",
 "304 31 OFFCURVE",
-"257 31 CURVE SMOOTH",
-"218 31 OFFCURVE",
-"196 63 OFFCURVE",
-"196 136 CURVE SMOOTH",
-"196 210 OFFCURVE",
-"219 399 OFFCURVE",
-"330 399 CURVE SMOOTH"
+"257 31 CURVE SMOOTH"
 );
 }
 );
@@ -46628,13 +46450,14 @@ unicode = 2202;
 },
 {
 glyphname = percent;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 16:58:51 +0000";
 layers = (
 {
 components = (
 {
+alignment = -1;
 name = fraction;
-transform = "{1, 0, 0, 1, 203, 0}";
+transform = "{1, 0, 0, 1, 206, 0}";
 },
 {
 name = zero.numerator;
@@ -46651,8 +46474,9 @@ width = 913;
 {
 components = (
 {
+alignment = -1;
 name = fraction;
-transform = "{1, 0, 0, 1, 203, 0}";
+transform = "{1, 0, 0, 1, 215, 0}";
 },
 {
 name = zero.numerator;
@@ -46671,13 +46495,14 @@ unicode = 0025;
 },
 {
 glyphname = perthousand;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 16:59:14 +0000";
 layers = (
 {
 components = (
 {
+alignment = -1;
 name = fraction;
-transform = "{1, 0, 0, 1, 203, 0}";
+transform = "{1, 0, 0, 1, 205, 0}";
 },
 {
 name = zero.numerator;
@@ -46698,8 +46523,9 @@ width = 1353;
 {
 components = (
 {
+alignment = -1;
 name = fraction;
-transform = "{1, 0, 0, 1, 203, 0}";
+transform = "{1, 0, 0, 1, 211, 0}";
 },
 {
 name = zero.numerator;
@@ -46721,88 +46547,8 @@ width = 1353;
 unicode = 2030;
 },
 {
-glyphname = uni2215;
-lastChange = "2016-08-16 11:12:00 +0000";
-layers = (
-{
-components = (
-{
-name = fraction;
-}
-);
-layerId = UUID0;
-width = 489;
-},
-{
-components = (
-{
-name = fraction;
-}
-);
-layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
-width = 489;
-}
-);
-unicode = 2215;
-},
-{
-glyphname = uni2219;
-lastChange = "2016-08-16 11:12:00 +0000";
-layers = (
-{
-layerId = UUID0;
-paths = (
-{
-closed = 1;
-nodes = (
-"10 250 LINE SMOOTH",
-"10 210 OFFCURVE",
-"43 177 OFFCURVE",
-"83 177 CURVE SMOOTH",
-"123 177 OFFCURVE",
-"156 210 OFFCURVE",
-"156 250 CURVE SMOOTH",
-"156 290 OFFCURVE",
-"123 323 OFFCURVE",
-"83 323 CURVE SMOOTH",
-"43 323 OFFCURVE",
-"10 290 OFFCURVE",
-"10 250 CURVE SMOOTH"
-);
-}
-);
-width = 166;
-},
-{
-layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
-paths = (
-{
-closed = 1;
-nodes = (
-"50 254 LINE SMOOTH",
-"50 206 OFFCURVE",
-"89 167 OFFCURVE",
-"137 167 CURVE SMOOTH",
-"185 167 OFFCURVE",
-"224 206 OFFCURVE",
-"224 254 CURVE SMOOTH",
-"224 302 OFFCURVE",
-"185 341 OFFCURVE",
-"137 341 CURVE SMOOTH",
-"89 341 OFFCURVE",
-"50 302 OFFCURVE",
-"50 254 CURVE SMOOTH"
-);
-}
-);
-width = 274;
-}
-);
-unicode = 2219;
-},
-{
 glyphname = lozenge;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -46810,23 +46556,23 @@ paths = (
 {
 closed = 1;
 nodes = (
+"347 -74 LINE",
 "547 347 LINE",
 "347 771 LINE",
 "251 771 LINE",
 "48 347 LINE",
-"248 -74 LINE",
-"347 -74 LINE"
+"248 -74 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"476 347 LINE",
-"301 -24 LINE",
-"297 -24 LINE",
 "119 348 LINE",
 "297 717 LINE",
-"301 717 LINE"
+"301 717 LINE",
+"476 347 LINE",
+"301 -24 LINE",
+"297 -24 LINE"
 );
 }
 );
@@ -46838,23 +46584,23 @@ paths = (
 {
 closed = 1;
 nodes = (
+"373 -77 LINE",
 "584 347 LINE",
 "374 774 LINE",
 "261 774 LINE",
 "48 347 LINE",
-"258 -77 LINE",
-"373 -77 LINE"
+"258 -77 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"488 347 LINE",
-"319 -7 LINE",
-"315 -7 LINE",
 "144 348 LINE",
 "315 700 LINE",
-"319 700 LINE"
+"319 700 LINE",
+"488 347 LINE",
+"319 -7 LINE",
+"315 -7 LINE"
 );
 }
 );
@@ -46865,7 +46611,7 @@ unicode = 25CA;
 },
 {
 glyphname = at;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -46873,19 +46619,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"552 44 LINE SMOOTH",
-"681 44 OFFCURVE",
-"785 175 OFFCURVE",
-"785 335 CURVE SMOOTH",
-"785 501 OFFCURVE",
-"674 630 OFFCURVE",
-"477 630 CURVE SMOOTH",
-"261 630 OFFCURVE",
-"70 474 OFFCURVE",
-"70 199 CURVE SMOOTH",
-"70 -40 OFFCURVE",
-"214 -152 OFFCURVE",
-"395 -152 CURVE SMOOTH",
 "493 -152 OFFCURVE",
 "575 -119 OFFCURVE",
 "660 -32 CURVE",
@@ -46919,22 +46652,24 @@ nodes = (
 "471 112 CURVE SMOOTH",
 "471 65 OFFCURVE",
 "500 44 OFFCURVE",
-"552 44 CURVE SMOOTH"
+"552 44 CURVE SMOOTH",
+"681 44 OFFCURVE",
+"785 175 OFFCURVE",
+"785 335 CURVE SMOOTH",
+"785 501 OFFCURVE",
+"674 630 OFFCURVE",
+"477 630 CURVE SMOOTH",
+"261 630 OFFCURVE",
+"70 474 OFFCURVE",
+"70 199 CURVE SMOOTH",
+"70 -40 OFFCURVE",
+"214 -152 OFFCURVE",
+"395 -152 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"530 390 LINE",
-"512 435 OFFCURVE",
-"491 454 OFFCURVE",
-"449 454 CURVE SMOOTH",
-"344 454 OFFCURVE",
-"225 336 OFFCURVE",
-"225 194 CURVE SMOOTH",
-"225 90 OFFCURVE",
-"288 44 OFFCURVE",
-"351 44 CURVE SMOOTH",
 "408 44 OFFCURVE",
 "445 82 OFFCURVE",
 "464 115 CURVE",
@@ -46955,7 +46690,17 @@ nodes = (
 "518 329 OFFCURVE",
 "516 322 OFFCURVE",
 "516 309 CURVE",
-"536 390 LINE"
+"536 390 LINE",
+"530 390 LINE",
+"512 435 OFFCURVE",
+"491 454 OFFCURVE",
+"449 454 CURVE SMOOTH",
+"344 454 OFFCURVE",
+"225 336 OFFCURVE",
+"225 194 CURVE SMOOTH",
+"225 90 OFFCURVE",
+"288 44 OFFCURVE",
+"351 44 CURVE SMOOTH"
 );
 }
 );
@@ -47058,19 +46803,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"535 44 LINE SMOOTH",
-"669 44 OFFCURVE",
-"771 176 OFFCURVE",
-"771 335 CURVE SMOOTH",
-"771 501 OFFCURVE",
-"660 630 OFFCURVE",
-"463 630 CURVE SMOOTH",
-"247 630 OFFCURVE",
-"56 474 OFFCURVE",
-"56 199 CURVE SMOOTH",
-"56 -40 OFFCURVE",
-"200 -152 OFFCURVE",
-"381 -152 CURVE SMOOTH",
 "479 -152 OFFCURVE",
 "561 -119 OFFCURVE",
 "646 -32 CURVE",
@@ -47104,22 +46836,24 @@ nodes = (
 "447 113 CURVE SMOOTH",
 "447 65 OFFCURVE",
 "481 44 OFFCURVE",
-"535 44 CURVE SMOOTH"
+"535 44 CURVE SMOOTH",
+"669 44 OFFCURVE",
+"771 176 OFFCURVE",
+"771 335 CURVE SMOOTH",
+"771 501 OFFCURVE",
+"660 630 OFFCURVE",
+"463 630 CURVE SMOOTH",
+"247 630 OFFCURVE",
+"56 474 OFFCURVE",
+"56 199 CURVE SMOOTH",
+"56 -40 OFFCURVE",
+"200 -152 OFFCURVE",
+"381 -152 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"507 395 LINE",
-"489 436 OFFCURVE",
-"468 454 OFFCURVE",
-"425 454 CURVE SMOOTH",
-"317 454 OFFCURVE",
-"196 335 OFFCURVE",
-"196 195 CURVE SMOOTH",
-"196 90 OFFCURVE",
-"264 44 OFFCURVE",
-"328 44 CURVE SMOOTH",
 "384 44 OFFCURVE",
 "423 79 OFFCURVE",
 "440 110 CURVE",
@@ -47140,7 +46874,17 @@ nodes = (
 "494 329 OFFCURVE",
 "492 322 OFFCURVE",
 "492 309 CURVE",
-"513 395 LINE"
+"513 395 LINE",
+"507 395 LINE",
+"489 436 OFFCURVE",
+"468 454 OFFCURVE",
+"425 454 CURVE SMOOTH",
+"317 454 OFFCURVE",
+"196 335 OFFCURVE",
+"196 195 CURVE SMOOTH",
+"196 90 OFFCURVE",
+"264 44 OFFCURVE",
+"328 44 CURVE SMOOTH"
 );
 }
 );
@@ -47151,7 +46895,7 @@ unicode = 0040;
 },
 {
 glyphname = ampersand;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -47261,7 +47005,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"535 0 LINE",
 "689 0 LINE",
 "326 556 LINE SMOOTH",
 "305 589 OFFCURVE",
@@ -47288,50 +47031,13 @@ nodes = (
 "180 606 CURVE SMOOTH",
 "180 543 OFFCURVE",
 "213 505 OFFCURVE",
-"239 465 CURVE SMOOTH"
+"239 465 CURVE SMOOTH",
+"535 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"530 455 LINE",
-"791 455 LINE",
-"791 480 LINE",
-"530 480 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"579 160 LINE",
-"634 232 OFFCURVE",
-"683 365 OFFCURVE",
-"683 464 CURVE",
-"649 464 LINE",
-"649 371 OFFCURVE",
-"614 255 OFFCURVE",
-"556 188 CURVE"
-);
-},
-{
-closed = 1;
-nodes = (
-"575 0 LINE",
-"766 0 LINE",
-"766 25 LINE",
-"575 25 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"263 457 LINE",
-"135 401 OFFCURVE",
-"20 316 OFFCURVE",
-"20 189 CURVE SMOOTH",
-"20 76 OFFCURVE",
-"110 -13 OFFCURVE",
-"271 -13 CURVE SMOOTH",
 "358 -13 OFFCURVE",
 "434 13 OFFCURVE",
 "515 100 CURVE",
@@ -47344,7 +47050,45 @@ nodes = (
 "155 260 CURVE SMOOTH",
 "155 335 OFFCURVE",
 "184 395 OFFCURVE",
-"284 430 CURVE"
+"284 430 CURVE",
+"263 457 LINE",
+"135 401 OFFCURVE",
+"20 316 OFFCURVE",
+"20 189 CURVE SMOOTH",
+"20 76 OFFCURVE",
+"110 -13 OFFCURVE",
+"271 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"766 0 LINE",
+"766 25 LINE",
+"575 25 LINE",
+"575 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"634 232 OFFCURVE",
+"683 365 OFFCURVE",
+"683 464 CURVE",
+"649 464 LINE",
+"649 371 OFFCURVE",
+"614 255 OFFCURVE",
+"556 188 CURVE",
+"579 160 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"791 455 LINE",
+"791 480 LINE",
+"530 480 LINE",
+"530 455 LINE"
 );
 }
 );
@@ -47451,7 +47195,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"541 0 LINE",
 "735 0 LINE",
 "377 554 LINE SMOOTH",
 "356 587 OFFCURVE",
@@ -47478,50 +47221,13 @@ nodes = (
 "196 598 CURVE SMOOTH",
 "196 544 OFFCURVE",
 "220 499 OFFCURVE",
-"245 465 CURVE"
+"245 465 CURVE",
+"541 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"567 455 LINE",
-"828 455 LINE",
-"828 480 LINE",
-"567 480 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"579 160 LINE",
-"654 232 OFFCURVE",
-"723 365 OFFCURVE",
-"723 464 CURVE",
-"684 464 LINE",
-"684 371 OFFCURVE",
-"633 255 OFFCURVE",
-"551 188 CURVE"
-);
-},
-{
-closed = 1;
-nodes = (
-"575 0 LINE",
-"822 0 LINE",
-"822 30 LINE",
-"575 30 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"273 437 LINE",
-"134 382 OFFCURVE",
-"20 306 OFFCURVE",
-"20 185 CURVE SMOOTH",
-"20 78 OFFCURVE",
-"109 -13 OFFCURVE",
-"272 -13 CURVE SMOOTH",
 "358 -13 OFFCURVE",
 "434 12 OFFCURVE",
 "515 95 CURVE",
@@ -47534,7 +47240,45 @@ nodes = (
 "180 292 CURVE SMOOTH",
 "180 350 OFFCURVE",
 "203 381 OFFCURVE",
-"294 405 CURVE"
+"294 405 CURVE",
+"273 437 LINE",
+"134 382 OFFCURVE",
+"20 306 OFFCURVE",
+"20 185 CURVE SMOOTH",
+"20 78 OFFCURVE",
+"109 -13 OFFCURVE",
+"272 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"822 0 LINE",
+"822 30 LINE",
+"575 30 LINE",
+"575 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"654 232 OFFCURVE",
+"723 365 OFFCURVE",
+"723 464 CURVE",
+"684 464 LINE",
+"684 371 OFFCURVE",
+"633 255 OFFCURVE",
+"551 188 CURVE",
+"579 160 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"828 455 LINE",
+"828 480 LINE",
+"567 480 LINE",
+"567 455 LINE"
 );
 }
 );
@@ -47545,7 +47289,7 @@ unicode = 0026;
 },
 {
 glyphname = paragraph;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -47607,14 +47351,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"261 754 LINE SMOOTH",
-"140 754 OFFCURVE",
-"29 660 OFFCURVE",
-"29 535 CURVE SMOOTH",
-"29 418 OFFCURVE",
-"111 319 OFFCURVE",
-"261 309 CURVE",
-"261 -123 LINE",
 "311 -123 LINE",
 "311 731 LINE",
 "422 731 LINE",
@@ -47622,7 +47358,15 @@ nodes = (
 "472 -123 LINE",
 "472 731 LINE",
 "617 731 LINE",
-"617 754 LINE"
+"617 754 LINE",
+"261 754 LINE SMOOTH",
+"140 754 OFFCURVE",
+"29 660 OFFCURVE",
+"29 535 CURVE SMOOTH",
+"29 418 OFFCURVE",
+"111 319 OFFCURVE",
+"261 309 CURVE",
+"261 -123 LINE"
 );
 }
 );
@@ -47634,14 +47378,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"252 754 LINE SMOOTH",
-"131 754 OFFCURVE",
-"20 660 OFFCURVE",
-"20 535 CURVE SMOOTH",
-"20 418 OFFCURVE",
-"102 319 OFFCURVE",
-"252 309 CURVE",
-"252 -157 LINE",
 "334 -157 LINE",
 "334 680 LINE",
 "431 680 LINE",
@@ -47649,7 +47385,15 @@ nodes = (
 "513 -157 LINE",
 "513 680 LINE",
 "608 680 LINE",
-"608 754 LINE"
+"608 754 LINE",
+"252 754 LINE SMOOTH",
+"131 754 OFFCURVE",
+"20 660 OFFCURVE",
+"20 535 CURVE SMOOTH",
+"20 418 OFFCURVE",
+"102 319 OFFCURVE",
+"252 309 CURVE",
+"252 -157 LINE"
 );
 }
 );
@@ -47660,7 +47404,7 @@ unicode = 00B6;
 },
 {
 glyphname = section;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:07:39 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -47668,11 +47412,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"393 220 LINE SMOOTH",
-"393 179 OFFCURVE",
-"352 155 OFFCURVE",
-"303 155 CURVE",
-"307 130 LINE",
 "407 130 OFFCURVE",
 "459 182 OFFCURVE",
 "459 263 CURVE SMOOTH",
@@ -47702,13 +47441,22 @@ nodes = (
 "94 613 CURVE SMOOTH",
 "94 403 OFFCURVE",
 "393 331 OFFCURVE",
-"393 220 CURVE SMOOTH"
+"393 220 CURVE SMOOTH",
+"393 179 OFFCURVE",
+"352 155 OFFCURVE",
+"303 155 CURVE",
+"307 130 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"106 423 LINE SMOOTH",
+"350 -123 OFFCURVE",
+"405 -56 OFFCURVE",
+"405 32 CURVE SMOOTH",
+"405 238 OFFCURVE",
+"106 312 OFFCURVE",
+"106 423 CURVE SMOOTH",
 "106 464 OFFCURVE",
 "147 488 OFFCURVE",
 "196 488 CURVE",
@@ -47736,13 +47484,7 @@ nodes = (
 "77 -2 CURVE SMOOTH",
 "77 -69 OFFCURVE",
 "139 -123 OFFCURVE",
-"239 -123 CURVE SMOOTH",
-"350 -123 OFFCURVE",
-"405 -56 OFFCURVE",
-"405 32 CURVE SMOOTH",
-"405 238 OFFCURVE",
-"106 312 OFFCURVE",
-"106 423 CURVE SMOOTH"
+"239 -123 CURVE SMOOTH"
 );
 }
 );
@@ -47754,11 +47496,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"373 206 LINE SMOOTH",
-"373 168 OFFCURVE",
-"341 143 OFFCURVE",
-"303 143 CURVE",
-"307 118 LINE",
 "414 118 OFFCURVE",
 "469 180 OFFCURVE",
 "469 266 CURVE SMOOTH",
@@ -47788,13 +47525,22 @@ nodes = (
 "74 602 CURVE SMOOTH",
 "74 409 OFFCURVE",
 "373 322 OFFCURVE",
-"373 206 CURVE SMOOTH"
+"373 206 CURVE SMOOTH",
+"373 168 OFFCURVE",
+"341 143 OFFCURVE",
+"303 143 CURVE",
+"307 118 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"126 392 LINE SMOOTH",
+"361 -161 OFFCURVE",
+"425 -92 OFFCURVE",
+"425 -3 CURVE SMOOTH",
+"425 189 OFFCURVE",
+"126 275 OFFCURVE",
+"126 392 CURVE SMOOTH",
 "126 430 OFFCURVE",
 "157 455 OFFCURVE",
 "196 455 CURVE",
@@ -47822,13 +47568,7 @@ nodes = (
 "77 -36 CURVE SMOOTH",
 "77 -105 OFFCURVE",
 "138 -161 OFFCURVE",
-"244 -161 CURVE SMOOTH",
-"361 -161 OFFCURVE",
-"425 -92 OFFCURVE",
-"425 -3 CURVE SMOOTH",
-"425 189 OFFCURVE",
-"126 275 OFFCURVE",
-"126 392 CURVE SMOOTH"
+"244 -161 CURVE SMOOTH"
 );
 }
 );
@@ -47839,7 +47579,7 @@ unicode = 00A7;
 },
 {
 glyphname = copyright;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -47847,7 +47587,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"413 -10 LINE SMOOTH",
 "622 -10 OFFCURVE",
 "793 158 OFFCURVE",
 "793 370 CURVE SMOOTH",
@@ -47865,25 +47604,6 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"414 715 LINE SMOOTH",
-"602 715 OFFCURVE",
-"754 562 OFFCURVE",
-"754 371 CURVE SMOOTH",
-"754 188 OFFCURVE",
-"604 29 OFFCURVE",
-"413 29 CURVE SMOOTH",
-"233 29 OFFCURVE",
-"79 182 OFFCURVE",
-"79 371 CURVE SMOOTH",
-"79 557 OFFCURVE",
-"230 715 OFFCURVE",
-"414 715 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"419 152 LINE SMOOTH",
 "464 152 OFFCURVE",
 "508 164 OFFCURVE",
 "543 187 CURVE",
@@ -47917,6 +47637,23 @@ nodes = (
 "289 152 OFFCURVE",
 "419 152 CURVE SMOOTH"
 );
+},
+{
+closed = 1;
+nodes = (
+"233 29 OFFCURVE",
+"79 182 OFFCURVE",
+"79 371 CURVE SMOOTH",
+"79 557 OFFCURVE",
+"230 715 OFFCURVE",
+"414 715 CURVE SMOOTH",
+"602 715 OFFCURVE",
+"754 562 OFFCURVE",
+"754 371 CURVE SMOOTH",
+"754 188 OFFCURVE",
+"604 29 OFFCURVE",
+"413 29 CURVE SMOOTH"
+);
 }
 );
 width = 833;
@@ -47927,7 +47664,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"416 -10 LINE SMOOTH",
 "622 -10 OFFCURVE",
 "793 158 OFFCURVE",
 "793 372 CURVE SMOOTH",
@@ -47945,25 +47681,6 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"416 705 LINE SMOOTH",
-"596 705 OFFCURVE",
-"744 554 OFFCURVE",
-"744 373 CURVE SMOOTH",
-"744 193 OFFCURVE",
-"598 39 OFFCURVE",
-"416 39 CURVE SMOOTH",
-"237 39 OFFCURVE",
-"89 188 OFFCURVE",
-"89 371 CURVE SMOOTH",
-"89 552 OFFCURVE",
-"234 705 OFFCURVE",
-"416 705 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"427 152 LINE SMOOTH",
 "471 152 OFFCURVE",
 "511 164 OFFCURVE",
 "543 187 CURVE",
@@ -47997,6 +47714,23 @@ nodes = (
 "294 152 OFFCURVE",
 "427 152 CURVE SMOOTH"
 );
+},
+{
+closed = 1;
+nodes = (
+"237 39 OFFCURVE",
+"89 188 OFFCURVE",
+"89 371 CURVE SMOOTH",
+"89 552 OFFCURVE",
+"234 705 OFFCURVE",
+"416 705 CURVE SMOOTH",
+"596 705 OFFCURVE",
+"744 554 OFFCURVE",
+"744 373 CURVE SMOOTH",
+"744 193 OFFCURVE",
+"598 39 OFFCURVE",
+"416 39 CURVE SMOOTH"
+);
 }
 );
 width = 833;
@@ -48006,7 +47740,7 @@ unicode = 00A9;
 },
 {
 glyphname = registered;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -48118,7 +47852,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"269 323 LINE SMOOTH",
 "393 323 OFFCURVE",
 "497 425 OFFCURVE",
 "497 555 CURVE SMOOTH",
@@ -48136,60 +47869,36 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"269 754 LINE SMOOTH",
-"376 754 OFFCURVE",
-"464 664 OFFCURVE",
-"464 555 CURVE SMOOTH",
-"464 448 OFFCURVE",
-"377 357 OFFCURVE",
-"269 357 CURVE SMOOTH",
+"282 427 LINE",
+"282 445 LINE",
+"148 445 LINE",
+"148 427 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"245 433 LINE",
+"245 695 LINE",
+"178 695 LINE",
+"178 433 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "162 357 OFFCURVE",
 "74 446 OFFCURVE",
 "74 554 CURVE SMOOTH",
 "74 663 OFFCURVE",
 "161 754 OFFCURVE",
-"269 754 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"178 433 LINE",
-"245 433 LINE",
-"245 695 LINE",
-"178 695 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"264 565 LINE SMOOTH",
-"330 565 OFFCURVE",
-"369 593 OFFCURVE",
-"369 633 CURVE SMOOTH",
-"369 672 OFFCURVE",
-"331 695 OFFCURVE",
-"286 695 CURVE SMOOTH",
-"148 695 LINE",
-"148 676 LINE",
-"268 676 LINE SMOOTH",
-"290 676 OFFCURVE",
-"301 669 OFFCURVE",
-"301 633 CURVE SMOOTH",
-"301 590 OFFCURVE",
-"289 580 OFFCURVE",
-"264 580 CURVE SMOOTH",
-"234 580 LINE",
-"234 565 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"148 427 LINE",
-"282 427 LINE",
-"282 445 LINE",
-"148 445 LINE"
+"269 754 CURVE SMOOTH",
+"376 754 OFFCURVE",
+"464 664 OFFCURVE",
+"464 555 CURVE SMOOTH",
+"464 448 OFFCURVE",
+"377 357 OFFCURVE",
+"269 357 CURVE SMOOTH"
 );
 },
 {
@@ -48215,6 +47924,29 @@ nodes = (
 "295 448 OFFCURVE",
 "325 427 OFFCURVE",
 "363 427 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"264 565 LINE SMOOTH",
+"330 565 OFFCURVE",
+"369 593 OFFCURVE",
+"369 633 CURVE SMOOTH",
+"369 672 OFFCURVE",
+"331 695 OFFCURVE",
+"286 695 CURVE SMOOTH",
+"148 695 LINE",
+"148 676 LINE",
+"268 676 LINE SMOOTH",
+"290 676 OFFCURVE",
+"301 669 OFFCURVE",
+"301 633 CURVE SMOOTH",
+"301 590 OFFCURVE",
+"289 580 OFFCURVE",
+"264 580 CURVE SMOOTH",
+"234 580 LINE",
+"234 565 LINE"
 );
 }
 );
@@ -48330,7 +48062,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"269 323 LINE SMOOTH",
 "393 323 OFFCURVE",
 "497 425 OFFCURVE",
 "497 555 CURVE SMOOTH",
@@ -48348,60 +48079,36 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"269 754 LINE SMOOTH",
-"376 754 OFFCURVE",
-"464 664 OFFCURVE",
-"464 555 CURVE SMOOTH",
-"464 448 OFFCURVE",
-"377 357 OFFCURVE",
-"269 357 CURVE SMOOTH",
+"282 427 LINE",
+"282 445 LINE",
+"148 445 LINE",
+"148 427 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"245 433 LINE",
+"245 695 LINE",
+"168 695 LINE",
+"168 433 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
 "162 357 OFFCURVE",
 "74 446 OFFCURVE",
 "74 554 CURVE SMOOTH",
 "74 663 OFFCURVE",
 "161 754 OFFCURVE",
-"269 754 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"168 433 LINE",
-"245 433 LINE",
-"245 695 LINE",
-"168 695 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"264 565 LINE SMOOTH",
-"336 565 OFFCURVE",
-"379 593 OFFCURVE",
-"379 633 CURVE SMOOTH",
-"379 672 OFFCURVE",
-"336 695 OFFCURVE",
-"286 695 CURVE SMOOTH",
-"148 695 LINE",
-"148 676 LINE",
-"268 676 LINE SMOOTH",
-"290 676 OFFCURVE",
-"301 669 OFFCURVE",
-"301 633 CURVE SMOOTH",
-"301 590 OFFCURVE",
-"289 580 OFFCURVE",
-"264 580 CURVE SMOOTH",
-"234 580 LINE",
-"234 565 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"148 427 LINE",
-"282 427 LINE",
-"282 445 LINE",
-"148 445 LINE"
+"269 754 CURVE SMOOTH",
+"376 754 OFFCURVE",
+"464 664 OFFCURVE",
+"464 555 CURVE SMOOTH",
+"464 448 OFFCURVE",
+"377 357 OFFCURVE",
+"269 357 CURVE SMOOTH"
 );
 },
 {
@@ -48428,6 +48135,29 @@ nodes = (
 "330 427 OFFCURVE",
 "373 427 CURVE SMOOTH"
 );
+},
+{
+closed = 1;
+nodes = (
+"264 565 LINE SMOOTH",
+"336 565 OFFCURVE",
+"379 593 OFFCURVE",
+"379 633 CURVE SMOOTH",
+"379 672 OFFCURVE",
+"336 695 OFFCURVE",
+"286 695 CURVE SMOOTH",
+"148 695 LINE",
+"148 676 LINE",
+"268 676 LINE SMOOTH",
+"290 676 OFFCURVE",
+"301 669 OFFCURVE",
+"301 633 CURVE SMOOTH",
+"301 590 OFFCURVE",
+"289 580 OFFCURVE",
+"264 580 CURVE SMOOTH",
+"234 580 LINE",
+"234 565 LINE"
+);
 }
 );
 width = 537;
@@ -48437,7 +48167,7 @@ unicode = 00AE;
 },
 {
 glyphname = trademark;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -48445,19 +48175,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"526 754 LINE",
-"372 754 LINE",
-"372 732 LINE",
-"416 732 LINE",
-"416 403 LINE",
-"372 403 LINE",
-"372 380 LINE",
-"500 380 LINE",
-"500 403 LINE",
-"445 403 LINE",
-"445 710 LINE",
-"449 710 LINE",
-"554 376 LINE",
 "591 376 LINE",
 "693 710 LINE",
 "697 710 LINE",
@@ -48472,21 +48189,25 @@ nodes = (
 "818 754 LINE",
 "688 754 LINE",
 "607 494 LINE",
-"603 494 LINE"
+"603 494 LINE",
+"526 754 LINE",
+"372 754 LINE",
+"372 732 LINE",
+"416 732 LINE",
+"416 403 LINE",
+"372 403 LINE",
+"372 380 LINE",
+"500 380 LINE",
+"500 403 LINE",
+"445 403 LINE",
+"445 710 LINE",
+"449 710 LINE",
+"554 376 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"27 633 LINE",
-"54 633 LINE",
-"55 689 OFFCURVE",
-"82 732 OFFCURVE",
-"129 732 CURVE SMOOTH",
-"146 732 LINE",
-"146 403 LINE",
-"82 403 LINE",
-"82 380 LINE",
 "297 380 LINE",
 "297 403 LINE",
 "233 403 LINE",
@@ -48497,7 +48218,16 @@ nodes = (
 "321 633 CURVE",
 "348 633 LINE",
 "348 754 LINE",
-"27 754 LINE"
+"27 754 LINE",
+"27 633 LINE",
+"54 633 LINE",
+"55 689 OFFCURVE",
+"82 732 OFFCURVE",
+"129 732 CURVE SMOOTH",
+"146 732 LINE",
+"146 403 LINE",
+"82 403 LINE",
+"82 380 LINE"
 );
 }
 );
@@ -48509,19 +48239,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"526 754 LINE",
-"372 754 LINE",
-"372 727 LINE",
-"406 727 LINE",
-"406 408 LINE",
-"372 408 LINE",
-"372 380 LINE",
-"500 380 LINE",
-"500 408 LINE",
-"445 408 LINE",
-"445 679 LINE",
-"449 679 LINE",
-"544 376 LINE",
 "601 376 LINE",
 "693 677 LINE",
 "697 677 LINE",
@@ -48536,21 +48253,25 @@ nodes = (
 "828 754 LINE",
 "688 754 LINE",
 "607 494 LINE",
-"603 494 LINE"
+"603 494 LINE",
+"526 754 LINE",
+"372 754 LINE",
+"372 727 LINE",
+"406 727 LINE",
+"406 408 LINE",
+"372 408 LINE",
+"372 380 LINE",
+"500 380 LINE",
+"500 408 LINE",
+"445 408 LINE",
+"445 679 LINE",
+"449 679 LINE",
+"544 376 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"27 633 LINE",
-"59 633 LINE",
-"60 689 OFFCURVE",
-"85 725 OFFCURVE",
-"129 727 CURVE SMOOTH",
-"136 727 LINE",
-"136 408 LINE",
-"82 408 LINE",
-"82 380 LINE",
 "297 380 LINE",
 "297 408 LINE",
 "243 408 LINE",
@@ -48561,7 +48282,16 @@ nodes = (
 "316 633 CURVE",
 "348 633 LINE",
 "348 754 LINE",
-"27 754 LINE"
+"27 754 LINE",
+"27 633 LINE",
+"59 633 LINE",
+"60 689 OFFCURVE",
+"85 725 OFFCURVE",
+"129 727 CURVE SMOOTH",
+"136 727 LINE",
+"136 408 LINE",
+"82 408 LINE",
+"82 380 LINE"
 );
 }
 );
@@ -48572,7 +48302,7 @@ unicode = 2122;
 },
 {
 glyphname = degree;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -48580,37 +48310,35 @@ paths = (
 {
 closed = 1;
 nodes = (
-"200 763 LINE SMOOTH",
-"118 763 OFFCURVE",
-"50 705 OFFCURVE",
-"50 610 CURVE SMOOTH",
-"50 515 OFFCURVE",
-"118 459 OFFCURVE",
-"199 459 CURVE SMOOTH",
 "280 459 OFFCURVE",
 "348 515 OFFCURVE",
 "348 608 CURVE SMOOTH",
 "348 693 OFFCURVE",
 "290 763 OFFCURVE",
-"200 763 CURVE SMOOTH"
+"200 763 CURVE SMOOTH",
+"118 763 OFFCURVE",
+"50 705 OFFCURVE",
+"50 610 CURVE SMOOTH",
+"50 515 OFFCURVE",
+"118 459 OFFCURVE",
+"199 459 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"201 718 LINE SMOOTH",
-"264 718 OFFCURVE",
-"296 671 OFFCURVE",
-"296 611 CURVE SMOOTH",
-"296 547 OFFCURVE",
-"260 503 OFFCURVE",
-"201 503 CURVE SMOOTH",
 "141 503 OFFCURVE",
 "103 549 OFFCURVE",
 "103 612 CURVE SMOOTH",
 "103 675 OFFCURVE",
 "140 718 OFFCURVE",
-"201 718 CURVE SMOOTH"
+"201 718 CURVE SMOOTH",
+"264 718 OFFCURVE",
+"296 671 OFFCURVE",
+"296 611 CURVE SMOOTH",
+"296 547 OFFCURVE",
+"260 503 OFFCURVE",
+"201 503 CURVE SMOOTH"
 );
 }
 );
@@ -48622,37 +48350,35 @@ paths = (
 {
 closed = 1;
 nodes = (
-"183 763 LINE SMOOTH",
-"101 763 OFFCURVE",
-"33 705 OFFCURVE",
-"33 610 CURVE SMOOTH",
-"33 515 OFFCURVE",
-"101 459 OFFCURVE",
-"182 459 CURVE SMOOTH",
 "263 459 OFFCURVE",
 "331 515 OFFCURVE",
 "331 608 CURVE SMOOTH",
 "331 693 OFFCURVE",
 "273 763 OFFCURVE",
-"183 763 CURVE SMOOTH"
+"183 763 CURVE SMOOTH",
+"101 763 OFFCURVE",
+"33 705 OFFCURVE",
+"33 610 CURVE SMOOTH",
+"33 515 OFFCURVE",
+"101 459 OFFCURVE",
+"182 459 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"184 708 LINE SMOOTH",
-"240 708 OFFCURVE",
-"269 665 OFFCURVE",
-"269 611 CURVE SMOOTH",
-"269 553 OFFCURVE",
-"237 513 OFFCURVE",
-"184 513 CURVE SMOOTH",
 "130 513 OFFCURVE",
 "96 555 OFFCURVE",
 "96 612 CURVE SMOOTH",
 "96 669 OFFCURVE",
 "129 708 OFFCURVE",
-"184 708 CURVE SMOOTH"
+"184 708 CURVE SMOOTH",
+"240 708 OFFCURVE",
+"269 665 OFFCURVE",
+"269 611 CURVE SMOOTH",
+"269 553 OFFCURVE",
+"237 513 OFFCURVE",
+"184 513 CURVE SMOOTH"
 );
 }
 );
@@ -48663,7 +48389,7 @@ unicode = 00B0;
 },
 {
 glyphname = bar;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -48671,10 +48397,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"154 788 LINE",
-"154 -123 LINE",
 "213 -123 LINE",
-"213 788 LINE"
+"213 788 LINE",
+"154 788 LINE",
+"154 -123 LINE"
 );
 }
 );
@@ -48686,10 +48412,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"144 788 LINE",
-"144 -123 LINE",
 "223 -123 LINE",
-"223 788 LINE"
+"223 788 LINE",
+"144 788 LINE",
+"144 -123 LINE"
 );
 }
 );
@@ -48700,7 +48426,7 @@ unicode = 007C;
 },
 {
 glyphname = brokenbar;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -48721,19 +48447,19 @@ paths = (
 {
 closed = 1;
 nodes = (
-"154 787 LINE",
-"154 417 LINE",
 "213 417 LINE",
-"213 787 LINE"
+"213 787 LINE",
+"154 787 LINE",
+"154 417 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"154 247 LINE",
-"154 -123 LINE",
 "213 -123 LINE",
-"213 247 LINE"
+"213 247 LINE",
+"154 247 LINE",
+"154 -123 LINE"
 );
 }
 );
@@ -48758,19 +48484,19 @@ paths = (
 {
 closed = 1;
 nodes = (
-"144 787 LINE",
-"144 377 LINE",
 "223 377 LINE",
-"223 787 LINE"
+"223 787 LINE",
+"144 787 LINE",
+"144 377 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"144 279 LINE",
-"144 -122 LINE",
 "223 -122 LINE",
-"223 279 LINE"
+"223 279 LINE",
+"144 279 LINE",
+"144 -122 LINE"
 );
 }
 );
@@ -48907,8 +48633,8 @@ width = 541;
 unicode = 2020;
 },
 {
-glyphname = uni2113;
-lastChange = "2016-08-16 11:12:00 +0000";
+glyphname = literSign;
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -48916,6 +48642,9 @@ paths = (
 {
 closed = 1;
 nodes = (
+"340 -11 OFFCURVE",
+"402 41 OFFCURVE",
+"445 123 CURVE",
 "425 136 LINE",
 "393 84 OFFCURVE",
 "359 38 OFFCURVE",
@@ -48940,10 +48669,7 @@ nodes = (
 "94 186 LINE SMOOTH",
 "94 65 OFFCURVE",
 "140 -11 OFFCURVE",
-"249 -11 CURVE SMOOTH",
-"340 -11 OFFCURVE",
-"402 41 OFFCURVE",
-"445 123 CURVE"
+"249 -11 CURVE SMOOTH"
 );
 },
 {
@@ -48970,6 +48696,9 @@ paths = (
 {
 closed = 1;
 nodes = (
+"365 -12 OFFCURVE",
+"428 34 OFFCURVE",
+"485 135 CURVE",
 "457 161 LINE",
 "419 106 OFFCURVE",
 "386 78 OFFCURVE",
@@ -48994,10 +48723,7 @@ nodes = (
 "97 193 LINE SMOOTH",
 "97 67 OFFCURVE",
 "156 -12 OFFCURVE",
-"275 -12 CURVE SMOOTH",
-"365 -12 OFFCURVE",
-"428 34 OFFCURVE",
-"485 135 CURVE"
+"275 -12 CURVE SMOOTH"
 );
 },
 {
@@ -49023,7 +48749,7 @@ unicode = 2113;
 },
 {
 glyphname = daggerdbl;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -49031,28 +48757,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"206 322 LINE",
-"247 266 OFFCURVE",
-"257 206 OFFCURVE",
-"257 141 CURVE",
-"152 141 OFFCURVE",
-"122 175 OFFCURVE",
-"78 175 CURVE SMOOTH",
-"38 175 OFFCURVE",
-"19 160 OFFCURVE",
-"19 129 CURVE SMOOTH",
-"19 96 OFFCURVE",
-"41 81 OFFCURVE",
-"80 81 CURVE SMOOTH",
-"122 81 OFFCURVE",
-"153 108 OFFCURVE",
-"257 117 CURVE",
-"252 10 OFFCURVE",
-"223 -20 OFFCURVE",
-"223 -64 CURVE SMOOTH",
-"223 -104 OFFCURVE",
-"238 -123 OFFCURVE",
-"269 -123 CURVE SMOOTH",
 "302 -123 OFFCURVE",
 "317 -102 OFFCURVE",
 "317 -62 CURVE SMOOTH",
@@ -49115,7 +48819,28 @@ nodes = (
 "257 502 CURVE",
 "257 437 OFFCURVE",
 "247 378 OFFCURVE",
-"206 322 CURVE"
+"206 322 CURVE",
+"247 266 OFFCURVE",
+"257 206 OFFCURVE",
+"257 141 CURVE",
+"152 141 OFFCURVE",
+"122 175 OFFCURVE",
+"78 175 CURVE SMOOTH",
+"38 175 OFFCURVE",
+"19 160 OFFCURVE",
+"19 129 CURVE SMOOTH",
+"19 96 OFFCURVE",
+"41 81 OFFCURVE",
+"80 81 CURVE SMOOTH",
+"122 81 OFFCURVE",
+"153 108 OFFCURVE",
+"257 117 CURVE",
+"252 10 OFFCURVE",
+"223 -20 OFFCURVE",
+"223 -64 CURVE SMOOTH",
+"223 -104 OFFCURVE",
+"238 -123 OFFCURVE",
+"269 -123 CURVE SMOOTH"
 );
 }
 );
@@ -49127,28 +48852,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"196 236 LINE",
-"237 169 OFFCURVE",
-"247 88 OFFCURVE",
-"247 9 CURVE",
-"170 14 OFFCURVE",
-"135 53 OFFCURVE",
-"82 53 CURVE SMOOTH",
-"44 53 OFFCURVE",
-"19 33 OFFCURVE",
-"19 -8 CURVE SMOOTH",
-"19 -51 OFFCURVE",
-"48 -71 OFFCURVE",
-"85 -71 CURVE SMOOTH",
-"135 -71 OFFCURVE",
-"171 -33 OFFCURVE",
-"247 -25 CURVE",
-"241 -121 OFFCURVE",
-"203 -164 OFFCURVE",
-"203 -221 CURVE SMOOTH",
-"203 -263 OFFCURVE",
-"224 -290 OFFCURVE",
-"269 -290 CURVE SMOOTH",
 "316 -290 OFFCURVE",
 "337 -260 OFFCURVE",
 "337 -219 CURVE SMOOTH",
@@ -49211,7 +48914,28 @@ nodes = (
 "247 464 CURVE",
 "247 385 OFFCURVE",
 "237 303 OFFCURVE",
-"196 236 CURVE"
+"196 236 CURVE",
+"237 169 OFFCURVE",
+"247 88 OFFCURVE",
+"247 9 CURVE",
+"170 14 OFFCURVE",
+"135 53 OFFCURVE",
+"82 53 CURVE SMOOTH",
+"44 53 OFFCURVE",
+"19 33 OFFCURVE",
+"19 -8 CURVE SMOOTH",
+"19 -51 OFFCURVE",
+"48 -71 OFFCURVE",
+"85 -71 CURVE SMOOTH",
+"135 -71 OFFCURVE",
+"171 -33 OFFCURVE",
+"247 -25 CURVE",
+"241 -121 OFFCURVE",
+"203 -164 OFFCURVE",
+"203 -221 CURVE SMOOTH",
+"203 -263 OFFCURVE",
+"224 -290 OFFCURVE",
+"269 -290 CURVE SMOOTH"
 );
 }
 );
@@ -49221,8 +48945,8 @@ width = 541;
 unicode = 2021;
 },
 {
-glyphname = uni2116;
-lastChange = "2016-08-16 11:12:00 +0000";
+glyphname = numero;
+lastChange = "2016-08-18 22:15:45 +0000";
 layers = (
 {
 components = (
@@ -49231,11 +48955,11 @@ name = N;
 },
 {
 name = ordmasculine;
-transform = "{1, 0, 0, 1, 740, 0}";
+transform = "{1, 0, 0, 1, 744, 0}";
 }
 );
 layerId = UUID0;
-width = 1075;
+width = 1082;
 },
 {
 background = {
@@ -49340,18 +49064,18 @@ name = N;
 },
 {
 name = ordmasculine;
-transform = "{1, 0, 0, 1, 780, 0}";
+transform = "{1, 0, 0, 1, 791, 0}";
 }
 );
 layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
-width = 1126;
+width = 1129;
 }
 );
 unicode = 2116;
 },
 {
 glyphname = estimated;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -49359,19 +49083,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"862 349 LINE",
-"862 352 OFFCURVE",
-"862 356 OFFCURVE",
-"862 359 CURVE SMOOTH",
-"862 565 OFFCURVE",
-"677 731 OFFCURVE",
-"448 731 CURVE SMOOTH",
-"220 731 OFFCURVE",
-"35 565 OFFCURVE",
-"35 359 CURVE SMOOTH",
-"35 154 OFFCURVE",
-"220 -12 OFFCURVE",
-"448 -12 CURVE SMOOTH",
 "581 -12 OFFCURVE",
 "701 45 OFFCURVE",
 "775 132 CURVE",
@@ -49388,17 +49099,25 @@ nodes = (
 "187 345 LINE SMOOTH",
 "187 348 OFFCURVE",
 "189 349 OFFCURVE",
-"192 349 CURVE SMOOTH"
+"192 349 CURVE SMOOTH",
+"862 349 LINE",
+"862 352 OFFCURVE",
+"862 356 OFFCURVE",
+"862 359 CURVE SMOOTH",
+"862 565 OFFCURVE",
+"677 731 OFFCURVE",
+"448 731 CURVE SMOOTH",
+"220 731 OFFCURVE",
+"35 565 OFFCURVE",
+"35 359 CURVE SMOOTH",
+"35 154 OFFCURVE",
+"220 -12 OFFCURVE",
+"448 -12 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"710 375 LINE SMOOTH",
-"710 373 OFFCURVE",
-"709 369 OFFCURVE",
-"706 369 CURVE SMOOTH",
-"192 369 LINE SMOOTH",
 "189 369 OFFCURVE",
 "187 373 OFFCURVE",
 "187 375 CURVE SMOOTH",
@@ -49414,7 +49133,12 @@ nodes = (
 "700 604 CURVE SMOOTH",
 "707 597 OFFCURVE",
 "710 588 OFFCURVE",
-"710 579 CURVE SMOOTH"
+"710 579 CURVE SMOOTH",
+"710 375 LINE SMOOTH",
+"710 373 OFFCURVE",
+"709 369 OFFCURVE",
+"706 369 CURVE SMOOTH",
+"192 369 LINE SMOOTH"
 );
 }
 );
@@ -49426,19 +49150,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"862 349 LINE",
-"862 352 OFFCURVE",
-"862 356 OFFCURVE",
-"862 359 CURVE SMOOTH",
-"862 565 OFFCURVE",
-"677 731 OFFCURVE",
-"448 731 CURVE SMOOTH",
-"220 731 OFFCURVE",
-"35 565 OFFCURVE",
-"35 359 CURVE SMOOTH",
-"35 154 OFFCURVE",
-"220 -12 OFFCURVE",
-"448 -12 CURVE SMOOTH",
 "581 -12 OFFCURVE",
 "701 45 OFFCURVE",
 "775 132 CURVE",
@@ -49455,17 +49166,25 @@ nodes = (
 "187 345 LINE SMOOTH",
 "187 348 OFFCURVE",
 "189 349 OFFCURVE",
-"192 349 CURVE SMOOTH"
+"192 349 CURVE SMOOTH",
+"862 349 LINE",
+"862 352 OFFCURVE",
+"862 356 OFFCURVE",
+"862 359 CURVE SMOOTH",
+"862 565 OFFCURVE",
+"677 731 OFFCURVE",
+"448 731 CURVE SMOOTH",
+"220 731 OFFCURVE",
+"35 565 OFFCURVE",
+"35 359 CURVE SMOOTH",
+"35 154 OFFCURVE",
+"220 -12 OFFCURVE",
+"448 -12 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"710 375 LINE SMOOTH",
-"710 373 OFFCURVE",
-"709 369 OFFCURVE",
-"706 369 CURVE SMOOTH",
-"192 369 LINE SMOOTH",
 "189 369 OFFCURVE",
 "187 373 OFFCURVE",
 "187 375 CURVE SMOOTH",
@@ -49481,7 +49200,12 @@ nodes = (
 "700 604 CURVE SMOOTH",
 "707 597 OFFCURVE",
 "710 588 OFFCURVE",
-"710 579 CURVE SMOOTH"
+"710 579 CURVE SMOOTH",
+"710 375 LINE SMOOTH",
+"710 373 OFFCURVE",
+"709 369 OFFCURVE",
+"706 369 CURVE SMOOTH",
+"192 369 LINE SMOOTH"
 );
 }
 );
@@ -49535,7 +49259,7 @@ unicode = 005E;
 },
 {
 glyphname = servicemark;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -49543,19 +49267,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"466 754 LINE",
-"312 754 LINE",
-"312 732 LINE",
-"356 732 LINE",
-"356 403 LINE",
-"312 403 LINE",
-"312 380 LINE",
-"440 380 LINE",
-"440 403 LINE",
-"385 403 LINE",
-"385 710 LINE",
-"389 710 LINE",
-"494 376 LINE",
 "531 376 LINE",
 "633 710 LINE",
 "637 710 LINE",
@@ -49570,16 +49281,25 @@ nodes = (
 "758 754 LINE",
 "628 754 LINE",
 "547 494 LINE",
-"543 494 LINE"
+"543 494 LINE",
+"466 754 LINE",
+"312 754 LINE",
+"312 732 LINE",
+"356 732 LINE",
+"356 403 LINE",
+"312 403 LINE",
+"312 380 LINE",
+"440 380 LINE",
+"440 403 LINE",
+"385 403 LINE",
+"385 710 LINE",
+"389 710 LINE",
+"494 376 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"77 403 LINE",
-"101 381 OFFCURVE",
-"128 371 OFFCURVE",
-"163 371 CURVE SMOOTH",
 "241 371 OFFCURVE",
 "284 419 OFFCURVE",
 "284 497 CURVE SMOOTH",
@@ -49619,7 +49339,11 @@ nodes = (
 "58 484 CURVE",
 "40 484 LINE",
 "40 378 LINE",
-"57 378 LINE"
+"57 378 LINE",
+"77 403 LINE",
+"101 381 OFFCURVE",
+"128 371 OFFCURVE",
+"163 371 CURVE SMOOTH"
 );
 }
 );
@@ -49631,19 +49355,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"466 754 LINE",
-"312 754 LINE",
-"312 727 LINE",
-"346 727 LINE",
-"346 408 LINE",
-"312 408 LINE",
-"312 380 LINE",
-"440 380 LINE",
-"440 408 LINE",
-"385 408 LINE",
-"385 679 LINE",
-"389 679 LINE",
-"484 376 LINE",
 "541 376 LINE",
 "633 677 LINE",
 "637 677 LINE",
@@ -49658,16 +49369,25 @@ nodes = (
 "768 754 LINE",
 "628 754 LINE",
 "547 494 LINE",
-"543 494 LINE"
+"543 494 LINE",
+"466 754 LINE",
+"312 754 LINE",
+"312 727 LINE",
+"346 727 LINE",
+"346 408 LINE",
+"312 408 LINE",
+"312 380 LINE",
+"440 380 LINE",
+"440 408 LINE",
+"385 408 LINE",
+"385 679 LINE",
+"389 679 LINE",
+"484 376 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"77 403 LINE",
-"101 381 OFFCURVE",
-"128 371 OFFCURVE",
-"163 371 CURVE SMOOTH",
 "241 371 OFFCURVE",
 "284 419 OFFCURVE",
 "284 497 CURVE SMOOTH",
@@ -49707,7 +49427,11 @@ nodes = (
 "58 484 CURVE",
 "40 484 LINE",
 "40 378 LINE",
-"57 378 LINE"
+"57 378 LINE",
+"77 403 LINE",
+"101 381 OFFCURVE",
+"128 371 OFFCURVE",
+"163 371 CURVE SMOOTH"
 );
 }
 );
@@ -49717,8 +49441,8 @@ width = 785;
 unicode = 2120;
 },
 {
-glyphname = uni030F;
-lastChange = "2016-08-16 11:12:00 +0000";
+glyphname = dblgravecomb;
+lastChange = "2016-08-18 21:39:28 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -49804,8 +49528,8 @@ width = 468;
 unicode = 030F;
 },
 {
-glyphname = uni0311;
-lastChange = "2016-08-16 11:12:00 +0000";
+glyphname = breveinvertedcomb;
+lastChange = "2016-08-18 21:39:28 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -49861,8 +49585,8 @@ width = 353;
 unicode = 0311;
 },
 {
-glyphname = commaaccent;
-lastChange = "2016-08-16 11:12:00 +0000";
+glyphname = commaaccentcomb;
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -49870,7 +49594,9 @@ paths = (
 {
 closed = 1;
 nodes = (
-"162 -172 LINE SMOOTH",
+"123 -272 OFFCURVE",
+"162 -232 OFFCURVE",
+"162 -172 CURVE SMOOTH",
 "162 -115 OFFCURVE",
 "126 -79 OFFCURVE",
 "78 -79 CURVE SMOOTH",
@@ -49889,10 +49615,7 @@ nodes = (
 "125 -218 OFFCURVE",
 "98 -252 OFFCURVE",
 "33 -286 CURVE",
-"53 -309 LINE",
-"123 -272 OFFCURVE",
-"162 -232 OFFCURVE",
-"162 -172 CURVE SMOOTH"
+"53 -309 LINE"
 );
 }
 );
@@ -49904,7 +49627,9 @@ paths = (
 {
 closed = 1;
 nodes = (
-"176 -174 LINE SMOOTH",
+"135 -276 OFFCURVE",
+"176 -236 OFFCURVE",
+"176 -174 CURVE SMOOTH",
 "176 -121 OFFCURVE",
 "147 -69 OFFCURVE",
 "86 -69 CURVE SMOOTH",
@@ -49923,21 +49648,18 @@ nodes = (
 "138 -226 OFFCURVE",
 "110 -253 OFFCURVE",
 "36 -292 CURVE",
-"56 -314 LINE",
-"135 -276 OFFCURVE",
-"176 -236 OFFCURVE",
-"176 -174 CURVE SMOOTH"
+"56 -314 LINE"
 );
 }
 );
 width = 186;
 }
 );
-unicode = F6C3;
+unicode = 0326;
 },
 {
-glyphname = uni030F.cap;
-lastChange = "2016-08-16 11:12:00 +0000";
+glyphname = dblgravecomb.cap;
+lastChange = "2016-08-19 17:28:22 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -50022,8 +49744,8 @@ width = 535;
 );
 },
 {
-glyphname = uni0311.cap;
-lastChange = "2016-08-16 11:12:00 +0000";
+glyphname = breveinvertedcomb.cap;
+lastChange = "2016-08-19 17:28:22 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -50078,8 +49800,8 @@ width = 353;
 );
 },
 {
-glyphname = uni02C9;
-lastChange = "2016-08-16 11:12:00 +0000";
+glyphname = firsttonechinese;
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -50087,10 +49809,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"10 637 LINE",
 "330 637 LINE",
 "330 703 LINE",
-"10 703 LINE"
+"10 703 LINE",
+"10 637 LINE"
 );
 }
 );
@@ -50102,10 +49824,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"10 627 LINE",
 "350 627 LINE",
 "350 713 LINE",
-"10 713 LINE"
+"10 713 LINE",
+"10 627 LINE"
 );
 }
 );
@@ -50116,7 +49838,7 @@ unicode = 02C9;
 },
 {
 glyphname = acute;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 21:48:17 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -50135,8 +49857,7 @@ nodes = (
 "171 754 OFFCURVE",
 "151 745 OFFCURVE",
 "128 714 CURVE SMOOTH",
-"10 554 LINE",
-"53 554 LINE"
+"10 554 LINE"
 );
 }
 );
@@ -50170,7 +49891,7 @@ unicode = 00B4;
 },
 {
 glyphname = breve;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -50178,10 +49899,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"10 733 LINE",
-"10 640 OFFCURVE",
-"64 576 OFFCURVE",
-"167 576 CURVE SMOOTH",
 "273 576 OFFCURVE",
 "323 644 OFFCURVE",
 "323 733 CURVE",
@@ -50191,7 +49908,11 @@ nodes = (
 "165 654 CURVE SMOOTH",
 "95 654 OFFCURVE",
 "47 677 OFFCURVE",
-"44 733 CURVE"
+"44 733 CURVE",
+"10 733 LINE",
+"10 640 OFFCURVE",
+"64 576 OFFCURVE",
+"167 576 CURVE SMOOTH"
 );
 }
 );
@@ -50203,10 +49924,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"10 733 LINE",
-"10 628 OFFCURVE",
-"67 556 OFFCURVE",
-"177 556 CURVE SMOOTH",
 "290 556 OFFCURVE",
 "343 632 OFFCURVE",
 "343 733 CURVE",
@@ -50216,7 +49933,11 @@ nodes = (
 "175 654 CURVE SMOOTH",
 "105 654 OFFCURVE",
 "57 677 OFFCURVE",
-"54 733 CURVE"
+"54 733 CURVE",
+"10 733 LINE",
+"10 628 OFFCURVE",
+"67 556 OFFCURVE",
+"177 556 CURVE SMOOTH"
 );
 }
 );
@@ -50227,7 +49948,7 @@ unicode = 02D8;
 },
 {
 glyphname = caron;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -50235,13 +49956,13 @@ paths = (
 {
 closed = 1;
 nodes = (
+"203 554 LINE",
+"334 754 LINE",
 "291 754 LINE",
 "172 648 LINE",
 "53 754 LINE",
 "10 754 LINE",
-"141 554 LINE",
-"203 554 LINE",
-"334 754 LINE"
+"141 554 LINE"
 );
 }
 );
@@ -50253,13 +49974,13 @@ paths = (
 {
 closed = 1;
 nodes = (
+"223 554 LINE",
+"374 754 LINE",
 "331 754 LINE",
 "192 668 LINE",
 "53 754 LINE",
 "10 754 LINE",
-"161 554 LINE",
-"223 554 LINE",
-"374 754 LINE"
+"161 554 LINE"
 );
 }
 );
@@ -50270,7 +49991,7 @@ unicode = 02C7;
 },
 {
 glyphname = cedilla;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 background = {
@@ -50316,6 +50037,14 @@ paths = (
 {
 closed = 1;
 nodes = (
+"165 -226 OFFCURVE",
+"217 -191 OFFCURVE",
+"217 -138 CURVE SMOOTH",
+"217 -92 OFFCURVE",
+"178 -66 OFFCURVE",
+"121 -66 CURVE SMOOTH",
+"102 -66 LINE",
+"126 10 LINE",
 "96 10 LINE",
 "62 -90 LINE",
 "114 -91 OFFCURVE",
@@ -50330,15 +50059,7 @@ nodes = (
 "10 -209 LINE",
 "21 -216 OFFCURVE",
 "50 -226 OFFCURVE",
-"90 -226 CURVE SMOOTH",
-"165 -226 OFFCURVE",
-"217 -191 OFFCURVE",
-"217 -138 CURVE SMOOTH",
-"217 -92 OFFCURVE",
-"178 -66 OFFCURVE",
-"121 -66 CURVE SMOOTH",
-"102 -66 LINE",
-"126 10 LINE"
+"90 -226 CURVE SMOOTH"
 );
 }
 );
@@ -50388,6 +50109,14 @@ paths = (
 {
 closed = 1;
 nodes = (
+"180 -235 OFFCURVE",
+"240 -200 OFFCURVE",
+"240 -138 CURVE SMOOTH",
+"240 -92 OFFCURVE",
+"199 -66 OFFCURVE",
+"136 -66 CURVE SMOOTH",
+"117 -66 LINE",
+"141 10 LINE",
 "96 10 LINE",
 "57 -100 LINE",
 "112 -101 OFFCURVE",
@@ -50402,15 +50131,7 @@ nodes = (
 "10 -218 LINE",
 "21 -225 OFFCURVE",
 "50 -235 OFFCURVE",
-"90 -235 CURVE SMOOTH",
-"180 -235 OFFCURVE",
-"240 -200 OFFCURVE",
-"240 -138 CURVE SMOOTH",
-"240 -92 OFFCURVE",
-"199 -66 OFFCURVE",
-"136 -66 CURVE SMOOTH",
-"117 -66 LINE",
-"141 10 LINE"
+"90 -235 CURVE SMOOTH"
 );
 }
 );
@@ -50421,7 +50142,7 @@ unicode = 00B8;
 },
 {
 glyphname = circumflex;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -50429,13 +50150,13 @@ paths = (
 {
 closed = 1;
 nodes = (
+"53 554 LINE",
+"172 660 LINE",
+"291 554 LINE",
 "334 554 LINE",
 "203 754 LINE",
 "141 754 LINE",
-"10 554 LINE",
-"53 554 LINE",
-"172 660 LINE",
-"291 554 LINE"
+"10 554 LINE"
 );
 }
 );
@@ -50447,13 +50168,13 @@ paths = (
 {
 closed = 1;
 nodes = (
+"53 554 LINE",
+"192 640 LINE",
+"331 554 LINE",
 "374 554 LINE",
 "223 754 LINE",
 "161 754 LINE",
-"10 554 LINE",
-"53 554 LINE",
-"192 640 LINE",
-"331 554 LINE"
+"10 554 LINE"
 );
 }
 );
@@ -50464,7 +50185,7 @@ unicode = 02C6;
 },
 {
 glyphname = dieresis;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -50472,28 +50193,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"10 667 LINE SMOOTH",
-"10 637 OFFCURVE",
-"35 612 OFFCURVE",
-"65 612 CURVE SMOOTH",
-"95 612 OFFCURVE",
-"120 637 OFFCURVE",
-"120 667 CURVE SMOOTH",
-"120 697 OFFCURVE",
-"95 722 OFFCURVE",
-"65 722 CURVE SMOOTH",
-"35 722 OFFCURVE",
-"10 697 OFFCURVE",
-"10 667 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"200 667 LINE SMOOTH",
-"200 637 OFFCURVE",
-"225 612 OFFCURVE",
-"255 612 CURVE SMOOTH",
 "285 612 OFFCURVE",
 "310 637 OFFCURVE",
 "310 667 CURVE SMOOTH",
@@ -50502,7 +50201,27 @@ nodes = (
 "255 722 CURVE SMOOTH",
 "225 722 OFFCURVE",
 "200 697 OFFCURVE",
-"200 667 CURVE SMOOTH"
+"200 667 CURVE SMOOTH",
+"200 637 OFFCURVE",
+"225 612 OFFCURVE",
+"255 612 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"95 612 OFFCURVE",
+"120 637 OFFCURVE",
+"120 667 CURVE SMOOTH",
+"120 697 OFFCURVE",
+"95 722 OFFCURVE",
+"65 722 CURVE SMOOTH",
+"35 722 OFFCURVE",
+"10 697 OFFCURVE",
+"10 667 CURVE SMOOTH",
+"10 637 OFFCURVE",
+"35 612 OFFCURVE",
+"65 612 CURVE SMOOTH"
 );
 }
 );
@@ -50514,28 +50233,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"10 667 LINE SMOOTH",
-"10 631 OFFCURVE",
-"40 601 OFFCURVE",
-"76 601 CURVE SMOOTH",
-"112 601 OFFCURVE",
-"142 631 OFFCURVE",
-"142 667 CURVE SMOOTH",
-"142 703 OFFCURVE",
-"112 733 OFFCURVE",
-"76 733 CURVE SMOOTH",
-"40 733 OFFCURVE",
-"10 703 OFFCURVE",
-"10 667 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"200 667 LINE SMOOTH",
-"200 631 OFFCURVE",
-"230 601 OFFCURVE",
-"266 601 CURVE SMOOTH",
 "302 601 OFFCURVE",
 "332 631 OFFCURVE",
 "332 667 CURVE SMOOTH",
@@ -50544,7 +50241,27 @@ nodes = (
 "266 733 CURVE SMOOTH",
 "230 733 OFFCURVE",
 "200 703 OFFCURVE",
-"200 667 CURVE SMOOTH"
+"200 667 CURVE SMOOTH",
+"200 631 OFFCURVE",
+"230 601 OFFCURVE",
+"266 601 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"112 601 OFFCURVE",
+"142 631 OFFCURVE",
+"142 667 CURVE SMOOTH",
+"142 703 OFFCURVE",
+"112 733 OFFCURVE",
+"76 733 CURVE SMOOTH",
+"40 733 OFFCURVE",
+"10 703 OFFCURVE",
+"10 667 CURVE SMOOTH",
+"10 631 OFFCURVE",
+"40 601 OFFCURVE",
+"76 601 CURVE SMOOTH"
 );
 }
 );
@@ -50555,7 +50272,7 @@ unicode = 00A8;
 },
 {
 glyphname = dotaccent;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -50563,10 +50280,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"10 667 LINE SMOOTH",
-"10 631 OFFCURVE",
-"40 601 OFFCURVE",
-"76 601 CURVE SMOOTH",
 "112 601 OFFCURVE",
 "142 631 OFFCURVE",
 "142 667 CURVE SMOOTH",
@@ -50575,7 +50288,10 @@ nodes = (
 "76 733 CURVE SMOOTH",
 "40 733 OFFCURVE",
 "10 703 OFFCURVE",
-"10 667 CURVE SMOOTH"
+"10 667 CURVE SMOOTH",
+"10 631 OFFCURVE",
+"40 601 OFFCURVE",
+"76 601 CURVE SMOOTH"
 );
 }
 );
@@ -50587,10 +50303,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"10 653 LINE SMOOTH",
-"10 610 OFFCURVE",
-"47 573 OFFCURVE",
-"90 573 CURVE SMOOTH",
 "134 573 OFFCURVE",
 "171 610 OFFCURVE",
 "171 653 CURVE SMOOTH",
@@ -50599,7 +50311,10 @@ nodes = (
 "90 734 CURVE SMOOTH",
 "47 734 OFFCURVE",
 "10 697 OFFCURVE",
-"10 653 CURVE SMOOTH"
+"10 653 CURVE SMOOTH",
+"10 610 OFFCURVE",
+"47 573 OFFCURVE",
+"90 573 CURVE SMOOTH"
 );
 }
 );
@@ -50663,29 +50378,11 @@ unicode = 0060;
 },
 {
 glyphname = hungarumlaut;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-18 22:02:17 +0000";
 layers = (
 {
 layerId = UUID0;
 paths = (
-{
-closed = 1;
-nodes = (
-"53 554 LINE",
-"188 648 LINE SMOOTH",
-"230 677 OFFCURVE",
-"238 695 OFFCURVE",
-"238 712 CURVE SMOOTH",
-"238 736 OFFCURVE",
-"221 754 OFFCURVE",
-"192 754 CURVE SMOOTH",
-"171 754 OFFCURVE",
-"151 745 OFFCURVE",
-"128 714 CURVE SMOOTH",
-"10 554 LINE",
-"53 554 LINE"
-);
-},
 {
 closed = 1;
 nodes = (
@@ -50700,8 +50397,24 @@ nodes = (
 "349 754 OFFCURVE",
 "329 745 OFFCURVE",
 "306 714 CURVE SMOOTH",
-"188 554 LINE",
-"231 554 LINE"
+"188 554 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"53 554 LINE",
+"188 648 LINE SMOOTH",
+"230 677 OFFCURVE",
+"238 695 OFFCURVE",
+"238 712 CURVE SMOOTH",
+"238 736 OFFCURVE",
+"221 754 OFFCURVE",
+"192 754 CURVE SMOOTH",
+"171 754 OFFCURVE",
+"151 745 OFFCURVE",
+"128 714 CURVE SMOOTH",
+"10 554 LINE"
 );
 }
 );
@@ -50710,23 +50423,6 @@ width = 426;
 {
 layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
 paths = (
-{
-closed = 1;
-nodes = (
-"73 554 LINE",
-"210 649 LINE SMOOTH",
-"248 676 OFFCURVE",
-"258 696 OFFCURVE",
-"258 714 CURVE SMOOTH",
-"258 738 OFFCURVE",
-"240 760 OFFCURVE",
-"202 760 CURVE SMOOTH",
-"179 760 OFFCURVE",
-"156 752 OFFCURVE",
-"131 718 CURVE SMOOTH",
-"10 554 LINE"
-);
-},
 {
 closed = 1;
 nodes = (
@@ -50743,6 +50439,23 @@ nodes = (
 "331 718 CURVE SMOOTH",
 "210 554 LINE"
 );
+},
+{
+closed = 1;
+nodes = (
+"73 554 LINE",
+"210 649 LINE SMOOTH",
+"248 676 OFFCURVE",
+"258 696 OFFCURVE",
+"258 714 CURVE SMOOTH",
+"258 738 OFFCURVE",
+"240 760 OFFCURVE",
+"202 760 CURVE SMOOTH",
+"179 760 OFFCURVE",
+"156 752 OFFCURVE",
+"131 718 CURVE SMOOTH",
+"10 554 LINE"
+);
 }
 );
 width = 468;
@@ -50752,7 +50465,7 @@ unicode = 02DD;
 },
 {
 glyphname = macron;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -50760,10 +50473,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"10 637 LINE",
 "330 637 LINE",
 "330 703 LINE",
-"10 703 LINE"
+"10 703 LINE",
+"10 637 LINE"
 );
 }
 );
@@ -50775,10 +50488,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"10 627 LINE",
 "350 627 LINE",
 "350 713 LINE",
-"10 713 LINE"
+"10 713 LINE",
+"10 627 LINE"
 );
 }
 );
@@ -50789,7 +50502,7 @@ unicode = 00AF;
 },
 {
 glyphname = ogonek;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -50797,7 +50510,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"100 -231 LINE",
 "138 -231 OFFCURVE",
 "176 -214 OFFCURVE",
 "197 -188 CURVE",
@@ -50818,7 +50530,8 @@ nodes = (
 "10 -147 CURVE SMOOTH",
 "10 -198 OFFCURVE",
 "46 -231 OFFCURVE",
-"100 -231 CURVE SMOOTH"
+"100 -231 CURVE SMOOTH",
+"100 -231 LINE"
 );
 }
 );
@@ -50860,7 +50573,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"99 -231 LINE SMOOTH",
 "138 -231 OFFCURVE",
 "174 -215 OFFCURVE",
 "197 -188 CURVE",
@@ -50881,7 +50593,8 @@ nodes = (
 "10 -149 CURVE SMOOTH",
 "10 -199 OFFCURVE",
 "45 -231 OFFCURVE",
-"99 -231 CURVE SMOOTH"
+"99 -231 CURVE SMOOTH",
+"99 -231 LINE SMOOTH"
 );
 }
 );
@@ -50892,7 +50605,7 @@ unicode = 02DB;
 },
 {
 glyphname = ring;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -50900,7 +50613,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"112 560 LINE SMOOTH",
 "168 560 OFFCURVE",
 "214 606 OFFCURVE",
 "214 662 CURVE SMOOTH",
@@ -50918,19 +50630,18 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"112 716 LINE SMOOTH",
-"141 716 OFFCURVE",
-"167 691 OFFCURVE",
-"167 662 CURVE SMOOTH",
-"167 632 OFFCURVE",
-"142 606 OFFCURVE",
-"112 606 CURVE SMOOTH",
 "82 606 OFFCURVE",
 "57 633 OFFCURVE",
 "57 662 CURVE SMOOTH",
 "57 691 OFFCURVE",
 "83 716 OFFCURVE",
-"112 716 CURVE SMOOTH"
+"112 716 CURVE SMOOTH",
+"141 716 OFFCURVE",
+"167 691 OFFCURVE",
+"167 662 CURVE SMOOTH",
+"167 632 OFFCURVE",
+"142 606 OFFCURVE",
+"112 606 CURVE SMOOTH"
 );
 }
 );
@@ -50942,7 +50653,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"112 560 LINE SMOOTH",
 "168 560 OFFCURVE",
 "214 606 OFFCURVE",
 "214 662 CURVE SMOOTH",
@@ -50960,19 +50670,18 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"112 706 LINE SMOOTH",
-"136 706 OFFCURVE",
-"157 686 OFFCURVE",
-"157 662 CURVE SMOOTH",
-"157 637 OFFCURVE",
-"137 616 OFFCURVE",
-"112 616 CURVE SMOOTH",
 "87 616 OFFCURVE",
 "67 638 OFFCURVE",
 "67 662 CURVE SMOOTH",
 "67 686 OFFCURVE",
 "88 706 OFFCURVE",
-"112 706 CURVE SMOOTH"
+"112 706 CURVE SMOOTH",
+"136 706 OFFCURVE",
+"157 686 OFFCURVE",
+"157 662 CURVE SMOOTH",
+"157 637 OFFCURVE",
+"137 616 OFFCURVE",
+"112 616 CURVE SMOOTH"
 );
 }
 );
@@ -50983,7 +50692,7 @@ unicode = 02DA;
 },
 {
 glyphname = tilde;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:05:53 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -50991,16 +50700,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"328 731 LINE",
-"321 710 OFFCURVE",
-"303 680 OFFCURVE",
-"265 680 CURVE SMOOTH",
-"219 680 OFFCURVE",
-"182 728 OFFCURVE",
-"128 728 CURVE SMOOTH",
-"62 728 OFFCURVE",
-"20 665 OFFCURVE",
-"10 603 CURVE",
 "43 603 LINE",
 "50 631 OFFCURVE",
 "73 652 OFFCURVE",
@@ -51010,7 +50709,17 @@ nodes = (
 "243 604 CURVE SMOOTH",
 "312 604 OFFCURVE",
 "348 668 OFFCURVE",
-"362 731 CURVE"
+"362 731 CURVE",
+"328 731 LINE",
+"321 710 OFFCURVE",
+"303 680 OFFCURVE",
+"265 680 CURVE SMOOTH",
+"219 680 OFFCURVE",
+"182 728 OFFCURVE",
+"128 728 CURVE SMOOTH",
+"62 728 OFFCURVE",
+"20 665 OFFCURVE",
+"10 603 CURVE"
 );
 }
 );
@@ -51022,16 +50731,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"368 731 LINE",
-"359 710 OFFCURVE",
-"335 680 OFFCURVE",
-"285 680 CURVE SMOOTH",
-"239 680 OFFCURVE",
-"202 728 OFFCURVE",
-"148 728 CURVE SMOOTH",
-"70 728 OFFCURVE",
-"22 655 OFFCURVE",
-"10 583 CURVE",
 "43 583 LINE",
 "52 611 OFFCURVE",
 "83 632 OFFCURVE",
@@ -51041,7 +50740,17 @@ nodes = (
 "263 584 CURVE SMOOTH",
 "344 584 OFFCURVE",
 "386 658 OFFCURVE",
-"402 731 CURVE"
+"402 731 CURVE",
+"368 731 LINE",
+"359 710 OFFCURVE",
+"335 680 OFFCURVE",
+"285 680 CURVE SMOOTH",
+"239 680 OFFCURVE",
+"202 728 OFFCURVE",
+"148 728 CURVE SMOOTH",
+"70 728 OFFCURVE",
+"22 655 OFFCURVE",
+"10 583 CURVE"
 );
 }
 );
@@ -51052,7 +50761,7 @@ unicode = 02DC;
 },
 {
 glyphname = caron.alt;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:28:22 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -51060,7 +50769,9 @@ paths = (
 {
 closed = 1;
 nodes = (
-"162 667 LINE SMOOTH",
+"115 544 OFFCURVE",
+"162 600 OFFCURVE",
+"162 667 CURVE SMOOTH",
 "162 721 OFFCURVE",
 "131 763 OFFCURVE",
 "80 763 CURVE SMOOTH",
@@ -51079,10 +50790,7 @@ nodes = (
 "125 617 OFFCURVE",
 "93 569 OFFCURVE",
 "33 529 CURVE",
-"53 506 LINE",
-"115 544 OFFCURVE",
-"162 600 OFFCURVE",
-"162 667 CURVE SMOOTH"
+"53 506 LINE"
 );
 }
 );
@@ -51094,7 +50802,9 @@ paths = (
 {
 closed = 1;
 nodes = (
-"176 647 LINE SMOOTH",
+"133 524 OFFCURVE",
+"176 573 OFFCURVE",
+"176 647 CURVE SMOOTH",
 "176 709 OFFCURVE",
 "146 764 OFFCURVE",
 "89 764 CURVE SMOOTH",
@@ -51113,10 +50823,7 @@ nodes = (
 "132 581 OFFCURVE",
 "105 543 OFFCURVE",
 "46 501 CURVE",
-"66 479 LINE",
-"133 524 OFFCURVE",
-"176 573 OFFCURVE",
-"176 647 CURVE SMOOTH"
+"66 479 LINE"
 );
 }
 );
@@ -51125,8 +50832,8 @@ width = 186;
 );
 },
 {
-glyphname = acute.cap;
-lastChange = "2016-08-16 11:12:00 +0000";
+glyphname = acute.case;
+lastChange = "2016-08-19 17:29:47 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -51177,8 +50884,8 @@ width = 313;
 );
 },
 {
-glyphname = breve.cap;
-lastChange = "2016-08-16 11:12:00 +0000";
+glyphname = breve.case;
+lastChange = "2016-08-19 17:29:47 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -51186,10 +50893,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"10 924 LINE",
-"10 843 OFFCURVE",
-"64 792 OFFCURVE",
-"167 792 CURVE SMOOTH",
 "273 792 OFFCURVE",
 "323 847 OFFCURVE",
 "323 924 CURVE",
@@ -51199,7 +50902,11 @@ nodes = (
 "165 860 CURVE SMOOTH",
 "95 860 OFFCURVE",
 "47 878 OFFCURVE",
-"44 924 CURVE"
+"44 924 CURVE",
+"10 924 LINE",
+"10 843 OFFCURVE",
+"64 792 OFFCURVE",
+"167 792 CURVE SMOOTH"
 );
 }
 );
@@ -51211,10 +50918,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"10 924 LINE",
-"10 843 OFFCURVE",
-"67 787 OFFCURVE",
-"177 787 CURVE SMOOTH",
 "290 787 OFFCURVE",
 "343 847 OFFCURVE",
 "343 924 CURVE",
@@ -51224,7 +50927,11 @@ nodes = (
 "175 880 CURVE SMOOTH",
 "105 880 OFFCURVE",
 "57 892 OFFCURVE",
-"54 924 CURVE"
+"54 924 CURVE",
+"10 924 LINE",
+"10 843 OFFCURVE",
+"67 787 OFFCURVE",
+"177 787 CURVE SMOOTH"
 );
 }
 );
@@ -51233,8 +50940,8 @@ width = 353;
 );
 },
 {
-glyphname = caron.cap;
-lastChange = "2016-08-16 11:12:00 +0000";
+glyphname = caron.case;
+lastChange = "2016-08-19 17:29:47 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -51242,13 +50949,13 @@ paths = (
 {
 closed = 1;
 nodes = (
+"203 792 LINE",
+"334 924 LINE",
 "291 924 LINE",
 "172 863 LINE",
 "53 924 LINE",
 "10 924 LINE",
-"141 792 LINE",
-"203 792 LINE",
-"334 924 LINE"
+"141 792 LINE"
 );
 }
 );
@@ -51260,13 +50967,13 @@ paths = (
 {
 closed = 1;
 nodes = (
+"243 788 LINE",
+"414 924 LINE",
 "361 924 LINE",
 "212 882 LINE",
 "63 924 LINE",
 "10 924 LINE",
-"181 788 LINE",
-"243 788 LINE",
-"414 924 LINE"
+"181 788 LINE"
 );
 }
 );
@@ -51275,8 +50982,8 @@ width = 424;
 );
 },
 {
-glyphname = circumflex.cap;
-lastChange = "2016-08-16 11:12:00 +0000";
+glyphname = circumflex.case;
+lastChange = "2016-08-19 17:29:47 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -51284,13 +50991,13 @@ paths = (
 {
 closed = 1;
 nodes = (
+"53 792 LINE",
+"172 853 LINE",
+"291 792 LINE",
 "334 792 LINE",
 "203 924 LINE",
 "141 924 LINE",
-"10 792 LINE",
-"53 792 LINE",
-"172 853 LINE",
-"291 792 LINE"
+"10 792 LINE"
 );
 }
 );
@@ -51302,13 +51009,13 @@ paths = (
 {
 closed = 1;
 nodes = (
+"63 788 LINE",
+"212 830 LINE",
+"361 788 LINE",
 "414 788 LINE",
 "243 924 LINE",
 "181 924 LINE",
-"10 788 LINE",
-"63 788 LINE",
-"212 830 LINE",
-"361 788 LINE"
+"10 788 LINE"
 );
 }
 );
@@ -51317,8 +51024,8 @@ width = 424;
 );
 },
 {
-glyphname = dieresis.cap;
-lastChange = "2016-08-16 11:12:00 +0000";
+glyphname = dieresis.case;
+lastChange = "2016-08-19 17:29:47 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -51326,28 +51033,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"10 855 LINE SMOOTH",
-"10 825 OFFCURVE",
-"35 800 OFFCURVE",
-"65 800 CURVE SMOOTH",
-"95 800 OFFCURVE",
-"120 825 OFFCURVE",
-"120 855 CURVE SMOOTH",
-"120 885 OFFCURVE",
-"95 910 OFFCURVE",
-"65 910 CURVE SMOOTH",
-"35 910 OFFCURVE",
-"10 885 OFFCURVE",
-"10 855 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"200 855 LINE SMOOTH",
-"200 825 OFFCURVE",
-"225 800 OFFCURVE",
-"255 800 CURVE SMOOTH",
 "285 800 OFFCURVE",
 "310 825 OFFCURVE",
 "310 855 CURVE SMOOTH",
@@ -51356,7 +51041,27 @@ nodes = (
 "255 910 CURVE SMOOTH",
 "225 910 OFFCURVE",
 "200 885 OFFCURVE",
-"200 855 CURVE SMOOTH"
+"200 855 CURVE SMOOTH",
+"200 825 OFFCURVE",
+"225 800 OFFCURVE",
+"255 800 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"95 800 OFFCURVE",
+"120 825 OFFCURVE",
+"120 855 CURVE SMOOTH",
+"120 885 OFFCURVE",
+"95 910 OFFCURVE",
+"65 910 CURVE SMOOTH",
+"35 910 OFFCURVE",
+"10 885 OFFCURVE",
+"10 855 CURVE SMOOTH",
+"10 825 OFFCURVE",
+"35 800 OFFCURVE",
+"65 800 CURVE SMOOTH"
 );
 }
 );
@@ -51368,28 +51073,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"10 858 LINE SMOOTH",
-"10 822 OFFCURVE",
-"40 792 OFFCURVE",
-"76 792 CURVE SMOOTH",
-"112 792 OFFCURVE",
-"142 822 OFFCURVE",
-"142 858 CURVE SMOOTH",
-"142 894 OFFCURVE",
-"112 924 OFFCURVE",
-"76 924 CURVE SMOOTH",
-"40 924 OFFCURVE",
-"10 894 OFFCURVE",
-"10 858 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"200 858 LINE SMOOTH",
-"200 822 OFFCURVE",
-"230 792 OFFCURVE",
-"266 792 CURVE SMOOTH",
 "302 792 OFFCURVE",
 "332 822 OFFCURVE",
 "332 858 CURVE SMOOTH",
@@ -51398,28 +51081,15 @@ nodes = (
 "266 924 CURVE SMOOTH",
 "230 924 OFFCURVE",
 "200 894 OFFCURVE",
-"200 858 CURVE SMOOTH"
-);
-}
-);
-width = 342;
-}
+"200 858 CURVE SMOOTH",
+"200 822 OFFCURVE",
+"230 792 OFFCURVE",
+"266 792 CURVE SMOOTH"
 );
 },
 {
-glyphname = dotaccent.cap;
-lastChange = "2016-08-16 11:12:00 +0000";
-layers = (
-{
-layerId = UUID0;
-paths = (
-{
 closed = 1;
 nodes = (
-"10 858 LINE SMOOTH",
-"10 822 OFFCURVE",
-"40 792 OFFCURVE",
-"76 792 CURVE SMOOTH",
 "112 792 OFFCURVE",
 "142 822 OFFCURVE",
 "142 858 CURVE SMOOTH",
@@ -51428,7 +51098,39 @@ nodes = (
 "76 924 CURVE SMOOTH",
 "40 924 OFFCURVE",
 "10 894 OFFCURVE",
-"10 858 CURVE SMOOTH"
+"10 858 CURVE SMOOTH",
+"10 822 OFFCURVE",
+"40 792 OFFCURVE",
+"76 792 CURVE SMOOTH"
+);
+}
+);
+width = 342;
+}
+);
+},
+{
+glyphname = dotaccent.case;
+lastChange = "2016-08-19 17:29:47 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"112 792 OFFCURVE",
+"142 822 OFFCURVE",
+"142 858 CURVE SMOOTH",
+"142 894 OFFCURVE",
+"112 924 OFFCURVE",
+"76 924 CURVE SMOOTH",
+"40 924 OFFCURVE",
+"10 894 OFFCURVE",
+"10 858 CURVE SMOOTH",
+"10 822 OFFCURVE",
+"40 792 OFFCURVE",
+"76 792 CURVE SMOOTH"
 );
 }
 );
@@ -51440,10 +51142,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"10 855 LINE SMOOTH",
-"10 818 OFFCURVE",
-"41 787 OFFCURVE",
-"78 787 CURVE SMOOTH",
 "116 787 OFFCURVE",
 "147 818 OFFCURVE",
 "147 855 CURVE SMOOTH",
@@ -51452,7 +51150,10 @@ nodes = (
 "78 924 CURVE SMOOTH",
 "41 924 OFFCURVE",
 "10 893 OFFCURVE",
-"10 855 CURVE SMOOTH"
+"10 855 CURVE SMOOTH",
+"10 818 OFFCURVE",
+"41 787 OFFCURVE",
+"78 787 CURVE SMOOTH"
 );
 }
 );
@@ -51461,8 +51162,8 @@ width = 157;
 );
 },
 {
-glyphname = grave.cap;
-lastChange = "2016-08-16 11:12:00 +0000";
+glyphname = grave.case;
+lastChange = "2016-08-19 17:29:47 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -51470,7 +51171,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"235 792 LINE",
 "278 792 LINE",
 "127 888 LINE SMOOTH",
 "80 918 OFFCURVE",
@@ -51481,7 +51181,8 @@ nodes = (
 "10 881 CURVE SMOOTH",
 "10 855 OFFCURVE",
 "27 835 OFFCURVE",
-"60 828 CURVE SMOOTH"
+"60 828 CURVE SMOOTH",
+"235 792 LINE"
 );
 }
 );
@@ -51493,7 +51194,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"240 787 LINE",
 "303 787 LINE",
 "142 891 LINE SMOOTH",
 "107 914 OFFCURVE",
@@ -51504,7 +51204,8 @@ nodes = (
 "10 878 CURVE SMOOTH",
 "10 855 OFFCURVE",
 "19 831 OFFCURVE",
-"63 822 CURVE SMOOTH"
+"63 822 CURVE SMOOTH",
+"240 787 LINE"
 );
 }
 );
@@ -51513,29 +51214,12 @@ width = 313;
 );
 },
 {
-glyphname = hungarumlaut.cap;
-lastChange = "2016-08-16 11:12:00 +0000";
+glyphname = hungarumlaut.case;
+lastChange = "2016-08-19 17:29:47 +0000";
 layers = (
 {
 layerId = UUID0;
 paths = (
-{
-closed = 1;
-nodes = (
-"53 792 LINE",
-"188 828 LINE SMOOTH",
-"220 837 OFFCURVE",
-"238 855 OFFCURVE",
-"238 881 CURVE SMOOTH",
-"238 907 OFFCURVE",
-"222 924 OFFCURVE",
-"194 924 CURVE SMOOTH",
-"180 924 OFFCURVE",
-"172 918 OFFCURVE",
-"128 884 CURVE SMOOTH",
-"10 792 LINE"
-);
-},
 {
 closed = 1;
 nodes = (
@@ -51552,6 +51236,23 @@ nodes = (
 "306 884 CURVE SMOOTH",
 "188 792 LINE"
 );
+},
+{
+closed = 1;
+nodes = (
+"53 792 LINE",
+"188 828 LINE SMOOTH",
+"220 837 OFFCURVE",
+"238 855 OFFCURVE",
+"238 881 CURVE SMOOTH",
+"238 907 OFFCURVE",
+"222 924 OFFCURVE",
+"194 924 CURVE SMOOTH",
+"180 924 OFFCURVE",
+"172 918 OFFCURVE",
+"128 884 CURVE SMOOTH",
+"10 792 LINE"
+);
 }
 );
 width = 426;
@@ -51559,23 +51260,6 @@ width = 426;
 {
 layerId = "3AE1663F-34E8-4710-91A2-69F84C961E5F";
 paths = (
-{
-closed = 1;
-nodes = (
-"73 787 LINE",
-"250 822 LINE SMOOTH",
-"294 831 OFFCURVE",
-"303 855 OFFCURVE",
-"303 878 CURVE SMOOTH",
-"303 902 OFFCURVE",
-"286 924 OFFCURVE",
-"253 924 CURVE SMOOTH",
-"224 924 OFFCURVE",
-"206 914 OFFCURVE",
-"171 891 CURVE SMOOTH",
-"10 787 LINE"
-);
-},
 {
 closed = 1;
 nodes = (
@@ -51592,6 +51276,23 @@ nodes = (
 "393 891 CURVE SMOOTH",
 "232 787 LINE"
 );
+},
+{
+closed = 1;
+nodes = (
+"73 787 LINE",
+"250 822 LINE SMOOTH",
+"294 831 OFFCURVE",
+"303 855 OFFCURVE",
+"303 878 CURVE SMOOTH",
+"303 902 OFFCURVE",
+"286 924 OFFCURVE",
+"253 924 CURVE SMOOTH",
+"224 924 OFFCURVE",
+"206 914 OFFCURVE",
+"171 891 CURVE SMOOTH",
+"10 787 LINE"
+);
 }
 );
 width = 535;
@@ -51599,8 +51300,8 @@ width = 535;
 );
 },
 {
-glyphname = macron.cap;
-lastChange = "2016-08-16 11:12:00 +0000";
+glyphname = macron.case;
+lastChange = "2016-08-19 17:29:47 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -51608,10 +51309,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"10 851 LINE",
 "330 851 LINE",
 "330 917 LINE",
-"10 917 LINE"
+"10 917 LINE",
+"10 851 LINE"
 );
 }
 );
@@ -51623,10 +51324,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"10 813 LINE",
 "350 813 LINE",
 "350 899 LINE",
-"10 899 LINE"
+"10 899 LINE",
+"10 813 LINE"
 );
 }
 );
@@ -51635,8 +51336,8 @@ width = 360;
 );
 },
 {
-glyphname = ring.cap;
-lastChange = "2016-08-16 11:12:00 +0000";
+glyphname = ring.case;
+lastChange = "2016-08-19 17:29:47 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -51644,7 +51345,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"101 777 LINE SMOOTH",
 "142 777 OFFCURVE",
 "174 811 OFFCURVE",
 "174 852 CURVE SMOOTH",
@@ -51662,19 +51362,18 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"101 891 LINE SMOOTH",
-"122 891 OFFCURVE",
-"141 873 OFFCURVE",
-"141 852 CURVE SMOOTH",
-"141 830 OFFCURVE",
-"123 810 OFFCURVE",
-"101 810 CURVE SMOOTH",
 "79 810 OFFCURVE",
 "60 830 OFFCURVE",
 "60 852 CURVE SMOOTH",
 "60 873 OFFCURVE",
 "80 891 OFFCURVE",
-"101 891 CURVE SMOOTH"
+"101 891 CURVE SMOOTH",
+"122 891 OFFCURVE",
+"141 873 OFFCURVE",
+"141 852 CURVE SMOOTH",
+"141 830 OFFCURVE",
+"123 810 OFFCURVE",
+"101 810 CURVE SMOOTH"
 );
 }
 );
@@ -51686,7 +51385,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"106 732 LINE SMOOTH",
 "159 732 OFFCURVE",
 "203 776 OFFCURVE",
 "203 828 CURVE SMOOTH",
@@ -51704,19 +51402,18 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"106 870 LINE SMOOTH",
-"129 870 OFFCURVE",
-"149 851 OFFCURVE",
-"149 828 CURVE SMOOTH",
-"149 805 OFFCURVE",
-"130 785 OFFCURVE",
-"106 785 CURVE SMOOTH",
 "83 785 OFFCURVE",
 "64 806 OFFCURVE",
 "64 828 CURVE SMOOTH",
 "64 851 OFFCURVE",
 "84 870 OFFCURVE",
-"106 870 CURVE SMOOTH"
+"106 870 CURVE SMOOTH",
+"129 870 OFFCURVE",
+"149 851 OFFCURVE",
+"149 828 CURVE SMOOTH",
+"149 805 OFFCURVE",
+"130 785 OFFCURVE",
+"106 785 CURVE SMOOTH"
 );
 }
 );
@@ -51725,8 +51422,8 @@ width = 213;
 );
 },
 {
-glyphname = tilde.cap;
-lastChange = "2016-08-16 11:12:00 +0000";
+glyphname = tilde.case;
+lastChange = "2016-08-19 17:29:47 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -51734,16 +51431,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"328 919 LINE",
-"321 898 OFFCURVE",
-"303 868 OFFCURVE",
-"265 868 CURVE SMOOTH",
-"219 868 OFFCURVE",
-"182 916 OFFCURVE",
-"128 916 CURVE SMOOTH",
-"62 916 OFFCURVE",
-"20 853 OFFCURVE",
-"10 791 CURVE",
 "43 791 LINE",
 "50 819 OFFCURVE",
 "73 840 OFFCURVE",
@@ -51753,7 +51440,17 @@ nodes = (
 "243 792 CURVE SMOOTH",
 "312 792 OFFCURVE",
 "348 856 OFFCURVE",
-"362 919 CURVE"
+"362 919 CURVE",
+"328 919 LINE",
+"321 898 OFFCURVE",
+"303 868 OFFCURVE",
+"265 868 CURVE SMOOTH",
+"219 868 OFFCURVE",
+"182 916 OFFCURVE",
+"128 916 CURVE SMOOTH",
+"62 916 OFFCURVE",
+"20 853 OFFCURVE",
+"10 791 CURVE"
 );
 }
 );
@@ -51765,16 +51462,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"368 924 LINE",
-"359 907 OFFCURVE",
-"335 884 OFFCURVE",
-"285 884 CURVE SMOOTH",
-"239 884 OFFCURVE",
-"202 924 OFFCURVE",
-"148 924 CURVE SMOOTH",
-"70 924 OFFCURVE",
-"22 854 OFFCURVE",
-"10 787 CURVE",
 "43 787 LINE",
 "52 811 OFFCURVE",
 "83 828 OFFCURVE",
@@ -51784,7 +51471,17 @@ nodes = (
 "263 788 CURVE SMOOTH",
 "344 788 OFFCURVE",
 "386 856 OFFCURVE",
-"402 924 CURVE"
+"402 924 CURVE",
+"368 924 LINE",
+"359 907 OFFCURVE",
+"335 884 OFFCURVE",
+"285 884 CURVE SMOOTH",
+"239 884 OFFCURVE",
+"202 924 OFFCURVE",
+"148 924 CURVE SMOOTH",
+"70 924 OFFCURVE",
+"22 854 OFFCURVE",
+"10 787 CURVE"
 );
 }
 );
@@ -51794,7 +51491,7 @@ width = 412;
 },
 {
 glyphname = NULL;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:28:22 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -51808,7 +51505,7 @@ width = 0;
 },
 {
 glyphname = espaciador;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:28:22 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -51816,10 +51513,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"0 -326 LINE",
 "134 -326 LINE",
 "134 924 LINE",
-"0 924 LINE"
+"0 924 LINE",
+"0 -326 LINE"
 );
 }
 );
@@ -51831,10 +51528,10 @@ paths = (
 {
 closed = 1;
 nodes = (
-"0 -326 LINE",
 "158 -326 LINE",
 "158 924 LINE",
-"0 924 LINE"
+"0 924 LINE",
+"0 -326 LINE"
 );
 }
 );
@@ -51844,7 +51541,7 @@ width = 158;
 },
 {
 glyphname = dotbelow;
-lastChange = "2016-08-16 11:12:00 +0000";
+lastChange = "2016-08-19 17:28:22 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -51852,10 +51549,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"10 -165 LINE SMOOTH",
-"10 -201 OFFCURVE",
-"40 -231 OFFCURVE",
-"76 -231 CURVE SMOOTH",
 "112 -231 OFFCURVE",
 "142 -201 OFFCURVE",
 "142 -165 CURVE SMOOTH",
@@ -51864,7 +51557,11 @@ nodes = (
 "76 -99 CURVE SMOOTH",
 "40 -99 OFFCURVE",
 "10 -129 OFFCURVE",
-"10 -165 CURVE SMOOTH"
+"10 -165 CURVE SMOOTH",
+"10 -165 LINE SMOOTH",
+"10 -201 OFFCURVE",
+"40 -231 OFFCURVE",
+"76 -231 CURVE SMOOTH"
 );
 }
 );
@@ -51876,10 +51573,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"10 -180 LINE SMOOTH",
-"10 -223 OFFCURVE",
-"47 -260 OFFCURVE",
-"90 -260 CURVE SMOOTH",
 "134 -260 OFFCURVE",
 "171 -223 OFFCURVE",
 "171 -180 CURVE SMOOTH",
@@ -51888,7 +51581,11 @@ nodes = (
 "90 -99 CURVE SMOOTH",
 "47 -99 OFFCURVE",
 "10 -136 OFFCURVE",
-"10 -180 CURVE SMOOTH"
+"10 -180 CURVE SMOOTH",
+"10 -180 LINE SMOOTH",
+"10 -223 OFFCURVE",
+"47 -260 OFFCURVE",
+"90 -260 CURVE SMOOTH"
 );
 }
 );
@@ -51897,7 +51594,6 @@ width = 181;
 );
 }
 );
-disablesAutomaticAlignment = 1;
 instances = (
 {
 interpolationWeight = 400;
@@ -51905,6 +51601,17 @@ instanceInterpolations = {
 UUID0 = 1;
 };
 name = Regular;
+},
+{
+interpolationWeight = 500;
+instanceInterpolations = {
+UUID0 = 0.666667;
+"3AE1663F-34E8-4710-91A2-69F84C961E5F" = 0.333333;
+};
+isBold = 1;
+linkStyle = Regular;
+name = Medium;
+weightClass = Medium;
 },
 {
 interpolationWeight = 700;
@@ -51938,7 +51645,7 @@ UUID0 = {
 V = -112;
 b = -18;
 comma = 32;
-guillemotleft = -52;
+guillemetleft = -52;
 guilsinglleft = -52;
 hyphen = -12;
 period = 28;
@@ -52038,7 +51745,7 @@ period = -16;
 "@MMK_R_y" = -44;
 Oslash = 12;
 V = -76;
-guillemotleft = -60;
+guillemetleft = -60;
 hyphen = -20;
 oslash = 8;
 quotedblleft = -52;
@@ -52155,8 +51862,8 @@ v = -16;
 V = -20;
 colon = -32;
 comma = -48;
-guillemotleft = -124;
-guillemotright = -112;
+guillemetleft = -124;
+guillemetright = -112;
 guilsinglleft = -124;
 hyphen = -76;
 m = -44;
@@ -52187,7 +51894,7 @@ x = -24;
 "@MMK_R_t" = -16;
 "@MMK_R_y" = -4;
 "@MMK_R_z" = -24;
-guillemotleft = -40;
+guillemetleft = -40;
 m = -24;
 p = -16;
 period = -4;
@@ -52216,8 +51923,8 @@ v = -4;
 Oslash = -36;
 colon = -12;
 comma = -64;
-guillemotleft = -92;
-guillemotright = -76;
+guillemetleft = -92;
+guillemetright = -76;
 guilsinglleft = -92;
 guilsinglright = -68;
 hyphen = -52;
@@ -52259,8 +51966,8 @@ x = -20;
 Oslash = -52;
 colon = -20;
 comma = -40;
-guillemotleft = -108;
-guillemotright = -96;
+guillemetleft = -108;
+guillemetright = -96;
 guilsinglleft = -108;
 guilsinglright = -92;
 hyphen = -64;
@@ -52320,7 +52027,7 @@ asterisk = 64;
 bracketright = 32;
 comma = 16;
 exclam = 56;
-guillemotleft = -56;
+guillemetleft = -56;
 oslash = -20;
 parenright = 70;
 period = 12;
@@ -52409,7 +52116,7 @@ x = -20;
 b = -8;
 colon = 24;
 comma = -36;
-guillemotleft = -60;
+guillemetleft = -60;
 hyphen = -56;
 m = 20;
 oslash = -16;
@@ -52513,7 +52220,7 @@ F = {
 "@MMK_R_u" = -8;
 colon = -16;
 comma = -80;
-guillemotleft = -92;
+guillemetleft = -92;
 hyphen = -48;
 oslash = -72;
 period = -80;
@@ -52554,7 +52261,7 @@ P = {
 "@MMK_R_y" = 16;
 colon = -24;
 comma = -108;
-guillemotleft = -116;
+guillemetleft = -116;
 hyphen = -76;
 oslash = -72;
 period = -104;
@@ -52597,8 +52304,8 @@ V = {
 Oslash = -56;
 colon = -32;
 comma = -84;
-guillemotleft = -112;
-guillemotright = -92;
+guillemetleft = -112;
+guillemetright = -92;
 guilsinglleft = -112;
 guilsinglright = -88;
 hyphen = -72;
@@ -52624,7 +52331,7 @@ X = {
 "@MMK_R_o" = -16;
 "@MMK_R_y" = -60;
 Oslash = -8;
-guillemotleft = -60;
+guillemetleft = -60;
 guilsinglleft = -60;
 hyphen = -20;
 quotedblleft = -32;
@@ -52653,7 +52360,7 @@ four = {
 four = 20;
 seven = -40;
 };
-guillemotleft = {
+guillemetleft = {
 "@MMK_R_J" = 16;
 "@MMK_R_T" = -108;
 "@MMK_R_U" = -36;
@@ -52661,7 +52368,7 @@ guillemotleft = {
 "@MMK_R_Y" = -100;
 V = -92;
 };
-guillemotright = {
+guillemetright = {
 "@MMK_R_A" = -44;
 "@MMK_R_AE" = -80;
 "@MMK_R_J" = -52;
@@ -52894,7 +52601,7 @@ two = -16;
 V = -92;
 b = 40;
 comma = 24;
-guillemotleft = -28;
+guillemetleft = -28;
 guilsinglleft = -44;
 period = 20;
 q = -16;
@@ -52988,7 +52695,7 @@ period = -4;
 "@MMK_R_y" = -64;
 Oslash = -28;
 V = -80;
-guillemotleft = -60;
+guillemetleft = -60;
 hyphen = -32;
 quotedblleft = -88;
 quotedblright = -76;
@@ -53096,8 +52803,8 @@ v = 8;
 "@MMK_R_z" = -52;
 colon = -36;
 comma = -68;
-guillemotleft = -104;
-guillemotright = -104;
+guillemetleft = -104;
+guillemetright = -104;
 guilsinglleft = -120;
 hyphen = -80;
 m = -48;
@@ -53129,7 +52836,7 @@ x = -44;
 "@MMK_R_y" = -8;
 "@MMK_R_z" = -20;
 comma = -32;
-guillemotleft = -28;
+guillemetleft = -28;
 m = -24;
 p = -24;
 period = -12;
@@ -53159,8 +52866,8 @@ v = -8;
 Oslash = -60;
 colon = -32;
 comma = -84;
-guillemotleft = -92;
-guillemotright = -84;
+guillemetleft = -92;
+guillemetright = -84;
 guilsinglleft = -108;
 guilsinglright = -84;
 hyphen = -68;
@@ -53202,8 +52909,8 @@ x = -52;
 Oslash = -80;
 colon = -40;
 comma = -72;
-guillemotleft = -108;
-guillemotright = -104;
+guillemetleft = -108;
+guillemetright = -104;
 guilsinglleft = -124;
 guilsinglright = -104;
 hyphen = -84;
@@ -53256,7 +52963,7 @@ asterisk = 158;
 bracketright = 98;
 comma = 16;
 exclam = 114;
-guillemotleft = -24;
+guillemetleft = -24;
 oslash = -8;
 parenright = 104;
 period = 16;
@@ -53340,7 +53047,7 @@ x = -20;
 b = -20;
 colon = 8;
 comma = -84;
-guillemotleft = -28;
+guillemetleft = -28;
 hyphen = -48;
 m = 16;
 oslash = -8;
@@ -53442,7 +53149,7 @@ F = {
 "@MMK_R_y" = -24;
 colon = -28;
 comma = -88;
-guillemotleft = -80;
+guillemetleft = -80;
 hyphen = -56;
 oslash = -80;
 period = -88;
@@ -53485,7 +53192,7 @@ P = {
 "@MMK_R_y" = 28;
 colon = -16;
 comma = -104;
-guillemotleft = -84;
+guillemetleft = -84;
 hyphen = -68;
 oslash = -60;
 period = -104;
@@ -53528,8 +53235,8 @@ V = {
 Oslash = -48;
 colon = -20;
 comma = -80;
-guillemotleft = -80;
-guillemotright = -76;
+guillemetleft = -80;
+guillemetright = -76;
 guilsinglleft = -96;
 guilsinglright = -76;
 hyphen = -60;
@@ -53555,7 +53262,7 @@ X = {
 "@MMK_R_o" = -12;
 "@MMK_R_y" = -64;
 Oslash = -28;
-guillemotleft = -52;
+guillemetleft = -52;
 guilsinglleft = -68;
 hyphen = -24;
 quotedblleft = -60;
@@ -53588,7 +53295,7 @@ seven = -44;
 germandbls = {
 quotedblleft = -24;
 };
-guillemotleft = {
+guillemetleft = {
 "@MMK_R_J" = 64;
 "@MMK_R_T" = -104;
 "@MMK_R_U" = -24;
@@ -53596,7 +53303,7 @@ guillemotleft = {
 "@MMK_R_Y" = -116;
 V = -76;
 };
-guillemotright = {
+guillemetright = {
 "@MMK_R_A" = -40;
 "@MMK_R_AE" = -64;
 "@MMK_R_J" = 12;


### PR DESCRIPTION
Vietnamese for italics, included kerning groups for Vietnamese
characters. The romans version 2 is the version used anchor/components
in all glyphs (not only Vietnamese). Also fixed compatibility, removed
overlapping points, used the glyphs naming convention. 
Please delete the medium instances when exporting.
